### PR TITLE
Login sql bugfix & docker-compose mysql now uses version 8.0

### DIFF
--- a/SQL/aaemu_login.sql
+++ b/SQL/aaemu_login.sql
@@ -17,7 +17,6 @@ CREATE TABLE `game_servers` (
   `hidden` tinyint(1) NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `users`

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,8 +2,9 @@ version: '3.1'
 
 services:
     db:
-        image: mysql:5.7
+        image: mysql:8.0
         restart: unless-stopped
+        command: --default_authentication_plugin=mysql_native_password
         volumes:
             - db-data:/var/lib/mysql
             - ./SQL:/docker-entrypoint-initdb.d


### PR DESCRIPTION
Removed reference to the variable `saved_cs_client ` in login SQL which doesn't exist; causing a MySQL error when running the SQL on a fresh instance: `ERROR 1231 (42000) at line 20: Variable 'character_set_client' can't be set to the value of 'NULL'`

Tested by running a clean container and volume in docker and entering the game world on a new character.

Updated docker-compose to use mysql 8.0