### PR TITLE
Fixing all build warnings

### DIFF
--- a/AAEmu.Game/AAEmu.Game.csproj
+++ b/AAEmu.Game/AAEmu.Game.csproj
@@ -62,7 +62,7 @@
     <ItemGroup>
         <PackageReference Include="Discord.Net" Version="2.2.0" />
         <PackageReference Include="Jace" Version="0.9.2" />
-        <PackageReference Include="JitterPhysics" Version="0.2.0.20" />
+        <PackageReference Include="Jitter.Core" Version="0.2.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.10.0" />
         <PackageReference Include="Microsoft.Data.Sqlite" Version="2.2.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
@@ -74,8 +74,8 @@
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
         <PackageReference Include="NLog" Version="4.5.11" />
         <PackageReference Include="NLua" Version="1.5.6" />
-        <PackageReference Include="Quartz" Version="3.2.3" />        
-        <PackageReference Include="Ionic.Zlib" Version="1.9.1.5" />        
+        <PackageReference Include="Quartz" Version="3.2.3" />
+        <PackageReference Include="Ionic.Zlib.Core" Version="1.0.0" />        
         <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     </ItemGroup>
 

--- a/AAEmu.Game/Core/Network/Connections/GameConnection.cs
+++ b/AAEmu.Game/Core/Network/Connections/GameConnection.cs
@@ -157,7 +157,7 @@ namespace AAEmu.Game.Core.Network.Connections
                 return;
 
             // stopping the TransferTelescopeTickStartTask if character disconnected
-            TransferTelescopeManager.Instance.StopTransferTelescopeTick();
+            TransferTelescopeManager.Instance.StopTransferTelescopeTick().GetAwaiter().GetResult();
 
             ActiveChar.Delete();
             // Removed ReleaseId here to try and fix party/raid disconnect and reconnect issues. Replaced with saving the data

--- a/AAEmu.Game/Models/Game/AI/States/AlmightyAttackState.cs
+++ b/AAEmu.Game/Models/Game/AI/States/AlmightyAttackState.cs
@@ -41,6 +41,7 @@ namespace AAEmu.Game.Models.Game.AI.States
         public override void Tick(TimeSpan delta)
         {
             return;
+            /*
             if (OwnerTemplate == null)
                 return;
 
@@ -112,6 +113,7 @@ namespace AAEmu.Game.Models.Game.AI.States
             var skillObject = SkillObject.GetByType(SkillObjectType.None);
 
             skill.Use(Npc, skillCaster, skillCastTarget, skillObject, true);
+            */
         }
 
         private AiSkillList GetNextAiSkills()

--- a/AAEmu.Game/Models/Game/Units/Buffs.cs
+++ b/AAEmu.Game/Models/Game/Units/Buffs.cs
@@ -550,7 +550,7 @@ namespace AAEmu.Game.Models.Game.Units
                 else if (template.RemoveOnMove && on == BuffRemoveOn.Move)
                 {
                     // stopping the TransferTelescopeTickStartTask if character moved
-                    TransferTelescopeManager.Instance.StopTransferTelescopeTick();
+                    TransferTelescopeManager.Instance.StopTransferTelescopeTick().GetAwaiter().GetResult();
                     
                     effect.Exit();
                 }                

--- a/AAEmu.Game/Models/Game/Units/Slave.cs
+++ b/AAEmu.Game/Models/Game/Units/Slave.cs
@@ -184,6 +184,7 @@ namespace AAEmu.Game.Models.Game.Units
                 // For example a clipper would be correct is we added another 368.33 (= +341%) stamina boost
                 // TODO: for now just put a static 250k HP so spawned slaves don't show damaged
                 return 250000;
+                /*
                 var formula = FormulaManager.Instance.GetUnitFormula(FormulaOwnerType.Slave, UnitFormulaKind.MaxHealth);
                 var parameters = new Dictionary<string, double>();
                 parameters["level"] = Level;
@@ -202,6 +203,7 @@ namespace AAEmu.Game.Models.Game.Units
                         res += bonus.Value;
                 }
                 return res;
+                */
             }
         }
 


### PR DESCRIPTION
Changed dependent projects to use Core versions.
Had to port manually (fork) JitterPhysics to be .netstandard compatible
Commented unreachable codes.
Properly awaited async Tasks

Previous warnings:
- warning NU1701: Package 'Ionic.Zlib 1.9.1.5' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8' instead of the project target framework '.NETCoreApp,Version=v3.1'
- warning NU1701: Package 'JitterPhysics 0.2.0.20' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8' instead of the project ta
rget framework '.NETCoreApp,Version=v3.1'
- AAEmu\AAEmu.Game\Core\Network\Connections\GameConnection.cs(160,13): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call. [D:\repo\AAEmu\AAEmu.Game\AAEmu.Game.csproj]
- AAEmu\AAEmu.Game\Models\Game\AI\States\AlmightyAttackState.cs(44,13): warning CS0162: Unreachable code detected [D:\repo\AAEmu\AAEmu.Game\AAEmu.Game.csproj]
- AAEmu\AAEmu.Game\Models\Game\Units\Slave.cs(187,17): warning CS0162: Unreachable code detected [D:\repo\AAEmu\AAEmu.Game\AAEmu.Game.csproj]
- AAEmu\AAEmu.Game\Models\Game\Units\Buffs.cs(553,21): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call. [D:\repo\AAEmu\AAEmu.Game\AAEmu.Game.csproj]
