### PR TITLE
[Requires Testing] Several code cleanup changes + teleport json

### DIFF
--- a/AAEmu.Commons/Network/PacketStream.cs
+++ b/AAEmu.Commons/Network/PacketStream.cs
@@ -4,13 +4,19 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Text;
+using System.Runtime.Serialization;
 using AAEmu.Commons.Conversion;
 using AAEmu.Commons.Utils;
 
 namespace AAEmu.Commons.Network
 {
-    public sealed class MarshalException : Exception // next: is it necessary?
+    [Serializable]
+    public class MarshalException : Exception
     {
+        public MarshalException() { }
+        public MarshalException(string message) : base(message) { }
+        public MarshalException(string message, Exception inner) : base(message, inner) { }
+        protected MarshalException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 
     /// <summary>

--- a/AAEmu.Game/GameService.cs
+++ b/AAEmu.Game/GameService.cs
@@ -237,7 +237,6 @@ namespace AAEmu.Game
         public void Dispose()
         {
             _log.Info("Disposing...");
-
             LogManager.Flush();
         }
     }

--- a/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotTree.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotTree.cs
@@ -147,7 +147,8 @@ namespace AAEmu.Game.Models.Game.Skills.Plots.Tree
                 }
 
                 FlushExecutionQueue(executeQueue, state);
-            } catch (Exception e)
+            }
+            catch (Exception e)
             {
                 _log.Error($"Main Loop Error: {e.Message}\n {e.StackTrace}");
             }

--- a/AAEmu.Game/Program.cs
+++ b/AAEmu.Game/Program.cs
@@ -19,6 +19,7 @@ namespace AAEmu.Game
     public static class Program
     {
         private static Logger _log = LogManager.GetCurrentClassLogger();
+        
         private static Thread _thread = Thread.CurrentThread;
         private static DateTime _startTime;
         private static string Name => Assembly.GetExecutingAssembly().GetName().Name;

--- a/AAEmu.Game/Scripts/Commands/AddBuff.cs
+++ b/AAEmu.Game/Scripts/Commands/AddBuff.cs
@@ -5,7 +5,6 @@ using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Units;
-using AAEmu.Game.Models.Tasks.Skills;
 
 namespace AAEmu.Game.Scripts.Commands
 {
@@ -24,10 +23,10 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Adds or removes a buff to selected target. Negative BuffId's will remove a buff. " +
-                "If precered by AsTarget (at) buff will be applied as if target was source. " +
-                "If you provide view as a parameter, it will list the current buffs on target." +
-                "You can also use 'v' instead of 'view' and 'at' or 't' instead of 'AsTarget'";
+            return "Adds or removes a buff to selected target. Negative BuffId's will remove a buff. "
+                 + "If preceded by AsTarget (at) buff will be applied as if target was source. "
+                 + "If you provide view as a parameter, it will list the current buffs on target. "
+                 + "You can also use 'v' instead of 'view' and 'at' or 't' instead of 'AsTarget'";
         }
 
         public void Execute(Character character, string[] args)
@@ -35,12 +34,12 @@ namespace AAEmu.Game.Scripts.Commands
             var firstArg = 0;
             if (args.Length <= 0)
             {
-                character.SendMessage("[AddBuff] " + CommandManager.CommandPrefix + "addbuff " + GetCommandLineHelp());
+                character.SendMessage($"[AddBuff] {CommandManager.CommandPrefix}addbuff {GetCommandLineHelp()}");
                 return;
             }
 
             Unit sourceUnit = character;
-            Unit targetUnit = null ;
+            Unit targetUnit = null;
 
             if (!(character.CurrentTarget is Unit selectedUnit))
             {
@@ -84,13 +83,13 @@ namespace AAEmu.Game.Scripts.Commands
 
             if (args.Length <= firstArg)
             {
-                character.SendMessage("|cFFFF0000[AddBuff] No buffId provided ?|r");
+                character.SendMessage("|cFFFF0000[AddBuff] No buffId provided?|r");
                 return;
             }
 
             if (!int.TryParse(args[firstArg], out var buffIdInt))
             {
-                character.SendMessage("|cFFFF0000[AddBuff] Parse error buffId !|r");
+                character.SendMessage("|cFFFF0000[AddBuff] Parse error buffId!|r");
                 return;
             }
 
@@ -110,24 +109,23 @@ namespace AAEmu.Game.Scripts.Commands
 
             if (buffIdInt > 0)
             {
-
                 var casterObj = new SkillCasterUnit(sourceUnit.ObjId);
                 var targetObj = SkillCastTarget.GetByType(SkillCastTargetType.Unit);
                 targetObj.ObjId = targetUnit.ObjId;
 
-                var newBuff = new Buff(targetUnit, sourceUnit, casterObj, buffTemplate, null, System.DateTime.UtcNow)
-                {
-                    AbLevel = abLevel
-                };
+                var newBuff = new Buff(targetUnit, sourceUnit, casterObj, buffTemplate, null, System.DateTime.UtcNow);
+                newBuff.AbLevel = abLevel;
                 targetUnit.Buffs.AddBuff(newBuff);
             }
             if (buffIdInt < 0)
             {
                 if (selectedUnit.Buffs.CheckBuff(buffId))
+                {
                     selectedUnit.Buffs.RemoveBuff(buffId);
+                }
                 else
                 {
-                    character.SendMessage("|cFFFF0000[AddBuff] Target didn't have buff to remove|r", buffId);
+                    character.SendMessage("|cFFFF0000[AddBuff] Target didn't have a buff to remove|r", buffId);
                 }
             }
             else

--- a/AAEmu.Game/Scripts/Commands/AddGold.cs
+++ b/AAEmu.Game/Scripts/Commands/AddGold.cs
@@ -23,14 +23,14 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Adds X amount of money to target (can be negative values).";
+            return "Adds X amount of money to target (can be negative).";
         }
 
         public void Execute(Character character, string[] args)
         {
             if (args.Length == 0)
             {
-                character.SendMessage("[Gold] "+ CommandManager.CommandPrefix + "addgold (target) <gold> [silver] [copper]");
+                character.SendMessage($"[Gold] {CommandManager.CommandPrefix}addgold (target) <gold> [silver] [copper]");
                 return;
             }
 
@@ -40,7 +40,6 @@ namespace AAEmu.Game.Scripts.Commands
             var argSilver = 0;
             var argCopper = 0;
             var amount = 0;
-
             if ((args.Length > firstarg) && (int.TryParse(args[firstarg], out amount)))
             {
                 argGold = amount;
@@ -55,19 +54,18 @@ namespace AAEmu.Game.Scripts.Commands
             }
 
             var argTotal = argCopper + (argSilver * 100) + (argGold * 10000);
-
             if (argTotal != 0)
             {
                 targetPlayer.Money += argTotal;
                 targetPlayer.SendPacket(new SCItemTaskSuccessPacket(ItemTaskType.AutoLootDoodadItem, new List<ItemTask> { new MoneyChange(argTotal) }, new List<ulong>()));
                 if (character.Id != targetPlayer.Id)
                 {
-                    character.SendMessage("[Gold] changed {0}'s money by {1}g {2}s {3}c",targetPlayer.Name,argGold,argSilver,argCopper);
+                    character.SendMessage("[Gold] Changed {0}'s money by {1}g {2}s {3}c", targetPlayer.Name, argGold, argSilver, argCopper);
                     targetPlayer.SendMessage("[GM] {0} has adjusted your money", character.Name);
                 }
             }
             else
-                character.SendMessage("[Gold] No valid amount provided ...");
+                character.SendMessage("[Gold] No valid amount provided...");
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/AddItem.cs
+++ b/AAEmu.Game/Scripts/Commands/AddItem.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
-using AAEmu.Game.Core.Packets.G2C;
+﻿using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Char;
@@ -25,14 +22,16 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Adds item with template <itemId> and amount [count] at a specific [grade]. If [count] is omitted, the amount is one. If [grade] is ommited, the default defined for that item will be used.";
+            return "Adds item with template <itemId> and amount [count] at a specific [grade]. "
+                 + "If [count] is omitted, the amount is one. If [grade] is ommited, the default "
+                 + "defined for that item will be used.";
         }
 
         public void Execute(Character character, string[] args)
         {
             if (args.Length == 0)
             {
-                character.SendMessage("[Items] " + CommandManager.CommandPrefix + "additem (target) <itemId> [count] [grade]");
+                character.SendMessage($"[Items] {CommandManager.CommandPrefix}additem (target) <itemId> [count] [grade]");
                 return;
             }
 
@@ -60,7 +59,7 @@ namespace AAEmu.Game.Scripts.Commands
             var itemTemplate = ItemManager.Instance.GetTemplate(itemId);
             if (itemTemplate == null)
             {
-                character.SendMessage("|cFFFF0000Item template does not exist for {0} !|r", itemId);
+                character.SendMessage($"|cFFFF0000Item template does not exist for {itemId}!|r");
                 return;
             }
 
@@ -87,8 +86,8 @@ namespace AAEmu.Game.Scripts.Commands
 
             if (character.Id != targetPlayer.Id)
             {
-                character.SendMessage("[Items] added item {0} to {1}'s inventory", itemId, targetPlayer.Name);
-                targetPlayer.SendMessage("[GM] {0} has added a item to your inventory", character.Name);
+                character.SendMessage("[Items] Added item {0} to {1}'s inventory", itemId, targetPlayer.Name);
+                targetPlayer.SendMessage("[GM] {0} has added an item to your inventory", character.Name);
             }
 
         }

--- a/AAEmu.Game/Scripts/Commands/AddLabor.cs
+++ b/AAEmu.Game/Scripts/Commands/AddLabor.cs
@@ -21,40 +21,39 @@ namespace AAEmu.Game.Scripts.Commands
         public string GetCommandHelpText()
         {
             // Optional TODO: Add the values by extracting them from actability_groups ?
-            return "Add or remove <amount> of labor. If [vocationSkillId] is provided, then target vocation skill also gains a amount of points.\n" +
-                "(1)Alchemy, (2)Construction, (3)Cooking, (4)Handicrafts, (5)Husbandry, (6)Farming, (7)Fishing, (8)Logging, (9)Gathering, (10)Machining, " +
-                "(11)Metalwork, (12)Printing, (13)Mining, (14)Masonry, (15)Tailoring, (16)Leatherwork, (17)Weaponry, (18)Carpentry, (20)Larceny, " +
-                "(21)Nuian, (22)Elven, (23)Dwarven, (25)Harani, (26)Firran, (27)Warborn, (29)Nuia Dialect, (30)Haranya Dialect, " +
-                "(31)Commerce, (33)Artistry, (34)Exploration";
+            return "Add or remove <amount> of labor. If [vocationSkillId] is provided, then target "
+                 + "vocation skill also gains a amount of points.\n"
+                 + "(1)Alchemy, (2)Construction, (3)Cooking, (4)Handicrafts, (5)Husbandry, (6)Farming, "
+                 + "(7)Fishing, (8)Logging, (9)Gathering, (10)Machining, (11)Metalwork, (12)Printing, "
+                 + "(13)Mining, (14)Masonry, (15)Tailoring, (16)Leatherwork, (17)Weaponry, (18)Carpentry, "
+                 + "(20)Larceny, (21)Nuian, (22)Elven, (23)Dwarven, (25)Harani, (26)Firran, (27)Warborn, "
+                 + "(29)Nuia Dialect, (30)Haranya Dialect, (31)Commerce, (33)Artistry, (34)Exploration";
         }
 
         public void Execute(Character character, string[] args)
         {
             if (args.Length == 0)
             {
-                character.SendMessage("[Labor] " + CommandManager.CommandPrefix + "addlabor (target) <count> [targetSkill]");
+                character.SendMessage($"[Labor] {CommandManager.CommandPrefix}addlabor (target) <count> [targetSkill]");
                 return;
             }
 
             Character targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out var firstarg);
 
             short count = 0;
-
             if ((args.Length > firstarg + 0) && (short.TryParse(args[firstarg + 0], out short argcount)))
                 count = argcount;
 
             int vocationSkillId = 0;
-
             if ((args.Length > firstarg + 1) && (int.TryParse(args[firstarg + 1], out int argvocationSkillId)))
                 vocationSkillId = argvocationSkillId;
 
             targetPlayer.ChangeLabor(count, vocationSkillId);
             if (character.Id != targetPlayer.Id)
             {
-                character.SendMessage("[Labor] added {0} labor to {1}", count, targetPlayer.Name);
+                character.SendMessage("[Labor] Added {0} labor to {1}", count, targetPlayer.Name);
                 targetPlayer.SendMessage("[GM] {0} has updated your labor by {1}", character.Name, count);
             }
-
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/AddPortals.cs
+++ b/AAEmu.Game/Scripts/Commands/AddPortals.cs
@@ -1,10 +1,6 @@
-﻿using System.Collections.Generic;
-using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
-using AAEmu.Game.Core.Packets.G2C;
+﻿using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.Items.Actions;
 using AAEmu.Game.Core.Managers.World;
 
 namespace AAEmu.Game.Scripts.Commands
@@ -24,15 +20,15 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Adds a portal with <name> to your teleport book.\n" +
-                "If [<x> <y> <z> <zoneid>] is ommited or incomplete, your current position will be used.";
+            return "Adds a portal with <name> to your teleport book.\n"
+                 + "If [<x> <y> <z> <zoneid>] is ommited or incomplete, your current position will be used.";
         }
 
         public void Execute(Character character, string[] args)
         {
             if (args.Length == 0)
             {
-                character.SendMessage("[Portal] " + CommandManager.CommandPrefix + "add_portal (target) <name> [<x> <y> <z> <zoneid>]");
+                character.SendMessage($"[Portal] {CommandManager.CommandPrefix}add_portal (target) <name> [<x> <y> <z> <zoneid>]");
                 //character.SendMessage("[Portal] *optional (will get actual position)");
                 return;
             }
@@ -46,7 +42,6 @@ namespace AAEmu.Game.Scripts.Commands
             var z = position.Z;
             var zRot = position.Roll;
             var zoneId = position.ZoneId;
-
             if ((args.Length == firstarg + 5) && (float.TryParse(args[firstarg + 1], out float argx)))
                 x = argx;
             if ((args.Length == firstarg + 5) && (float.TryParse(args[firstarg + 2], out float argy)))
@@ -57,12 +52,12 @@ namespace AAEmu.Game.Scripts.Commands
                 zoneId = argzoneId;
             // If not using the current location, set the rotation to zero
             if (args.Length == firstarg + 5)
-                zRot = 0 ;
+                zRot = 0;
 
             targetPlayer.Portals.AddPrivatePortal(x, y, z, zRot, zoneId, portalName);
             if (character.Id != targetPlayer.Id)
             {
-                character.SendMessage("[Portal] added {0} labor to {1}'s portal book", portalName, targetPlayer.Name);
+                character.SendMessage("[Portal] Added {0} to {1}'s portal book", portalName, targetPlayer.Name);
                 targetPlayer.SendMessage("[GM] {0} has added the entry \"{1}\" to your portal book", character.Name, portalName);
             }
             else

--- a/AAEmu.Game/Scripts/Commands/AddXP.cs
+++ b/AAEmu.Game/Scripts/Commands/AddXP.cs
@@ -1,5 +1,4 @@
 ﻿using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Core.Managers.World;
@@ -28,7 +27,7 @@ namespace AAEmu.Game.Scripts.Commands
         {
             if (args.Length == 0)
             {
-                character.SendMessage("[XP] " + CommandManager.CommandPrefix + "add_xp (target) <exp>");
+                character.SendMessage($"[XP] {CommandManager.CommandPrefix} add_xp (target) <exp>");
                 return;
             }
 

--- a/AAEmu.Game/Scripts/Commands/Announce.cs
+++ b/AAEmu.Game/Scripts/Commands/Announce.cs
@@ -1,35 +1,12 @@
-﻿/*
-* Announce.cs
-* Author: SargeDG
-* Updated by: ZeromusXYZ
-* usage: /Announce <NoticeType> <Color> <VisibleTime> <message>
-* usage example: /announce 3 FFFF00 2500 Text here is in yellow
-*  
-* 
-* [Information]
-* Check SCNoticeMessagePacket for information on how the packet
-* is constructed. It send as follows
-* 1 byte for the message type (default seems to be 3, but we don't know what the values mean)
-* 2 chars for a hex-string for alpha of the text color
-* 1 int for the time before it fades (in ms)
-* 6 chars for a hex-string RGB value of the text color
-* remainder is the message itself
-* 
-*/
-
-using System.Collections.Generic;
+﻿using System;
+using System.Drawing;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using System;
-using AAEmu.Game.Models.Game.Chat;
-using System.Collections.Concurrent;
 using AAEmu.Game.Core.Managers.World;
-using System.Drawing;
 
 namespace AAEmu.Game.Scripts.Commands
-         
 {
     public class Announce : ICommand
     {
@@ -45,16 +22,16 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Broadcasts a server-wide message in a given style.\r\n" +
-                "<NoticeType> is a value from 1-3 (default 3), " +
-                "<Color> is a RGB or ARGB value in Hex, " +
-                "<VisibleTime> is in milliseconds\r\n" +
-                "If the first arguments isn't a valid NoticeType, all arguments are treated as the message using default color and time settings for type 3.\r\n" +
-                "examples:\r\n" +
-                CommandManager.CommandPrefix + "announce 3 FF00FF00 5000 Text here use as many spaces as you wish\r\n" +
-                CommandManager.CommandPrefix + "announce 3 FFFF00 2500 Text here is in yellow\r\n" +
-                CommandManager.CommandPrefix + "announce 3 red 2500 Text here is in red\r\n" +
-                CommandManager.CommandPrefix + "announce Automaticly generated lime text";
+            return "Broadcasts a server-wide message in a given style.\r\n"
+                 + "<NoticeType> is a value from 1-3 (default 3), "
+                 + "<Color> is a RGB or ARGB value in Hex, "
+                 + "<VisibleTime> is in milliseconds\r\n"
+                 + "If the first arguments isn't a valid NoticeType, all arguments are treated as the message using default color and time settings for type 3.\r\n"
+                 + "examples:\r\n"
+                 + $"{CommandManager.CommandPrefix}announce 3 FF00FF00 5000 Text here use as many spaces as you wish\r\n"
+                 + $"{CommandManager.CommandPrefix}announce 3 FFFF00 2500 Text here is in yellow\r\n"
+                 + $"{CommandManager.CommandPrefix}announce 3 red 2500 Text here is in red\r\n"
+                 + $"{CommandManager.CommandPrefix}announce Automaticly generated lime text";
         }
 
         public Color NameOrHexColor(String hex)
@@ -65,7 +42,7 @@ namespace AAEmu.Game.Scripts.Commands
                 if ((nameCol.R != 0) || (nameCol.G != 0) || (nameCol.B != 0))
                     return nameCol; // Only accept try by name when it didn't return pure black
 
-                //remove the # at the front
+                // remove the # at the front
                 hex = hex.Replace("#", "");
 
                 byte a = 255;
@@ -73,16 +50,15 @@ namespace AAEmu.Game.Scripts.Commands
                 byte g = 255;
                 byte b = 255;
 
+                // handle ARGB strings (8 characters long)
                 int start = 0;
-
-                //handle ARGB strings (8 characters long)
                 if (hex.Length == 8)
                 {
                     a = byte.Parse(hex.Substring(0, 2), System.Globalization.NumberStyles.HexNumber);
                     start = 2;
                 }
 
-                //convert RGB characters to bytes
+                // convert RGB characters to bytes
                 r = byte.Parse(hex.Substring(start, 2), System.Globalization.NumberStyles.HexNumber);
                 g = byte.Parse(hex.Substring(start + 2, 2), System.Globalization.NumberStyles.HexNumber);
                 b = byte.Parse(hex.Substring(start + 4, 2), System.Globalization.NumberStyles.HexNumber);
@@ -97,50 +73,49 @@ namespace AAEmu.Game.Scripts.Commands
 
         public void Execute(Character character, string[] args)
         {
-            //if no arguments send help information
+            // if no arguments send help information
             if (args.Length == 0)
-            {                                
-                character.SendMessage("[Announce] syntax: " + CommandManager.CommandPrefix + "announce [<NoticeType> <Color> <VisibleTime>] <message>");
-                character.SendMessage("[Announce] example1: " + CommandManager.CommandPrefix + "announce 3 FFFF00 2500 Text here is in yellow");
-                character.SendMessage("[Announce] example2: " + CommandManager.CommandPrefix + "announce 3 red 2500 Text here is in red");
-                character.SendMessage("[Announce] example3: " + CommandManager.CommandPrefix + "announce Automaticly generated lime text");
+            {
+                character.SendMessage(
+                          $"[Announce] syntax: {CommandManager.CommandPrefix}announce [<NoticeType> <Color> <VisibleTime>] <message>\n"
+                        + $"[Announce] example1: {CommandManager.CommandPrefix}announce 3 FFFF00 2500 Text here is in yellow\n"
+                        + $"[Announce] example2: {CommandManager.CommandPrefix}announce 3 red 2500 Text here is in red\n"
+                        + $"[Announce] example3: {CommandManager.CommandPrefix}announce Automaticly generated lime text"
+                    );
                 return;
             }
 
             try
             {
-                // initialze variables
-                byte _type = 0;
-                Color _color = Color.Lime;
-                Int32 _visibletime = 0;
+                byte type = 0;
+                Color color = Color.Lime;
+                Int32 visibleTime = 0;
                 int firstArg = 3;
-                string _message = "";
+                string message = "";
 
                 if (byte.TryParse(args[0], out byte typeval))
-                    _type = typeval;
+                    type = typeval;
 
-                if ((_type < 1) || (_type > 3))
+                if ((type < 1) || (type > 3))
                 {
-                    // Invalid type, assume the user only provided text, and handle everything autmatically
+                    // Invalid type, assume the user only provided text, and handle everything automatically
                     firstArg = 0;
-                    _type = 3;
+                    type = 3;
                 }
                 else
                 {
-                    _color = NameOrHexColor(args[1]);
+                    color = NameOrHexColor(args[1]);
                     if (Int32.TryParse(args[2], out Int32 vistimeval))
-                        _visibletime = vistimeval;
+                        visibleTime = vistimeval;
                 }
 
                 int x = firstArg;
                 for (; x < args.Length; x++)
-                    _message += args[x] + " ";
+                    message += args[x] + " ";
 
-                //broadcast to all online clients in server
-                WorldManager.Instance.BroadcastPacketToServer(new SCNoticeMessagePacket(_type, _color, _visibletime, _message));
-
-                //send back confirmation script executed to script runner
-                character.SendMessage("[Announce] Script Executed.");
+                // broadcast to all online clients in server
+                WorldManager.Instance.BroadcastPacketToServer(new SCNoticeMessagePacket(type, color, visibleTime, message));
+                character.SendMessage("[Announce] Sent announcement.");
             }
             catch (Exception x)
             {

--- a/AAEmu.Game/Scripts/Commands/Appellation.cs
+++ b/AAEmu.Game/Scripts/Commands/Appellation.cs
@@ -27,7 +27,7 @@ namespace AAEmu.Game.Scripts.Commands
         {
             if (args.Length == 0)
             {
-                character.SendMessage("[Title] " + CommandManager.CommandPrefix + "set_title <titleId>");
+                character.SendMessage($"[Title] {CommandManager.CommandPrefix}set_title <titleId>");
                 return;
             }
 

--- a/AAEmu.Game/Scripts/Commands/Around.cs
+++ b/AAEmu.Game/Scripts/Commands/Around.cs
@@ -1,14 +1,10 @@
 ﻿using System;
-using System.Text;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.NPChar;
-using AAEmu.Game.Core.Managers.UnitManagers;
-using AAEmu.Game.Models.Game.World.Transform;
-using System.Numerics;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.World;
 
@@ -29,10 +25,10 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Creates a list of specified <objectType> in a [radius] radius around you. Default radius is 30.\n" +
-                "Note: Only lists objects in viewing range of you (recommended maximum radius of 100).";
+            return "Creates a list of specified <objectType> in a [radius] around you. Default radius is 30.\n"
+                 + "Note: Only lists objects in viewing range of you (recommended maximum radius of 100).";
         }
-        
+
         public int ShowObjectData(Character character, GameObject go, int index, string indexPrefix, bool verbose)
         {
             var indexStr = indexPrefix;
@@ -41,28 +37,25 @@ namespace AAEmu.Game.Scripts.Commands
             indexStr += (index + 1).ToString();
 
             if (go is Doodad gDoodad)
-                character.SendMessage("#{0} -> BcId: {1} DoodadTemplateId: {2} - @DOODAD_NAME({2})", 
-                    indexStr, gDoodad.ObjId, gDoodad.TemplateId);
-            else
-            if (go is Character gChar)
-                character.SendMessage("#{0} -> BcId: {1} CharacterId: {2} - {3}", 
-                    indexStr, gChar.ObjId, gChar.Id, gChar.Name);
-            else
-            if (go is BaseUnit gBase)
-                character.SendMessage("#{0} -> BcId: {1} - {2}", 
-                    indexStr, gBase.ObjId, gBase.Name);
+                character.SendMessage("#{0} -> BcId: {1} DoodadTemplateId: {2} - @DOODAD_NAME({2})", indexStr, gDoodad.ObjId, gDoodad.TemplateId);
+            else if (go is Character gChar)
+                character.SendMessage("#{0} -> BcId: {1} CharacterId: {2} - {3}", indexStr, gChar.ObjId, gChar.Id, gChar.Name);
+            else if (go is BaseUnit gBase)
+                character.SendMessage("#{0} -> BcId: {1} - {2}", indexStr, gBase.ObjId, gBase.Name);
             else
                 character.SendMessage("#{0} -> BcId: {1}", indexStr, go.ObjId.ToString());
+
             if (verbose)
             {
                 // var shorts = go.Transform.World.ToRollPitchYawShorts();
                 // var shortString = "(short[3])(r:" + shorts.Item1.ToString() + " p:" + shorts.Item2.ToString() + " y:" + shorts.Item3.ToString()+")";
-                character.SendMessage("#{0} -> {1}",indexStr,go.Transform.ToFullString(true,true));
+                character.SendMessage("#{0} -> {1}", indexStr, go.Transform.ToFullString(true, true));
             }
 
             // Cycle Children
             for (var i = 0; i < go.Transform.Children.Count; i++)
                 ShowObjectData(character, go.Transform.Children[i]?.GameObject, i, indexStr, verbose);
+            
             return 1 + go.Transform.Children.Count;
         }
 
@@ -70,20 +63,19 @@ namespace AAEmu.Game.Scripts.Commands
         {
             if (args.Length < 1)
             {
-                character.SendMessage("[Around] Using: " + CommandManager.CommandPrefix + "around " + GetCommandLineHelp());
+                character.SendMessage($"[Around] Using: {CommandManager.CommandPrefix}around {GetCommandLineHelp()}");
                 return;
             }
 
-            float radius = 30f;
+            float radius = 30.0f;
             if ((args.Length > 1) && (!float.TryParse(args[1], out radius)))
             {
-                character.SendMessage("|cFFFF0000[Around] Error parsing Radius !|r");
+                character.SendMessage("|cFFFF0000[Around] Error parsing Radius!|r");
                 return;
             }
 
             var verbose = ((args.Length > 2) && (!string.IsNullOrWhiteSpace(args[2])));
-
-            var sb = new StringBuilder();
+            // var sb = new StringBuilder();
             switch (args[0])
             {
                 case "doodad":
@@ -102,7 +94,7 @@ namespace AAEmu.Game.Scripts.Commands
                             character.SendMessage("#{0} -> {1} = {2}\n",(i + 1).ToString(),doodads[i].Transform.ToString(),shortString);
                         }
                     }
-                    character.SendMessage(sb.ToString());
+                    // character.SendMessage(sb.ToString());
                     character.SendMessage("[Around] Doodad count: {0}", doodads.Count);
                     break;
 

--- a/AAEmu.Game/Scripts/Commands/BuildHouse.cs
+++ b/AAEmu.Game/Scripts/Commands/BuildHouse.cs
@@ -1,5 +1,4 @@
 using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
@@ -30,7 +29,7 @@ namespace AAEmu.Game.Scripts.Commands
             var targetHouse = character.CurrentTarget as House;
             if (targetHouse == null)
             {
-                character.SendMessage("You must target a house");
+                character.SendMessage("[BuildHouse] You must target a house");
                 return;
             }
 

--- a/AAEmu.Game/Scripts/Commands/ChangeLevel.cs
+++ b/AAEmu.Game/Scripts/Commands/ChangeLevel.cs
@@ -22,16 +22,15 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Adds experience points needed to reach target <level> (allowed range is 1-55)\n" +
-                "Do note that going above the intended max level might break skills.";
+            return "Adds experience points needed to reach target <level> (allowed range is 1-55)\n"
+                 + "Note: Going above the intended max level may break skills.";
         }
 
         public void Execute(Character character, string[] args)
         {
             if (args.Length == 0)
             {
-                character.SendMessage("[Level] " + CommandManager.CommandPrefix + "set_level (target) <level>");
-                //character.SendMessage("[Level] level: 1-100");
+                character.SendMessage($"[Level] {CommandManager.CommandPrefix}set_level (target) <level>");
                 return;
             }
 
@@ -45,7 +44,7 @@ namespace AAEmu.Game.Scripts.Commands
 
             if (level <= 0 && level > 55)
             {
-                character.SendMessage("|cFFFF0000[Level] Allowed level range: 1-55|r");
+                character.SendMessage("|cFFFF0000[Level] Level outside range: 1-55|r");
                 return;
             }
 

--- a/AAEmu.Game/Scripts/Commands/CofferActions.cs
+++ b/AAEmu.Game/Scripts/Commands/CofferActions.cs
@@ -1,17 +1,10 @@
-﻿using System;
-using System.Linq;
-using System.Text;
+﻿using System.Linq;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.DoodadObj;
-using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Core.Managers.UnitManagers;
-using AAEmu.Game.Models.Game.World.Transform;
-using System.Numerics;
-using AAEmu.Game.Models.Game.Units;
-using AAEmu.Game.Models.Game.World;
 
 namespace AAEmu.Game.Scripts.Commands
 {
@@ -30,28 +23,27 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "View or manipulate a coffer doodad, using one of the following actions:\n" +
-                "close - Force-Closes a coffer so it can be opened again by other people.\n" +
-                "view - View the coffer contents\n" +
-                "\n" +
-                "If doodadObjId is ommited, the first found coffer in a 4m radius will be used.\n";
+            return "View or manipulate a coffer doodad, using one of the following actions:\n"
+                 + "close - Force-Closes a coffer so it can be opened again by other people.\n"
+                 + "view - View the coffer contents\n\n"
+                 + "If doodadObjId is ommited, the first found coffer in a 4m radius will be used.\n";
         }
         
         public void Execute(Character character, string[] args)
         {
-            float checkRadius = 4f;
+            float checkRadius = 4.0f;
             var action = args.Length >= 1 ? args[0].ToLower() : "help";
             var doodadObjIdStr = args.Length >= 2 ? args[1] : "0";
             
             if (action == "help")
             {
-                character.SendMessage("[Coffer] Usage: " + CommandManager.CommandPrefix + "coffer " + GetCommandLineHelp());
+                character.SendMessage($"[Coffer] Usage: {CommandManager.CommandPrefix}coffer {GetCommandLineHelp()}");
                 return;
             }
 
             if (!uint.TryParse(doodadObjIdStr, out var doodadObjId))
             {
-                character.SendMessage("|cFFFF0000[Coffer] Error parsing doodadObjId !|r");
+                character.SendMessage("|cFFFF0000[Coffer] Error parsing doodadObjId!|r");
                 return;
             }
 
@@ -61,7 +53,7 @@ namespace AAEmu.Game.Scripts.Commands
                 var doodads = WorldManager.Instance.GetAround<DoodadCoffer>(character, checkRadius);
                 if (doodads.Count <= 0)
                 {
-                    character.SendMessage("|cFFFF0000[Coffer] No coffers found nearby !|r");
+                    character.SendMessage("|cFFFF0000[Coffer] No coffers found nearby!|r");
                     return;
                 }
                 coffer = doodads.First();
@@ -73,15 +65,9 @@ namespace AAEmu.Game.Scripts.Commands
                     coffer = dCoffer;
                 else
                 {
-                    character.SendMessage($"|cFFFF0000[Coffer] No coffers found with objId: {doodadObjId} !|r");
+                    character.SendMessage($"|cFFFF0000[Coffer] No coffers found with objId: {doodadObjId}!|r");
                     return;
                 }
-            }
-
-            if (coffer == null)
-            {
-                character.SendMessage($"|cFFFF0000[Coffer] Not sure how we got here !?|r");
-                return;
             }
 
             character.SendMessage($"[Coffer] objId: {coffer.ObjId}, DoodadDbId: {coffer.DbId}, ItemContainerDbId: {coffer.ItemContainer.ContainerId}, UsedBy: {coffer.OpenedBy?.Name ?? "<nobody>"}");
@@ -92,7 +78,7 @@ namespace AAEmu.Game.Scripts.Commands
                     foreach (var item in coffer.ItemContainer.Items)
                     {
                         var slotName = item.Slot.ToString();
-                        var countName = "|ng;" + item.Count.ToString() + "|r x ";
+                        var countName = $"|ng;{item.Count.ToString()}|r x ";
                         if (item.Count == 1)
                             countName = string.Empty;
                         character.SendMessage($"[|nd;@DOODAD_NAME({coffer.TemplateId})|r][{slotName}] |nb;{item.Id}|r {countName}|nn;{item.TemplateId}|r = @ITEM_NAME({item.TemplateId})");
@@ -101,7 +87,7 @@ namespace AAEmu.Game.Scripts.Commands
                     break;
                 case "close":
                     if (!DoodadManager.Instance.CloseCofferDoodad(null, coffer.ObjId))
-                        character.SendMessage($"|cFFFF0000[Coffer] Failed to close coffer {coffer.ObjId} ?|r");
+                        character.SendMessage($"|cFFFF0000[Coffer] Failed to close coffer {coffer.ObjId}?|r");
                     else
                         character.SendMessage($"[Coffer] Closed Coffer {coffer.ObjId}");
                     break;

--- a/AAEmu.Game/Scripts/Commands/Damage.cs
+++ b/AAEmu.Game/Scripts/Commands/Damage.cs
@@ -1,9 +1,6 @@
 using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.World;
-using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Scripts.Commands
@@ -23,25 +20,23 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Damages self or your current target based on raw damage or Hp percentage, usage:\n" +
-                   "/damage 9999  -> Inflicts 9999 damage\n" +
-                   "/damage 80 %  -> Inflicts 80% of target's max hp damage\n" +
-                   "/damage 20%   -> Inflicts 20% of target's max hp damage";
+            return "Damages self or your current target based on raw damage or Hp percentage, usage:\n"
+                 + $"{CommandManager.CommandPrefix}damage 9999 -> Inflicts 9999 damage\n"
+                 + $"{CommandManager.CommandPrefix}damage 80 % -> Inflicts 80% of target's max hp damage\n"
+                 + $"{CommandManager.CommandPrefix}damage 20%  -> Inflicts 20% of target's max hp damage";
         }
 
         public void Execute(Character character, string[] args)
         {
             if (args.Length < 1)
             {
-                character.SendMessage("[Damage] " + CommandManager.CommandPrefix + "damage (self or target) <damage> [%]");
+                character.SendMessage($"[Damage] {CommandManager.CommandPrefix}damage (self or target) <damage> [%]");
                 return;
             }
             
-            Unit target = null;
+            Unit target = character;
             if (character.CurrentTarget is Unit curTarget)
                 target = curTarget;
-            else
-                target = character;
             
             var damageStr = args[0];
             bool isPercent = false;

--- a/AAEmu.Game/Scripts/Commands/Despawn.cs
+++ b/AAEmu.Game/Scripts/Commands/Despawn.cs
@@ -1,23 +1,19 @@
 ﻿using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.Id;
 using AAEmu.Game.Core.Managers.World;
-using AAEmu.Game.Core.Managers.UnitManagers;
-using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.NPChar;
-using AAEmu.Game.Models.Game.World;
-using AAEmu.Game.Utils;
-using NLog;
-using System;
 using AAEmu.Game.Models.Game.Units;
+using NLog;
 
 namespace AAEmu.Game.Scripts.Commands
 {
     public class Despawn : ICommand
     {
         protected static Logger _log = LogManager.GetCurrentClassLogger();
+
         public void OnLoad()
         {
             CommandManager.Instance.Register("despawn", this);
@@ -30,14 +26,14 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Despawns a npc or doodad using by <objId> or <templateId> inside a <radius> range.";
+            return "Despawns an npc or doodad using by <objId> or <templateId> inside a <radius> range.";
         }
 
         public void Execute(Character character, string[] args)
         {
             if (args.Length < 2)
             {
-                character.SendMessage("[Despawn] " + CommandManager.CommandPrefix + "despawn "+ GetCommandLineHelp());
+                character.SendMessage($"[Despawn] {CommandManager.CommandPrefix}despawn {GetCommandLineHelp()}");
                 return;
             }
 
@@ -50,7 +46,7 @@ namespace AAEmu.Game.Scripts.Commands
                 character.SendMessage("|cFFFF0000[Despawn] Parse error unitId|r");
                 return;
             }
-            if ((args.Length >= 3) && (!float.TryParse(args[2],out radius)))
+            if (useRadius && (!float.TryParse(args[2], out radius)))
             {
                 character.SendMessage("|cFFFF0000[Despawn] Parse error radius|r");
                 return;
@@ -71,7 +67,7 @@ namespace AAEmu.Game.Scripts.Commands
                         }
                         else
                         {
-                            character.SendMessage("|cFFFF0000[Despawn] Doodad with Id {0} Does not exist |r", unitId);
+                            character.SendMessage("|cFFFF0000[Despawn] Doodad with Id {0} doesn't exist|r", unitId);
                         }
                         break;
                     case "npc":
@@ -85,7 +81,7 @@ namespace AAEmu.Game.Scripts.Commands
                         }
                         else
                         {
-                            character.SendMessage("|cFFFF0000[Despawn] NPC with objectId {0} don't exist|r", unitId);
+                            character.SendMessage("|cFFFF0000[Despawn] NPC with objectId {0} doesn't exist|r", unitId);
                         }
                         break;
                     case "unit":
@@ -99,7 +95,7 @@ namespace AAEmu.Game.Scripts.Commands
                         }
                         else
                         {
-                            character.SendMessage("|cFFFF0000[Despawn] NPC with objectId {0} don't exist|r", unitId);
+                            character.SendMessage("|cFFFF0000[Despawn] NPC with objectId {0} doesn't exist|r", unitId);
                         }
                         break;
                     default:
@@ -110,7 +106,6 @@ namespace AAEmu.Game.Scripts.Commands
             else
             {
                 var removedCount = 0;
-                // Use radius
                 switch (action)
                 {
                     case "doodad":

--- a/AAEmu.Game/Scripts/Commands/Dist.cs
+++ b/AAEmu.Game/Scripts/Commands/Dist.cs
@@ -1,9 +1,6 @@
 ﻿using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.UnitManagers;
-using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Utils;
 
 namespace AAEmu.Game.Scripts.Commands
@@ -34,8 +31,7 @@ namespace AAEmu.Game.Scripts.Commands
             var rawDistanceZ = MathUtil.CalculateDistance(character.Transform.World.Position, target.Transform.World.Position, true);
             var modelDistance = character.GetDistanceTo(target);
             var modelDistanceZ = character.GetDistanceTo(target, true);
-
-            character.SendMessage("[Distance]\nRaw distance : {0}\nRaw distance (Z) : {1}\nModel adjusted distance: {2}\nModel adjusted distance (Z): {3}", rawDistance, rawDistanceZ, modelDistance, modelDistanceZ);
+            character.SendMessage($"[Distance]\nRaw distance : {rawDistance}\nRaw distance (Z) : {rawDistanceZ}\nModel adjusted distance: {modelDistance}\nModel adjusted distance (Z): {modelDistanceZ}");
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/Dloc.cs
+++ b/AAEmu.Game/Scripts/Commands/Dloc.cs
@@ -1,24 +1,12 @@
 ﻿using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
 using AAEmu.Game.Core.Managers.World;
-using AAEmu.Game.Core.Managers.UnitManagers;
-using AAEmu.Game.Models.Game.Units.Movements;
-using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.DoodadObj;
-using AAEmu.Game.Models.Game.NPChar;
-using AAEmu.Game.Models.Game.World;
-using AAEmu.Game.Utils;
-using AAEmu.Commons.Utils;
-using NLog;
-using System;
 
 namespace AAEmu.Game.Scripts.Commands
 {
     public class Dloc : ICommand
     {
-        protected static Logger _log = LogManager.GetCurrentClassLogger();
         public void OnLoad()
         {
             CommandManager.Instance.Register("dloc", this);
@@ -31,14 +19,14 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "change doodad position";
+            return "Change doodad position.";
         }
 
         public void Execute(Character character, string[] args)
         {
             if (args.Length < 4)
             {
-                character.SendMessage("[dloc] /dloc <doodadID> <x> <y> <z> - Use x y z instead of a value to keep current position");
+                character.SendMessage($"[dloc] {CommandManager.CommandPrefix}dloc <doodadID> <x> <y> <z> - Use x y z instead of a value to keep current position");
                 return;
             }
 
@@ -74,7 +62,7 @@ namespace AAEmu.Game.Scripts.Commands
                 }
                 else
                 {
-                    character.SendMessage("[dloc] doodad is null!");
+                    character.SendMessage("[dloc] doodadID is null!");
                 }
             }
         }

--- a/AAEmu.Game/Scripts/Commands/Dummy.cs
+++ b/AAEmu.Game/Scripts/Commands/Dummy.cs
@@ -1,10 +1,7 @@
-﻿using System.Text;
-using AAEmu.Game.Core.Managers;
+﻿using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.UnitManagers;
-using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Utils;
 
@@ -32,7 +29,6 @@ namespace AAEmu.Game.Scripts.Commands
 
         public void Execute(Character character, string[] args)
         {
-            float angle;
             
             if (!NpcManager.Instance.Exist(DUMMY_NPC_TEMPLATE_ID))
             {
@@ -41,7 +37,7 @@ namespace AAEmu.Game.Scripts.Commands
             }
 
             var spawnPos = character.Transform.CloneDetached();
-            spawnPos.Local.AddDistanceToFront(3f);
+            spawnPos.Local.AddDistanceToFront(3.0f);
 
             var npcSpawner = new NpcSpawner
             {
@@ -49,7 +45,7 @@ namespace AAEmu.Game.Scripts.Commands
                 UnitId = DUMMY_NPC_TEMPLATE_ID,
                 Position = character.Transform.CloneAsSpawnPosition()
             };
-            angle = (float)MathUtil.CalculateAngleFrom(npcSpawner.Position.X, npcSpawner.Position.Y, character.Transform.World.Position.X, character.Transform.World.Position.Y);
+            float angle = (float)MathUtil.CalculateAngleFrom(npcSpawner.Position.X, npcSpawner.Position.Y, character.Transform.World.Position.X, character.Transform.World.Position.Y);
             npcSpawner.Position.Yaw = 0;
             npcSpawner.Position.Pitch = 0;
             npcSpawner.Position.Roll = angle.DegToRad();

--- a/AAEmu.Game/Scripts/Commands/Dummy.cs
+++ b/AAEmu.Game/Scripts/Commands/Dummy.cs
@@ -29,7 +29,6 @@ namespace AAEmu.Game.Scripts.Commands
 
         public void Execute(Character character, string[] args)
         {
-            
             if (!NpcManager.Instance.Exist(DUMMY_NPC_TEMPLATE_ID))
             {
                 character.SendMessage("|cFFFF0000[Dummy] Dummy NPC does not exist|r");

--- a/AAEmu.Game/Scripts/Commands/ExpireItem.cs
+++ b/AAEmu.Game/Scripts/Commands/ExpireItem.cs
@@ -1,13 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
-using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.Items.Actions;
-using AAEmu.Game.Core.Managers.World;
 
 namespace AAEmu.Game.Scripts.Commands
 {
@@ -26,7 +21,7 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Sets item's expiration time to [minutes] minutes, 30 seconds if no time is provided. For debugging only.";
+            return "Sets an item's expiration time to [minutes], 30 seconds if no time is provided.";
         }
 
         public void Execute(Character character, string[] args)
@@ -37,33 +32,33 @@ namespace AAEmu.Game.Scripts.Commands
                 return;
             }
 
-			ulong itemId = 0;
-            if ( (args.Length > 0) && (ulong.TryParse(args[0], out var argitemId)) )
+            ulong itemId = 0;
+            if ((args.Length > 0) && (ulong.TryParse(args[0], out var argitemId)))
                 itemId = argitemId;
 
             double minutes = 0.5;
-            if ( (args.Length > 1) && (double.TryParse(args[1], out var argMinutes)) )
+            if ((args.Length > 1) && (double.TryParse(args[1], out var argMinutes)))
                 minutes = argMinutes;
 
             if (itemId <= 0)
             {
-                character.SendMessage("[ExpireItem] invalid itemId");
+                character.SendMessage("[ExpireItem] Invalid itemId");
                 return;
             }
 
-			var item = ItemManager.Instance.GetItemByItemId(itemId);
-			var newTime = DateTime.UtcNow.AddMinutes(minutes);
-			if (minutes >= 0)
-			{
-				item.ExpirationTime = newTime ;
-	            character.SendPacket(new SCSyncItemLifespanPacket(true, item.Id, item.TemplateId, newTime));
-			}
-			else
-			{
-				item.ExpirationTime = DateTime.MinValue ;
-	            character.SendPacket(new SCSyncItemLifespanPacket(false, item.Id, item.TemplateId, DateTime.MinValue));
-			}
-            character.SendMessage($"Item expire time updated to {newTime}");
+            var item = ItemManager.Instance.GetItemByItemId(itemId);
+            var newTime = DateTime.UtcNow.AddMinutes(minutes);
+            if (minutes >= 0)
+            {
+                item.ExpirationTime = newTime;
+                character.SendPacket(new SCSyncItemLifespanPacket(true, item.Id, item.TemplateId, newTime));
+            }
+            else
+            {
+                item.ExpirationTime = DateTime.MinValue;
+                character.SendPacket(new SCSyncItemLifespanPacket(false, item.Id, item.TemplateId, DateTime.MinValue));
+            }
+            character.SendMessage($"[ExpireItem] Item expire time updated to {newTime}");
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/Fly.cs
+++ b/AAEmu.Game/Scripts/Commands/Fly.cs
@@ -1,9 +1,9 @@
-﻿using AAEmu.Game.Core.Managers;
+﻿using System.Collections.Generic;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Core.Managers.World;
-using System.Collections.Generic;
 
 namespace AAEmu.Game.Scripts.Commands
 {
@@ -11,19 +11,6 @@ namespace AAEmu.Game.Scripts.Commands
     {
         private static List<uint> characterFlyStateCache = new List<uint>();
 
-        private bool GetCacheState(uint characterId)
-        {
-            return characterFlyStateCache.Contains(characterId);
-        }
-
-        private void SetCacheState(uint characterId, bool state)
-        {
-            if (state && !GetCacheState(characterId))
-                characterFlyStateCache.Add(characterId);
-            else
-                characterFlyStateCache.Remove(characterId);
-        }
-        
         public void OnLoad()
         {
             CommandManager.Instance.Register("fly", this);
@@ -47,19 +34,22 @@ namespace AAEmu.Game.Scripts.Commands
             if (args.Length > 0)
                 targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out firstArg);
 
-            var isFlying = !GetCacheState(targetPlayer.Id); // We cache the playerId, not the ObjectId
-
+            var isFlying = !characterFlyStateCache.Contains(targetPlayer.Id);
             if (args.Length > firstArg)
             {
                 if (!bool.TryParse(args[firstArg + 0], out isFlying))
                 {
-                    character.SendMessage("|cFFFF0000[Fly] bool parse error!|r");
+                    character.SendMessage("|cFFFF0000[Fly] Bool parse error!|r");
                     return;
                 }
             }
+
             targetPlayer.SendPacket(new SCUnitFlyingStateChangedPacket(targetPlayer.ObjId, isFlying));
-            targetPlayer.SendMessage($"[Fly] State changed to |cFFFFFFFF{isFlying}|r.");
-            SetCacheState(targetPlayer.Id, isFlying);
+            targetPlayer.SendMessage($"[Fly] State changed to |cFFFFFFFF{isFlying}|r");
+            if (isFlying)
+                characterFlyStateCache.Add(targetPlayer.Id);
+            else
+                characterFlyStateCache.Remove(targetPlayer.Id);
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/GetAttribute.cs
+++ b/AAEmu.Game/Scripts/Commands/GetAttribute.cs
@@ -28,20 +28,19 @@ namespace AAEmu.Game.Scripts.Commands
 
         public void Execute(Character character, string[] args)
         {
-            Unit target = character;
-            int argsIdx = 0;
-
             if (args.Length == 0)
             {
-                character.SendMessage("[GetAttribute] " + CommandManager.CommandPrefix + "getattribute <attrId || attrName> [target]");
+                character.SendMessage($"[GetAttribute] {CommandManager.CommandPrefix}getattribute <attrId || attrName> [target]");
                 return;
             }
 
+            Unit target = character;
+            int argsIdx = 0;
             if (args.Length > 1 && args[0] == "target")
             {
                 if (character.CurrentTarget == null || !(character.CurrentTarget is Unit))
                 {
-                    character.SendPacket(new SCChatMessagePacket(ChatType.System, $"No Target Selected"));
+                    character.SendPacket(new SCChatMessagePacket(ChatType.System, "No Target Selected"));
                     return;
                 }
                 target = (Unit)character.CurrentTarget;

--- a/AAEmu.Game/Scripts/Commands/GetPosition.cs
+++ b/AAEmu.Game/Scripts/Commands/GetPosition.cs
@@ -21,7 +21,7 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Displays information about the position of you, or your target if a target is selected or provided as a argument.";
+            return "Displays information about the position of you, or your target if a target is selected or provided as an argument.";
         }
 
         public void Execute(Character character, string[] args)
@@ -29,7 +29,6 @@ namespace AAEmu.Game.Scripts.Commands
             if (character.CurrentTarget != null && character.CurrentTarget != character)
             {
                 var pos = character.CurrentTarget.Transform.CloneAsSpawnPosition();
-
                 if (character.CurrentTarget is Npc npc)
                     character.SendMessage("[Position] Id: {0}, ObjId: {1}, TemplateId: {2} X: |cFFFFFFFF{3}|r  Y: |cFFFFFFFF{4}|r  Z: |cFFFFFFFF{5}|r", npc.Spawner.Id, character.CurrentTarget.ObjId, npc.TemplateId, pos.X, pos.Y, pos.Z);
             }
@@ -39,9 +38,7 @@ namespace AAEmu.Game.Scripts.Commands
                 if (args.Length > 0)
                     targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out var firstarg);
 
-
                 var pos = targetPlayer.Transform.CloneAsSpawnPosition();
-
                 var zonename = "???";
                 var zone = ZoneManager.Instance.GetZoneByKey(pos.ZoneId);
                 if (zone != null)

--- a/AAEmu.Game/Scripts/Commands/Heal.cs
+++ b/AAEmu.Game/Scripts/Commands/Heal.cs
@@ -4,7 +4,6 @@ using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Core.Managers.World;
-using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Scripts.Commands
@@ -38,36 +37,31 @@ namespace AAEmu.Game.Scripts.Commands
             
             if ((targetPlayer is Character) && (playerTarget != null))
             {
+                // This check is needed otherwise the player will be kicked
                 if (targetPlayer.Hp == 0)
                 {
-                    // This check is needed otherwise the player will be kicked
                     character.SendMessage("Cannot heal a dead target, use the revive command instead");
+                    return;
                 }
-                else
-                {
-                    targetPlayer.Hp = targetPlayer.MaxHp;
-                    targetPlayer.Mp = targetPlayer.MaxMp;
-                    targetPlayer.BroadcastPacket(new SCUnitPointsPacket(targetPlayer.ObjId, targetPlayer.Hp, targetPlayer.Mp), true);
-                }
+                targetPlayer.Hp = targetPlayer.MaxHp;
+                targetPlayer.Mp = targetPlayer.MaxMp;
+                targetPlayer.BroadcastPacket(new SCUnitPointsPacket(targetPlayer.ObjId, targetPlayer.Hp, targetPlayer.Mp), true);
+                return;
             }
-            else
+            // Player is trying to heal some other unit
             if (playerTarget is Unit unit)
             {
-                // Player is trying to heal some other unit
                 if (unit.Hp == 0)
                 {
                     character.SendMessage("Cannot heal a dead target");
+                    return;
                 }
-                else
-                {
-                    unit.Hp = unit.MaxHp;
-                    unit.Mp = unit.MaxMp;
-                    unit.BroadcastPacket(new SCUnitPointsPacket(unit.ObjId, unit.Hp, unit.Mp), true);
-                    character.SendMessage("{0} => {1}/{2} HP, {3}/{4} MP",
-                        unit.Name, unit.Hp, unit.MaxHp, unit.Mp, unit.MaxMp);
-                }
+                unit.Hp = unit.MaxHp;
+                unit.Mp = unit.MaxMp;
+                unit.BroadcastPacket(new SCUnitPointsPacket(unit.ObjId, unit.Hp, unit.Mp), true);
+                character.SendMessage($"{unit.Name} => {unit.Hp}/{unit.MaxHp} HP, {unit.Mp}/{unit.MaxMp} MP");
+                return;
             }
-            
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/Height.cs
+++ b/AAEmu.Game/Scripts/Commands/Height.cs
@@ -28,8 +28,9 @@ namespace AAEmu.Game.Scripts.Commands
             if (args.Length > 0)
                 targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out var firstarg);
 
-            var height = WorldManager.Instance.GetHeight(targetPlayer.Transform.ZoneId, targetPlayer.Transform.World.Position.X, targetPlayer.Transform.World.Position.Y);
-            character.SendMessage("[Height] {2} Z-Pos: {0} - Floor: {1}", character.Transform.World.Position.Z, height, targetPlayer.Name);
+            var pos = targetPlayer.Transform.World.Position;
+            var height = WorldManager.Instance.GetHeight(targetPlayer.Transform.ZoneId, pos.X, pos.Y);
+            character.SendMessage("[Height] {2} Z-Pos: {0} - Floor: {1}", pos.Z, height, targetPlayer.Name);
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/Help.cs
+++ b/AAEmu.Game/Scripts/Commands/Help.cs
@@ -1,8 +1,6 @@
-﻿using System.Text;
-using AAEmu.Game.Core.Managers;
+﻿using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Core.Managers.World;
 
 namespace AAEmu.Game.Scripts.Commands
 {
@@ -41,11 +39,11 @@ namespace AAEmu.Game.Scripts.Commands
                         var cmd = CommandManager.Instance.GetCommandInterfaceByName(thisCommand);
                         var argText = cmd.GetCommandLineHelp();
                         var helpText = cmd.GetCommandHelpText();
-                        character.SendMessage("Help for: |cFFFFFFFF" + CommandManager.CommandPrefix + thisCommand + " " + argText + "|r\n|cFF999999" + helpText + "|r");
+                        character.SendMessage($"Help for: |cFFFFFFFF{CommandManager.CommandPrefix}{thisCommand} {argText}|r\n|cFF999999{helpText}|r");
                     }
                 }
                 if (!foundIt)
-                    character.SendMessage("Command not found: " + CommandManager.CommandPrefix + thisCommand);
+                    character.SendMessage($"Command not found: {CommandManager.CommandPrefix}{thisCommand}");
                 return;
             }
 
@@ -60,7 +58,7 @@ namespace AAEmu.Game.Scripts.Commands
                 var cmd = CommandManager.Instance.GetCommandInterfaceByName(command);
                 var arghelp = cmd.GetCommandLineHelp();
                 if (arghelp != string.Empty)
-                    character.SendMessage(CommandManager.CommandPrefix + command + " |cFF999999" + arghelp + "|r");
+                    character.SendMessage($"{CommandManager.CommandPrefix}{command}|cFF999999{arghelp}|r");
                 else
                     character.SendMessage(CommandManager.CommandPrefix + command);
             }

--- a/AAEmu.Game/Scripts/Commands/HouseBindingMove.cs
+++ b/AAEmu.Game/Scripts/Commands/HouseBindingMove.cs
@@ -27,13 +27,18 @@ namespace AAEmu.Game.Scripts.Commands
 
         public void Execute(Character character, string[] args)
         {
-            if (character.CurrentTarget != null && character.CurrentTarget is House house)
+            if (args.Length < 4)
             {
-                if (args.Length < 4)
-                {
-                    character.SendMessage("[HouseBindings] " + CommandManager.CommandPrefix + "house_binding_move <AttachPointId> <X> <Y> <Z>");
-                    return;
-                }
+                character.SendMessage("[HouseBindings] {CommandManager.CommandPrefix}house_binding_move <AttachPointId> <X> <Y> <Z>");
+                return;
+            }
+            if (character.CurrentTarget == null)
+            {
+                character.SendMessage("|cFFFF0000[HouseBindings] Target a house first|r");
+                return;
+            }
+            if (character.CurrentTarget is House house)
+            {
                 if (uint.TryParse(args[0], out var attachPointIdVal) &&
                     float.TryParse(args[1], out var x) &&
                     float.TryParse(args[2], out var y) &&
@@ -41,25 +46,24 @@ namespace AAEmu.Game.Scripts.Commands
                 {
                     var attachPointId = (AttachPointKind)attachPointIdVal;
                     var attachPointObj = house.AttachedDoodads.Find(o => o.AttachPoint == attachPointId);
-                    if (attachPointObj != null)
+                    if (attachPointObj == null)
                     {
-                        house.Delete();
-
-                        attachPointObj.Transform.Local.SetPosition(x, y, z);
-
-                        house.Spawn();
-                        
-                        character.CurrentTarget = house;
-
-                        character
-                            .BroadcastPacket(
-                                new SCTargetChangedPacket(character.ObjId, character.CurrentTarget?.ObjId ?? 0), true);
-                    } else
                         character.SendMessage("|cFFFF0000[HouseBindings] Not found this attach doodad|r");
-                } else
+                        return;
+                    }
+                    
+                    house.Delete();
+                    attachPointObj.Transform.Local.SetPosition(x, y, z);
+                    house.Spawn();
+                    character.CurrentTarget = house;
+                    character.BroadcastPacket(
+                            new SCTargetChangedPacket(character.ObjId, character.CurrentTarget?.ObjId ?? 0), true);
+                }
+                else
+                {
                     character.SendMessage("|cFFFF0000[HouseBindings] Throw parse args|r");
-            } else
-                character.SendMessage("|cFFFF0000[HouseBindings] First select house|r");
+                }
+            }
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/IgnoreCooldowns.cs
+++ b/AAEmu.Game/Scripts/Commands/IgnoreCooldowns.cs
@@ -1,8 +1,6 @@
 ﻿using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Core.Managers.World;
 
 namespace AAEmu.Game.Scripts.Commands
 {
@@ -16,7 +14,7 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandLineHelp()
         {
-            return "<true||false>";
+            return "true || false";
         }
 
         public string GetCommandHelpText()
@@ -28,7 +26,7 @@ namespace AAEmu.Game.Scripts.Commands
         {
             if (args.Length == 0)
             {
-                character.SendMessage("[IgnoreCooldowns] " + CommandManager.CommandPrefix + "ignorecd <true||false>");
+                character.SendMessage($"[IgnoreCooldowns] {CommandManager.CommandPrefix}ignorecd true || false");
                 return;
             }
 

--- a/AAEmu.Game/Scripts/Commands/Invisible.cs
+++ b/AAEmu.Game/Scripts/Commands/Invisible.cs
@@ -13,19 +13,19 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandLineHelp()
         {
-            return "<true||false>";
+            return "true || false";
         }
 
         public string GetCommandHelpText()
         {
-            return "Sets yourself as invisible to other players";
+            return "Sets yourself as invisible to other players.";
         }
 
         public void Execute(Character character, string[] args)
         {
             if (args.Length == 0)
             {
-                character.SendMessage("[Invisible] " + CommandManager.CommandPrefix + "invisible <true||false>");
+                character.SendMessage($"[Invisible] {CommandManager.CommandPrefix}invisible true || false");
                 return;
             }
 

--- a/AAEmu.Game/Scripts/Commands/Kick.cs
+++ b/AAEmu.Game/Scripts/Commands/Kick.cs
@@ -21,31 +21,28 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Kicks target";
+            return "Kicks target.";
         }
 
         public void Execute(Character character, string[] args)
         {
             if (args.Length < 3)
             {
-                character.SendMessage("[Kick] Usage : {0}", GetCommandLineHelp());
+                character.SendMessage($"[Kick] Usage : {GetCommandLineHelp()}");
                 return;
             }
 
             var targetChar = uint.TryParse(args[0], out uint characterId) ? WorldManager.Instance.GetCharacterById(characterId) : WorldManager.Instance.GetCharacter(args[0]);
-            
             if (targetChar == null)
             {
                 character.SendMessage("[Kick] Target not found");
                 return;
             }
-            
-            var reason = (KickedReason)byte.Parse(args[1]);
-            var msg = "";
-            for (var x = 2; x < args.Length; x++)
-                msg += args[x] + " ";
 
-            targetChar.SendPacket(new SCKickedPacket(reason, msg));
+            if (KickedReason.TryParse(args[1], out KickedReason reason))
+                targetChar.SendPacket(new SCKickedPacket(reason, string.Join(' ', args, 2, args.Length - 2)));
+            else
+                character.SendMessage("[Kick] Invalid reason");
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/Kill.cs
+++ b/AAEmu.Game/Scripts/Commands/Kill.cs
@@ -2,7 +2,6 @@
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.Units.Static;

--- a/AAEmu.Game/Scripts/Commands/Kit.cs
+++ b/AAEmu.Game/Scripts/Commands/Kit.cs
@@ -3,8 +3,6 @@ using System.IO;
 using System.Collections.Generic;
 using AAEmu.Commons.IO;
 using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
-using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Items.Actions;
@@ -85,30 +83,26 @@ namespace AAEmu.Game.Scripts.Commands
         {
             if (args.Length == 0)
             {
-                character.SendMessage("[Items] " + CommandManager.CommandPrefix + "kit (target) <kitname>");
-                character.SendMessage("[Items] " + kitconfig.itemkitnames.Count.ToString() + " kits have been loaded, use " + CommandManager.CommandPrefix + "kit ?  to get a list of kits");
+                character.SendMessage($"[Items] {CommandManager.CommandPrefix}kit (target) <kitname>");
+                character.SendMessage($"[Items] {kitconfig.itemkitnames.Count.ToString()} kits have been loaded, use {CommandManager.CommandPrefix}kit ?  to get a list of kits");
                 return;
             }
 
             Character targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out var firstarg);
 
             string kitname = string.Empty;
-            int itemsAdded = 0;
-
             if (args.Length > firstarg + 0)
                 kitname = args[firstarg + 0].ToLower();
 
             if (kitname == "?")
             {
-                character.SendMessage("[Items] " + CommandManager.CommandPrefix + "kit has the following kits registered:");
-                string s = string.Empty;
-                foreach (var n in kitconfig.itemkitnames)
-                    s += n + "  ";
-                character.SendMessage("|cFFFFFFFF" + s + "|r");
+                character.SendMessage($"[Items] {CommandManager.CommandPrefix}kit has the following kits registered:");
+                character.SendMessage("|cFFFFFFFF" + string.Join("  ", kitconfig.itemkitnames) + "|r");
                 return;
             }
 
             //_log.Debug("foreach kit in kitconfig.itemkits");
+            int itemsAdded = 0;
             foreach (var kit in kitconfig.itemkits)
             {
                 //_log.Debug("kit.kitname: " + kit.kitname);
@@ -140,20 +134,19 @@ namespace AAEmu.Game.Scripts.Commands
                     itemsAdded++;
                     //_log.Debug("kit.itemID: " + kit.itemID.ToString()+ " added to " + targetPlayer.Name);
                 }
-
             }
 
             if (itemsAdded > 0)
             {
                 if (character.Id != targetPlayer.Id)
                 {
-                    character.SendMessage("[Items] added {0} items to {1}'s inventory", itemsAdded, targetPlayer.Name);
-                    targetPlayer.SendMessage("[GM] {0} has added a {1} item to your inventory", character.Name, itemsAdded);
+                    character.SendMessage($"[Items] added {itemsAdded} items to {targetPlayer.Name}'s inventory");
+                    targetPlayer.SendMessage($"[GM] {character.Name} has added a {itemsAdded} item to your inventory");
                 }
             }
             else
             {
-                character.SendMessage("[Items] No items in kit \"{0}\"", kitname);
+                character.SendMessage($"[Items] No items in kit \"{kitname}\"");
             }
 
         }
@@ -171,7 +164,6 @@ namespace AAEmu.Game.Scripts.Commands
                 if (string.IsNullOrWhiteSpace(contents))
                     throw new IOException($"File {filePath} doesn't exists or is empty.");
                 jsonkit = JsonConvert.DeserializeObject<GMItemKitConfig>(contents);
-
                 kitconfig.itemkits.AddRange(jsonkit.itemkits);
             }
             catch (Exception x)
@@ -187,7 +179,6 @@ namespace AAEmu.Game.Scripts.Commands
                         kitconfig.itemkitnames.Add(kn);
             }
             kitconfig.itemkitnames.Sort();
-
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/Move.cs
+++ b/AAEmu.Game/Scripts/Commands/Move.cs
@@ -1,13 +1,8 @@
 ﻿using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Managers.World;
-using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Packets.G2C;
-using AAEmu.Game.Models.Game.Skills.Effects;
-using AAEmu.Game.Models.Game.Skills.Templates;
-using AAEmu.Game.Models.Game.Units.Movements;
 
 namespace AAEmu.Game.Scripts.Commands
 {
@@ -25,14 +20,14 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Move yourself or (target) player to position <x> <y> <z>.\n" +
-                "You can also use \"ToMe\" instead of coordinates to teleport (target) to your location.\n" +
-                "Or you can only specify a target player to move to that player.\n" +
-                "Examples:\n" +
-                CommandManager.CommandPrefix + "move 21000 12500 200\n" +
-                CommandManager.CommandPrefix + "move TargetPlayer 21000 12500 200\n" +
-                CommandManager.CommandPrefix + "move TargetPlayer ToMe\n" +
-                CommandManager.CommandPrefix + "move TargetPlayer";
+            return "Move yourself or (target) player to position <x> <y> <z>.\n"
+                 + "You can also use \"ToMe\" instead of coordinates to teleport (target) to your location.\n"
+                 + "Or you can only specify a target player to move to that player.\n"
+                 + "Examples:\n"
+                 + $"{CommandManager.CommandPrefix}move 21000 12500 200\n"
+                 + $"{CommandManager.CommandPrefix}move TargetPlayer 21000 12500 200\n"
+                 + $"{CommandManager.CommandPrefix}move TargetPlayer ToMe\n"
+                 + $"{CommandManager.CommandPrefix}move TargetPlayer";
         }
 
         public void Execute(Character character, string[] args)
@@ -43,7 +38,6 @@ namespace AAEmu.Game.Scripts.Commands
                 targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out firstarg);
 
             var MoveToMe = false;
-
             if ((targetPlayer != character) && (args.Length == 2) && (args[1].ToLower() == "tome"))
             {
                 MoveToMe = true;
@@ -51,7 +45,7 @@ namespace AAEmu.Game.Scripts.Commands
 
             if ((!MoveToMe) && (args.Length < firstarg+3) && (targetPlayer == character))
             {
-                character.SendMessage("[Move] " + CommandManager.CommandPrefix + "move " + GetCommandLineHelp());
+                character.SendMessage($"[Move] {CommandManager.CommandPrefix}move {GetCommandLineHelp()}");
                 return;
             }
 
@@ -59,9 +53,9 @@ namespace AAEmu.Game.Scripts.Commands
             {
                 var myX = character.Transform.World.Position.X;
                 var myY = character.Transform.World.Position.Y;
-                var myZ = character.Transform.World.Position.Z + 2f; // drop them slightly above you to avoid weird collision stuff
+                var myZ = character.Transform.World.Position.Z + 2.0f; // drop them slightly above you to avoid weird collision stuff
                 if (targetPlayer != character)
-                    targetPlayer.SendMessage("[Move] |cFFFFFFFF{0}|r has called upon your presence !", character.Name);
+                    targetPlayer.SendMessage("[Move] |cFFFFFFFF{0}|r has called upon your presence!", character.Name);
                 targetPlayer.DisabledSetPosition = true;
                 targetPlayer.SendPacket(new SCTeleportUnitPacket(0, 0, myX, myY, myZ, 0f));
                 character.SendMessage("[Move] Moved |cFFFFFFFF{0}|r to your location.", targetPlayer.Name);
@@ -72,7 +66,7 @@ namespace AAEmu.Game.Scripts.Commands
             {
                 var targetX = targetPlayer.Transform.World.Position.X;
                 var targetY = targetPlayer.Transform.World.Position.Y;
-                var targetZ = targetPlayer.Transform.World.Position.Z + 2f; // drop me slightly above them to avoid weird collision stuff
+                var targetZ = targetPlayer.Transform.World.Position.Z + 2.0f; // drop me slightly above them to avoid weird collision stuff
                 character.DisabledSetPosition = true;
                 character.SendPacket(new SCTeleportUnitPacket(0, 0, targetX, targetY, targetZ, 0f));
                 character.SendMessage("[Move] Moved to |cFFFFFFFF{0}|r.", targetPlayer.Name);
@@ -82,7 +76,7 @@ namespace AAEmu.Game.Scripts.Commands
             if ((args.Length == firstarg + 3) && float.TryParse(args[firstarg + 0], out var newX) && float.TryParse(args[firstarg + 1], out var newY) && float.TryParse(args[firstarg + 2], out var newZ))
             {
                 if (targetPlayer != character)
-                    targetPlayer.SendMessage("[Move] |cFFFFFFFF{0}|r has moved you do position X: {1}, Y: {2}, Z: {3}", character.Name, newX, newY, newZ);
+                    targetPlayer.SendMessage("[Move] |cFFFFFFFF{0}|r has moved you to position X: {1}, Y: {2}, Z: {3}", character.Name, newX, newY, newZ);
                 targetPlayer.DisabledSetPosition = true;
                 targetPlayer.SendPacket(new SCTeleportUnitPacket(0, 0, newX, newY, newZ, 0f));
                 character.SendMessage("[Move] |cFFFFFFFF{0}|r moved to X: {1}, Y: {2}, Z: {3}", targetPlayer.Name, newX, newY, newZ);
@@ -91,7 +85,6 @@ namespace AAEmu.Game.Scripts.Commands
             {
                 character.SendMessage("|cFFFF0000[Move] Position parse error|r");
             }
-
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/MoveAll.cs
+++ b/AAEmu.Game/Scripts/Commands/MoveAll.cs
@@ -8,18 +8,6 @@ namespace AAEmu.Game.Scripts.Commands
 {
     public class MoveAll : ICommand
     {
-        public void Execute(Character character, string[] args)
-        {
-            foreach (var otherChar in WorldManager.Instance.GetAllCharacters())
-            {
-                if (otherChar != character)
-                {
-                    otherChar.DisabledSetPosition = true;
-                    otherChar.SendPacket(new SCTeleportUnitPacket(0, 0, character.Transform.World.Position.X, character.Transform.World.Position.Y, character.Transform.World.Position.Z + 1.0f, 0f));
-                }
-            }
-        }
-
         public void OnLoad()
         {
             string[] name = { "move_all", "moveall" };
@@ -34,6 +22,19 @@ namespace AAEmu.Game.Scripts.Commands
         public string GetCommandHelpText()
         {
             return "Moves every player to your location";
+        }
+
+        public void Execute(Character character, string[] args)
+        {
+            foreach (var otherChar in WorldManager.Instance.GetAllCharacters())
+            {
+                if (otherChar != character)
+                {
+                    otherChar.DisabledSetPosition = true;
+                    var pos = character.Transform.World.Position;
+                    otherChar.SendPacket(new SCTeleportUnitPacket(0, 0, pos.X, pos.Y, pos.Z + 1.0f, 0.0f));
+                }
+            }
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/MoveTo.cs
+++ b/AAEmu.Game/Scripts/Commands/MoveTo.cs
@@ -1,21 +1,12 @@
-﻿using NLog;
-using System;
-
-using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Models.Game.Units.Movements;
+﻿using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.NPChar;
-using AAEmu.Game.Models.Game.World;
-using AAEmu.Game.Utils;
-using AAEmu.Commons.Utils;
-using AAEmu.Game.Models.Game.Units.Route;
 
 namespace AAEmu.Game.Scripts.Commands
 {
     public class MoveTo : ICommand
     {
-        protected static Logger _log = LogManager.GetCurrentClassLogger();
         public void OnLoad()
         {
             CommandManager.Instance.Register("moveto", this);
@@ -28,32 +19,30 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return
-                "what is he doing:\n" +
-                "- automatically writes the route to the file;\n" +
-                "- you can load path data from a file;\n- moves along the route.\n\n" +
-                "To start, you need to create the route (s), recording occurs as follows:\n" +
-                "1. Start recording;\n" +
-                "2. Take a route;\n" +
-                "3. Stop recording.\n" +
-                "=== here is an example file structure (x, y, z) ===\n" +
-                "|15629,0|14989,02|141,2055|\n" +
-                "|15628,0|14987,24|141,3826|\n" +
-                "|15626,0|14983,88|141,3446|\n" +
-                "===================================================;\n";
+            return "what is he doing:\n"
+                 + "- automatically writes the route to the file;\n"
+                 + "- you can load path data from a file;\n- moves along the route.\n\n"
+                 + "To start, you need to create the route (s), recording occurs as follows:\n"
+                 + "1. Start recording;\n"
+                 + "2. Take a route;\n"
+                 + "3. Stop recording.\n"
+                 + "=== here is an example file structure (x, y, z) ===\n"
+                 + "|15629,0|14989,02|141,2055|\n"
+                 + "|15628,0|14987,24|141,3826|\n"
+                 + "|15626,0|14983,88|141,3446|\n"
+                 + "===================================================;\n";
         }
+
         public void Execute(Character character, string[] args)
         {
-            string nameFile = "movefile";
-            string cmd = "";
-            Simulation moveTo;
-            bool run = true;
-            // bool walk = false;
             if (args.Length < 1)
             {
                 character.SendMessage("[MoveTo] /moveto <rec||save filename||go filename||back filename||stop||run||walk>");
                 return;
             }
+
+            string cmd = "";
+            string nameFile = "movefile";
             if (args[0] == "rec" || args[0] == "stop" || args[0] == "run" || args[0] == "walk")
             {
                 cmd = args[0];
@@ -65,12 +54,12 @@ namespace AAEmu.Game.Scripts.Commands
             }
             else
             {
-                character.SendMessage("[MoveTo] there should be two parameters, a command and a file_name...");
+                character.SendMessage("[MoveTo] There should be two parameters, a command and a file_name...");
                 return;
             }
 
             character.SendMessage("[MoveTo] cmd: {0}, nameFile: {1}", cmd, nameFile);
-            moveTo = character.Simulation; // take the AI ​​movement
+            var moveTo = character.Simulation; // take the AI ​​movement
             moveTo.npc = (Npc)character.CurrentTarget;
             if (moveTo.npc == null)
             {
@@ -81,36 +70,36 @@ namespace AAEmu.Game.Scripts.Commands
                 switch (cmd)
                 {
                     case "rec":
-                        character.SendMessage("[MoveTo] start recording...");
+                        character.SendMessage("[MoveTo] Start recording...");
                         moveTo.StartRecord(moveTo, character);
                         break;
                     case "save":
-                        character.SendMessage("[MoveTo] have finished recording...");
+                        character.SendMessage("[MoveTo] Finished recording...");
                         moveTo.MoveFileName = nameFile;
                         moveTo.StopRecord(moveTo);
                         break;
                     case "go":
-                        character.SendMessage("[MoveTo] walk go...");
+                        character.SendMessage("[MoveTo] Walk go...");
                         moveTo.MoveFileName = nameFile;
                         moveTo.ReadPath();
                         moveTo.GoToPath((Npc)character.CurrentTarget, true);
                         break;
                     case "back":
-                        character.SendMessage("[MoveTo] walk back...");
+                        character.SendMessage("[MoveTo] Walk back...");
                         moveTo.MoveFileName = nameFile;
                         moveTo.ReadPath();
                         moveTo.GoToPath((Npc)character.CurrentTarget, false);
                         break;
                     case "run":
-                        character.SendMessage("[MoveTo] turned on running mode...");
-                        moveTo.runningMode = run;
+                        character.SendMessage("[MoveTo] Turned on running mode...");
+                        moveTo.runningMode = true;
                         break;
                     //case "walk":
-                    //    character.SendMessage("[MoveTo] turned off running mode...");
-                    //    moveTo.runningMode = walk;
+                    //    character.SendMessage("[MoveTo] Turned off running mode...");
+                    //    moveTo.runningMode = true;
                     //    break;
                     case "stop":
-                        character.SendMessage("[MoveTo] standing still...");
+                        character.SendMessage("[MoveTo] Standing still...");
                         moveTo.StopMove((Npc)character.CurrentTarget);
                         break;
                 }

--- a/AAEmu.Game/Scripts/Commands/Nrot.cs
+++ b/AAEmu.Game/Scripts/Commands/Nrot.cs
@@ -1,25 +1,14 @@
 ﻿using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
-using AAEmu.Game.Core.Managers.World;
-using AAEmu.Game.Core.Managers.UnitManagers;
 using AAEmu.Game.Models.Game.Units.Movements;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.DoodadObj;
-using AAEmu.Game.Models.Game.NPChar;
-using AAEmu.Game.Models.Game.World;
-using AAEmu.Game.Utils;
 using AAEmu.Commons.Utils;
-using NLog;
-using System;
-using System.Numerics;
 
 namespace AAEmu.Game.Scripts.Commands
 {
     public class Nrot : ICommand
     {
-        protected static Logger _log = LogManager.GetCurrentClassLogger();
         public void OnLoad()
         {
             CommandManager.Instance.Register("nrot", this);
@@ -32,54 +21,47 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "change target unit rotation";
+            return "Change target unit rotation";
         }
 
         public void Execute(Character character, string[] args)
         {
             if (args.Length < 3)
             {
-                character.SendMessage("[nrot] /nrot <x> <y> <z>");
+                character.SendMessage($"[nrot] {CommandManager.CommandPrefix}nrot <x> <y> <z>");
                 return;
             }
 
             if (character.CurrentTarget != null)
             {
-                float value = 0;
-                var rpyDegrees = character.CurrentTarget.Transform.Local.ToRollPitchYawDegrees();
-                float x = character.CurrentTarget.Transform.Local.Position.X;
-                float y = character.CurrentTarget.Transform.Local.Position.Y;
-                float z = character.CurrentTarget.Transform.Local.Position.Z;
+                var local = character.CurrentTarget.Transform.Local;
 
-                if (float.TryParse(args[0], out value) && args[0] != "x")
+                float x = local.Position.X;
+                float y = local.Position.Y;
+                float z = local.Position.Z;
+                if (float.TryParse(args[0], out float vx) && args[0] != "x")
                 {
-                    x = value;
+                    x = vx;
+                }
+                if (float.TryParse(args[1], out float vy) && args[1] != "y")
+                {
+                    y = vy;
+                }
+                if (float.TryParse(args[2], out float vz) && args[0] != "z")
+                {
+                    z = vz;
                 }
 
-                if (float.TryParse(args[1], out value) && args[1] != "y")
-                {
-                    y = value;
-                }
-
-                if (float.TryParse(args[2], out value) && args[0] != "z")
-                {
-                    z = value;
-                }
-
-                var Seq = (uint)Rand.Next(0, 10000);
                 var moveType = (UnitMoveType)MoveType.GetType(MoveTypeEnum.Unit);
+                moveType.X = local.Position.X;
+                moveType.Y = local.Position.Y;
+                moveType.Z = local.Position.Z;
+                local.SetRotationDegree(x, y, z);
 
-                moveType.X = character.CurrentTarget.Transform.Local.Position.X;
-                moveType.Y = character.CurrentTarget.Transform.Local.Position.Y;
-                moveType.Z = character.CurrentTarget.Transform.Local.Position.Z;
-                
-                character.CurrentTarget.Transform.Local.SetRotationDegree(x, y, z);
-
-                var characterRot = character.CurrentTarget.Transform.Local.ToRollPitchYawSBytes();
-                moveType.RotationX = characterRot.Item1 ;
-                moveType.RotationY = characterRot.Item2 ;
-                moveType.RotationZ = characterRot.Item3 ;
-
+                var characterRot = local.ToRollPitchYawSBytes();
+                moveType.RotationX = characterRot.Item1;
+                moveType.RotationY = characterRot.Item2;
+                moveType.RotationZ = characterRot.Item3;
                 moveType.Flags = 5;
                 moveType.DeltaMovement = new sbyte[3];
                 moveType.DeltaMovement[0] = 0;
@@ -87,9 +69,9 @@ namespace AAEmu.Game.Scripts.Commands
                 moveType.DeltaMovement[2] = 0;
                 moveType.Stance = 1; //combat=0, idle=1
                 moveType.Alertness = 0; //idle=0, combat=2
-                moveType.Time = Seq;
+                moveType.Time = (uint)Rand.Next(0, 10000);
 
-                character.SendMessage("[nrot] New position {0}", character.CurrentTarget.Transform.Local.ToString());
+                character.SendMessage($"[nrot] New position {local.ToString()}");
                 character.BroadcastPacket(new SCOneUnitMovementPacket(character.CurrentTarget.ObjId, moveType), true);
             }
             else

--- a/AAEmu.Game/Scripts/Commands/Online.cs
+++ b/AAEmu.Game/Scripts/Commands/Online.cs
@@ -1,5 +1,4 @@
-
-
+using System.Text;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game;
@@ -28,15 +27,10 @@ namespace AAEmu.Game.Scripts.Commands
         public void Execute(Character character, string[] args)
         {
             var characters = WorldManager.Instance.GetAllCharacters();
-            var finalMessage = characters.Count + " players online. |cFFFFFFFF";
-            foreach (var onlineCharacter in characters)
-            {
-                finalMessage += (onlineCharacter.Name + "|r,|cFFFFFFFF ");
-            }
-
-            finalMessage += "|r";
-
-            character.SendMessage(finalMessage);
+            var sb = new StringBuilder();
+            for (int i = 0; i < characters.Count; i++)
+                sb.Append($"{characters[i].Name}|r,|cFFFFFFFF");
+            character.SendMessage($"{characters.Count} players online. |cFFFFFFFF{sb.ToString()}|r");
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/PingPosition.cs
+++ b/AAEmu.Game/Scripts/Commands/PingPosition.cs
@@ -25,25 +25,24 @@ namespace AAEmu.Game.Scripts.Commands
 
         public void Execute(Character character, string[] args)
         {
-
-            if ((character.LocalPingPosition.X == 0f) && (character.LocalPingPosition.Y == 0f))
+            var pos = character.LocalPingPosition;
+            if ((pos.X == 0.0f) && (pos.Y == 0.0f))
             {
-                character.SendMessage("|cFFFFFF00[PingPos] Make sure you marked a location on the map WHILE IN A PARTY OR RAID, using this command.\n" +
-                    "If required, you can use the /soloparty command to make a party of just yourself.|r");
+                character.SendMessage("|cFFFFFF00[PingPos] Must mark a location on the map WHILE IN A PARTY OR RAID before using this command.\n"
+                                    + "See also, /soloparty command to make a solo party.|r");
             }
             else
             {
-                var height = WorldManager.Instance.GetHeight(character.Transform.ZoneId, character.LocalPingPosition.X, character.LocalPingPosition.Y);
-                if (height == 0f)
+                var height = WorldManager.Instance.GetHeight(character.Transform.ZoneId, pos.X, pos.Y);
+                if (height == 0.0f)
                 {
-                    character.SendMessage("|cFFFF0000[PingPos] |cFFFFFFFFX:" + character.LocalPingPosition.X.ToString("0.0") + " Y:" + character.LocalPingPosition.Y.ToString("0.0") + " Z: ???|r");
+                    character.SendMessage($"|cFFFF0000[PingPos] |cFFFFFFFFX:{pos.X.ToString("0.0")} Y:{pos.Y.ToString("0.0")} Z: ???|r");
                 }
                 else
                 {
-                    character.SendMessage("|cFFFF0000[PingPos] |cFFFFFFFFX:" + character.LocalPingPosition.X.ToString("0.0") + " Y:" + character.LocalPingPosition.Y.ToString("0.0") + " Z:" + height.ToString("0.0") + "|r");
+                    character.SendMessage($"|cFFFF0000[PingPos] |cFFFFFFFFX:{pos.X.ToString("0.0")} Y:{pos.Y.ToString("0.0")} Z:{height.ToString("0.0")}|r");
                 }
             }
-
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/Pirate.cs
+++ b/AAEmu.Game/Scripts/Commands/Pirate.cs
@@ -1,6 +1,4 @@
 ﻿using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.World;
-using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 
@@ -28,29 +26,28 @@ namespace AAEmu.Game.Scripts.Commands
         {
             if (args.Length == 0)
             {
-                character.SendMessage("[Faction] " + CommandManager.CommandPrefix + "faction <nuian||haranyan||elf||firran||pirate||friendly>");
+                character.SendMessage($"[Faction] {CommandManager.CommandPrefix}faction <nuian||haranyan||elf||firran||pirate||friendly>");
                 return;
             }
 
-            var newFactionId = 0u;
-
+            uint newFactionId = 0;
             var factionString = args[0];
             if (factionString == "nuian")
-                newFactionId = 101u;
+                newFactionId = 101;
             else if (factionString == "elf")
-                newFactionId = 103u;
+                newFactionId = 103;
             else if (factionString == "haranyan")
-                newFactionId = 109u;
+                newFactionId = 109;
             else if (factionString == "firran")
-                newFactionId = 113u;
+                newFactionId = 113;
             else if (factionString == "pirate")
-                newFactionId = 161u;
+                newFactionId = 161;
             else if (factionString == "red")
-                newFactionId = 159u;
+                newFactionId = 159;
             else if (factionString == "blue")
-                newFactionId = 160u;
+                newFactionId = 160;
             else if (factionString == "friendly")
-                newFactionId = 1u;
+                newFactionId = 1;
             else
             {
                 character.SendMessage("Invalid faction");

--- a/AAEmu.Game/Scripts/Commands/Proc.cs
+++ b/AAEmu.Game/Scripts/Commands/Proc.cs
@@ -12,21 +12,6 @@ namespace AAEmu.Game.Scripts.Commands
             string[] name = { "proc" };
             CommandManager.Instance.Register(name, this);
         }
-        
-        public void Execute(Character character, string[] args)
-        {
-            if (args.Length == 0)
-            {
-                character.SendMessage("[Proc] " + CommandManager.CommandPrefix + "test_proc <proc id>");
-                return;
-            }
-
-            if (uint.TryParse(args[0], out var procId))
-            {
-                var proc = new ItemProc(procId);
-                proc.Apply(character, true);
-            }
-        }
 
         public string GetCommandLineHelp()
         {
@@ -37,6 +22,20 @@ namespace AAEmu.Game.Scripts.Commands
         {
             return "Triggers a proc from item_procs";
         }
-    }
 
+        public void Execute(Character character, string[] args)
+        {
+            if (args.Length == 0)
+            {
+                character.SendMessage($"[Proc] {CommandManager.CommandPrefix}test_proc <proc id>");
+                return;
+            }
+
+            if (uint.TryParse(args[0], out var procId))
+            {
+                var proc = new ItemProc(procId);
+                proc.Apply(character, true);
+            }
+        }
+    }
 }

--- a/AAEmu.Game/Scripts/Commands/ReloadAuction.cs
+++ b/AAEmu.Game/Scripts/Commands/ReloadAuction.cs
@@ -1,11 +1,6 @@
-﻿using System.Collections.Generic;
-using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
-using AAEmu.Game.Core.Packets.G2C;
+﻿using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.Items.Actions;
-using AAEmu.Game.Core.Managers.World;
 
 namespace AAEmu.Game.Scripts.Commands
 {
@@ -26,6 +21,7 @@ namespace AAEmu.Game.Scripts.Commands
         {
             return "Reloads the AuctionManager";
         }
+
         public void Execute(Character character, string[] args)
         {
             AuctionManager.Instance.Load();

--- a/AAEmu.Game/Scripts/Commands/ReloadConfigs.cs
+++ b/AAEmu.Game/Scripts/Commands/ReloadConfigs.cs
@@ -1,19 +1,15 @@
-﻿using System.Collections.Generic;
+﻿using System;
 using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
-using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.Items.Actions;
-using AAEmu.Game.Core.Managers.World;
 using NLog;
-using System;
 
 namespace AAEmu.Game.Scripts.Commands
 {
     class ReloadConfigs : ICommand
     {
         private static Logger _log = LogManager.GetCurrentClassLogger();
+
         public void OnLoad()
         {
             string[] name = { "reloadconfig", "reload_configs", "reload_configurations" };
@@ -29,18 +25,19 @@ namespace AAEmu.Game.Scripts.Commands
         {
             return "Reloads the ConfigurationManager";
         }
+
         public void Execute(Character character, string[] args)
         {
             try
             {
                 Program.LoadConfiguration();
                 //ConfigurationManager.Instance.Load();
-                character.SendMessage("Configuration reloaded");
+                character.SendMessage("[ReloadConfigs] Configuration reloaded");
             }
             catch (Exception e)
             {
+                character.SendMessage("[ReloadConfigs] Configurations failed reloading - check error output");
                 _log.Error(e.Message);
-                character.SendMessage("Configurations failed reloading - check error output");
             }
         }
     }

--- a/AAEmu.Game/Scripts/Commands/ResetSkillCooldowns.cs
+++ b/AAEmu.Game/Scripts/Commands/ResetSkillCooldowns.cs
@@ -1,8 +1,6 @@
 ﻿using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Core.Managers.World;
 
 namespace AAEmu.Game.Scripts.Commands
 {

--- a/AAEmu.Game/Scripts/Commands/Revive.cs
+++ b/AAEmu.Game/Scripts/Commands/Revive.cs
@@ -21,30 +21,29 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Revives target";
+            return "Revives target.";
         }
 
         public void Execute(Character character, string[] args)
         {
             Character targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args.Length > 0 ? args[0] : null, out var _);
-            if (targetPlayer != null)
-            {
-                if(targetPlayer.Hp == 0)
-                {
-                    targetPlayer.Hp = targetPlayer.MaxHp;
-                    targetPlayer.Mp = targetPlayer.MaxMp;
-                    targetPlayer.BroadcastPacket(new SCCharacterResurrectedPacket(targetPlayer.ObjId, targetPlayer.Transform.World.Position.X, targetPlayer.Transform.World.Position.Y, targetPlayer.Transform.World.Position.Z, targetPlayer.Transform.World.Rotation.Z), true);
-                    targetPlayer.BroadcastPacket(new SCUnitPointsPacket(targetPlayer.ObjId, targetPlayer.Hp, targetPlayer.Mp), true);
-                }
-                else
-                {
-                    character.SendMessage("Target is already alive");
-                }
-            }
-            else
+            if (targetPlayer == null)
             {
                 character.SendMessage("Cannot revive this target");
+                return;
             }
+            if(targetPlayer.Hp != 0)
+            {
+                character.SendMessage("Target is already alive");
+                return;
+            }
+
+            targetPlayer.Hp = targetPlayer.MaxHp;
+            targetPlayer.Mp = targetPlayer.MaxMp;
+
+            var pos = targetPlayer.Transform.World.Position;
+            targetPlayer.BroadcastPacket(new SCCharacterResurrectedPacket(targetPlayer.ObjId, pos.X, pos.Y, pos.Z, targetPlayer.Transform.World.Rotation.Z), true);
+            targetPlayer.BroadcastPacket(new SCUnitPointsPacket(targetPlayer.ObjId, targetPlayer.Hp, targetPlayer.Mp), true);
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/Rotate.cs
+++ b/AAEmu.Game/Scripts/Commands/Rotate.cs
@@ -1,24 +1,14 @@
 ﻿using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
-using AAEmu.Game.Core.Managers.World;
-using AAEmu.Game.Core.Managers.UnitManagers;
 using AAEmu.Game.Models.Game.Units.Movements;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.DoodadObj;
-using AAEmu.Game.Models.Game.NPChar;
-using AAEmu.Game.Models.Game.World;
 using AAEmu.Game.Utils;
-using AAEmu.Commons.Utils;
-using NLog;
-using System;
 
 namespace AAEmu.Game.Scripts.Commands
 {
     public class Rotate : ICommand
     {
-        protected static Logger _log = LogManager.GetCurrentClassLogger();
         public void OnLoad()
         {
             CommandManager.Instance.Register("rotate", this);
@@ -36,60 +26,60 @@ namespace AAEmu.Game.Scripts.Commands
 
         public void Execute(Character character, string[] args)
         {
-            //if (args.Length < 2)
-            //{
-            //    character.SendMessage("[Rotate] /rotate <objType: npc, doodad> <objId>");
+            // if (args.Length < 2)
+            // {
+            //    character.SendMessage($"[Rotate] {CommandManager.CommandPrefix}rotate <objType: npc, doodad> <objId>");
             //    return;
-            //}
+            // }
 
-            if (character.CurrentTarget != null)
+            var target = character.CurrentTarget;
+            if (target == null)
             {
-                character.SendMessage("[Rotate] Unit: {0}, ObjId: {1}", character.CurrentTarget.Name, character.CurrentTarget.ObjId);
-
-                var Seq = (uint)Rand.Next(0, 10000);
-                var moveType = (UnitMoveType)MoveType.GetType(MoveTypeEnum.Unit);
-                
-                moveType.X = character.CurrentTarget.Transform.World.Position.X;
-                moveType.Y = character.CurrentTarget.Transform.World.Position.Y;
-                moveType.Z = character.CurrentTarget.Transform.World.Position.Z;
-
-                var angle = (float)MathUtil.CalculateAngleFrom(character.CurrentTarget, character) - 90f;
-                var rotZ = MathUtil.ConvertDegreeToSByteDirection(angle);
-                /*
-                if (args.Length > 0)
-                {
-                    if (!sbyte.TryParse(args[0], out rotZ))
-                        character.SendMessage("Rotation sbyte out of range");
-                }
-
-                var angle2 = angle;
-                angle = (float)MathUtil.ConvertSbyteDirectionToDegree(rotZ);
-                */
-                character.CurrentTarget.Transform.Local.SetRotationDegree(0f,0f,angle);
-                
-                //character.CurrentTarget.Transform.Local.LookAt(character.Transform.Local.Position);
-
-                moveType.RotationX = MathUtil.ConvertRadianToDirection(character.CurrentTarget.Transform.Local.Rotation.X);
-                moveType.RotationY = MathUtil.ConvertRadianToDirection(character.CurrentTarget.Transform.Local.Rotation.Y);
-                moveType.RotationZ = MathUtil.ConvertRadianToDirection(character.CurrentTarget.Transform.Local.Rotation.Z);
-                //moveType.RotationZ = rotZ;
-
-                moveType.ActorFlags = 5;
-                moveType.DeltaMovement = new sbyte[3];
-                moveType.DeltaMovement[0] = 0;
-                moveType.DeltaMovement[1] = 0;
-                moveType.DeltaMovement[2] = 0;
-                moveType.Stance = 1; //combat=0, idle=1
-                moveType.Alertness = 0; //idle=0, combat=2
-                moveType.Time += 50; // has to change all the time for normal motion.
-
-                character.BroadcastPacket(new SCOneUnitMovementPacket(character.CurrentTarget.ObjId, moveType), true);
-                character.SendMessage("New rotation {0}° ({1} rad, sbyte {2}) for {3}",angle, character.CurrentTarget.Transform.Local.Rotation.Z.ToString("0.00"),rotZ,character.CurrentTarget.ObjId);
-                character.SendMessage("New position {0}",character.CurrentTarget.Transform.Local.ToString());
-                //character.SendMessage("New position A1:{0}  A2:{1}  {2}",angle,angle2,character.CurrentTarget.Transform.Local.ToString());
-            }
-            else
                 character.SendMessage("[Rotate] You need to target something first");
+                return;
+            }
+
+            character.SendMessage("[Rotate] Unit: {0}, ObjId: {1}", target.Name, target.ObjId);
+
+            var moveType = (UnitMoveType)MoveType.GetType(MoveTypeEnum.Unit);
+            var pos = target.Transform.World.Position;
+            moveType.X = pos.X;
+            moveType.Y = pos.Y;
+            moveType.Z = pos.Z;
+
+            var angle = (float)MathUtil.CalculateAngleFrom(target, character) - 90f;
+            var rotZ = MathUtil.ConvertDegreeToSByteDirection(angle);
+            /*
+            if (args.Length > 0)
+            {
+                if (!sbyte.TryParse(args[0], out rotZ))
+                    character.SendMessage("Rotation sbyte out of range");
+            }
+
+            var angle2 = angle;
+            angle = (float)MathUtil.ConvertSbyteDirectionToDegree(rotZ);
+            */
+            var local = target.Transform.Local;
+            local.SetRotationDegree(0.0f, 0.0f, angle);
+            //local.LookAt(character.Transform.Local.Position);
+
+            moveType.RotationX = MathUtil.ConvertRadianToDirection(local.Rotation.X);
+            moveType.RotationY = MathUtil.ConvertRadianToDirection(local.Rotation.Y);
+            moveType.RotationZ = MathUtil.ConvertRadianToDirection(local.Rotation.Z);
+            //moveType.RotationZ = rotZ;
+            moveType.ActorFlags = 5;
+            moveType.DeltaMovement = new sbyte[3];
+            moveType.DeltaMovement[0] = 0;
+            moveType.DeltaMovement[1] = 0;
+            moveType.DeltaMovement[2] = 0;
+            moveType.Stance = 1; //combat=0, idle=1
+            moveType.Alertness = 0; //idle=0, combat=2
+            moveType.Time += 50; // has to change all the time for normal motion.
+
+            character.BroadcastPacket(new SCOneUnitMovementPacket(target.ObjId, moveType), true);
+            character.SendMessage("New rotation {0}° ({1} rad, sbyte {2}) for {3}", angle, local.Rotation.Z.ToString("0.00"), rotZ, target.ObjId);
+            character.SendMessage($"New position {local.ToString()}");
+            //character.SendMessage($"New position A1:{angle}  A2:{angle2}  {local.ToString()}");
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/Scripts.cs
+++ b/AAEmu.Game/Scripts/Commands/Scripts.cs
@@ -26,7 +26,7 @@ namespace AAEmu.Game.Scripts.Commands
         {
             if (args.Length == 0)
             {
-                character.SendMessage("[Scripts] Using: " + CommandManager.CommandPrefix + "scripts <action>");
+                character.SendMessage($"[Scripts] Using: {CommandManager.CommandPrefix}scripts <action>");
                 //character.SendMessage("[Scripts] Action: reload");
                 return;
             }
@@ -39,7 +39,7 @@ namespace AAEmu.Game.Scripts.Commands
                     if (ScriptCompiler.Compile())
                         character.SendMessage("[Scripts] Reload - Success");
                     else
-                        character.SendMessage("|cFFFF0000[Scripts] Reload - There were errors, please check the server logs for details !|r");
+                        character.SendMessage("|cFFFF0000[Scripts] Reload - There were errors, please check the server logs for details!|r");
                     break;
                 case "save":
                     if (SaveManager.Instance.DoSave())

--- a/AAEmu.Game/Scripts/Commands/ShowInventory.cs
+++ b/AAEmu.Game/Scripts/Commands/ShowInventory.cs
@@ -1,11 +1,7 @@
-﻿using System.Collections.Generic;
-using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
-using AAEmu.Game.Core.Packets.G2C;
+﻿using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Items;
-using AAEmu.Game.Models.Game.Items.Actions;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.NPChar;
@@ -16,7 +12,7 @@ namespace AAEmu.Game.Scripts.Commands
     {
         public void OnLoad()
         {
-            string[] name = { "showinv", "show_inv", "showinventory", "show_inventory", "inventory" };
+            string[] name = { "showinv", "show_inv", "showinventory", "show_inventory", "inventory", "invy" };
             CommandManager.Instance.Register(name, this);
         }
 
@@ -27,74 +23,68 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Show content of target's item container.\rEquipment = 1, Inventory = 2 (default), Bank = 3, Trade = 4, Mail = 5";
+            return "Show content of target's item container.\n"
+                 + "Equipment = 1, Inventory = 2 (default), Bank = 3, Trade = 4, Mail = 5";
         }
 
         public void Execute(Character character, string[] args)
         {
-            if ((!(character.CurrentTarget is Character)) && (character.CurrentTarget is Unit unit))
+            if (character.CurrentTarget is not Character && character.CurrentTarget is Unit unit)
             {
-                var targetContainer = unit.Equipment;
                 var templateName = "Unit";
-                foreach (var item in targetContainer.Items)
+                foreach (var item in unit.Equipment.Items)
                 {
                     if (unit is Npc npc)
-                        templateName = string.Format("|nc;@NPC_NAME({0})|r", npc.TemplateId);
+                        templateName = $"|nc;@NPC_NAME({npc.TemplateId})|r";
                     var slotName = ((EquipmentItemSlot)item.Slot).ToString();
-                    var countName = "|ng;" + item.Count.ToString() + "|r x ";
+                    var countName = $"|ng;{item.Count.ToString()}|r x ";
                     if (item.Count == 1)
                         countName = string.Empty;
                     character.SendMessage("[{0}][{1}] {2}|nn;{3}|r = @ITEM_NAME({3})", templateName, slotName, countName, item.TemplateId);
                 }
-                character.SendMessage("[ShowInv][{0}][{1}] {2} entries", templateName, targetContainer.ContainerType, targetContainer.Items.Count);
 
+                character.SendMessage("[ShowInv] [{0}][{1}] {2} entries", templateName, unit.Equipment.ContainerType, unit.Equipment.Items.Count);
                 return;
             }
-            else
+
+            Character targetPlayer = character;
+            var firstarg = 0;
+            if (args.Length > 0)
+                targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out firstarg);
+
+            var containerId = SlotType.Inventory;
+            if ((args.Length > firstarg) && (uint.TryParse(args[firstarg], out uint argcontainerId)))
             {
-                Character targetPlayer = character;
-                var firstarg = 0;
-                if (args.Length > 0)
-                    targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out firstarg);
-
-                var containerId = SlotType.Inventory;
-
-                if ((args.Length > firstarg + 0) && (uint.TryParse(args[firstarg + 0], out uint argcontainerId)))
+                if ((argcontainerId < 0 || argcontainerId > (byte)SlotType.Mail) && argcontainerId != (byte)SlotType.System)
                 {
-                    if (((argcontainerId >= 0) && (argcontainerId <= (byte)SlotType.Mail)) || (argcontainerId == (byte)SlotType.System))
-                        containerId = (SlotType)argcontainerId;
-                    else
-                    {
-                        character.SendMessage("|cFFFF0000[ShowInv] Invalid container Id |r");
-                        return;
-                    }
+                    character.SendMessage("|cFFFF0000[ShowInv] Invalid container Id |r");
+                    return;
                 }
-
-
-                var targetContainer = targetPlayer.Inventory.Bag;
-                if (targetPlayer.Inventory._itemContainers.TryGetValue(containerId, out targetContainer))
-                {
-                    foreach (var item in targetContainer.Items)
-                    {
-                        var slotName = targetContainer.ContainerType.ToString() + "-" + item.Slot.ToString();
-                        if (item.SlotType == SlotType.Equipment)
-                            slotName = ((EquipmentItemSlot)item.Slot).ToString();
-                        var countName = "|ng;" + item.Count.ToString() + "|r x ";
-                        if (item.Count == 1)
-                            countName = string.Empty;
-                        character.SendMessage("[|nd;{0}|r][{1}] |nb;{2}|r {3}|nn;{4}|r = @ITEM_NAME({4})",
-                            targetPlayer.Name, slotName,
-                            item.Id, countName, item.TemplateId
-                            );
-                    }
-                    character.SendMessage("[ShowInv][|nd;{0}|r][{1}] {2} entries", targetPlayer.Name, targetContainer.ContainerType, targetContainer.Items.Count);
-                }
-                else
-                {
-                    character.SendMessage("|cFFFF0000[ShowInv] Unused container Id.|r");
-                }
+                containerId = (SlotType)argcontainerId;
             }
 
+            var targetContainer = targetPlayer.Inventory.Bag;
+            if (targetPlayer.Inventory._itemContainers.TryGetValue(containerId, out targetContainer))
+            {
+                foreach (var item in targetContainer.Items)
+                {
+                    var slotName = targetContainer.ContainerType.ToString() + "-" + item.Slot.ToString();
+                    if (item.SlotType == SlotType.Equipment)
+                        slotName = ((EquipmentItemSlot)item.Slot).ToString();
+                    var countName = $"|ng;{item.Count.ToString()}|r x ";
+                    if (item.Count == 1)
+                        countName = string.Empty;
+                    character.SendMessage("[|nd;{0}|r][{1}] |nb;{2}|r {3}|nn;{4}|r = @ITEM_NAME({4})",
+                                            targetPlayer.Name, slotName,
+                                            item.Id, countName, item.TemplateId
+                                            );
+                }
+
+                character.SendMessage("[ShowInv][|nd;{0}|r][{1}] {2} entries", targetPlayer.Name, targetContainer.ContainerType, targetContainer.Items.Count);
+                return;
+            }
+
+            character.SendMessage("|cFFFF0000[ShowInv] Unused container Id.|r");
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/Snow.cs
+++ b/AAEmu.Game/Scripts/Commands/Snow.cs
@@ -8,10 +8,8 @@ namespace AAEmu.Game.Scripts.Commands
 {
     public class Snow : ICommand
     {
-
         public void OnLoad()
         {
-            ///register script
             CommandManager.Instance.Register("snow", this);
         }
 
@@ -22,36 +20,27 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Enables or disables snow effect across the server";
+            return "Enables or disables snow effect across the server.";
         }
 
         public void Execute(Character character, string[] args)
         {
-            // If no argument is provided send usage information
             if (args.Length == 0)
             {
-                character.SendMessage("[Snow] " + CommandManager.CommandPrefix + "snow <true/false>");
+                character.SendMessage($"[Snow] {CommandManager.CommandPrefix}snow <true/false>");
                 return;
             }
 
-            // determine if we recived true,false or something else             
             if (bool.TryParse(args[0], out var isSnowing))
             {
-                //Set Snowing state to user input, This will 
                 // enable Snow on all players who login to the server
                 WorldManager.Instance.IsSnowing = isSnowing;
-
-                //Turn snow on or off for all online characters,
-                //put this on the script level so it only gets executed once when GM enables/disables snow
+                // Turn snow on or off for all online characters
                 WorldManager.Instance.BroadcastPacketToServer(new SCOnOffSnowPacket(isSnowing));
-            }
-            else
-            {
-                // user input was invalid notify them
-                character.SendMessage("[Snow] Use true or false.");
+                return;
             }
 
-
+            character.SendMessage($"[Snow] Couldn't parse {args[0]} as true/false");
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/SoloParty.cs
+++ b/AAEmu.Game/Scripts/Commands/SoloParty.cs
@@ -1,10 +1,6 @@
 ﻿using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
-using AAEmu.Game.Core.Managers.UnitManagers;
-using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Scripts.Commands
 {
@@ -23,16 +19,18 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Creates a party with just yourself in it. This can be usefull to use with \"" + CommandManager.CommandPrefix + "teleport .\" command.";
+            return $"Creates a party with just yourself in it. This can be useful to use with \"{CommandManager.CommandPrefix}teleport .\" command.";
         }
 
         public void Execute(Character character, string[] args)
         {
-            var currentTeam = TeamManager.Instance.GetActiveTeamByUnit(character.Id);
-            if (currentTeam != null)
-                character.SendMessage("|cFFFFFF00[SoloParty] You are already in a party !|r");
-            else
-                TeamManager.Instance.CreateSoloTeam(character,true);
+            if (TeamManager.Instance.GetActiveTeamByUnit(character.Id) != null)
+            {
+                character.SendMessage("|cFFFFFF00[SoloParty] You are already in a party!|r");
+                return;
+            }
+
+            TeamManager.Instance.CreateSoloTeam(character,true);
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/Spawn.cs
+++ b/AAEmu.Game/Scripts/Commands/Spawn.cs
@@ -1,24 +1,18 @@
-﻿using AAEmu.Game.Core.Managers;
+﻿using System.Globalization;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.Id;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Managers.UnitManagers;
-using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.NPChar;
-using AAEmu.Game.Models.Game.World;
-using AAEmu.Game.Models.Game.World.Transform;
 using AAEmu.Game.Utils;
-using NLog;
-using System;
-using System.Globalization;
 
 namespace AAEmu.Game.Scripts.Commands
 {
     public class Spawn : ICommand
     {
-        protected static Logger _log = LogManager.GetCurrentClassLogger();
         public void OnLoad()
         {
             CommandManager.Instance.Register("spawn", this);
@@ -31,107 +25,105 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Spawns a npc or doodad using <unitId> as a template. Or remove a doodad";
+            return "Spawns an npc or doodad using <unitId> or removes a doodad.";
         }
 
         public void Execute(Character character, string[] args)
         {
             if (args.Length < 2)
             {
-                character.SendMessage("[Spawn] " + CommandManager.CommandPrefix + "spawn <npc||doodad||remove> <unitId> [rotationZ]");
+                character.SendMessage($"[Spawn] {CommandManager.CommandPrefix}spawn <npc||doodad||remove> <unitId> [rotationZ]");
                 return;
             }
 
-            if (uint.TryParse(args[1], out var unitId))
+            if (!uint.TryParse(args[1], out var unitId))
             {
-                // character.SendMessage("[Spawn] Arg 0 --- {0} Arg 1 {1}", args[0], args[1]);
-
-                float angle;
-                float newRotZ;
-                var charPos = character.Transform.CloneDetached();
-                switch (args[0])
-                {
-                    case "remove":
-                        var myDoodad = WorldManager.Instance.GetDoodad(unitId);
-
-                        if ((myDoodad != null) && (myDoodad is Doodad))
-                        {
-                            character.SendMessage("[Spawn] Removing Doodad with ID {0}", myDoodad.ObjId);
-                            ObjectIdManager.Instance.ReleaseId(myDoodad.ObjId);
-                            myDoodad.Delete();
-                        }
-                        else
-                        {
-                            character.SendMessage("|cFFFF0000[Spawn] Doodad with Id {0} Does not exist |r", unitId);
-                        }
-                        break;
-                    case "npc":
-                        if (!NpcManager.Instance.Exist(unitId))
-                        {
-                            character.SendMessage("|cFFFF0000[Spawn] NPC {0} don't exist|r", unitId);
-                            return;
-                        }
-                        var npcSpawner = new NpcSpawner();
-                        npcSpawner.Id = 0;
-                        npcSpawner.UnitId = unitId;
-                        charPos.Local.AddDistanceToFront(3f);
-                        angle = (float)MathUtil.CalculateAngleFrom(charPos, character.Transform);
-                        npcSpawner.Position = charPos.CloneAsSpawnPosition();
-                        //(newX, newY) = MathUtil.AddDistanceToFront(3f, character.Transform.World.Position.X, character.Transform.World.Position.Y, character.Transform.World.Rotation.Z);
-                        //npcSpawner.Position.Y = newY;
-                        //npcSpawner.Position.X = newX;
-                        // angle = (float)MathUtil.CalculateAngleFrom(npcSpawner.Position.X, npcSpawner.Position.Y, character.Transform.World.Position.X, character.Transform.World.Position.Y);
-                        if ((args.Length > 2) && (float.TryParse(args[2], NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out newRotZ)))
-                        {
-                            angle = newRotZ.DegToRad();
-                            character.SendMessage("[Spawn] NPC {0} using angle {1}° = {2} rad", unitId, newRotZ, angle);
-                        }
-                        else
-                        {
-                            angle = angle.DegToRad();
-                            character.SendMessage("[Spawn] NPC {0} facing you using angle {1} rad", unitId, angle);
-                        }
-                        npcSpawner.Position.Yaw = angle;
-                        npcSpawner.Position.Pitch = 0;
-                        npcSpawner.Position.Roll = 0;
-                        npcSpawner.SpawnAll();
-                        // character.SendMessage("[Spawn] NPC {0} spawned with angle {1}", unitId, angle);
-                        break;
-                    case "doodad":
-                        if (!DoodadManager.Instance.Exist(unitId))
-                        {
-                            character.SendMessage("|cFFFF0000[Spawn] Doodad {0} don't exist|r", unitId);
-                            return;
-                        }
-                        var doodadSpawner = new DoodadSpawner();
-                        doodadSpawner.Id = 0;
-                        doodadSpawner.UnitId = unitId;
-                        charPos.Local.AddDistanceToFront(3f);
-                        angle = (float)MathUtil.CalculateAngleFrom(charPos, character.Transform);
-                        doodadSpawner.Position = charPos.CloneAsSpawnPosition();
-                        //(newX, newY) = MathUtil.AddDistanceToFront(3f, character.Transform.World.Position.X, character.Transform.World.Position.Y, character.Transform.World.Rotation.Z);
-                        //doodadSpawner.Position.Y = newY;
-                        //doodadSpawner.Position.X = newX;
-                        //angle = (float)MathUtil.CalculateAngleFrom(doodadSpawner.Position.Y, doodadSpawner.Position.X, character.Transform.World.Position.Y, character.Transform.World.Position.X);
-                        if ((args.Length > 2) && (float.TryParse(args[2], NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var degrees)))
-                        {
-                            angle = degrees.DegToRad();
-                            character.SendMessage("[Spawn] Doodad {0} using user provided angle {1}° = {2} rad", unitId, degrees, angle);
-                        }
-                        else
-                        {
-                            angle = angle.DegToRad();
-                            character.SendMessage("[Spawn] Doodad {0} facing you, using characters angle {1}", unitId, angle);
-                        }
-                        doodadSpawner.Position.Yaw = angle;
-                        doodadSpawner.Position.Pitch = 0;
-                        doodadSpawner.Position.Roll = 0;
-                        doodadSpawner.Spawn(0, 0, character.ObjId);
-                        break;
-                }
+                character.SendMessage("|cFFFF0000[Spawn] Couldn't parse unitId|r");
+                return;
             }
-            else
-                character.SendMessage("|cFFFF0000[Spawn] Throw parse unitId|r");
+
+            // character.SendMessage("[Spawn] Arg 0 --- {0} Arg 1 {1}", args[0], args[1]);
+
+            float angle;
+            float newRotZ;
+            var charPos = character.Transform.CloneDetached();
+            switch (args[0])
+            {
+                case "remove":
+                    var myDoodad = WorldManager.Instance.GetDoodad(unitId);
+                    if (myDoodad == null || myDoodad is not Doodad)
+                    {
+                        character.SendMessage("|cFFFF0000[Spawn] Doodad with Id {0} Doesn't exist|r", unitId);
+                        return;
+                    }
+                    character.SendMessage("[Spawn] Removing Doodad with ID {0}", myDoodad.ObjId);
+                    ObjectIdManager.Instance.ReleaseId(myDoodad.ObjId);
+                    myDoodad.Delete();
+                    break;
+                case "npc":
+                    if (!NpcManager.Instance.Exist(unitId))
+                    {
+                        character.SendMessage("|cFFFF0000[Spawn] NPC {0} doesn't exist|r", unitId);
+                        return;
+                    }
+                    var npcSpawner = new NpcSpawner();
+                    npcSpawner.Id = 0;
+                    npcSpawner.UnitId = unitId;
+                    charPos.Local.AddDistanceToFront(3.0f);
+                    angle = (float)MathUtil.CalculateAngleFrom(charPos, character.Transform);
+                    npcSpawner.Position = charPos.CloneAsSpawnPosition();
+                    //(newX, newY) = MathUtil.AddDistanceToFront(3.0f, character.Transform.World.Position.X, character.Transform.World.Position.Y, character.Transform.World.Rotation.Z);
+                    //npcSpawner.Position.Y = newY;
+                    //npcSpawner.Position.X = newX;
+                    // angle = (float)MathUtil.CalculateAngleFrom(npcSpawner.Position.X, npcSpawner.Position.Y, character.Transform.World.Position.X, character.Transform.World.Position.Y);
+                    if ((args.Length > 2) && (float.TryParse(args[2], NumberStyles.Float, CultureInfo.InvariantCulture, out newRotZ)))
+                    {
+                        angle = newRotZ.DegToRad();
+                        character.SendMessage("[Spawn] NPC {0} using angle {1}° = {2} rad", unitId, newRotZ, angle);
+                    }
+                    else
+                    {
+                        angle = angle.DegToRad();
+                        character.SendMessage("[Spawn] NPC {0} facing you using angle {1} rad", unitId, angle);
+                    }
+                    npcSpawner.Position.Yaw = angle;
+                    npcSpawner.Position.Pitch = 0;
+                    npcSpawner.Position.Roll = 0;
+                    npcSpawner.SpawnAll();
+                    // character.SendMessage("[Spawn] NPC {0} spawned with angle {1}", unitId, angle);
+                    break;
+                case "doodad":
+                    if (!DoodadManager.Instance.Exist(unitId))
+                    {
+                        character.SendMessage("|cFFFF0000[Spawn] Doodad {0} doesn't exist|r", unitId);
+                        return;
+                    }
+                    var doodadSpawner = new DoodadSpawner();
+                    doodadSpawner.Id = 0;
+                    doodadSpawner.UnitId = unitId;
+                    charPos.Local.AddDistanceToFront(3.0f);
+                    angle = (float)MathUtil.CalculateAngleFrom(charPos, character.Transform);
+                    doodadSpawner.Position = charPos.CloneAsSpawnPosition();
+                    //(newX, newY) = MathUtil.AddDistanceToFront(3.0f, character.Transform.World.Position.X, character.Transform.World.Position.Y, character.Transform.World.Rotation.Z);
+                    //doodadSpawner.Position.Y = newY;
+                    //doodadSpawner.Position.X = newX;
+                    //angle = (float)MathUtil.CalculateAngleFrom(doodadSpawner.Position.Y, doodadSpawner.Position.X, character.Transform.World.Position.Y, character.Transform.World.Position.X);
+                    if ((args.Length > 2) && (float.TryParse(args[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var degrees)))
+                    {
+                        angle = degrees.DegToRad();
+                        character.SendMessage("[Spawn] Doodad {0} using user provided angle {1}° = {2} rad", unitId, degrees, angle);
+                    }
+                    else
+                    {
+                        angle = angle.DegToRad();
+                        character.SendMessage("[Spawn] Doodad {0} facing you, using characters angle {1}", unitId, angle);
+                    }
+                    doodadSpawner.Position.Yaw = angle;
+                    doodadSpawner.Position.Pitch = 0;
+                    doodadSpawner.Position.Roll = 0;
+                    doodadSpawner.Spawn(0, 0, character.ObjId);
+                    break;
+            }
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/SpawnGrid.cs
+++ b/AAEmu.Game/Scripts/Commands/SpawnGrid.cs
@@ -1,23 +1,15 @@
 ﻿using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
-using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Managers.UnitManagers;
-using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.NPChar;
-using AAEmu.Game.Models.Game.World;
 using AAEmu.Game.Utils;
-using NLog;
-using System;
 
 namespace AAEmu.Game.Scripts.Commands
 {
     public class SpawnGrid : ICommand
     {
-        protected static Logger _log = LogManager.GetCurrentClassLogger();
-
         public void OnLoad()
         {
             string[] names = { "spawngrid", "spawngroup" };
@@ -31,8 +23,9 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Spawns a large amount of NPCs or doodads using <templateID> as a template in a grid in front of you using specified number of colums, rows and spacing.\n" +
-                "Example: " + CommandManager.CommandPrefix + "spawngrid doodad 320 5 5 2";
+            return "Spawns a large amount of NPCs or doodads using <templateID> as a template "
+                 + "in a grid in front of you using specified number of colums, rows and spacing.\n"
+                 + $"Example: {CommandManager.CommandPrefix}spawngrid doodad 320 5 5 2";
         }
 
         public void SpawnDoodad(uint unitId, Character character, float newX, float newY)
@@ -70,16 +63,15 @@ namespace AAEmu.Game.Scripts.Commands
         {
             if (args.Length < 5)
             {
-                character.SendMessage("[Spawn] " + CommandManager.CommandPrefix + "spawngrid " + GetCommandLineHelp());
+                character.SendMessage($"[Spawn] {CommandManager.CommandPrefix}spawngrid {GetCommandLineHelp()}");
                 return;
             }
 
-            string action = args[0].ToLower();
-            uint templateId ;
+            uint templateId;
             uint columns;
             uint rows;
             float spacing;
-            if (!uint.TryParse(args[1],out templateId) || !uint.TryParse(args[2], out columns) || !uint.TryParse(args[3], out rows) || !float.TryParse(args[4], out spacing))
+            if (!uint.TryParse(args[1], out templateId) || !uint.TryParse(args[2], out columns) || !uint.TryParse(args[3], out rows) || !float.TryParse(args[4], out spacing))
             {
                 character.SendMessage("|cFFFF0000[Spawn] Parse error|r");
                 return;
@@ -91,19 +83,20 @@ namespace AAEmu.Game.Scripts.Commands
             if (spacing < 0.1f)
                 spacing = 0.1f;
 
+            string action = args[0].ToLower();
             switch(action)
             {
                 case "npc":
                     if (!NpcManager.Instance.Exist(templateId))
                     {
-                        character.SendMessage("|cFFFF0000[Spawn] NPC {0} don't exist|r", templateId);
+                        character.SendMessage($"|cFFFF0000[Spawn] NPC {templateId} don't exist|r");
                         return;
                     }
                     break;
                 case "doodad":
                     if (!DoodadManager.Instance.Exist(templateId))
                     {
-                        character.SendMessage("|cFFFF0000[Spawn] Doodad {0} don't exist|r", templateId);
+                        character.SendMessage($"|cFFFF0000[Spawn] Doodad {templateId} don't exist|r");
                         return;
                     }
                     break;
@@ -112,14 +105,13 @@ namespace AAEmu.Game.Scripts.Commands
                     return;
             }
 
-            float startX;
-            float startY;
-
             // Origin point for spawns
-            (startX, startY) = MathUtil.AddDistanceToFront(3f, character.Transform.World.Position.X, character.Transform.World.Position.Y, character.Transform.World.Rotation.Z);
+            // float startX;
+            // float startY;
+            // (startX, startY) = MathUtil.AddDistanceToFront(3f, character.Transform.World.Position.X, character.Transform.World.Position.Y, character.Transform.World.Rotation.Z);
             for (var y = 0; y < rows; y++)
             {
-                float sizeY = rows * spacing;
+                // float sizeY = rows * spacing;
                 float posY = (y+1) * spacing;
                 for (var x = 0; x < columns; x++)
                 {
@@ -139,7 +131,6 @@ namespace AAEmu.Game.Scripts.Commands
                     }
                 }
             }
-
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/Teleport.cs
+++ b/AAEmu.Game/Scripts/Commands/Teleport.cs
@@ -1,23 +1,32 @@
-﻿using AAEmu.Game.Core.Managers;
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Linq;
+using System.Collections.Generic;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Core.Packets.G2C;
-using System.Collections.Generic;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+using AAEmu.Commons.IO;
+using Newtonsoft.Json;
+using NLog;
 
 namespace AAEmu.Game.Scripts.Commands
 {
     public class Teleport : ICommand
     {
-        public List<TPloc> locations = new List<TPloc>();
-        public const bool AllowPingPos = true ; // Enable or Disable /teleport . (dot) command functionality
+        private readonly Logger _log = LogManager.GetCurrentClassLogger();
+
+        public const bool AllowPingPos = true; // Enable or Disable /teleport . (dot) command functionality
+
+        private List<TPLoc> _locations = new List<TPLoc>();
+        private string _locationList;
 
         public void OnLoad()
         {
             CommandManager.Instance.Register("teleport", this);
- 
-            loadLocations();
+            InitTeleports();
         }
 
         public string GetCommandLineHelp()
@@ -28,516 +37,12 @@ namespace AAEmu.Game.Scripts.Commands
         public string GetCommandHelpText()
         {
             if (AllowPingPos)
-                return
-                    "Teleports you to target location. if no [location] is provided, you will get a list of available names. " +
-                    "You can also use a period (.) as a location name to teleport to a location you marked on the map.";
+                return "Teleports you to target location. if no [location] is provided, "
+                     + "you will get a list of available names. You can also use a period "
+                     + "(.) as a location name to teleport to a location you marked on the map.";
             /*else
-                return "Teleports you to target location. if no [location] is provided, you will get a list of available names."; */
-        }
-
-        public void loadLocations()
-        {
-            #region west
-            // West
-            // locations.Add(new TPloc { Region = TeleReg.West, Name = "aubrecradle", Info = "Aubre Cradle, Ironwrought", X = 7664, Y = 12957, Z = 400 });//228,71
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.West,
-                Name = "cinderstone",
-                Info = "Cinderstone Moor, Seachild Wharf",
-                X = 15400,
-                Y = 11543,
-                Z = 107,
-                AltNames = new string[] {"cinder"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.West,
-                Name = "dewstone",
-                Info = "Dewstone Plains, Sandcloud",
-                X = 12204,
-                Y = 13305,
-                Z = 178,
-                AltNames = new string[] {"dew"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.West,
-                Name = "gweonid",
-                Info = "Gweonid Forest, Memoria",
-                X = 10604,
-                Y = 14925,
-                Z = 280,
-                AltNames = new string[] {"gwen"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.West,
-                Name = "halcyona",
-                Info = "Halcyona, Suns End",
-                X = 9342,
-                Y = 10321,
-                Z = 187,
-                AltNames = new string[] {"halcy"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.West,
-                Name = "hellswamp",
-                Info = "Hellswamp, Anarchi",
-                X = 7482,
-                Y = 9853,
-                Z = 189,
-                AltNames = new string[] {"hell"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.West,
-                Name = "karkasse",
-                Info = "Karkasse Ridgelands, Lavis",
-                X = 10470,
-                Y = 17346,
-                Z = 186,
-                AltNames = new string[] {"kar", "karkase"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.West,
-                Name = "lilyut",
-                Info = "Lilyut Hills, Windshade",
-                X = 12666,
-                Y = 15520,
-                Z = 165,
-                AltNames = new string[] {"lily", "lili"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.West,
-                Name = "marianople",
-                Info = "Marianople, Marianople",
-                X = 11144,
-                Y = 12066,
-                Z = 145,
-                AltNames = new string[] {"maria", "west"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.West,
-                Name = "sanddeep",
-                Info = "Sanddeep, Golden Fable Harbor",
-                X = 10720,
-                Y = 9591,
-                Z = 105,
-                AltNames = new string[] {"sand"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.West,
-                Name = "solzreed",
-                Info = "Solzreed Peninsula, Cresent Throne",
-                X = 15369,
-                Y = 13864,
-                Z = 159,
-                AltNames = new string[] {"solz"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.West,
-                Name = "twocrowns",
-                Info = "Two Crowns, Ezna",
-                X = 13500,
-                Y = 10531,
-                Z = 223,
-                AltNames = new string[] {"2c", "twoc"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.West,
-                Name = "whitearden",
-                Info = "White Arden, Birchkeep",
-                X = 9682,
-                Y = 12775,
-                Z = 161,
-                AltNames = new string[] {"arden"}
-            });
-            #endregion
-
-            #region east
-            // East
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.East,
-                Name = "arcumiris",
-                Info = "Arcum Iris, Parchsun Settlement",
-                X = 20509,
-                Y = 7173,
-                Z = 193,
-                AltNames = new string[] {"arcum"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.East,
-                Name = "falcorth",
-                Info = "Falcorth Plains, Oxion Clan",
-                X = 23818,
-                Y = 9102,
-                Z = 589
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.East,
-                Name = "hasla",
-                Info = "Hasla, Veroe",
-                X = 30029,
-                Y = 8760,
-                Z = 539
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.East,
-                Name = "mahadevi",
-                Info = "Mahadevi, City of Towers",
-                X = 19284,
-                Y = 8620,
-                Z = 227,
-                AltNames = new string[] {"maha"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.East,
-                Name = "perinoor",
-                Info = "Perinor Ruins, Stonehew",
-                X = 27787,
-                Y = 6732,
-                Z = 572,
-                AltNames = new string[] {"peri", "perinor"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.East,
-                Name = "rookborne",
-                Info = "Rookborne Basin, Watermist",
-                X = 25388,
-                Y = 9753,
-                Z = 714,
-                AltNames = new string[] {"rook", "rookborn"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.East,
-                Name = "silentforest",
-                Info = "Silent Forest, Count Sebastians Retreat",
-                X = 23306,
-                Y = 12526,
-                Z = 271,
-                AltNames = new string[] {"sf", "silent"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.East,
-                Name = "solis",
-                Info = "Solis Headlands, Austera",
-                X = 16743,
-                Y = 9018,
-                Z = 120,
-                AltNames = new string[] {"austera", "east"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.East,
-                Name = "tigerspine",
-                Info = "Tigerspine Mountains, Anvilton",
-                X = 21772,
-                Y = 8089,
-                Z = 404,
-                AltNames = new string[] {"tiger"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.East,
-                Name = "villanelle",
-                Info = "Villanelle, Lutesong Harbor",
-                X = 21178,
-                Y = 10604,
-                Z = 119,
-                AltNames = new string[] {"villa"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.East,
-                Name = "windscour",
-                Info = "Windscour Savanah, Skyfang",
-                X = 25926,
-                Y = 6855,
-                Z = 362,
-                AltNames = new string[] {"windscoure", "ws"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.East,
-                Name = "ynyster",
-                Info = "Ynystere, Caernord",
-                X = 20931,
-                Y = 13158,
-                Z = 116,
-                AltNames = new string[] {"yny"}
-            });
-            #endregion
-
-            #region origin
-            // Auroria
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Auroria,
-                Name = "calmlands",
-                Info = "Calmlands",
-                X = 22349,
-                Y = 24941,
-                Z = 189
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Auroria,
-                Name = "diamondshores",
-                Info = "Diamond Shores",
-                X = 19332,
-                Y = 26883,
-                Z = 130,
-                AltNames = new string[] {"ds", "auroria", "origin"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Auroria,
-                Name = "exeloch",
-                Info = "Exeloch",
-                X = 22349,
-                Y = 24941,
-                Z = 189,
-                AltNames = new string[] {"exe"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Auroria,
-                Name = "goldenruins",
-                Info = "Golden Ruins",
-                X = 17230,
-                Y = 27501,
-                Z = 141,
-                AltNames = new string[] {"golden"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Auroria,
-                Name = "heedmar",
-                Info = "Heedmar",
-                X = 20110,
-                Y = 24568,
-                Z = 156
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Auroria,
-                Name = "marcala",
-                Info = "Marcala",
-                X = 20140,
-                Y = 24768,
-                Z = 189
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Auroria,
-                Name = "nuimari",
-                Info = "Nuimari",
-                X = 21731,
-                Y = 23751,
-                Z = 146
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Auroria,
-                Name = "reedwind",
-                Info = "Reedwind",
-                X = 19628,
-                Y = 28339,
-                Z = 295
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Auroria,
-                Name = "sungold",
-                Info = "Sungold Fields",
-                X = 22349,
-                Y = 24941,
-                Z = 189
-            });
-            // locations.Add(new TPloc { Region = TeleReg.Origin, Name = "whalesong", Info = "Whalesong Harbor", X = 14436, Y = 26696, Z = 135, altNames = ("whale"} });
-            #endregion
-
-            #region misc
-            // Others
-            // locations.Add(new TPloc { Region = TeleReg.Other, Name = "aegisisland", Info = "Aegis Island", X = 14436, Y = 26696, Z = 134, altNames = ("aegis"} });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Other,
-                Name = "freedich",
-                Info = "Sunspeck Sea, Freedich Island",
-                X = 20944,
-                Y = 18799,
-                Z = 134,
-                AltNames = new string[] {"freeditch", "free"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Other,
-                Name = "growlgate",
-                Info = "Stormraw Sound, Growlgate Island",
-                X = 15138,
-                Y = 22983,
-                Z = 105,
-                AltNames = new string[] {"pirate"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Other,
-                Name = "ynys",
-                Info = "Arcadian Sea, Ynys Island, Docks",
-                X = 16570,
-                Y = 14885,
-                Z = 102
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Other,
-                Name = "nuiajail",
-                Info = "Marianople, Guard Barracks",
-                X = 10860,
-                Y = 11950,
-                Z = 132,
-                AltNames = new string[] {"nuianjail", "westjail"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Other,
-                Name = "haranyajail",
-                Info = "Solis Headlands, Isle of Penance",
-                X = 17000,
-                Y = 9566,
-                Z = 135,
-                AltNames = new string[] {"haranijail", "eastjail"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Other,
-                Name = "nuian",
-                Info = "Solzreed, Nuian Starter Area", 
-                X = 15578,
-                Y = 15382,
-                Z = 128
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Other,
-                Name = "elf",
-                Info = "Gweonid Forest, Elven Starter Area", 
-                X = 10388,
-                Y = 15982,
-                Z = 370
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Other,
-                Name = "harani",
-                Info = "Arcum Iris, Harani Starting Area",
-                X = 19304,
-                Y = 7646,
-                Z = 215,
-                AltNames = new string[] {"harihana"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Other,
-                Name = "firran",
-                Info = "Falcorth Plains, Firran Starting Area",
-                X = 23881,
-                Y = 10495,
-                Z = 592,
-                AltNames = new string[] {"ferre"}
-            });
-            #endregion
-
-            #region dungeons
-            // Dungeons
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Dungeons,
-                Name = "sharpwind",
-                Info = "Dewstone Plains, Sharpwind Mines",
-                X = 11375,
-                Y = 13135,
-                Z = 146,
-                AltNames = new string[] {"sm", "gsm", "mines"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Dungeons,
-                Name = "burnt",
-                Info = "Cinderstone, Burnt Castle Armory",
-                X = 15683,
-                Y = 12590,
-                Z = 170,
-                AltNames = new string[] {"bc", "bca", "gbc", "castle", "orchidna"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Dungeons,
-                Name = "cellar",
-                Info = "Mahadevi, City of Towers, Palace Cellar",
-                X = 19317,
-                Y = 8512,
-                Z = 198,
-                AltNames = new string[] {"pc", "gpc", "sewer"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Dungeons,
-                Name = "hadir",
-                Info = "Ynystere, Hadir Farm",
-                X = 20022,
-                Y = 12777,
-                Z = 140,
-                AltNames = new string[] {"hf", "ghf", "farm"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Dungeons,
-                Name = "cradle",
-                Info = "Rookborne Basin, Kroloal Cradle",
-                X = 26862,
-                Y = 9042,
-                Z = 777,
-                AltNames = new string[] {"kc", "gkc", "kroloal", "kroloa", "koala"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Dungeons,
-                Name = "abyss",
-                Info = "Hellswamp, Howling Abyss",
-                X = 7800,
-                Y = 10315,
-                Z = 251,
-                AltNames = new string[] {"ha", "gha", "howling"}
-            });
-            locations.Add(new TPloc
-            {
-                Region = TeleportCommandRegions.Dungeons,
-                Name = "serpentis",
-                Info = "Exeloch, Serpentis",
-                X = 23041,
-                Y = 25848,
-                Z = 142,
-                AltNames = new string[] {"snake", "snek"}
-            });
-            #endregion
+                return "Teleports you to target location. if no [location] is provided, you "
+                     + "will get a list of available names."; */
         }
 
         public void Execute(Character character, string[] args)
@@ -548,40 +53,42 @@ namespace AAEmu.Game.Scripts.Commands
 
                 if (AllowPingPos && (n == "."))
                 {
-                    if ((character.LocalPingPosition.X == 0f) && (character.LocalPingPosition.Y == 0f))
+                    var localPos = character.LocalPingPosition;
+                    if ((localPos.X == 0.0f) && (localPos.Y == 0.0f))
                     {
-                        character.SendMessage("|cFFFFFF00[Teleport] Make sure you marked a location on the map WHILE IN A PARTY OR RAID, before using this teleport function.\n" +
-                            "If required, you can use the /soloparty command to make a party of just yourself.|r");
+                        character.SendMessage("|cFFFFFF00[Teleport] Make sure you marked a location on the map WHILE "
+                                            + "IN A PARTY OR RAID before using this teleport function.\n"
+                                            + "See also, the /soloparty command to make a solo party.|r");
                     }
                     else
                     {
-                        var height = WorldManager.Instance.GetHeight(character.Transform.ZoneId, character.LocalPingPosition.X, character.LocalPingPosition.Y);
+                        var height = WorldManager.Instance.GetHeight(character.Transform.ZoneId, localPos.X, localPos.Y);
                         if (height == 0f)
                         {
-                            character.SendMessage("|cFFFF0000[Teleport] Target height was |cFFFFFFFFzero|cFFFF0000. " +
-                                "You likely tried to teleport out of bounds, or no heightmaps where loaded on the server.\n" +
-                                "If you still want to move to the target location, you can use |cFFFFFFFF/move|cFFFF0000 to go to the following location|cFF40FF40\n" +
-                                "X:"+ character.LocalPingPosition.X.ToString("0.0") +" Y:"+character.LocalPingPosition.Y.ToString("0.0") + "|r");
+                            character.SendMessage("|cFFFF0000[Teleport] Target height was |cFFFFFFFFzero|cFFFF0000. "
+                                + "You likely tried to teleport out of bounds, or no heightmaps where loaded on the server.\n"
+                                + "If you still want to move to the target location, you can use "
+                                + "|cFFFFFFFF/move|cFFFF0000 to go to the following location|cFF40FF40\n"
+                                + $"X:{localPos.X.ToString("0.0")} Y:{localPos.Y.ToString("0.0")}|r");
                         }
                         else
                         {
-                            height += 2.5f; // compensate a bit for terrain irregularities
-                            character.SendMessage("Teleporting to |cFFFFFFFFX:" + character.LocalPingPosition.X + " Y:" + character.LocalPingPosition.Y + " Z:" + height + "|r");
+                            height += 2.5f; // Compensate a bit for terrain irregularities
+                            character.SendMessage($"Teleporting to |cFFFFFFFFX:{localPos.X} Y:{localPos.Y} Z:{height}|r");
                             character.ForceDismount();
                             character.DisabledSetPosition = true;
-                            character.SendPacket(new SCTeleportUnitPacket(0, 0, character.LocalPingPosition.X, character.LocalPingPosition.Y, height, 0));
+                            character.SendPacket(new SCTeleportUnitPacket(0, 0, localPos.X, localPos.Y, height, 0));
                         }
                     }
                 }
-                else
-                if (character.InstanceId != WorldManager.DefaultInstanceId)
+                else if (character.InstanceId != WorldManager.DefaultInstanceId)
                 {
                     character.SendMessage("|cFFFFFF00[Teleport] Named teleports are not allowed inside a instance.|r");
                 }
                 else
                 {
                     bool foundIt = false;
-                    foreach (TPloc item in locations)
+                    foreach (TPLoc item in _locations)
                     {
                         if (item.Name == n)
                         {
@@ -600,52 +107,81 @@ namespace AAEmu.Game.Scripts.Commands
                         }
                         if (foundIt)
                         {
-                            character.SendMessage("Teleporting to |cFFFFFFFF" + item.Info + "|r");
+                            character.SendMessage($"[Teleport] Teleporting to |cFFFFFFFF{item.Info}|r");
                             character.ForceDismount();
                             character.DisabledSetPosition = true;
                             character.SendPacket(new SCTeleportUnitPacket(0, 0, item.X, item.Y, item.Z, 0));
-
                             break;
                         }
                     }
                     if (!foundIt)
                     {
-                        character.SendMessage("|cFFFF0000[Teleport] Unavailable Location [" + args[0] + "]|r");
+                        character.SendMessage($"|cFFFF0000[Teleport] Unavailable Location [{args[0]}]|r");
                     }
                 }
+                return;
             }
-            else
+
+            if (AllowPingPos)
+                character.SendMessage($"Usage : {CommandManager.CommandPrefix}teleport <Location>\n"
+                                    + "Use a period (.) to teleport to YOUR marked location on the map, "
+                                    + "or use one of the following locations :");
+            /*else
+                character.SendMessage($"Usage : {CommandManager.CommandPrefix}teleport <Location>\n"
+                                    + "Teleport to one of the following locations :"); */
+            character.SendMessage(_locationList);
+        }
+
+        private void InitTeleports()
+        {
+            TPLocList json = new TPLocList();
+            try
             {
-                if (AllowPingPos)
-                    character.SendMessage("Usage : " + CommandManager.CommandPrefix + "teleport <Location>\n" +
-                                          "Use a period (.) to teleport to YOUR marked location on the map, " +
-                                          "or use one of the following locations :");
-                /*else
-                    character.SendMessage("Usage : " + CommandManager.CommandPrefix + "teleport <Location>\n" +
-                                          "Teleport to one of the following locations :"); */
-                
-                List<string> sb = new List<string>();
-                foreach (TeleportCommandRegions r in System.Enum.GetValues(typeof(TeleportCommandRegions)) )
-                    sb.Add("|cFFFFFFFF"+r.ToString() + "|r: ");
-                foreach (TPloc item in locations)
-                {
-                    sb[(int)item.Region] += item.Name + "  " ;
-                }
-                foreach (string s in sb)
-                    character.SendMessage(s+"\n");
+                var filePath = Path.Combine(FileManager.AppPath, "Scripts", "Commands", "teleports.json");
+                var contents = FileManager.GetFileContents(filePath);
+                if (string.IsNullOrWhiteSpace(contents))
+                    throw new IOException($"File {filePath} doesn't exists or is empty.");
+                json = JsonConvert.DeserializeObject<TPLocList>(contents);
+                _locations.Clear();
+                _locations.AddRange(json.tplocs);
+                _locations.Sort();
+
+                // Order teleports by region nicely
+                var sb = new StringBuilder();
+                foreach (TeleportCommandRegions r in Enum.GetValues(typeof(TeleportCommandRegions)))
+                    sb.Append($"|cFFFFFFFF{r.ToString()}|r: {string.Join(' ', _locations.Where((tp) => tp.Region == r))}\n");
+                _locationList = sb.ToString();
+            }
+            catch (Exception x)
+            {
+                _log.Error("Exception: " + x.Message);
             }
         }
     }
 
     public enum TeleportCommandRegions { East = 0, West = 1, Auroria = 2, Dungeons = 3, Other = 4 }
 
-    public class TPloc{
-        public string Name {get; set;}
-        public string Info {get; set;}
-        public int X {get; set;}
-        public int Y {get; set;}
-        public int Z {get; set;}
+    public class TPLoc
+    {
+        [JsonProperty("Name")]
+        public string Name { get; set; }
+        [JsonProperty("Info")]
+        public string Info { get; set; }
+        [JsonProperty("X")]
+        public int X { get; set; }
+        [JsonProperty("Y")]
+        public int Y { get; set; }
+        [JsonProperty("Z")]
+        public int Z { get; set; }
+        [JsonProperty("AltNames")]
         public string[] AltNames { get; set; }
+        [JsonProperty("Region")]
         public TeleportCommandRegions Region { get; set; }
+    }
+
+    public class TPLocList
+    {
+        [JsonProperty("Teleports")]
+        public List<TPLoc> tplocs = new List<TPLoc>();
     }
 }

--- a/AAEmu.Game/Scripts/Commands/TestAI.cs
+++ b/AAEmu.Game/Scripts/Commands/TestAI.cs
@@ -1,6 +1,5 @@
 ﻿using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Models.Game;
-using AAEmu.Game.Models.Game.AI.UnitTypes;
 using AAEmu.Game.Models.Game.AI.v2.AiCharacters;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.NPChar;
@@ -11,7 +10,7 @@ namespace AAEmu.Game.Scripts.Commands
     {
         public void OnLoad()
         {
-            string[] name = { "testai","ai" };
+            string[] name = new string[] { "testai", "ai" };
             CommandManager.Instance.Register(name, this);
         }
 
@@ -22,26 +21,20 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Forces the HoldPosition AI to the target";
+            return "Forces the HoldPosition AI to the target.";
         }
 
         public void Execute(Character character, string[] args)
         {
-            if (character.CurrentTarget == null)
+            if (character.CurrentTarget != null && character.CurrentTarget is Npc npc)
             {
-                character.SendMessage("You gotta target shit homie");
+                npc.Patrol = null;
+                npc.Ai = new AlmightyNpcAiCharacter() { Owner = npc, IdlePosition = npc.Transform.CloneDetached() };
+                AIManager.Instance.AddAi(npc.Ai);
                 return;
             }
 
-            if (!(character.CurrentTarget is Npc npc))
-            {
-                character.SendMessage("You gotta target a NPC homie");
-                return;
-            }
-
-            npc.Patrol = null;
-            npc.Ai = new AlmightyNpcAiCharacter() {Owner = npc, IdlePosition = npc.Transform.CloneDetached()};
-            AIManager.Instance.AddAi(npc.Ai);
+            character.SendMessage("[TestAI] An NPC is not targetted.");
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/TestAuctionHouse.cs
+++ b/AAEmu.Game/Scripts/Commands/TestAuctionHouse.cs
@@ -1,12 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
-using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.Items.Actions;
-using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game.Auction;
 
 namespace AAEmu.Game.Scripts.Commands
@@ -15,7 +10,7 @@ namespace AAEmu.Game.Scripts.Commands
     {
         public void OnLoad()
         {
-            string[] name = { "testauctionhouse","testah" };
+            string[] name = { "testauctionhouse", "testah" };
             CommandManager.Instance.Register(name, this);
         }
 
@@ -32,46 +27,45 @@ namespace AAEmu.Game.Scripts.Commands
         public void Execute(Character character, string[] args)
         {
             var allItems = ItemManager.Instance.GetAllItems();
-            character.SendMessage($"Trying to add {allItems.Count} items to the Auction House!");
-            
+            character.SendMessage($"[TestAuctionHouse] Trying to add {allItems.Count} items to the Auction House!");
+
             var amount = 0;
             foreach (var item in allItems)
             {
-                var newAuctionItem = new AuctionItem
-                {
-                    ID = AuctionManager.Instance.GetNextId(),
-                    Duration = 5,
-                    ItemID = item.Id,
-                    ObjectID = 0,
-                    Grade = 0,
-                    Flags = 0,
-                    StackSize = 1,
-                    DetailType = 0,
-                    CreationTime = DateTime.UtcNow,
-                    EndTime = DateTime.UtcNow.AddSeconds(172800),
-                    LifespanMins = 0,
-                    Type1 = 0,
-                    WorldId = 0,
-                    UnpackDateTIme = DateTime.UtcNow,
-                    UnsecureDateTime = DateTime.UtcNow,
-                    WorldId2 = 0,
-                    ClientId = 0,
-                    ClientName = "",
-                    StartMoney = 0,
-                    DirectMoney = 1,
-                    BidWorldID = 0,
-                    BidderId = 0,
-                    BidderName = "",
-                    BidMoney = 0,
-                    Extra = 0,
-                    IsDirty = true
-                };
-                
-                AuctionManager.Instance.AddAuctionItem(newAuctionItem);
+                AuctionManager.Instance.AddAuctionItem(
+                    new AuctionItem {
+                        ID = AuctionManager.Instance.GetNextId(),
+                        Duration = 5,
+                        ItemID = item.Id,
+                        ObjectID = 0,
+                        Grade = 0,
+                        Flags = 0,
+                        StackSize = 1,
+                        DetailType = 0,
+                        CreationTime = DateTime.UtcNow,
+                        EndTime = DateTime.UtcNow.AddSeconds(172800),
+                        LifespanMins = 0,
+                        Type1 = 0,
+                        WorldId = 0,
+                        UnpackDateTIme = DateTime.UtcNow,
+                        UnsecureDateTime = DateTime.UtcNow,
+                        WorldId2 = 0,
+                        ClientId = 0,
+                        ClientName = "",
+                        StartMoney = 0,
+                        DirectMoney = 1,
+                        BidWorldID = 0,
+                        BidderId = 0,
+                        BidderName = "",
+                        BidMoney = 0,
+                        Extra = 0,
+                        IsDirty = true
+                    }
+                );
                 amount++;
             }
 
-            character.SendMessage($"Added {amount} items to the Auction House!");
+            character.SendMessage($"[TestAuctionHouse] Added {amount} items to the Auction House!");
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/TestChatChannel.cs
+++ b/AAEmu.Game/Scripts/Commands/TestChatChannel.cs
@@ -1,14 +1,8 @@
-﻿using System;
-using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
-using AAEmu.Game.Core.Managers.UnitManagers;
-using AAEmu.Game.Core.Managers.World;
+﻿using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.Expeditions;
-using AAEmu.Game.Models.Game.Faction;
-using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.Game.Chat;
 
 namespace AAEmu.Game.Scripts.Commands
 {
@@ -27,8 +21,9 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Command used to manually send join/leave channel packets to yourself used for testing\r" +
-                "You can also use list to show a list of all current chat channels, or clean to remove any non-system channel that has zero users in it.";
+            return "Manually send join/leave channel packets to yourself. Used for testing.\n"
+                 + "You can also use list to show a list of all current chat channels, or clean "
+                 + "to remove any non-system channel that has zero users in it.";
         }
 
         public void Execute(Character character, string[] args)
@@ -48,30 +43,31 @@ namespace AAEmu.Game.Scripts.Commands
             if ((args.Length == 1) && (args[0].ToLower() == "clean"))
             {
                 var removed = ChatManager.Instance.CleanUpChannels();
-                character.SendMessage("[TestChatChannel] {0} empty channel(s) removed", removed);
+                character.SendMessage($"[TestChatChannel] {removed} empty channel(s) removed");
                 return;
             }
 
             if (args.Length < 4)
             {
-                character.SendMessage("[TestChatChannel] " + CommandManager.CommandPrefix + "test_chat_channel "+GetCommandLineHelp());
+                character.SendMessage($"[TestChatChannel] {CommandManager.CommandPrefix}test_chat_channel {GetCommandLineHelp()}");
                 return;
             }
 
-            var chattype = (AAEmu.Game.Models.Game.Chat.ChatType)byte.Parse(args[1]);
+            var chattype = (ChatType)byte.Parse(args[1]);
             var chatsubtype = byte.Parse(args[2]);
             var chatfaction = uint.Parse(args[3]);
-            
+
             if (args[0].ToLower() == "join")
             {
                 character.SendPacket(new SCJoinedChatChannelPacket(chattype, chatsubtype, chatfaction));
+                return;
             }
-            
+
             if (args[0].ToLower() == "leave")
             {
                 character.SendPacket(new SCLeavedChatChannelPacket(chattype, chatsubtype, chatfaction));
+                return;
             }
-            
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/TestCombat.cs
+++ b/AAEmu.Game/Scripts/Commands/TestCombat.cs
@@ -20,20 +20,21 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Command to test combat related packets. You can try to use cleared if you are stuck in combat for example.";
+            return "Command to test combat related packets. You can try to use cleared "
+                 + "if you are stuck in combat for example.";
         }
 
         public void Execute(Character character, string[] args)
         {
             if (args.Length == 0)
             {
-                character.SendMessage("[TestCombat] mods: engaged, cleared, first_hit");
+                character.SendMessage("[TestCombat] Mods: engaged, cleared, first_hit");
                 return;
             }
 
             switch (args[0])
             {
-                case "engaged": // TODO Battle Start
+                case "engaged": // TODO: Battle Start
                     if (character.CurrentTarget != null)
                     {
                         character.SendPacket(new SCCombatEngagedPacket(character.ObjId));
@@ -43,7 +44,7 @@ namespace AAEmu.Game.Scripts.Commands
                         character.SendMessage("[TestCombat] not have target");
 
                     break;
-                case "cleared": // TODO Battle End
+                case "cleared": // TODO: Battle End
                     if (character.CurrentTarget != null)
                     {
                         character.SendPacket(new SCCombatClearedPacket(character.ObjId));
@@ -60,7 +61,7 @@ namespace AAEmu.Game.Scripts.Commands
                     else
                         character.SendMessage("[TestCombat] not have target");
                     break;
-                case "text": // TODO Combat Effect
+                case "text": // TODO: Combat Effect
                     character.SendPacket(new SCCombatTextPacket(0, character.ObjId, 0));
                     break;
             }

--- a/AAEmu.Game/Scripts/Commands/TestEcho.cs
+++ b/AAEmu.Game/Scripts/Commands/TestEcho.cs
@@ -1,10 +1,6 @@
 ﻿using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
-using AAEmu.Game.Core.Managers.UnitManagers;
-using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Scripts.Commands
 {
@@ -22,20 +18,16 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Repeats the provided arguments in chat as raw text";
+            return "Repeats the provided arguments in chat as raw text.";
         }
 
         public void Execute(Character character, string[] args)
         {
-            string s = string.Empty;
-            foreach (string a in args)
-                s = s + a + " ";
-            
             // Un-escape the string, as the client sends it escaped
             // It is required if you want to test things like @NPC_NAME() and |cFF00FFFF text colors |r
             // s = s.Replace("@@", "@").Replace("||", "|");
 
-            character.SendMessage("|cFFFFFFFF[Echo]|r " + s);
+            character.SendMessage($"|cFFFFFFFF[Echo]|r {string.Join(' ', args)}");
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/TestFSets.cs
+++ b/AAEmu.Game/Scripts/Commands/TestFSets.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Features;
 
 namespace AAEmu.Game.Scripts.Commands
@@ -24,20 +22,18 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Shows currently active fsets of the server";
+            return "Shows currently active fsets of the server.";
         }
 
         public void Execute(Character character, string[] args)
         {
-            foreach (var fObj in Enum.GetValues(typeof(Feature)))
+            foreach (Feature fObj in Enum.GetValues(typeof(Feature)))
             {
-                var f = (Feature)fObj;
-                if (FeaturesManager.Fsets.Check(f))
-                    character.SendMessage("[Feature] |cFF00FF00ON  |cFF80FF80" + f.ToString() + "|r");
+                if (FeaturesManager.Fsets.Check(fObj))
+                    character.SendMessage($"[Feature] |cFF00FF00ON  |cFF80FF80{fObj}|r");
                 else
-                    character.SendMessage("[Feature] |cFFFF0000OFF |cFF802020" + f.ToString() + "|r");
+                    character.SendMessage($"[Feature] |cFFFF0000OFF |cFF802020{fObj}|r");
             }
-
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/TestGuild.cs
+++ b/AAEmu.Game/Scripts/Commands/TestGuild.cs
@@ -1,14 +1,6 @@
-﻿using System;
-using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
-using AAEmu.Game.Core.Managers.UnitManagers;
-using AAEmu.Game.Core.Managers.World;
-using AAEmu.Game.Core.Packets.G2C;
+﻿using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.Expeditions;
-using AAEmu.Game.Models.Game.Faction;
-using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Scripts.Commands
 {
@@ -34,19 +26,11 @@ namespace AAEmu.Game.Scripts.Commands
         {
             if (args.Length == 0)
             {
-                character.SendMessage("[TestGuild] " + CommandManager.CommandPrefix + "testguild " + GetCommandLineHelp());
+                character.SendMessage($"[TestGuild] {CommandManager.CommandPrefix}testguild {GetCommandLineHelp()}");
                 return;
             }
 
-            var guildName = string.Empty;
-            foreach(var a in args)
-            {
-                if (guildName != string.Empty)
-                    guildName += " ";
-                guildName += a;
-            }
-
-            ExpeditionManager.Instance.CreateExpedition(guildName, character.Connection);
+            ExpeditionManager.Instance.CreateExpedition(string.Join(' ', args), character.Connection);
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/TestHeight.cs
+++ b/AAEmu.Game/Scripts/Commands/TestHeight.cs
@@ -1,18 +1,11 @@
-﻿using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
+﻿using System;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Managers.UnitManagers;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.DoodadObj;
-using AAEmu.Game.Models.Game.NPChar;
-using AAEmu.Game.Models.Game.World;
-using AAEmu.Game.Utils;
-using NLog;
-using System;
-using AAEmu.Game.Models.Game.Units.Movements;
-
 
 namespace AAEmu.Game.Scripts.Commands
 {
@@ -31,10 +24,13 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Gets your or target's current height and that of the supposed floor (using heightmap data)\n" +
-                "testpos will move you near freedich underwater\r" +
-                "mark creates a grid of pillar doodads used for measuring the floor at 2m intervals (exact heightmap points)\r" +
-                "line creates a cross of pillar doodads used for measuring the floor at 1m intervals (for in-between points)";
+            return "Gets your or target's current height and that of the supposed "
+                 + "floor (using heightmap data)\n"
+                 + "testpos will move you near freedich underwater\n"
+                 + "mark creates a grid of pillar doodads used for measuring the "
+                 + "floor at 2m intervals (exact heightmap points)\n"
+                 + "line creates a cross of pillar doodads used for measuring the "
+                 + "floor at 1m intervals (for in-between points)";
         }
 
         public void Execute(Character character, string[] args)
@@ -47,10 +43,11 @@ namespace AAEmu.Game.Scripts.Commands
             if ((args.Length > firstarg) && (args[firstarg] == "testpos"))
             {
                 targetPlayer.DisabledSetPosition = true;
-                targetPlayer.SendPacket(new SCTeleportUnitPacket(0, 0, 22500f, 18500f, 10f, 0f));
-                targetPlayer.SendMessage("[Move] |cFFFFFFFF{0}|r moved to X: {1}, Y: {2}, Z: {3}", targetPlayer.Name, 22500f, 18500f, 10f);
+                targetPlayer.SendPacket(new SCTeleportUnitPacket(0, 0, 22500.0f, 18500.0f, 10.0f, 0.0f));
+                targetPlayer.SendMessage("[Move] |cFFFFFFFF{0}|r moved to X: {1}, Y: {2}, Z: {3}", targetPlayer.Name, 22500.0f, 18500.0f, 10.0f);
+                return;
             }
-            else
+
             if ((args.Length > firstarg) && (args[firstarg] == "mark"))
             { 
                 // Place markers
@@ -60,12 +57,12 @@ namespace AAEmu.Game.Scripts.Commands
                 rY = rY - (rY % 2);
                 uint unitId = 5622;
                 for (var y = rY - 10; y <= rY + 10; y += 2)
+                {
                     for (var x = rX - 10; x <= rX + 10; x += 2)
                     {
                         if (!DoodadManager.Instance.Exist(unitId))
-                        {
                             return;
-                        }
+
                         var doodadSpawner = new DoodadSpawner();
                         doodadSpawner.Id = 0;
                         doodadSpawner.UnitId = unitId;
@@ -78,9 +75,10 @@ namespace AAEmu.Game.Scripts.Commands
                         doodadSpawner.Position.Roll = 0;
                         doodadSpawner.Spawn(0);
                     }
-
+                }
+                return;
             }
-            else
+
             if ((args.Length > firstarg) && (args[firstarg] == "line"))
             {
                 // Place markers
@@ -92,12 +90,11 @@ namespace AAEmu.Game.Scripts.Commands
                 float rX = rXX;
                 float rY = rYY;
                 uint unitId = 5622;
-                for (var x = rX - 10f; x <= rX + 10f; x += 1f)
+                for (var x = rX - 10.0f; x <= rX + 10.0f; x += 1.0f)
                 {
                     if (!DoodadManager.Instance.Exist(unitId))
-                    {
                         return;
-                    }
+
                     var doodadSpawner = new DoodadSpawner();
                     doodadSpawner.Id = 0;
                     doodadSpawner.UnitId = unitId;
@@ -110,12 +107,11 @@ namespace AAEmu.Game.Scripts.Commands
                     doodadSpawner.Position.Roll = 0;
                     doodadSpawner.Spawn(0);
                 }
-                for (var y = rY - 10f; y <= rY + 10f; y += 1f)
+                for (var y = rY - 10.0f; y <= rY + 10.0f; y += 1.0f)
                 {
                     if (!DoodadManager.Instance.Exist(unitId))
-                    {
                         return;
-                    }
+
                     var doodadSpawner = new DoodadSpawner();
                     doodadSpawner.Id = 0;
                     doodadSpawner.UnitId = unitId;
@@ -128,37 +124,38 @@ namespace AAEmu.Game.Scripts.Commands
                     doodadSpawner.Position.Roll = 0;
                     doodadSpawner.Spawn(0);
                 }
-
+                return;
             }
-            else
-            {
-                // Show info
-                var world = WorldManager.Instance.GetWorldByZone(targetPlayer.Transform.ZoneId);
 
-                var height = world.GetHeight(targetPlayer.Transform.World.Position.X,targetPlayer.Transform.World.Position.Y);
-                var hDelta = character.Transform.World.Position.Z - height;
-                character.SendMessage("[Height] {2} Z-Pos: {0} - Floor: {1} - HeightmapDelta: {3}", character.Transform.World.Position.Z, height, targetPlayer.Name, hDelta);
+            // Show info
+            var modelWorld = WorldManager.Instance.GetWorldByZone(targetPlayer.Transform.ZoneId);
 
-                character.SendMessage("[Position] |cFFFFFFFF{0}|r X: |cFFFFFFFF{1:F1}|r  Y: |cFFFFFFFF{2:F1}|r  Z: |cFFFFFFFF{3:F1}|r ",
-                    targetPlayer.Name, targetPlayer.Transform.World.Position.X, targetPlayer.Transform.World.Position.Y, targetPlayer.Transform.World.Position.Z);
+            var targetWorld = targetPlayer.Transform.World;
+            var charWorld = character.Transform.World;
+            var height = modelWorld.GetHeight(targetWorld.Position.X, targetWorld.Position.Y);
+            var hDelta = charWorld.Position.Z - height;
+            character.SendMessage("[Height] {2} Z-Pos: {0} - Floor: {1} - HeightmapDelta: {3}",
+                    charWorld.Position.Z, height, targetPlayer.Name, hDelta);
 
-                var borderLeft = (int)Math.Floor(targetPlayer.Transform.World.Position.X);
-                borderLeft = borderLeft - (borderLeft % 2);
-                var borderRight = borderLeft + 2; // we're using a divider of 2 of the heightmaps in memory, so we need to compensate with that in mind (instead of 1)
-                var borderBottom = (int)Math.Floor(targetPlayer.Transform.World.Position.Y);
-                borderBottom = borderBottom - (borderBottom % 2);
-                var borderTop = borderBottom + 2;
+            character.SendMessage("[Position] |cFFFFFFFF{0}|r X: |cFFFFFFFF{1:F1}|r  Y: |cFFFFFFFF{2:F1}|r  Z: |cFFFFFFFF{3:F1}|r ",
+                    targetPlayer.Name, targetWorld.Position.X, targetWorld.Position.Y, targetWorld.Position.Z);
 
-                // Get heights for these points
-                var heightTL = world.GetRawHeightMapHeight(borderLeft, borderTop);        // 10
-                var heightTR = world.GetRawHeightMapHeight(borderRight, borderTop);       // 6
-                var heightBL = world.GetRawHeightMapHeight(borderLeft, borderBottom);     // 14
-                var heightBR = world.GetRawHeightMapHeight(borderRight, borderBottom);    // 16
-                character.SendMessage("[Height] TL @ {0}x{1} = {2}", borderLeft, borderTop, heightTL);
-                character.SendMessage("[Height] TR @ {0}x{1} = {2}", borderRight, borderTop, heightTR);
-                character.SendMessage("[Height] BL @ {0}x{1} = {2}", borderLeft, borderBottom, heightBL);
-                character.SendMessage("[Height] BR @ {0}x{1} = {2}", borderRight, borderBottom, heightBR);
-            }
+            var borderLeft = (int)Math.Floor(targetWorld.Position.X);
+            borderLeft = borderLeft - (borderLeft % 2);
+            var borderRight = borderLeft + 2; // We're using a multiple of 2 in the heightmaps in memory, so we need to compensate with that in mind (instead of 1)
+            var borderBottom = (int)Math.Floor(targetWorld.Position.Y);
+            borderBottom = borderBottom - (borderBottom % 2);
+            var borderTop = borderBottom + 2;
+
+            // Get heights for these points
+            var heightTL = modelWorld.GetRawHeightMapHeight(borderLeft, borderTop);     // 10
+            var heightTR = modelWorld.GetRawHeightMapHeight(borderRight, borderTop);    // 6
+            var heightBL = modelWorld.GetRawHeightMapHeight(borderLeft, borderBottom);  // 14
+            var heightBR = modelWorld.GetRawHeightMapHeight(borderRight, borderBottom); // 16
+            character.SendMessage($"[Height] TL @ {borderLeft}x{borderTop} = {heightTL}");
+            character.SendMessage($"[Height] TR @ {borderRight}x{borderTop} = {heightTR}");
+            character.SendMessage($"[Height] BL @ {borderLeft}x{borderBottom} = {heightBL}");
+            character.SendMessage($"[Height] BR @ {borderRight}x{borderBottom} = {heightBR}");
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/TestHouse.cs
+++ b/AAEmu.Game/Scripts/Commands/TestHouse.cs
@@ -1,13 +1,7 @@
 ﻿using System;
-using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
-using AAEmu.Game.Core.Managers.UnitManagers;
-using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.Units;
-using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Mails;
 using AAEmu.Game.Models.Game.Housing;
 
@@ -28,23 +22,28 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Available commands;\n" +
-                "|cFFFFFFFFinfo|r -> Shows various house info\n" +
-                "|cFFFFFFFFtaxmail|r -> Creates a tax due mail for the house owner\n" +
-                "|cFFFFFFFFsetforsale <money> [buyer]|r -> Forces a house for sale to be set, with optional [buyer] specified. Specify 0 money to clear the sale. (does not return any certificates)\n" +
-                "|cFFFFFFFFsettaxpaid|r -> Sets the house's taxdue date as if just build and paid for.\n" +
-                "|cFFFFFFFFsettaxdue|r -> Sets the house's taxdue date to now.\n" +
-                "|cFFFFFFFFsettaxduesoon|r -> Sets the house's taxdue date to 20 seconds from now.\n" +
-                "|cFFFFFFFFsetdemosoon|r -> Sets the house's demolition date to 20 seconds from now.\n" +
-                "|cFFFFFFFFforcedemo|r -> Forcefully demolishes a house right now, but returns all furniture regardless if it is normally returned or not.\n" +
-                "";
+            return "Available commands;\n"
+                 + "|cFFFFFFFFinfo|r -> Shows various house info\n"
+                 + "|cFFFFFFFFtaxmail|r -> Creates a tax due mail for the house owner\n"
+                 + "|cFFFFFFFFsetforsale <money> [buyer]|r -> Forces a house for sale to be set, "
+                 + "with optional [buyer] specified. Specify 0 money to clear the sale. (does not "
+                 + "return any certificates)\n"
+                 + "|cFFFFFFFFsettaxpaid|r -> Sets the house's taxdue date as if just build and "
+                 + "paid for.\n"
+                 + "|cFFFFFFFFsettaxdue|r -> Sets the house's taxdue date to now.\n"
+                 + "|cFFFFFFFFsettaxduesoon|r -> Sets the house's taxdue date to 20 seconds "
+                 + "from now.\n"
+                 + "|cFFFFFFFFsetdemosoon|r -> Sets the house's demolition date to 20 seconds "
+                 + "from now.\n"
+                 + "|cFFFFFFFFforcedemo|r -> Forcefully demolishes a house right now, but returns "
+                 + "all furniture regardless if it is normally returned or not.\n";
         }
 
         public void Execute(Character character, string[] args)
         {
             if (args.Length <= 0)
             {
-                character.SendMessage("[House] " + GetCommandHelpText());
+                character.SendMessage($"[House] {GetCommandHelpText()}");
                 return;
             }
 
@@ -62,8 +61,8 @@ namespace AAEmu.Game.Scripts.Commands
 
             try
             {
-                var a0 = args[0].ToLower();
-                if (a0 == "info")
+                var arg0 = args[0].ToLower();
+                if (arg0 == "info")
                 {
                     character.SendMessage("[House] ObjId: {0} - HouseId: {1} - TemplateId: {2} - ModelId: {3} - {4}",
                         house.ObjId, house.Id, house.TemplateId, house.ModelId, house.Name);
@@ -73,48 +72,48 @@ namespace AAEmu.Game.Scripts.Commands
                         out var hostileTaxRate, out _);
 
                     if (DateTime.UtcNow >= house.TaxDueDate)
-                        character.SendMessage("[House] Tax Due: {0}{1} by {2}", totalTaxAmountDue,
+                        character.SendMessage("[House] Taxes Due: {0}{1} by {2}", totalTaxAmountDue,
                             house.Template.HeavyTax ? "" : "(no heavy tax)", house.TaxDueDate);
                     else if (DateTime.UtcNow >= house.TaxDueDate.AddDays(7))
-                        character.SendMessage("[House] Tax Overdue: {0}{1}, demolition at {2}", totalTaxAmountDue * 2,
+                        character.SendMessage("[House] Taxes Overdue: {0}{1}, demolition at {2}", totalTaxAmountDue * 2,
                             house.Template.HeavyTax ? "" : "(no heavy tax)", house.ProtectionEndDate);
                 }
-                else if (a0 == "taxmail")
+                else if (arg0 == "taxmail")
                 {
                     var newMail = new MailForTax(house);
                     newMail.FinalizeMail();
                     newMail.Send();
-                    character.SendMessage("[House] Created tax for {0}", house.Name);
+                    character.SendMessage($"[House] Created taxes for {house.Name}");
                 }
-                else if (a0 == "settaxpaid")
+                else if (arg0 == "settaxpaid")
                 {
                     house.ProtectionEndDate = DateTime.UtcNow.AddDays(21);
                     HousingManager.Instance.UpdateTaxInfo(house);
-                    character.SendMessage("[House] {0} tax paid", house.Name);
+                    character.SendMessage($"[House] {house.Name} taxes now paid");
                 }
-                else if (a0 == "settaxdue")
+                else if (arg0 == "settaxdue")
                 {
                     house.ProtectionEndDate = DateTime.UtcNow.AddDays(14);
                     HousingManager.Instance.UpdateTaxInfo(house);
-                    character.SendMessage("[House] {0} tax due", house.Name);
+                    character.SendMessage($"[House] {house.Name} taxes now due");
                 }
-                else if (a0 == "settaxoverdue")
+                else if (arg0 == "settaxoverdue")
                 {
                     house.ProtectionEndDate = DateTime.UtcNow.AddDays(7);
                     HousingManager.Instance.UpdateTaxInfo(house);
-                    character.SendMessage("[House] {0} tax overdue", house.Name);
+                    character.SendMessage($"[House] {house.Name} taxes now overdue");
                 }
-                else if (a0 == "setdemosoon")
+                else if (arg0 == "setdemosoon")
                 {
                     house.ProtectionEndDate = DateTime.UtcNow.AddSeconds(20);
                     HousingManager.Instance.UpdateTaxInfo(house);
-                    character.SendMessage("[House] {0} demolished in about 20 seconds", house.Name);
+                    character.SendMessage($"[House] {house.Name} will demolish in about 20 seconds");
                 }
-                else if (a0 == "setforsale")
+                else if (arg0 == "setforsale")
                 {
-                    var price = 0u;
-                    var buyer = string.Empty;
-                    var buyerId = 0u;
+                    uint price = 0;
+                    string buyer = string.Empty;
+                    uint buyerId = 0;
 
                     if (args.Length > 1)
                     {
@@ -139,7 +138,7 @@ namespace AAEmu.Game.Scripts.Commands
                         }
                         else
                         {
-                            character.SendMessage("[House] invalid buyer name {0}", args[2]);
+                            character.SendMessage($"[House] Invalid buyer name {args[2]}");
                             return;
                         }
                     }
@@ -152,40 +151,39 @@ namespace AAEmu.Game.Scripts.Commands
                         // Set for sale
                         if (house.SellPrice > 0)
                         {
-                            character.SendMessage("[House] Is already for sale, clear first to assign a new value");
+                            character.SendMessage($"[House] {house.Name} already for sale, clear first to assign a new value");
                             return;
                         }
 
                         if (HousingManager.Instance.SetForSale(house, price, buyerId, null))
-                            character.SendMessage("[House] Setting {0} for sale with a price of {1} to buy for {2}.",
-                                house.Name, price, buyer);
+                            character.SendMessage($"[House] Setting {house.Name} for sale with a price of {price} to buy for {buyer}.");
                         else
-                            character.SendMessage("[House] Failed to set {0} for sale !", house.Name);
+                            character.SendMessage($"[House] Failed to set {house.Name} for sale!");
                     }
                     else
                     {
                         if (house.SellPrice <= 0)
                         {
-                            character.SendMessage("[House] This house wasn't for sale.");
+                            character.SendMessage("[House] This house isn't for sale.");
                             return;
                         }
 
                         // Remove sale (for GM commands we don't return certificates)
                         if (HousingManager.Instance.CancelForSale(house, false))
-                            character.SendMessage("[House] {0} is no longer for sale", house.Name);
+                            character.SendMessage($"[House] {house.Name} is no longer for sale");
                         else
-                            character.SendMessage("[House] Failed to remove sale from {0} !", house.Name);
+                            character.SendMessage($"[House] Failed to remove sale from {house.Name}!");
                     }
 
                 }
-                else if (a0 == "forcedemo")
+                else if (arg0 == "forcedemo")
                 {
                     HousingManager.Instance.Demolish(null, house, false, true);
-                    character.SendMessage("[House] {0} demolished with full restore", house.Name);
+                    character.SendMessage($"[House] {house.Name} demolished with full restore");
                 }
                 else
                 {
-                    character.SendMessage("[House] Unknown command: {0}", a0);
+                    character.SendMessage($"[House] Unknown command: {arg0}");
                 }
             }
             catch (Exception e)

--- a/AAEmu.Game/Scripts/Commands/TestMails.cs
+++ b/AAEmu.Game/Scripts/Commands/TestMails.cs
@@ -1,15 +1,10 @@
 ﻿using System;
-using AAEmu.Game.Core.Packets.G2C;
+using System.Text;
 using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
-using AAEmu.Game.Core.Managers.UnitManagers;
-using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Mails;
-using AAEmu.Game.Models.Game.Housing;
 
 namespace AAEmu.Game.Scripts.Commands
 {
@@ -28,7 +23,7 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Sends a dummy mail to yourself of given type";
+            return "Sends a dummy mail to yourself of a given type.";
         }
 
         public void Execute(Character character, string[] args)
@@ -43,24 +38,19 @@ namespace AAEmu.Game.Scripts.Commands
             if (args.Length <= 0)
             {
                 // List all mailtypes
-                var s = "[TestMail] " + GetCommandHelpText() + "\r";
-                s += "Possible MailTypes:\r";
-                character.SendMessage(s);
-                s = string.Empty;
+                var sb = new StringBuilder();
+                sb.Append($"[TestMail] {GetCommandHelpText()}\nPossible MailTypes:\n");
                 foreach (var t in Enum.GetValues(typeof(MailType)))
-                {
-                    s += string.Format("{0}={1}", (byte)t, t.ToString());
-                    s += "  ";
-                }
-                character.SendMessage(s);
+                    sb.Append($"{(byte)t}={t}  ");
+                character.SendMessage(sb.ToString());
                 return;
             }
 
             MailType mType = MailType.InvalidMailType;
             if (args.Length > 0)
             {
-                var a0 = args[0].ToLower();
-                switch (a0)
+                var arg0 = args[0].ToLower();
+                switch (arg0)
                 {
                     case "list":
                         character.SendMessage("[TestMail] List of Mails");
@@ -78,7 +68,7 @@ namespace AAEmu.Game.Scripts.Commands
                         return;
                     case "check":
                         character.Mails.SendUnreadMailCount();
-                        character.SendMessage("[TestMail] {0} unread mails", character.Mails.unreadMailCount.Received);
+                        character.SendMessage("[TestMail] {0} unread mail", character.Mails.unreadMailCount.Received);
                         return;
                     default:
                         if (MailType.TryParse(args[0], out MailType mTypeByName))
@@ -89,59 +79,51 @@ namespace AAEmu.Game.Scripts.Commands
 
             if (mType == MailType.InvalidMailType)
             {
-                character.SendMessage("[TestMail] Invalid type: {0}", mType);
+                character.SendMessage($"[TestMail] Invalid type: {mType}");
                 return;
             }
 
-            character.SendMessage("[TestMail] Testing type: {0}", mType);
+            character.SendMessage($"[TestMail] Testing type: {mType}");
             try
             {
                 var mail = new BaseMail();
-
                 mail.MailType = mType;
-                mail.Title = "TestMail " + mType.ToString();
+                mail.Title = $"TestMail {mType.ToString()}";
                 mail.ReceiverName = character.Name;
-
                 mail.Header.SenderId = character.Id;
                 mail.Header.SenderName = character.Name;
                 mail.Header.ReceiverId = character.Id;
-
                 mail.Header.Attachments = 0;
                 mail.Header.Extra = 0;
-
                 mail.Body.Text = "Test Mail Body";
                 mail.Body.SendDate = DateTime.UtcNow;
                 mail.Body.RecvDate = DateTime.UtcNow;
 
                 if (args.Length > 1)
                 {
-                    var n = args[1];
-                    mail.Header.SenderName = n;
-                    mail.Header.SenderId = NameManager.Instance.GetCharacterId(n);
-                    character.SendMessage("[TestMail] From: {0}", n);
+                    mail.Header.SenderName = args[1];
+                    mail.Header.SenderId = NameManager.Instance.GetCharacterId(args[1]);
+                    character.SendMessage($"[TestMail] From: {args[1]}");
                 }
 
                 if (args.Length > 2)
                 {
-                    var n = args[2];
-                    mail.Title = n;
-                    character.SendMessage("[TestMail] Title: {0}", n);
+                    mail.Title = args[2];
+                    character.SendMessage($"[TestMail] Title: {args[2]}");
                 }
 
                 if (args.Length > 3)
                 {
-                    var n = args[3];
-                    mail.Body.Text = n;
-                    character.SendMessage("[TestMail] Body: {0}", n);
+                    mail.Body.Text = args[3];
+                    character.SendMessage($"[TestMail] Body: {args[3]}");
                 }
 
                 if (args.Length > 4)
                 {
-                    var n = args[4];
-                    if (int.TryParse(n, out var copper))
+                    if (int.TryParse(args[4], out var copper))
                     {
                         mail.Body.CopperCoins = copper;
-                        character.SendMessage("[TestMail] Money: {0}", copper);
+                        character.SendMessage($"[TestMail] Money: {copper}");
                     }
                     else
                     {
@@ -151,11 +133,10 @@ namespace AAEmu.Game.Scripts.Commands
 
                 if (args.Length > 5)
                 {
-                    var n = args[5];
-                    if (int.TryParse(n, out var billing))
+                    if (int.TryParse(args[5], out var billing))
                     {
                         mail.Body.BillingAmount = billing;
-                        character.SendMessage("[TestMail] BillingCost: {0}", billing);
+                        character.SendMessage($"[TestMail] BillingCost: {billing}");
                     }
                     else
                     {
@@ -176,7 +157,7 @@ namespace AAEmu.Game.Scripts.Commands
                                 var itemTemplate = ItemManager.Instance.GetTemplate(itemId);
                                 if (itemTemplate == null)
                                 {
-                                    character.SendMessage("|cFFFF0000Item template does not exist for {0} !|r", itemId);
+                                    character.SendMessage($"|cFFFF0000Item template does not exist for {itemId}!|r");
                                     return;
                                 }
 
@@ -206,7 +187,6 @@ namespace AAEmu.Game.Scripts.Commands
                         }
                     }
                 }
-
 
                 mail.Send();
             }

--- a/AAEmu.Game/Scripts/Commands/TestSlave.cs
+++ b/AAEmu.Game/Scripts/Commands/TestSlave.cs
@@ -22,7 +22,7 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Spawns a test slave";
+            return "Spawns a test slave.";
         }
 
         public void Execute(Character character, string[] args)
@@ -36,12 +36,11 @@ namespace AAEmu.Game.Scripts.Commands
             slave.Faction = FactionManager.Instance.GetFaction(143);
             slave.Level = 50;
             slave.Transform = character.Transform.CloneDetached(slave);
-            slave.Transform.Local.AddDistanceToFront(5f);
+            slave.Transform.Local.AddDistanceToFront(5.0f);
             slave.Hp = slave.MaxHp = 190000;
             slave.Faction = character.Faction;
             slave.ModelParams = new UnitCustomModelParams();
             slave.Template = SlaveManager.Instance.GetSlaveTemplate(slave.TemplateId);
-
             slave.Spawn();
         }
     }

--- a/AAEmu.Game/Scripts/Commands/TestTracker.cs
+++ b/AAEmu.Game/Scripts/Commands/TestTracker.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Packets.G2C;
+﻿using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Core.Managers.World;
-using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.World;
 
@@ -25,7 +22,7 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Toggle movement debug information for target";
+            return "Toggle movement debug information for target.";
         }
 
         public void Execute(Character character, string[] args)
@@ -36,17 +33,17 @@ namespace AAEmu.Game.Scripts.Commands
             if ((args.Length > 0) && (uint.TryParse(args[0], out var targetObjIdVal)))
                 targetObject = WorldManager.Instance.GetGameObject(targetObjIdVal);
 
-            if ((targetObject != null) && (targetObject.Transform != null))
-            {
-                character.SendMessage("[TestTracking] {0} tracking {1} - {2}",
-                    targetObject.Transform.ToggleDebugTracker(character) ? "Now" : "No longer",
-                    targetObject.ObjId,
-                    (targetObject is BaseUnit bu) ? bu.Name : "<gameobject>");
-            }
-            else
+            if (targetObject == null || targetObject.Transform == null)
             {
                 character.SendMessage("[TestTracking] Invalid object");
+                return;
             }
+
+            character.SendMessage("[TestTracking] {0} tracking {1} - {2}",
+                targetObject.Transform.ToggleDebugTracker(character) ? "Now" : "No longer",
+                targetObject.ObjId,
+                (targetObject is BaseUnit bu) ? bu.Name : "<gameobject>"
+            );
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/TestTransfer.cs
+++ b/AAEmu.Game/Scripts/Commands/TestTransfer.cs
@@ -1,9 +1,6 @@
 ﻿using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
-using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Scripts.Commands
 {
@@ -22,15 +19,15 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Spawns a transportation vehicle";
+            return "Spawns a transportation vehicle.";
         }
 
         public void Execute(Character character, string[] args)
         {
-            character.SendMessage("[testtransfer] function disabled");
+            character.SendMessage("[TestTransfer] function disabled");
             //if (args.Length < 1)
             //{
-            //    character.SendMessage("[test_transfer] /test_transfer unitId (1..6{124})");
+            //    character.SendMessage("[TestTransfer] /test_transfer unitId (1..6{124})");
             //    return;
             //}
             //var transfer = new Transfer();
@@ -110,7 +107,7 @@ namespace AAEmu.Game.Scripts.Commands
             //owner.Spawn();
 
             //var transfer = new Transfer();
-            //transfer.TemplateId = owner.Template.TransferBindings[0].TransferId; // взять из owner transferId для второй части повозки
+            //transfer.TemplateId = owner.Template.TransferBindings[0].TransferId; // take from owner transferId for second wagon part
             //transfer.ModelId = transfer.Template.ModelId;
             //transfer.ObjId = ObjectIdManager.Instance.GetNextId();
             //transfer.TlId = (ushort)TlIdManager.Instance.GetNextId();

--- a/AAEmu.Game/Scripts/Commands/TestZoneState.cs
+++ b/AAEmu.Game/Scripts/Commands/TestZoneState.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
-using AAEmu.Game.Core.Managers.UnitManagers;
+﻿using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.World.Zones;
-using AAEmu.Game.Core.Packets.G2C;
 
 namespace AAEmu.Game.Scripts.Commands
 {
@@ -36,7 +31,7 @@ namespace AAEmu.Game.Scripts.Commands
                 foreach (var conflict in ZoneManager.Instance.GetConflicts())
                 {
                     var zonegroup = ZoneManager.Instance.GetZoneGroupById(conflict.ZoneGroupId);
-                    character.SendMessage("|cFFFFFFFF[ZoneState] |r ZoneGroup: " + zonegroup.Name + " (" + conflict.ZoneGroupId.ToString() + ") State: " + conflict.CurrentZoneState.ToString());
+                    character.SendMessage($"|cFFFFFFFF[ZoneState] |r ZoneGroup: {zonegroup.Name} ({conflict.ZoneGroupId}) State: {conflict.CurrentZoneState}");
 
                     /*
                     Connection.SendPacket(
@@ -68,20 +63,18 @@ namespace AAEmu.Game.Scripts.Commands
                     zonegroupid = (ushort)(thiszone.GroupId);
             }
 
-            if (zonegroupid > 0)
-            {
-                var zonegroup = ZoneManager.Instance.GetZoneGroupById(zonegroupid);
-                var zs = (ZoneConflictType)zonestate;
-
-                zonegroup.Conflict.SetState(zs);
-                //broadcast to all online clients in server
-                //WorldManager.Instance.BroadcastPacketToServer(new SCConflictZoneStatePacket(zonegroupid, (ZoneConflictType)zonestate, DateTime.MinValue));
-                character.SendMessage("|cFFFFFFFF[ZoneState] |rChanged ZoneGroup: " + zonegroupid.ToString() + " to State: " + zs.ToString());
-            }
-            else
+            if (zonegroupid == 0)
             {
                 character.SendMessage("|cFFFF0000[ZoneState] Invalid zone group id|r");
+                return;
             }
+
+            var zs = (ZoneConflictType)zonestate;
+
+            ZoneManager.Instance.GetZoneGroupById(zonegroupid).Conflict.SetState(zs);
+            // Broadcast to all online clients in server
+            // WorldManager.Instance.BroadcastPacketToServer(new SCConflictZoneStatePacket(zonegroupid, (ZoneConflictType)zonestate, DateTime.MinValue));
+            character.SendMessage($"|cFFFFFFFF[ZoneState] |rChanged ZoneGroup: {zonegroupid} to State: {zs}");
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/TickDoodad.cs
+++ b/AAEmu.Game/Scripts/Commands/TickDoodad.cs
@@ -1,22 +1,13 @@
 ﻿using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
 using AAEmu.Game.Core.Managers.World;
-using AAEmu.Game.Core.Managers.UnitManagers;
-using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.DoodadObj;
-using AAEmu.Game.Models.Game.NPChar;
-using AAEmu.Game.Models.Game.World;
-using AAEmu.Game.Utils;
-using NLog;
-using System;
 
 namespace AAEmu.Game.Scripts.Commands
 {
     public class TickDoodad : ICommand
     {
-        protected static Logger _log = LogManager.GetCurrentClassLogger();
         public void OnLoad()
         {
             CommandManager.Instance.Register("tickdoodad", this);
@@ -36,12 +27,12 @@ namespace AAEmu.Game.Scripts.Commands
         {
             if (args.Length < 1)
             {
-                character.SendMessage("[tickdoodad] " + CommandManager.CommandPrefix + "tickdoodad " + GetCommandLineHelp());
+                character.SendMessage($"[tickdoodad] {CommandManager.CommandPrefix}tickdoodad {GetCommandLineHelp()}");
                 return;
             }
 
             uint unitId;
-            float radius = 30f;
+            float radius = 30.0f;
             if (!uint.TryParse(args[0], out unitId))
             {
                 character.SendMessage("|cFFFF0000[tickdoodad] Parse error unitId|r");
@@ -62,7 +53,7 @@ namespace AAEmu.Game.Scripts.Commands
                     }
                 }
             }
-            character.SendMessage("[tickdoodad] phased {0} Doodad(s) with TemplateID {1} - @DOODAD_NAME({1})", tickedCount, unitId);
+            character.SendMessage($"[tickdoodad] phased {tickedCount} Doodad(s) with TemplateID {unitId} - @DOODAD_NAME({unitId})");
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/TowerDef.cs
+++ b/AAEmu.Game/Scripts/Commands/TowerDef.cs
@@ -3,7 +3,6 @@ using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.TowerDefs;
-using AAEmu.Game.Utils.Scripts;
 
 namespace AAEmu.Game.Scripts.Commands
 {
@@ -11,7 +10,8 @@ namespace AAEmu.Game.Scripts.Commands
     {
         public void OnLoad()
         {
-            CommandManager.Instance.Register(new []{"tower_def", "td", "towerdef"}, this);
+            string[] name = { "tower_def", "td", "towerdef" };
+            CommandManager.Instance.Register(name, this);
         }
 
         public string GetCommandLineHelp()
@@ -21,17 +21,18 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandHelpText()
         {
-            return "Actions are: list, start, end, next";
+            return "Actions are: list, start, end, next.";
         }
 
         public void Execute(Character character, string[] args)
         {
             if (args.Length == 0)
             {
-                character.SendMessage("[Tower Defense] Usage: " + CommandManager.CommandPrefix + "tower_def <action> <params>");
+                character.SendMessage($"[Tower Defense] Usage: {CommandManager.CommandPrefix}tower_def <action> <params>");
                 return;
             }
 
+            var zoneId = character.Transform.ZoneId;
             switch (args[0])
             {
                 case "list":
@@ -43,7 +44,7 @@ namespace AAEmu.Game.Scripts.Commands
                     {
                         TowerDefId = startId,
                         ZoneGroupId = 5
-                    }, character.Transform.ZoneId);
+                    }, zoneId);
                     character.SendPacket(startPacket);
                     break;
                 case "end":
@@ -53,7 +54,7 @@ namespace AAEmu.Game.Scripts.Commands
                     {
                         TowerDefId = endId,
                         ZoneGroupId = 5
-                    }, character.Transform.ZoneId);
+                    }, zoneId);
                     character.SendPacket(endPacket);
                     break;
                 case "next":
@@ -65,7 +66,7 @@ namespace AAEmu.Game.Scripts.Commands
                     {
                         TowerDefId = nextId,
                         ZoneGroupId = 5
-                    }, character.Transform.ZoneId, step);
+                    }, zoneId, step);
                     character.SendPacket(nextPacket);
                     break;
             }

--- a/AAEmu.Game/Scripts/Commands/UseSkill.cs
+++ b/AAEmu.Game/Scripts/Commands/UseSkill.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
@@ -35,11 +34,12 @@ namespace AAEmu.Game.Scripts.Commands
             Unit source = character;
             Unit target = character.CurrentTarget == null ? character : (Unit)character.CurrentTarget;
 
-            if (target == null) return;
+            if (target == null)
+                return;
 
             if (args.Length == 0)
             {
-                character.SendMessage("[UseSkill] " + CommandManager.CommandPrefix + "useskill [target] <SkillId>");
+                character.SendMessage($"[UseSkill] {CommandManager.CommandPrefix}useskill [target] <SkillId>");
                 return;
             }
 
@@ -81,7 +81,7 @@ namespace AAEmu.Game.Scripts.Commands
 
         private void DoAoe(Character character, SkillTemplate skill)
         {
-            foreach (var target in WorldManager.Instance.GetAround<Unit>(character, 20f))
+            foreach (var target in WorldManager.Instance.GetAround<Unit>(character, 20.0f))
             {
                 var casterObj = new SkillCasterUnit(target.ObjId);
                 var targetObj = SkillCastTarget.GetByType(SkillCastTargetType.Unit);

--- a/AAEmu.Game/Scripts/Commands/WipeAuctionHouse.cs
+++ b/AAEmu.Game/Scripts/Commands/WipeAuctionHouse.cs
@@ -1,11 +1,6 @@
-﻿using System.Collections.Generic;
-using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.Id;
-using AAEmu.Game.Core.Packets.G2C;
+﻿using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.Items.Actions;
-using AAEmu.Game.Core.Managers.World;
 
 namespace AAEmu.Game.Scripts.Commands
 {
@@ -13,27 +8,26 @@ namespace AAEmu.Game.Scripts.Commands
     {
         public void OnLoad()
         {
-            string[] name = { "wipeauctionhouse", "wipeah"};
+            string[] name = { "wipeauctionhouse", "wipeah" };
             CommandManager.Instance.Register(name, this);
         }
 
         public string GetCommandLineHelp()
         {
-            return "Deletes ALL Items from the AH. No going back from this.";
+            return "";
         }
 
         public string GetCommandHelpText()
         {
             return "Deletes ALL Items from the AH. No going back from this.";
         }
+
         public void Execute(Character character, string[] args)
         {
             AuctionManager.Instance.Load();
 
             foreach (var item in AuctionManager.Instance._auctionItems)
-            {
                 AuctionManager.Instance._deletedAuctionItemIds.Add((long)item.ID);
-            }
 
             AuctionManager.Instance._auctionItems.Clear();
             SaveManager.Instance.DoSave();

--- a/AAEmu.Game/Scripts/Commands/kits.json
+++ b/AAEmu.Game/Scripts/Commands/kits.json
@@ -1,31 +1,31 @@
 {
     "itemkits": [
-	//Consumables
-		{
+    //Consumables
+        {
             // Desert Fire
             "names": [ "consumables" ],
             "id": 19042,
             "count": 1000
         },
-		{
+        {
             // Nui's Nova
             "names": [ "consumables" ],
             "id": 19043,
             "count": 100
         },
-		{
+        {
             // Mossy Pool
             "names": [ "consumables" ],
             "id": 31775,
             "count": 1000
         },
-		{
+        {
             // Kraken's Might
             "names": [ "consumables" ],
             "id": 19041,
             "count": 100
         },
-		{
+        {
             // Expansion Scroll
             "names": [ "consumables" ],
             "id": 8000025,
@@ -82,7 +82,7 @@
             "count": 1
         },
 
-	// Mag Meadow Cloth
+    // Mag Meadow Cloth
         {
             // Mag Meadow Hood
             "names": [ "meadow_cloth" ],
@@ -948,253 +948,253 @@
             "grade": 5,
             "count": 1
         },
-	//Gliders
-	    {
+    //Gliders
+        {
             // Sloth Glider
             "names": [ "glider" ],
             "id": 30621,
             "count": 1
         },
-	    {
+        {
             // Red Dragon Glider 
             "names": [ "glider" ],
             "id": 18175,
             "count": 1
         },
-	    {
+        {
             // Ezi's Glider
             "names": [ "glider" ],
             "id": 18174,
             "count": 1
         },
-	    {
+        {
             // Legendary Dragon Wings
             "names": [ "glider" ],
             "id": 29039,
             "count": 1
         },
-	    {
+        {
             // Feathered Dragon Glider
             "names": [ "glider" ],
             "id": 18173,
             "count": 1
         },
 
-	//Accesories
-		{
-			// Magnificent Earth Necklace
-			"names": [ "accessories" ],
-			"id": 31619,
-			"grade": 5,
-			"count": 1
-		},
-		{
-			// Magnificent Flame Necklace
-			"names": [ "accessories" ],
-			"id": 31620,
-			"grade": 5,
-			"count": 1
-		},
-		{
-			// Magnificent Life Necklace
-			"names": [ "accessories" ],
-			"id": 31621,
-			"grade": 5,
-			"count": 1
-		},
-		{
-			// Magnificent Wind Necklace
-			"names": [ "accessories" ],
-			"id": 31622,
-			"grade": 5,
-			"count": 1
-		},
-		{
-			// Magnificent Wave Necklace
-			"names": [ "accessories" ],
-			"id": 31623,
-			"grade": 5,
-			"count": 1
-		},
-		{
-			// Magnificent Earth Earring
-			"names": [ "accessories" ],
-			"id": 31624,
-			"grade": 5,
-			"count": 1
-		},
-		{
-			// Magnificent Flame Earring
-			"names": [ "accessories" ],
-			"id": 31625,
-			"grade": 5,
-			"count": 1
-		},
-		{
-			// Magnificent Wind Earring
-			"names": [ "accessories" ],
-			"id": 31626,
-			"grade": 5,
-			"count": 1
-		},
-		{
-			// Magnificent Wave Earring
-			"names": [ "accessories" ],
-			"id": 31627,
-			"grade": 5,
-			"count": 1
-		},
-		{
-			// Magnificent Life Earring
-			"names": [ "accessories" ],
-			"id": 31628,
-			"grade": 5,
-			"count": 1
-		},
-		{
-			// Magnificent Earth Ring
-			"names": [ "accessories" ],
-			"id": 31629,
-			"grade": 5,
-			"count": 1
-		},
-		{
-			// Magnificent Flame Ring
-			"names": [ "accessories" ],
-			"id": 31630,
-			"grade": 5,
-			"count": 1
-		},
-		{
-			// Magnificent Wave Ring
-			"names": [ "accessories" ],
-			"id": 31631,
-			"grade": 5,
-			"count": 1
-		},
-		{
-			// Magnificent Wind Ring
-			"names": [ "accessories" ],
-			"id": 31632,
-			"grade": 5,
-			"count": 1
-		},
-		{
-			// Magnificent Life Ring	
-			"names": [ "accessories" ],
-			"id": 31633,
-			"grade": 5,
-			"count": 1
-		},
-		
-	//Weapon Kit
-	    {
+    //Accesories
+        {
+            // Magnificent Earth Necklace
+            "names": [ "accessories" ],
+            "id": 31619,
+            "grade": 5,
+            "count": 1
+        },
+        {
+            // Magnificent Flame Necklace
+            "names": [ "accessories" ],
+            "id": 31620,
+            "grade": 5,
+            "count": 1
+        },
+        {
+            // Magnificent Life Necklace
+            "names": [ "accessories" ],
+            "id": 31621,
+            "grade": 5,
+            "count": 1
+        },
+        {
+            // Magnificent Wind Necklace
+            "names": [ "accessories" ],
+            "id": 31622,
+            "grade": 5,
+            "count": 1
+        },
+        {
+            // Magnificent Wave Necklace
+            "names": [ "accessories" ],
+            "id": 31623,
+            "grade": 5,
+            "count": 1
+        },
+        {
+            // Magnificent Earth Earring
+            "names": [ "accessories" ],
+            "id": 31624,
+            "grade": 5,
+            "count": 1
+        },
+        {
+            // Magnificent Flame Earring
+            "names": [ "accessories" ],
+            "id": 31625,
+            "grade": 5,
+            "count": 1
+        },
+        {
+            // Magnificent Wind Earring
+            "names": [ "accessories" ],
+            "id": 31626,
+            "grade": 5,
+            "count": 1
+        },
+        {
+            // Magnificent Wave Earring
+            "names": [ "accessories" ],
+            "id": 31627,
+            "grade": 5,
+            "count": 1
+        },
+        {
+            // Magnificent Life Earring
+            "names": [ "accessories" ],
+            "id": 31628,
+            "grade": 5,
+            "count": 1
+        },
+        {
+            // Magnificent Earth Ring
+            "names": [ "accessories" ],
+            "id": 31629,
+            "grade": 5,
+            "count": 1
+        },
+        {
+            // Magnificent Flame Ring
+            "names": [ "accessories" ],
+            "id": 31630,
+            "grade": 5,
+            "count": 1
+        },
+        {
+            // Magnificent Wave Ring
+            "names": [ "accessories" ],
+            "id": 31631,
+            "grade": 5,
+            "count": 1
+        },
+        {
+            // Magnificent Wind Ring
+            "names": [ "accessories" ],
+            "id": 31632,
+            "grade": 5,
+            "count": 1
+        },
+        {
+            // Magnificent Life Ring	
+            "names": [ "accessories" ],
+            "id": 31633,
+            "grade": 5,
+            "count": 1
+        },
+        
+    //Weapon Kit
+        {
             // Mag Flame Nodachi
             "names": [ "2hmelee" ],
             "id": 20285,
             "grade": 5,
             "count": 1
         },		
-	    {
+        {
             // Mag Lightning Nodachi
             "names": [ "2hmelee" ],
             "id": 20284,
             "grade": 5,
             "count": 1
         },
-	    {
+        {
             // Mag Gale Nodachi
             "names": [ "2hmelee" ],
             "id": 20286,
             "grade": 5,
             "count": 1
         },
-	    {
+        {
             // Mag Flame Greatsword
             "names": [ "2hmelee" ],
             "id": 20245,
             "grade": 5,
             "count": 1
         },
-	    {
+        {
             // Mag Meadow Staff
             "names": [ "2hmagic" ],
             "id": 20437,
             "grade": 5,
             "count": 1
         },
-	    {
+        {
             // Mag Desert Sword
             "names": [ "1hmelee" ],
             "id": 20223,
             "grade": 5,
             "count": 1
         },
-	    {
+        {
             // Mag Squall Dagger
             "names": [ "1hmelee" ],
             "id": 20196,
             "grade": 5,
             "count": 1
         },
-	    {
+        {
             // Mag Wave Scepter
             "names": [ "1hmagic" ],
             "id": 20418,
             "grade": 5,
             "count": 1
         },
-	    {
+        {
             // Obsidian Club
             "names": [ "1hclub" ],
             "id": 34609,
             "grade": 5,
             "count": 1
         },
-	//Shields
-	    {
-			// Magnificent Quake Shield
-			"names": [ "shields" ],
-			"id": 20528,
-			"grade": 5,
-			"count": 1
-		},
-		{
-			// Magnificent Desert Shield
-			"names": [ "shields" ],
-			"id": 20529,
-			"grade": 5,
-			"count": 1
-		},
-		{
-			// Magnificent Lake Shield
-			"names": [ "shields" ],
-			"id": 20530,
-			"grade": 5,
-			"count": 1
-		},
-	    {
+    //Shields
+        {
+            // Magnificent Quake Shield
+            "names": [ "shields" ],
+            "id": 20528,
+            "grade": 5,
+            "count": 1
+        },
+        {
+            // Magnificent Desert Shield
+            "names": [ "shields" ],
+            "id": 20529,
+            "grade": 5,
+            "count": 1
+        },
+        {
+            // Magnificent Lake Shield
+            "names": [ "shields" ],
+            "id": 20530,
+            "grade": 5,
+            "count": 1
+        },
+        {
             // Mag Volcano Bow
             "names": [ "bow" ],
             "id": 20462,
             "grade": 5,
             "count": 1
         },
-	    {
+        {
             // Mag Lightning Bow
             "names": [ "bow" ],
             "id": 20463,
             "grade": 5,
             "count": 1
         },
-	    {
+        {
             // Mag Tidal Bow
             "names": [ "bow" ],
             "id": 20464,
             "grade": 5,
             "count": 1
         },
-	    {
+        {
             // Mag Sunset Bow
             "names": [ "bow" ],
             "id": 20465,

--- a/AAEmu.Game/Scripts/Commands/teleports.json
+++ b/AAEmu.Game/Scripts/Commands/teleports.json
@@ -1,0 +1,440 @@
+{
+    "Teleports":
+    [
+        {
+            "Region": 1,
+            "Name": "cinderstone",
+            "Info": "Cinderstone Moor, Seachild Wharf",
+            "X": 15400,
+            "Y": 11543,
+            "Z": 107,
+            "AltNames": [ "cinder" ]
+        },
+        {
+            "Region": 1,
+            "Name": "dewstone",
+            "Info": "Dewstone Plains, Sandcloud",
+            "X": 12204,
+            "Y": 13305,
+            "Z": 178,
+            "AltNames": [ "dew" ]
+        },
+        {
+            "Region": 1,
+            "Name": "gweonid",
+            "Info": "Gweonid Forest, Memoria",
+            "X": 10604,
+            "Y": 14925,
+            "Z": 280,
+            "AltNames": [ "gwen" ]
+        },
+        {
+            "Region": 1,
+            "Name": "halcyona",
+            "Info": "Halcyona, Suns End",
+            "X": 9342,
+            "Y": 10321,
+            "Z": 187,
+            "AltNames": [ "halcy" ]
+        },
+        {
+            "Region": 1,
+            "Name": "hellswamp",
+            "Info": "Hellswamp, Anarchi",
+            "X": 7482,
+            "Y": 9853,
+            "Z": 189,
+            "AltNames": [ "hell" ]
+        },
+        {
+            "Region": 1,
+            "Name": "karkasse",
+            "Info": "Karkasse Ridgelands, Lavis",
+            "X": 10470,
+            "Y": 17346,
+            "Z": 186,
+            "AltNames": [ "kar", "karkase" ]
+        },
+        {
+            "Region": 1,
+            "Name": "lilyut",
+            "Info": "Lilyut Hills, Windshade",
+            "X": 12666,
+            "Y": 15520,
+            "Z": 165,
+            "AltNames": [ "lily", "lili" ]
+        },
+        {
+            "Region": 1,
+            "Name": "marianople",
+            "Info": "Marianople, Marianople",
+            "X": 11144,
+            "Y": 12066,
+            "Z": 145,
+            "AltNames": [ "maria", "west" ]
+        },
+        {
+            "Region": 1,
+            "Name": "sanddeep",
+            "Info": "Sanddeep, Golden Fable Harbor",
+            "X": 10720,
+            "Y": 9591,
+            "Z": 105,
+            "AltNames": [ "sand" ]
+        },
+        {
+            "Region": 1,
+            "Name": "solzreed",
+            "Info": "Solzreed Peninsula, Cresent Throne",
+            "X": 15369,
+            "Y": 13864,
+            "Z": 159,
+            "AltNames": [ "solz" ]
+        },
+        {
+            "Region": 1,
+            "Name": "twocrowns",
+            "Info": "Two Crowns, Ezna",
+            "X": 13500,
+            "Y": 10531,
+            "Z": 223,
+            "AltNames": [ "2c", "twoc" ]
+        },
+        {
+            "Region": 1,
+            "Name": "whitearden",
+            "Info": "White Arden, Birchkeep",
+            "X": 9682,
+            "Y": 12775,
+            "Z": 161,
+            "AltNames": [ "arden" ]
+        },
+        {
+            "Region": 0,
+            "Name": "arcumiris",
+            "Info": "Arcum Iris, Parchsun Settlement",
+            "X": 20509,
+            "Y": 7173,
+            "Z": 193,
+            "AltNames": [ "arcum" ]
+        },
+        {
+            "Region": 0,
+            "Name": "falcorth",
+            "Info": "Falcorth Plains, Oxion Clan",
+            "X": 23818,
+            "Y": 9102,
+            "Z": 589
+        },
+        {
+            "Region": 0,
+            "Name": "hasla",
+            "Info": "Hasla, Veroe",
+            "X": 30029,
+            "Y": 8760,
+            "Z": 539
+        },
+        {
+            "Region": 0,
+            "Name": "mahadevi",
+            "Info": "Mahadevi, City of Towers",
+            "X": 19284,
+            "Y": 8620,
+            "Z": 227,
+            "AltNames": [ "maha" ]
+        },
+        {
+            "Region": 0,
+            "Name": "perinoor",
+            "Info": "Perinor Ruins, Stonehew",
+            "X": 27787,
+            "Y": 6732,
+            "Z": 572,
+            "AltNames": [ "peri", "perinor" ]
+        },
+        {
+            "Region": 0,
+            "Name": "rookborne",
+            "Info": "Rookborne Basin, Watermist",
+            "X": 25388,
+            "Y": 9753,
+            "Z": 714,
+            "AltNames": [ "rook", "rookborn" ]
+        },
+        {
+            "Region": 0,
+            "Name": "silentforest",
+            "Info": "Silent Forest, Count Sebastians Retreat",
+            "X": 23306,
+            "Y": 12526,
+            "Z": 271,
+            "AltNames": [ "sf", "silent" ]
+        },
+        {
+            "Region": 0,
+            "Name": "solis",
+            "Info": "Solis Headlands, Austera",
+            "X": 16743,
+            "Y": 9018,
+            "Z": 120,
+            "AltNames": [ "austera", "east" ]
+        },
+        {
+            "Region": 0,
+            "Name": "tigerspine",
+            "Info": "Tigerspine Mountains, Anvilton",
+            "X": 21772,
+            "Y": 8089,
+            "Z": 404,
+            "AltNames": [ "tiger" ]
+        },
+        {
+            "Region": 0,
+            "Name": "villanelle",
+            "Info": "Villanelle, Lutesong Harbor",
+            "X": 21178,
+            "Y": 10604,
+            "Z": 119,
+            "AltNames": [ "villa" ]
+        },
+        {
+            "Region": 0,
+            "Name": "windscour",
+            "Info": "Windscour Savanah, Skyfang",
+            "X": 25926,
+            "Y": 6855,
+            "Z": 362,
+            "AltNames": [ "windscoure", "ws" ]
+        },
+        {
+            "Region": 0,
+            "Name": "ynyster",
+            "Info": "Ynystere, Caernord",
+            "X": 20931,
+            "Y": 13158,
+            "Z": 116,
+            "AltNames": [ "yny" ]
+        },
+        // Auroria
+        {
+            "Region": 2,
+            "Name": "calmlands",
+            "Info": "Calmlands",
+            "X": 22349,
+            "Y": 24941,
+            "Z": 189
+        },
+        {
+            "Region": 2,
+            "Name": "diamondshores",
+            "Info": "Diamond Shores",
+            "X": 19332,
+            "Y": 26883,
+            "Z": 130,
+            "AltNames": [ "ds", "auroria", "origin" ]
+        },
+        {
+            "Region": 2,
+            "Name": "exeloch",
+            "Info": "Exeloch",
+            "X": 22349,
+            "Y": 24941,
+            "Z": 189,
+            "AltNames": [ "exe" ]
+        },
+        {
+            "Region": 2,
+            "Name": "goldenruins",
+            "Info": "Golden Ruins",
+            "X": 17230,
+            "Y": 27501,
+            "Z": 141,
+            "AltNames": [ "golden" ]
+        },
+        {
+            "Region": 2,
+            "Name": "heedmar",
+            "Info": "Heedmar",
+            "X": 20110,
+            "Y": 24568,
+            "Z": 156
+        },
+        {
+            "Region": 2,
+            "Name": "marcala",
+            "Info": "Marcala",
+            "X": 20140,
+            "Y": 24768,
+            "Z": 189
+        },
+        {
+            "Region": 2,
+            "Name": "nuimari",
+            "Info": "Nuimari",
+            "X": 21731,
+            "Y": 23751,
+            "Z": 146
+        },
+        {
+            "Region": 2,
+            "Name": "reedwind",
+            "Info": "Reedwind",
+            "X": 19628,
+            "Y": 28339,
+            "Z": 295
+        },
+        {
+            "Region": 2,
+            "Name": "sungold",
+            "Info": "Sungold Fields",
+            "X": 22349,
+            "Y": 24941,
+            "Z": 189
+        },
+        // new TPloc { "Region": TeleReg.Origin, "Name": "whalesong", "Info": "Whalesong Harbor", "X": 14436, "Y": 26696, "Z": 135, "AltNames": ("whale"} },
+        // Others
+        // new TPloc { "Region": TeleReg.Other, "Name": "aegisisland", "Info": "Aegis Island", "X": 14436, "Y": 26696, "Z": 134, "AltNames": ("aegis"} },
+        {
+            "Region": 4,
+            "Name": "freedich",
+            "Info": "Sunspeck Sea, Freedich Island",
+            "X": 20944,
+            "Y": 18799,
+            "Z": 134,
+            "AltNames": [ "freeditch", "free" ]
+        },
+        {
+            "Region": 4,
+            "Name": "growlgate",
+            "Info": "Stormraw Sound, Growlgate Island",
+            "X": 15138,
+            "Y": 22983,
+            "Z": 105,
+            "AltNames": [ "pirate" ]
+        },
+        {
+            "Region": 4,
+            "Name": "ynys",
+            "Info": "Arcadian Sea, Ynys Island, Docks",
+            "X": 16570,
+            "Y": 14885,
+            "Z": 102
+        },
+        {
+            "Region": 4,
+            "Name": "nuiajail",
+            "Info": "Marianople, Guard Barracks",
+            "X": 10860,
+            "Y": 11950,
+            "Z": 132,
+            "AltNames": [ "nuianjail", "westjail" ]
+        },
+        {
+            "Region": 4,
+            "Name": "haranyajail",
+            "Info": "Solis Headlands, Isle of Penance",
+            "X": 17000,
+            "Y": 9566,
+            "Z": 135,
+            "AltNames": [ "haranijail", "eastjail" ]
+        },
+        {
+            "Region": 4,
+            "Name": "nuian",
+            "Info": "Solzreed, Nuian Starter Area", 
+            "X": 15578,
+            "Y": 15382,
+            "Z": 128
+        },
+        {
+            "Region": 4,
+            "Name": "elf",
+            "Info": "Gweonid Forest, Elven Starter Area", 
+            "X": 10388,
+            "Y": 15982,
+            "Z": 370
+        },
+        {
+            "Region": 4,
+            "Name": "harani",
+            "Info": "Arcum Iris, Harani Starting Area",
+            "X": 19304,
+            "Y": 7646,
+            "Z": 215,
+            "AltNames": [ "harihana" ]
+        },
+        {
+            "Region": 4,
+            "Name": "firran",
+            "Info": "Falcorth Plains, Firran Starting Area",
+            "X": 23881,
+            "Y": 10495,
+            "Z": 592,
+            "AltNames": [ "ferre" ]
+        },
+        // Dungeons
+        {
+            "Region": 3,
+            "Name": "sharpwind",
+            "Info": "Dewstone Plains, Sharpwind Mines",
+            "X": 11375,
+            "Y": 13135,
+            "Z": 146,
+            "AltNames": [ "sm", "gsm", "mines" ]
+        },
+        {
+            "Region": 3,
+            "Name": "burnt",
+            "Info": "Cinderstone, Burnt Castle Armory",
+            "X": 15683,
+            "Y": 12590,
+            "Z": 170,
+            "AltNames": [ "bc", "bca", "gbc", "castle", "orchidna" ]
+        },
+        {
+            "Region": 3,
+            "Name": "cellar",
+            "Info": "Mahadevi, City of Towers, Palace Cellar",
+            "X": 19317,
+            "Y": 8512,
+            "Z": 198,
+            "AltNames": [ "pc", "gpc", "sewer" ]
+        },
+        {
+            "Region": 3,
+            "Name": "hadir",
+            "Info": "Ynystere, Hadir Farm",
+            "X": 20022,
+            "Y": 12777,
+            "Z": 140,
+            "AltNames": [ "hf", "ghf", "farm" ]
+        },
+        {
+            "Region": 3,
+            "Name": "cradle",
+            "Info": "Rookborne Basin, Kroloal Cradle",
+            "X": 26862,
+            "Y": 9042,
+            "Z": 777,
+            "AltNames": [ "kc", "gkc", "kroloal", "kroloa", "koala" ]
+        },
+        {
+            "Region": 3,
+            "Name": "abyss",
+            "Info": "Hellswamp, Howling Abyss",
+            "X": 7800,
+            "Y": 10315,
+            "Z": 251,
+            "AltNames": [ "ha", "gha", "howling" ]
+        },
+        {
+            "Region": 3,
+            "Name": "serpentis",
+            "Info": "Exeloch, Serpentis",
+            "X": 23041,
+            "Y": 25848,
+            "Z": 142,
+            "AltNames": [ "snake", "snek" ]
+        }
+    ]
+}

--- a/AAEmu.Game/Utils/DB/SQLite.cs
+++ b/AAEmu.Game/Utils/DB/SQLite.cs
@@ -25,7 +25,7 @@ namespace AAEmu.Game.Utils.DB
             }
             catch (Exception e)
             {
-                _log.Error(e,"Error on SQLite connect: {0}", e.Message);
+                _log.Error(e,"Error connecting to SQLite: {0}", e.Message);
                 return null;
             }
 

--- a/AAEmu.Game/Utils/MathUtil.cs
+++ b/AAEmu.Game/Utils/MathUtil.cs
@@ -338,16 +338,16 @@ namespace AAEmu.Game.Utils
 
         public static Vector3 GetVectorFromQuat(Quaternion quat)
         {
-                double sqw = quat.W*quat.W;
-                double sqx = quat.X*quat.X;
-                double sqy = quat.Y*quat.Y;
-                double sqz = quat.Z*quat.Z;
-                
-                var rotX = (float)Math.Atan2(2.0 * (quat.X*quat.Y + quat.Z*quat.W),(sqx - sqy - sqz + sqw));
-                var rotY = (float)Math.Atan2(2.0 * (quat.Y*quat.Z + quat.X*quat.W),(-sqx - sqy + sqz + sqw));
-                var rotZ = (float)Math.Asin(-2.0 * (quat.X*quat.Z - quat.Y*quat.W)/(sqx + sqy + sqz + sqw));
+            double sqw = quat.W*quat.W;
+            double sqx = quat.X*quat.X;
+            double sqy = quat.Y*quat.Y;
+            double sqz = quat.Z*quat.Z;
+            
+            var rotX = (float)Math.Atan2(2.0 * (quat.X*quat.Y + quat.Z*quat.W),(sqx - sqy - sqz + sqw));
+            var rotY = (float)Math.Atan2(2.0 * (quat.Y*quat.Z + quat.X*quat.W),(-sqx - sqy + sqz + sqw));
+            var rotZ = (float)Math.Asin(-2.0 * (quat.X*quat.Z - quat.Y*quat.W)/(sqx + sqy + sqz + sqw));
 
-                return new Vector3(rotX, rotY, rotZ);
+            return new Vector3(rotX, rotY, rotZ);
         }
 
         private const double Pi = 3.14159;

--- a/AAEmu.Game/Utils/MathUtil.cs
+++ b/AAEmu.Game/Utils/MathUtil.cs
@@ -342,7 +342,7 @@ namespace AAEmu.Game.Utils
             double sqx = quat.X*quat.X;
             double sqy = quat.Y*quat.Y;
             double sqz = quat.Z*quat.Z;
-            
+
             var rotX = (float)Math.Atan2(2.0 * (quat.X*quat.Y + quat.Z*quat.W),(sqx - sqy - sqz + sqw));
             var rotY = (float)Math.Atan2(2.0 * (quat.Y*quat.Z + quat.X*quat.W),(-sqx - sqy + sqz + sqw));
             var rotZ = (float)Math.Asin(-2.0 * (quat.X*quat.Z - quat.Y*quat.W)/(sqx + sqy + sqz + sqw));

--- a/AAEmu.Game/Utils/Scripts/ScriptCompiler.cs
+++ b/AAEmu.Game/Utils/Scripts/ScriptCompiler.cs
@@ -16,6 +16,7 @@ namespace AAEmu.Game.Utils.Scripts
     public static class ScriptCompiler
     {
         private static readonly Logger _log = LogManager.GetCurrentClassLogger();
+        
         private static Assembly _assembly;
         private static Dictionary<string, ScriptObject> _scriptsObjects = new Dictionary<string, ScriptObject>();
 
@@ -75,7 +76,7 @@ namespace AAEmu.Game.Utils.Scripts
 
             if (files.Length == 0)
             {
-                _log.Info("Compile done (no files found)");
+                _log.Info("Compile success (no files found)");
                 assembly = null;
                 return true;
             }
@@ -116,7 +117,7 @@ namespace AAEmu.Game.Utils.Scripts
             bool res = true;
             if (diagnostics.Length == 0)
             {
-                _log.Info("Compile done (0 errors, 0 warnings)");
+                _log.Info("Compile success (0 errors, 0 warnings)");
             }
             else
             {
@@ -129,7 +130,7 @@ namespace AAEmu.Game.Utils.Scripts
                     _log.Error("Compile failed ({0} errors, {1} warnings)", errorCount, warningCount);
                 }
                 else
-                    _log.Info("Compile done ({0} errors, {1} warnings)", errorCount, warningCount);
+                    _log.Info("Compile success ({0} errors, {1} warnings)", errorCount, warningCount);
 
                 var result = diagnostics.Where(diagnostic =>
                     diagnostic.Severity == DiagnosticSeverity.Error ||


### PR DESCRIPTION
This code is purely clean up but because I shifted some code around it requires it to be read through.

I included an oddity into this PR where AAEmu.Game.Scripts.Commands.Teleport.cs initializes itself with a json instead of hard coded teleport locations. This needs reviewed, too.

I need to revisit WaterEdit.cs because I lazily skipped over it because bed time.

```
Did the following:

- String cleanup/grammar/translation
- Code cleanup
- Comment cleanup
- Import cleanup
- Code tweaks for guard clauses
- Prioritized use of $"{...}" when it made sense
- Fixed reinventing the wheel many times with string.Join
- Switched to 0.0f format floats
- Prioritized use of StringBuilder where available
- In-lined some functions which were not inlined for some reason
- Reordered some variable by when they were first used
- Reduced verbosity
- Converted several tabs to spaces
- Removed useless tabs because repo code convention has pits
- Reordered functions in scripts to match style
- Variables whose values were used to determine type are strongly typed
- Removed weird cases where packages were specified when pointless
- AAEmu.Game.Scripts.Commands.Teleport.cs:
  - Created teleports.json to hold teleports
  - Is reloadable but didn't implement a reload argument
```