### PR TITLE
[Game] Add support for dyeing of gear

### DIFF
--- a/AAEmu.Game/Models/Game/Items/EquipItem.cs
+++ b/AAEmu.Game/Models/Game/Items/EquipItem.cs
@@ -23,6 +23,11 @@ public class EquipItem : Item
     public virtual int Spi => 0;
     public virtual byte MaxDurability => 0;
 
+    /// <summary>
+    /// The item ID of the dye pot that was used on the equipment.
+    /// </summary>
+    public uint DyeItemId { get; set; }
+
     public int RepairCost
     {
         get
@@ -47,6 +52,7 @@ public class EquipItem : Item
     public EquipItem(ulong id, ItemTemplate template, int count) : base(id, template, count)
     {
         GemIds = new uint[7];
+        DyeItemId = ((EquipItemTemplate)Template).DefaultDyeItemId;
     }
 
     public override void Read(PacketStream stream)
@@ -80,7 +86,7 @@ public class EquipItem : Item
         RuneId = stream.ReadUInt32();
 
         ChargeStartTime = stream.ReadDateTime();
-        stream.ReadBytes(4);
+        DyeItemId = stream.ReadUInt32();
 
         for (var i = 0; i < GemIds.Length; i++)
             GemIds[i] = stream.ReadUInt32();
@@ -97,7 +103,7 @@ public class EquipItem : Item
         stream.Write(RuneId);
 
         stream.Write(Template.BindType == ItemBindType.BindOnUnpack ? UnpackTime : ChargeStartTime);
-        stream.Write((uint)0);
+        stream.Write(DyeItemId);
 
         foreach (var gemId in GemIds)
             stream.Write(gemId);

--- a/AAEmu.Game/Models/Game/Items/Templates/EquipItemTemplate.cs
+++ b/AAEmu.Game/Models/Game/Items/Templates/EquipItemTemplate.cs
@@ -14,4 +14,5 @@ public class EquipItemTemplate : ItemTemplate
     public int ChargeCount { get; set; } // does not seem to be actually used anywhere in the DB
     public ItemLookConvert ItemLookConvert { get; set; }
     public uint EquipItemSetId { get; set; }
+    public uint DefaultDyeItemId { get; set; }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/Dyeing.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/Dyeing.cs
@@ -1,6 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Items.Actions;
+using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects.SpecialEffects;
@@ -20,7 +25,27 @@ public class Dyeing : SpecialEffectAction
         int value3,
         int value4)
     {
-        // TODO ...
         if (caster is Character) { Logger.Debug("Special effects: Dyeing value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4); }
+
+        // TODO: Should check whether the item being dyed is actually dyeable (listed in dyeable_items table).
+
+        var owner = (Character)caster;
+        var skillItem = casterObj as SkillItem;
+        var skillTargetItem = (SkillCastItemTarget)targetObj;
+        var targetItem = owner.Inventory.GetItemById(skillTargetItem.Id);
+        var equipItem = (EquipItem)targetItem;
+
+        // Check the item used is in the Dye (33) category.
+        // Could alternatively look up the item template ID in the item_dyeings table to verify it can be used as a dye.
+        var template = ItemManager.Instance.GetTemplate(skillItem.ItemTemplateId);
+        if (template.CategoryId != 33)
+        {
+            Logger.Warn($"{owner.Name} tried to dye with a non-dye item - item id {skillItem.ItemId} and template id {skillItem.ItemTemplateId}");
+            return;
+        }
+
+        equipItem.DyeItemId = skillItem.ItemTemplateId;
+
+        owner.SendPacket(new SCItemTaskSuccessPacket(ItemTaskType.Dyeing, [new ItemUpdate(equipItem)], new List<ulong>()));
     }
 }


### PR DESCRIPTION
Items that are dyeable, for example the Griffin Guard Uniform (29021), previously would not be shown with a dye dot in the corner of the icon, and would have the wrong colour applied.

The table `dyeable_items` contains the mapping from dyeable item ID to its default dye colour. In the case of the Griffin Guard Uniform, `dyeable_items` gives the default dye as the Purple Pigment item (28238), which matches the expected colour: https://archeage.fandom.com/wiki/Griffin_Guard_Uniform?file=Griffin_Guard_Uniform.jpg

This PR applies the default dye colour to newly-created dyeable items, as well as allowing dyeing to work by implementing the `Dyeing` `SpecialEffectAction`.

There is an outstanding to-do to check the item being dyed is allowed to be dyed (though the client doesn't allow this to happen anyway).

Existing items on your character or in your inventory will continue to be undyed, but dyes can now be used on them.

![image](https://github.com/AAEmu/AAEmu/assets/32184718/1e1d3ef2-3849-4152-bd5f-05630ccd4a36)
![image](https://github.com/AAEmu/AAEmu/assets/32184718/e77f0281-ef75-45f7-929b-b918ae8b3834)

