### PR TITLE
Add links for compact.sqlite3 to container docs

### DIFF
--- a/Docs/Docker-Installation-Guide.md
+++ b/Docs/Docker-Installation-Guide.md
@@ -4,7 +4,7 @@ We made this little docker installation script in powershell or bash - depending
 - New people to this project who wants a server to run quicker and with less headache even if it's easy if you know your basics.
 
 ## Prerequisites
-Get the **compact.sqlite3** server database and the **game_pak** of the ArcheAge client version you are using. And put them where the script tell you too.
+Get the **compact.sqlite3** server database ([Google Drive](https://drive.google.com/file/d/18Nm_Q7OgWOfdw_8Xl4TBXa1Z51uGHEIh/view) or [MEGA](https://mega.nz/file/ujhFAaIS#disveSrjdUVjY9mZ3Q2xJ2b7I4te2gwbKnzMYD8HLZ4)) and the **game_pak** of the ArcheAge client version you are using. And put them where the script tell you too.
 
 **Windows**:
 - Git : https://git-scm.com/downloads


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Just adding links for compact.sqlite3 that were missing from the docker docs.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Main motivation is to reduce the friction in setting up AAEmu using docker containers. Even if by a little bit.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (any changes that deal with code organization, code flow, logic, decoupling, etc.)
- [ ] Optimization ()
- [x] Documentation Update (self explanatory)
- [ ] Misc Tasks (Repo organization, maintenance and other tasks that don't fit any of the above)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
