### PR TITLE
[Game] Added support for taming nets

### DIFF
--- a/AAEmu.Game/Core/Managers/UnitManagers/NpcManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/NpcManager.cs
@@ -467,7 +467,7 @@ public class NpcManager : Singleton<NpcManager>
                         template.ShowNameTag = reader.GetBoolean("show_name_tag", true);
                         template.VisibleToCreatorOnly = reader.GetBoolean("visible_to_creator_only", true);
                         template.NoExp = reader.GetBoolean("no_exp", true);
-                        template.PetItemId = reader.GetInt32("pet_item_id", 0);
+                        template.PetItemId = reader.GetUInt32("pet_item_id", 0);
                         template.BaseSkillId = reader.GetInt32("base_skill_id");
                         template.TrackFriendship = reader.GetBoolean("track_friendship", true);
                         template.Priest = reader.GetBoolean("priest", true);

--- a/AAEmu.Game/Core/Packets/G2C/SCAiAggroPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCAiAggroPacket.cs
@@ -8,14 +8,18 @@ public class SCAiAggroPacket : GamePacket
     private readonly uint _npcId;
     private readonly int _count;
     private readonly uint _hostileUnitId;
-    private readonly int _value;
+    private readonly int _summarizeDamage;
+    private readonly int _value2;
+    private readonly int _value3;
 
-    public SCAiAggroPacket(uint npcId, int count, uint hostileUnitId = 0, int summarizeDamage = 0) : base(SCOffsets.SCAiAggroPacket, 1)
+    public SCAiAggroPacket(uint npcId, int count, uint hostileUnitId = 0, int summarizeDamage = 0, int val2 = 0, int val3 = 0) : base(SCOffsets.SCAiAggroPacket, 1)
     {
         _npcId = npcId;
         _count = count;
         _hostileUnitId = hostileUnitId;
-        _value = summarizeDamage;
+        _summarizeDamage = summarizeDamage;
+        _value2 = val2;
+        _value3 = val3;
     }
 
     public override PacketStream Write(PacketStream stream)
@@ -26,9 +30,9 @@ public class SCAiAggroPacket : GamePacket
         if (_count > 0)
         {
             stream.WriteBc(_hostileUnitId);
-            stream.Write(_value); // value 
-            stream.Write(0);   // value
-            stream.Write(0);   // value
+            stream.Write(_summarizeDamage); // value1 
+            stream.Write(_value2);   // value2
+            stream.Write(_value3);   // value3
             stream.Write((byte)135); // topFlags
 
             /*

--- a/AAEmu.Game/Models/Game/NPChar/Npc.cs
+++ b/AAEmu.Game/Models/Game/NPChar/Npc.cs
@@ -1076,6 +1076,9 @@ public partial class Npc : Unit
                 if (!player.Quests.IsQuestComplete(Template.EngageCombatGiveQuestId) && !player.Quests.HasQuest(Template.EngageCombatGiveQuestId))
                     player.Quests.AddQuest(Template.EngageCombatGiveQuestId);
             }
+            
+            // Send initial hit packet as well
+            unit.SendPacketToPlayers([this, unit], new SCCombatFirstHitPacket(this.ObjId, unit.ObjId, 0));
         }
 
         if (player == null)

--- a/AAEmu.Game/Models/Game/NPChar/NpcTemplate.cs
+++ b/AAEmu.Game/Models/Game/NPChar/NpcTemplate.cs
@@ -27,7 +27,7 @@ public class NpcTemplate
     public bool ShowNameTag { get; set; }
     public bool VisibleToCreatorOnly { get; set; }
     public bool NoExp { get; set; }
-    public int PetItemId { get; set; }
+    public uint PetItemId { get; set; }
     public int BaseSkillId { get; set; }
     public bool TrackFriendship { get; set; }
     public bool Priest { get; set; }

--- a/AAEmu.Game/Models/Game/Skills/Effects/AggroEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/AggroEffect.cs
@@ -67,7 +67,7 @@ public class AggroEffect : EffectTemplate
         }
 
         var value = (int)Rand.Next(min, max);
-        npc.SendPacketToPlayers([caster, npc], new SCAiAggroPacket(npc.ObjId, 1, caster.ObjId, value));
+        npc.SendPacketToPlayers([caster, npc], new SCAiAggroPacket(npc.ObjId, 1, caster.ObjId, value, 0 , 0));
         npc.AddUnitAggro(AggroKind.Damage, character, value);
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/DamageEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/DamageEffect.cs
@@ -416,12 +416,10 @@ public class DamageEffect : EffectTemplate
             packetBuilder.AddPacket(packet);
         else
             trg.BroadcastPacket(packet, true);
-        if (trg is Npc)
+
+        if (trg is Npc npc)
         {
-            trg.SendPacketToPlayers([trg, caster], new SCAiAggroPacket(trg.ObjId, 1, caster.ObjId, ((Unit)caster).SummarizeDamage));
-        }
-        if (trg is Npc npc/* && npc.CurrentTarget != caster*/)
-        {
+            trg.SendPacketToPlayers([trg, caster], new SCAiAggroPacket(trg.ObjId, 1, caster.ObjId, ((Unit)caster).SummarizeDamage, 0, 0));
             npc.OnDamageReceived((Unit)caster, value);
         }
 

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/ApplyReagents.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/ApplyReagents.cs
@@ -35,5 +35,10 @@ public class ApplyReagents : SpecialEffectAction
                 player.Inventory.Bag.ConsumeItem(Items.Actions.ItemTaskType.SkillReagents, reagent.ItemId, reagent.Amount, null);
             }
         }
+        else if (casterObj is SkillItem item)
+        {
+            var player = (Character)caster;
+            player.Inventory.Bag.ConsumeItem(Items.Actions.ItemTaskType.SkillReagents, item.ItemTemplateId, 1, null);
+        }
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/CapturePet.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/CapturePet.cs
@@ -1,12 +1,18 @@
 ﻿using System;
-
+using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Items.Actions;
+using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.Game.Units.Static;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects.SpecialEffects;
 
 public class CapturePet : SpecialEffectAction
 {
+    protected override SpecialType SpecialEffectActionType => SpecialType.CapturePet;
+    
     public override void Execute(BaseUnit caster,
         SkillCaster casterObj,
         BaseUnit target,
@@ -20,7 +26,79 @@ public class CapturePet : SpecialEffectAction
         int value3,
         int value4)
     {
-        // TODO ...
-        if (caster is Character) { Logger.Debug("Special effects: CapturePet value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4); }
+        // Only players are allowed to capture pets
+        if (caster is not Character player)
+            return; 
+
+        Logger.Debug("Special effects: CapturePet value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4);
+
+        // Need to grab the actual target from the buff owner itself, as target will be the player in this case
+        BaseUnit targetObject = null;
+        if (castObj is CastBuff castBuff)
+        {
+            targetObject = castBuff.Buff.Owner;
+        }
+        
+        if (targetObject is not Npc targetNpc)
+        {
+            Logger.Warn($"Special effects: CapturePet {player.Name} tried to capture a non-Npc");
+            return;
+        }
+        
+        // TODO: Verify Target Buffs
+        // 6675 Capture-able target (tag 1304)
+        
+        // TODO: Verify Target NPC Grade
+
+        // TODO: Currently hard-coded since I can't find any table with this information
+        // You could add things here if you make new pet items for them, and add the current passive buffs to the NPCs
+        var captureItem = 0u;
+        switch (targetNpc.TemplateId)
+        {
+            case 2048: // Giant Queen Bee Lv26
+            case 3494: // Queen Bee Lv7
+            case 8561: // Queen Bee Lv18
+            case 13621: // Queen Bee Lv10
+                captureItem = 28483; // Nymphal Queen Bee
+                break;
+            case 7978: // Windlord
+                captureItem = 27203; // Captive Windlord
+                break;
+            case 8181: // Flamelord
+                captureItem = 27204; // Captive Flamelord
+                break;
+            case 8123: // Farkrag the Wanderer
+                captureItem = 27205; // Captive Farkrag the Wanderer
+                break;
+            case 5985: // Daruda the Watcher
+                captureItem = 27207; // Captive Daruda the Watcher
+                break;
+            case 5984: // Tarian the Grim
+                captureItem = 27209; // Captive Tarian the Grim
+                break;
+            case 6446: // Gatekeeper Harrod (final form)
+                captureItem = 27210; // Captive Harrod the Gatekeeper
+                break;
+        }
+
+        // If valid target
+        if (captureItem > 0)
+        {
+            // And player can get the item
+            if (!player.Inventory.Bag.AcquireDefaultItem(ItemTaskType.CapturePet, captureItem, 1))
+            {
+                player.SendErrorMessage(ErrorMessageType.BagFull);
+                return;
+            }
+
+            // Capture (kill) the target
+            targetNpc.ReduceCurrentHp(player, targetNpc.MaxHp, KillReason.Capture);
+            // Immediately despawn it
+            targetNpc.DoDespawn(targetNpc);
+        }
+        else
+        {
+            player.SendMessage($"Unable to capture this target yet, take a screenshot of this, and inform the developers. NPC {targetNpc.TemplateId}");
+        }
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/CapturePet.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/CapturePet.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using AAEmu.Game.Core.Managers.World;
-using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Items.Actions;
 using AAEmu.Game.Models.Game.NPChar;
@@ -50,42 +49,17 @@ public class CapturePet : SpecialEffectAction
         
         // TODO: Verify Target NPC Grade
 
-        // TODO: Currently hard-coded since I can't find any table with this information
-        // You could add things here if you make new pet items for them, and add the current passive buffs to the NPCs
-        var captureItem = 0u;
-        switch (targetNpc.TemplateId)
-        {
-            case 2048: // Giant Queen Bee Lv26
-            case 3494: // Queen Bee Lv7
-            case 8561: // Queen Bee Lv18
-            case 13621: // Queen Bee Lv10
-                captureItem = 28483; // Nymphal Queen Bee
-                break;
-            case 7978: // Windlord
-                captureItem = 27203; // Captive Windlord
-                break;
-            case 8181: // Flamelord
-                captureItem = 27204; // Captive Flamelord
-                break;
-            case 8123: // Farkrag the Wanderer
-                captureItem = 27205; // Captive Farkrag the Wanderer
-                break;
-            case 5985: // Daruda the Watcher
-                captureItem = 27207; // Captive Daruda the Watcher
-                break;
-            case 5984: // Tarian the Grim
-                captureItem = 27209; // Captive Tarian the Grim
-                break;
-            case 6446: // Gatekeeper Harrod (final form)
-                captureItem = 27210; // Captive Harrod the Gatekeeper
-                break;
-        }
-
         // If valid target
-        if (captureItem > 0)
+        if (targetNpc.Template.PetItemId > 0)
         {
+            var itemTemplate = ItemManager.Instance.GetTemplate(targetNpc.Template.PetItemId);
+            if (itemTemplate == null)
+            {
+                player.SendErrorMessage(ErrorMessageType.BagInvalidItem);
+                return;
+            }
             // And player can get the item
-            if (!player.Inventory.Bag.AcquireDefaultItem(ItemTaskType.CapturePet, captureItem, 1))
+            if (!player.Inventory.Bag.AcquireDefaultItem(ItemTaskType.CapturePet, targetNpc.Template.PetItemId, 1))
             {
                 player.SendErrorMessage(ErrorMessageType.BagFull);
                 return;


### PR DESCRIPTION
- Implemented the ``CapturePet`` special effect (with too many magic numbers)
- Added a missing ``SCCombatFirstHitPacket`` on initial aggro so the NPC is marked as "occupied" by the client.
- Added consumption of source item if reagents list is empty with a ``ApplyReagent`` effect.
