### PR TITLE
[Game] Teleport Book cannot be used when not in the main world

### DIFF
--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -241,6 +241,14 @@ public class Skill
             return SkillResult.TooFarRange;
         }
 
+        if (Template.Effects.Count > 0 && Template.Effects.First()?.Template is OpenPortalEffect)
+        {
+            if (0 != caster.InstanceId)
+            {
+                return SkillResult.InvalidLocation;
+            }
+        }
+
         // Calculate casting time if needed
         var castTime = 0;
         if (Template.CastingTime > 0)


### PR DESCRIPTION
Prevent players from opening portals when they are not in the main world.