### PR TITLE
[Game] Fixed an error when resetting daily tasks to get the time, `Today` is the local time zone

### DIFF
--- a/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
@@ -607,7 +607,7 @@ public class CharacterQuests
         // TODO: Put Server timezone offset in configuration file, currently using local machine midnight
         // var utcDelta = DateTime.Now - DateTime.UtcNow;
         // var isOld = (DateTime.Today + utcDelta - Owner.LeaveTime.Date) >= TimeSpan.FromDays(1);
-        var isOld = (DateTime.Today - Owner.LeaveTime.Date) >= TimeSpan.FromDays(1);
+        var isOld = (DateTime.UtcNow.Date - Owner.LeaveTime.Date) >= TimeSpan.FromDays(1);
         if (isOld)
             ResetDailyQuests(false);
     }


### PR DESCRIPTION
This problem will cause the daily task to be reset always when the local time zone is inconsistent with the Utc time zone and the local time zone is in the eastern zone (ex: Utc+X:00) within the difference time (within X hours).