### PR TITLE
[Game] Added code to validate Family member status on login

### DIFF
--- a/AAEmu.Game/Core/Managers/FamilyManager.cs
+++ b/AAEmu.Game/Core/Managers/FamilyManager.cs
@@ -180,13 +180,22 @@ public class FamilyManager : Singleton<FamilyManager>
     /// <param name="character"></param>
     public void OnCharacterLogin(Character character)
     {
-        var family = _families[character.Family];
-        var member = _familyMembers[character.Id];
-        member.Character = character;
+        var family = _families.GetValueOrDefault(character.Family);
+        var member = _familyMembers.GetValueOrDefault(character.Id);
+        if (family == null || member == null)
+        {
+            // Family no longer valid
+            character.Family = 0;
+        }
+        else
+        {
+            // Update Member field and send family packets
+            member.Character = character;
 
-        ChatManager.Instance.GetFamilyChat(family.Id)?.JoinChannel(character);
-        character.SendPacket(new SCFamilyDescPacket(family));
-        family.SendPacket(new SCFamilyMemberOnlinePacket(family.Id, member.Id, true));
+            ChatManager.Instance.GetFamilyChat(family.Id)?.JoinChannel(character);
+            character.SendPacket(new SCFamilyDescPacket(family));
+            family.SendPacket(new SCFamilyMemberOnlinePacket(family.Id, member.Id, true));
+        }
     }
 
     /// <summary>

--- a/AAEmu.Game/Models/Game/Family.cs
+++ b/AAEmu.Game/Models/Game/Family.cs
@@ -42,6 +42,7 @@ public class Family : PacketMarshaler
     {
         var member = GetMember(character);
         RemoveMember(member);
+        character.Family = 0;
     }
 
     public FamilyMember GetMember(Character character)


### PR DESCRIPTION
- Added additional checks to ``FamilyManager.OnCharacterLogin`` to prevent exceptions in case of a orphaned family member (family members table out of sync)
- Added missing Family ID reset when a character leaves a family. Initial save of family data would remove it, but next character save would put it back.
