### PR TITLE
Fix ship ownership buff not working issue.

### DIFF
--- a/AAEmu.Game/Core/Managers/SlaveManager.cs
+++ b/AAEmu.Game/Core/Managers/SlaveManager.cs
@@ -211,6 +211,13 @@ public class SlaveManager : Singleton<SlaveManager>
         if (slave == null || slave.AttachedCharacters.ContainsKey(attachPoint))
             return;
 
+        // Check if the vehicle has the MasterOwnership buff and if the character is not the owner, block the attachment.
+        if (slave.Buffs.CheckBuff((uint)BuffConstants.MasterOwnership) && slave.Summoner.ObjId != character.ObjId)
+        {
+            character.SendErrorMessage(ErrorMessageType.SlaveAlreadyHasMaster);
+            return;
+        }
+
         character.BroadcastPacket(new SCUnitAttachedPacket(character.ObjId, attachPoint, bondKind, objId), true);
         character.AttachedPoint = attachPoint;
         switch (attachPoint)

--- a/AAEmu.Game/Core/Managers/SlaveManager.cs
+++ b/AAEmu.Game/Core/Managers/SlaveManager.cs
@@ -212,9 +212,9 @@ public class SlaveManager : Singleton<SlaveManager>
             return;
 
         // Check if the vehicle has the MasterOwnership buff and if the character is not the owner, block the attachment.
-        if (slave.Buffs.CheckBuff((uint)BuffConstants.MasterOwnership) && slave.Summoner.ObjId != character.ObjId)
+        if (attachPoint == AttachPointKind.Driver && slave.Buffs.CheckBuff((uint)BuffConstants.MasterOwnership) && slave.Summoner.ObjId != character.ObjId)
         {
-            character.SendErrorMessage(ErrorMessageType.SlaveAlreadyHasMaster);
+            character.SendErrorMessage(ErrorMessageType.SlaveAlreadyHasMaster); // 仅阻止驾驶座附加
             return;
         }
 

--- a/AAEmu.Game/Models/Game/Skills/BuffConstants.cs
+++ b/AAEmu.Game/Models/Game/Skills/BuffConstants.cs
@@ -29,6 +29,7 @@ public enum BuffConstants : uint
     EquipTwoHanded = 8227,
     InBeautySalon = 6117,
     SearchSchoolOfFish = 5736,
-    Overburdened = 831 // SustainBuff - Carrying heavy objects reduces movement speed and prevents teleporting or gliding.
-   // Overburdened = 7221
+    Overburdened = 831, // SustainBuff - Carrying heavy objects reduces movement speed and prevents teleporting or gliding.
+    MasterOwnership = 4867  // Vehicle ownership buff, prevents non-owners from attaching to the vehicle.
+    // Overburdened = 7221
 }


### PR DESCRIPTION
This PR fixes an issue where the ship ownership buff was not functioning as expected. After this fix, the buff properly identifies the ship owner and prevents non-owners from attaching or using the ship.