### PR TITLE
[Game] Fix Web API sending mails causing online characters to not rec…

### DIFF
--- a/AAEmu.Game/Services/WebApi/Controllers/MailController.cs
+++ b/AAEmu.Game/Services/WebApi/Controllers/MailController.cs
@@ -74,7 +74,8 @@ internal class MailController : BaseController
 
                         foreach (var expeditionMember in expedition.Members)
                         {
-                            var character = Character.Load(expeditionMember.CharacterId);
+                            var character = WorldManager.Instance.GetCharacterById(expeditionMember.CharacterId) ??
+                                            Character.Load(expeditionMember.CharacterId);
                             if (character == null || character.DeleteTime > DateTime.MinValue ||
                                 character.DeleteRequestTime > DateTime.MinValue)
                             {
@@ -143,7 +144,8 @@ internal class MailController : BaseController
                 {
                     foreach (uint recipient in mailRequest.Recipients)
                     {
-                        var character = Character.Load(recipient);
+                        var character = WorldManager.Instance.GetCharacterById(recipient) ??
+                                        Character.Load(recipient);
                         if (character == null || character.DeleteTime > DateTime.MinValue ||
                             character.DeleteRequestTime > DateTime.MinValue)
                         {


### PR DESCRIPTION
[Game] Fix Web API sending mails causing online characters to not receive notifications of subsequent backpack item changes


The specific manifestations are as follows
When loading character information directly from the database, a new character object will be created and associated with a backpack object. At this point, the online character will be unlinked, resulting in the inability to receive subsequent notification packets.