### PR TITLE
Avoiding loading logger unnecessary (Huge impact)

### DIFF
--- a/AAEmu.Game/Models/Game/Skills/Buff.cs
+++ b/AAEmu.Game/Models/Game/Skills/Buff.cs
@@ -21,7 +21,7 @@ public enum EffectState
 
 public class Buff
 {
-    protected static Logger Logger => LogManager.GetCurrentClassLogger();
+    protected static Logger Logger = LogManager.GetCurrentClassLogger();
 
     private object _lock = new();
     private int _count;

--- a/AAEmu.Game/Models/Game/World/GameObject.cs
+++ b/AAEmu.Game/Models/Game/World/GameObject.cs
@@ -11,7 +11,7 @@ namespace AAEmu.Game.Models.Game.World;
 
 public class GameObject : IGameObject
 {
-    protected static Logger Logger => LogManager.GetCurrentClassLogger();
+    protected static Logger Logger = LogManager.GetCurrentClassLogger();
 
     public Guid Guid { get; set; } = Guid.NewGuid();
     public uint ObjId { get; set; }


### PR DESCRIPTION
Changing the logging property to actually store the logger instead of generate a new reference everytimne the property is accessed.

Considerable impact on server initialization.