### PR TITLE
[Game] Fix looting rules (for NPCs)

### DIFF
--- a/AAEmu.Game/Core/Managers/ItemManager.cs
+++ b/AAEmu.Game/Core/Managers/ItemManager.cs
@@ -61,7 +61,6 @@ public class ItemManager : Singleton<ItemManager>
     private Dictionary<uint, List<LootPackDroppingNpc>> _lootPackDroppingNpc;
     private Dictionary<uint, List<LootPackConvertFish>> _lootPackConvertFish;
     private Dictionary<int, GradeDistributions> _itemGradeDistributions;
-    private Dictionary<uint, List<Item>> _lootDropItems;
 
     // ItemLookConvert
     private Dictionary<uint, ItemLookConvert> _itemLookConverts;
@@ -100,11 +99,6 @@ public class ItemManager : Singleton<ItemManager>
         return _grades.GetValueOrDefault(grade);
     }
 
-    public bool RemoveLootDropItems(uint objId)
-    {
-        return _lootDropItems.Remove(objId);
-    }
-
     public Holdable GetHoldable(uint id)
     {
         return _holdables.GetValueOrDefault(id);
@@ -125,7 +119,7 @@ public class ItemManager : Singleton<ItemManager>
         return _enchantingSupports.GetValueOrDefault(itemId);
     }
 
-    private List<LootPackDroppingNpc> GetLootPackIdByNpcId(uint npcId)
+    public List<LootPackDroppingNpc> GetLootPackIdByNpcId(uint npcId)
     {
         return _lootPackDroppingNpc.TryGetValue(npcId, out var value) ? value : [];
     }
@@ -140,128 +134,9 @@ public class ItemManager : Singleton<ItemManager>
         return _lootPackConvertFish.TryGetValue(itemId, out var value) ? value : [];
     }
 
-    /// <summary>
-    /// Gets all loot items for the specified BaseUnit
-    /// </summary>
-    /// <param name="objId"></param>
-    /// <returns></returns>
-    public List<Item> GetLootDropItems(uint objId)
-    {
-        return _lootDropItems.TryGetValue(objId, out var item) ? item : [];
-    }
-
     public List<ItemTemplate> GetAllItems()
     {
         return _templates.Values.ToList();
-    }
-
-    public List<Item> CreateLootDropItems(uint npcId, BaseUnit killer)
-    {
-        var items = GetLootDropItems(npcId);
-
-        // Already generated?
-        if (items.Count > 0)
-        {
-            return items;
-        }
-
-        // Check if NPC actually exists
-        var unit = WorldManager.Instance.GetNpc(npcId);
-        if (unit == null)
-        {
-            return items;
-        }
-
-        // Get drop lists
-        var lootPackDroppingNpcs = GetLootPackIdByNpcId(unit.TemplateId);
-        if (lootPackDroppingNpcs.Count <= 0)
-        {
-            return items;
-        }
-
-        // Calculate loot rates
-        var lootDropRate = 1f;
-        var lootGoldRate = 1f;
-
-        // Check all people with a claim on the NPC
-
-        var eligiblePlayers = new HashSet<Character>();
-        if (unit.CharacterTagging.TagTeam != 0)
-        {
-            //A team has tagging rights
-            var team = TeamManager.Instance.GetActiveTeam(unit.CharacterTagging.TagTeam);
-            if (team != null)
-            {
-                foreach (var member in team.Members)
-                {
-                    if (member == null || member.Character == null)
-                        continue;
-
-                    var distance = member.Character.Transform.World.Position - unit.Transform.World.Position;
-                    if (distance.Length() <= 200)
-                    {
-                        //This player is in range of the mob and in a group with tagging rights.
-                        eligiblePlayers.Add(member.Character);
-                    }
-                }
-            }
-            else if (unit.CharacterTagging.Tagger != null)
-            {
-                //A player has tag rights
-                eligiblePlayers.Add(unit.CharacterTagging.Tagger);
-            }
-
-        }
-        else if (unit.CharacterTagging.Tagger != null)
-        {
-            //A player has tag rights
-            eligiblePlayers.Add(unit.CharacterTagging.Tagger);
-        }
-        if (eligiblePlayers.Count > 0)
-        {
-            var maxDropRateMul = -100f;
-            var maxLootGoldMul = -100f;
-
-            foreach (var pl in eligiblePlayers)
-            {
-
-                var aggroDropMul = (100f + pl.DropRateMul) / 100f;
-                var aggroGoldMul = (100f + pl.LootGoldMul) / 100f;
-                if (aggroDropMul > maxDropRateMul)
-                    maxDropRateMul = aggroDropMul;
-                if (aggroGoldMul > maxLootGoldMul)
-                    maxLootGoldMul = aggroGoldMul;
-
-            }
-
-            lootDropRate = maxDropRateMul;
-            lootGoldRate = maxLootGoldMul;
-
-        }
-        else if (killer is Character player)
-        {
-            lootDropRate *= (100f + player.DropRateMul) / 100f;
-            lootGoldRate *= (100f + player.LootGoldMul) / 100f;
-            Logger.Info($"Unit killed without aggro: {unit.ObjId} ({unit.TemplateId}) by {player.Name}");
-        }
-
-        // Base ID used for identifying the loot
-        var baseId = ((ulong)unit.ObjId << 32) + 65536;
-
-        // Generate the actual loot
-        foreach (var lootPackDropping in lootPackDroppingNpcs)
-        {
-            var lootPack = LootGameData.Instance.GetPack(lootPackDropping.LootPackId);
-            if (lootPack == null)
-                continue;
-            items = lootPack.GenerateNpcPackItems(ref baseId, killer, lootDropRate, lootGoldRate);
-            if (!_lootDropItems.TryAdd(npcId, items))
-                _lootDropItems[npcId].AddRange(items);
-        }
-
-        if (!_lootDropItems.TryGetValue(npcId, out items))
-            items = [];
-        return items;
     }
 
     public List<Item> GetLootConvertFish(uint templateId)
@@ -309,82 +184,6 @@ public class ItemManager : Singleton<ItemManager>
         }
 
         return items;
-    }
-
-    /// <summary>
-    /// Initiate Loot item (loot all items / open loot selection window)
-    /// </summary>
-    /// <param name="character"></param>
-    /// <param name="lootOwnerObjId"></param>
-    /// <param name="lootAll"></param>
-    /// <returns>True if everything was looted, false if not all could be looted</returns>
-    public bool TookLootDropItems(Character character, uint lootOwnerObjId, bool lootAll)
-    {
-        // TODO: Bug fix for the following; 
-        /*
-         * Have full inventory 
-         * -> Open Loot (G) 
-         * -> press (F) to loot all while open (fail, bag full) 
-         * -> free up bag space 
-         * -> click for manual loot doesn't trigger a new packet. so it won't loot
-         * Note: Re-opening the loot window lets you loot the remaining items
-        */
-        var isDone = true;
-        var lootDropItems = Instance.GetLootDropItems(lootOwnerObjId);
-        if (lootAll)
-        {
-            for (var i = lootDropItems.Count - 1; i >= 0; --i)
-            {
-                isDone &= TookLootDropItem(character, LootOwnerType.None, lootOwnerObjId, lootDropItems, lootDropItems[i], lootDropItems[i].Count);
-            }
-            if (lootDropItems.Count > 0)
-                character.SendPacket(new SCLootBagDataPacket(lootDropItems, true));
-        }
-        else
-        {
-            isDone = lootDropItems.Count <= 0;
-            character.SendPacket(new SCLootBagDataPacket(lootDropItems, false));
-        }
-        return isDone;
-    }
-
-    /// <summary>
-    /// Takes lootDropItem from LootDropItems and adds them to character's Bag
-    /// </summary>
-    /// <param name="character"></param>
-    /// <param name="lootOwnerObjId"></param>
-    /// <param name="lootDropItems"></param>
-    /// <param name="lootDropItem"></param>
-    /// <param name="count"></param>
-    /// <param name="lootOwnerType"></param>
-    /// <returns>Returns false if the item could not be picked up.</returns>
-    public bool TookLootDropItem(Character character, LootOwnerType lootOwnerType, uint lootOwnerObjId, List<Item> lootDropItems, Item lootDropItem, int count)
-    {
-        // var objId = (uint)(lootDropItem.Id >> 32);
-        if (lootDropItem.TemplateId == Item.Coins)
-        {
-            character.AddMoney(SlotType.Inventory, lootDropItem.Count);
-        }
-        else
-        {
-            if (!character.Inventory.Bag.AcquireDefaultItem(ItemTaskType.Loot, lootDropItem.TemplateId,
-                count > lootDropItem.Count ? lootDropItem.Count : count, lootDropItem.Grade))
-            {
-                // character.SendErrorMessage(ErrorMessageType.BagFull);
-                character.SendPacket(new SCLootItemFailedPacket(ErrorMessageType.BagFull, lootOwnerType, lootOwnerObjId, 0, lootDropItem.TemplateId));
-                return false;
-            }
-        }
-
-        lootDropItems.Remove(lootDropItem);
-        character.SendPacket(new SCLootItemTookPacket(lootDropItem.TemplateId, 0, lootOwnerType, lootOwnerObjId, lootDropItem.Id, lootDropItem.Count));
-
-        if (lootDropItems.Count <= 0)
-        {
-            RemoveLootDropItems(lootOwnerObjId);
-            character.BroadcastPacket(new SCLootableStatePacket(lootOwnerType, lootOwnerObjId, false), true);
-        }
-        return true;
     }
 
     public GradeDistributions GetGradeDistributions(byte id)
@@ -634,8 +433,8 @@ public class ItemManager : Singleton<ItemManager>
         /*
         _lootPacks = new Dictionary<uint, List<Loot>>();
         _lootGroups = new Dictionary<uint, List<LootGroups>>();
-        */
         _lootDropItems = [];
+        */
         _itemDoodadTemplates = [];
         _itemProcTemplates = [];
         _armorGradeBuffs = [];

--- a/AAEmu.Game/Core/Managers/ItemManager.cs
+++ b/AAEmu.Game/Core/Managers/ItemManager.cs
@@ -140,9 +140,14 @@ public class ItemManager : Singleton<ItemManager>
         return _lootPackConvertFish.TryGetValue(itemId, out var value) ? value : [];
     }
 
-    public List<Item> GetLootDropItems(uint npcId)
+    /// <summary>
+    /// Gets all loot items for the specified BaseUnit
+    /// </summary>
+    /// <param name="objId"></param>
+    /// <returns></returns>
+    public List<Item> GetLootDropItems(uint objId)
     {
-        return _lootDropItems.TryGetValue(npcId, out var item) ? item : [];
+        return _lootDropItems.TryGetValue(objId, out var item) ? item : [];
     }
 
     public List<ItemTemplate> GetAllItems()
@@ -310,10 +315,10 @@ public class ItemManager : Singleton<ItemManager>
     /// Initiate Loot item (loot all items / open loot selection window)
     /// </summary>
     /// <param name="character"></param>
-    /// <param name="id"></param>
+    /// <param name="lootOwnerObjId"></param>
     /// <param name="lootAll"></param>
     /// <returns>True if everything was looted, false if not all could be looted</returns>
-    public bool TookLootDropItems(Character character, uint id, bool lootAll)
+    public bool TookLootDropItems(Character character, uint lootOwnerObjId, bool lootAll)
     {
         // TODO: Bug fix for the following; 
         /*
@@ -325,12 +330,12 @@ public class ItemManager : Singleton<ItemManager>
          * Note: Re-opening the loot window lets you loot the remaining items
         */
         var isDone = true;
-        var lootDropItems = Instance.GetLootDropItems(id);
+        var lootDropItems = Instance.GetLootDropItems(lootOwnerObjId);
         if (lootAll)
         {
             for (var i = lootDropItems.Count - 1; i >= 0; --i)
             {
-                isDone &= TookLootDropItem(character, lootDropItems, lootDropItems[i], lootDropItems[i].Count);
+                isDone &= TookLootDropItem(character, LootOwnerType.None, lootOwnerObjId, lootDropItems, lootDropItems[i], lootDropItems[i].Count);
             }
             if (lootDropItems.Count > 0)
                 character.SendPacket(new SCLootBagDataPacket(lootDropItems, true));
@@ -347,13 +352,15 @@ public class ItemManager : Singleton<ItemManager>
     /// Takes lootDropItem from LootDropItems and adds them to character's Bag
     /// </summary>
     /// <param name="character"></param>
+    /// <param name="lootOwnerObjId"></param>
     /// <param name="lootDropItems"></param>
     /// <param name="lootDropItem"></param>
     /// <param name="count"></param>
+    /// <param name="lootOwnerType"></param>
     /// <returns>Returns false if the item could not be picked up.</returns>
-    public bool TookLootDropItem(Character character, List<Item> lootDropItems, Item lootDropItem, int count)
+    public bool TookLootDropItem(Character character, LootOwnerType lootOwnerType, uint lootOwnerObjId, List<Item> lootDropItems, Item lootDropItem, int count)
     {
-        var objId = (uint)(lootDropItem.Id >> 32);
+        // var objId = (uint)(lootDropItem.Id >> 32);
         if (lootDropItem.TemplateId == Item.Coins)
         {
             character.AddMoney(SlotType.Inventory, lootDropItem.Count);
@@ -364,18 +371,18 @@ public class ItemManager : Singleton<ItemManager>
                 count > lootDropItem.Count ? lootDropItem.Count : count, lootDropItem.Grade))
             {
                 // character.SendErrorMessage(ErrorMessageType.BagFull);
-                character.SendPacket(new SCLootItemFailedPacket(ErrorMessageType.BagFull, lootDropItem.Id, lootDropItem.TemplateId));
+                character.SendPacket(new SCLootItemFailedPacket(ErrorMessageType.BagFull, lootOwnerType, lootOwnerObjId, 0, lootDropItem.TemplateId));
                 return false;
             }
         }
 
         lootDropItems.Remove(lootDropItem);
-        character.SendPacket(new SCLootItemTookPacket(lootDropItem.TemplateId, lootDropItem.Id, lootDropItem.Count));
+        character.SendPacket(new SCLootItemTookPacket(lootDropItem.TemplateId, 0, lootOwnerType, lootOwnerObjId, lootDropItem.Id, lootDropItem.Count));
 
         if (lootDropItems.Count <= 0)
         {
-            RemoveLootDropItems(objId);
-            character.BroadcastPacket(new SCLootableStatePacket(objId, false), true);
+            RemoveLootDropItems(lootOwnerObjId);
+            character.BroadcastPacket(new SCLootableStatePacket(lootOwnerType, lootOwnerObjId, false), true);
         }
         return true;
     }

--- a/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
@@ -400,12 +400,10 @@ public class CharacterManager : Singleton<CharacterManager>
         Logger.Info("Loaded {0} character templates", _templates.Count);
     }
 
-    public static void PlayerRoll(Character Self, int max)
+    public static void PlayerRoll(Character player, int max)
     {
-
         var roll = Rand.Next(1, max);
-        Self.BroadcastPacket(new SCChatMessagePacket(ChatType.System, string.Format(Self.Name + " rolled " + roll.ToString() + ".")), true);
-
+        player.BroadcastPacket(new SCChatMessagePacket(ChatType.System, $"{player.Name} rolled {roll}."), true);
     }
 
     public int GetEffectiveAccessLevel(Character character)

--- a/AAEmu.Game/Core/Managers/World/SpawnManager.cs
+++ b/AAEmu.Game/Core/Managers/World/SpawnManager.cs
@@ -944,10 +944,10 @@ public class SpawnManager : Singleton<SpawnManager>
                 }
             }
 
-            var despawns = GetDespawnsReady();
-            if (despawns.Count > 0)
+            var deSpawns = GetDespawnsReady();
+            if (deSpawns.Count > 0)
             {
-                foreach (var obj in despawns)
+                foreach (var obj in deSpawns)
                 {
                     if (obj.Despawn >= DateTime.UtcNow)
                         continue;

--- a/AAEmu.Game/Core/Managers/World/SpawnManager.cs
+++ b/AAEmu.Game/Core/Managers/World/SpawnManager.cs
@@ -921,6 +921,9 @@ public class SpawnManager : Singleton<SpawnManager>
         return res;
     }
 
+    /// <summary>
+    /// Handles timed re-spawning and de-spawning tick
+    /// </summary>
     private void CheckRespawns()
     {
         while (_work)
@@ -969,6 +972,16 @@ public class SpawnManager : Singleton<SpawnManager>
                         obj.Delete();
                     }
                     RemoveDespawn(obj);
+                }
+            }
+
+            // Check if any Npcs with loot need to be made public
+            var makePublic = WorldManager.Instance.GetNpcsToMakePublicLooting();
+            if (makePublic.Count > 0)
+            {
+                foreach (var npc in makePublic)
+                {
+                    npc.LootingContainer.MakeLootPublic();
                 }
             }
 

--- a/AAEmu.Game/Core/Managers/World/WorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/WorldManager.cs
@@ -738,20 +738,17 @@ public class WorldManager : Singleton<WorldManager>, IWorldManager
 
     public GameObject GetGameObject(uint objId)
     {
-        _objects.TryGetValue(objId, out var ret);
-        return ret;
+        return _objects.GetValueOrDefault(objId);
     }
 
     public BaseUnit GetBaseUnit(uint objId)
     {
-        _baseUnits.TryGetValue(objId, out var ret);
-        return ret;
+        return _baseUnits.GetValueOrDefault(objId);
     }
 
     public Doodad GetDoodad(uint objId)
     {
-        _doodads.TryGetValue(objId, out var ret);
-        return ret;
+        return _doodads.GetValueOrDefault(objId);
     }
 
     public Doodad GetDoodadByDbId(uint dbId)

--- a/AAEmu.Game/Core/Managers/World/WorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/WorldManager.cs
@@ -9,7 +9,6 @@ using System.Xml;
 using AAEmu.Commons.IO;
 using AAEmu.Commons.Utils;
 using AAEmu.Commons.Utils.XML;
-using AAEmu.Game.Core.Managers.AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.Id;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Packets.G2C;
@@ -1398,4 +1397,23 @@ public class WorldManager : Singleton<WorldManager>, IWorldManager
         //    Logger.Info($"[Dungeon] could not delete the list of NpcEventSpawners for dungeon id={worldId}!");
         //}
     }
+
+    /// <summary>
+    /// Get a list of NPCs that have loot and are past the "make public" time
+    /// </summary>
+    /// <returns></returns>
+    public HashSet<Npc> GetNpcsToMakePublicLooting()
+    {
+        HashSet<Npc> temp;
+        lock (_npcs)
+        {
+            temp = [.. _npcs.Values];
+        }
+
+        var res = new HashSet<Npc>();
+        foreach (var item in temp.Where(item => item.LootingContainer.CanMakePublic()))
+            res.Add(item);
+        return res;
+    }
+
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSChangeLootingRulePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSChangeLootingRulePacket.cs
@@ -20,8 +20,7 @@ public class CSChangeLootingRulePacket : GamePacket
 
         var changeFlags = stream.ReadByte();
 
-        // Logger.Warn("ChangeLootingRule, TeamId: {0}, Flag: {1}, Rule: {2}/{3}/{4}/{5}", teamId, changeFlags, lootingRule.LootMethod, lootingRule.Type,
-        //     lootingRule.Id, lootingRule.RollForBop);
-        TeamManager.Instance.ChangeLootingRule(Connection.ActiveChar, teamId, lootingRule, changeFlags);
+        Logger.Warn($"ChangeLootingRule, TeamId: {teamId}, Flag: {changeFlags}, Rule Method:{lootingRule.LootMethod}, Grade:{lootingRule.MinimumGrade}, LootMaster: {lootingRule.LootMaster}, RollForBoP: {lootingRule.RollForBindOnPickup}");
+        TeamManager.Instance.ChangeLootingRule(Connection.ActiveChar, teamId, changeFlags, lootingRule.LootMethod, lootingRule.MinimumGrade, lootingRule.LootMaster, lootingRule.RollForBindOnPickup);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSChangeLootingRulePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSChangeLootingRulePacket.cs
@@ -5,12 +5,11 @@ using AAEmu.Game.Models.Game.Team;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
-public class CSChangeLootingRulePacket : GamePacket
+/// <summary>
+/// Leader changed looting rules
+/// </summary>
+public class CSChangeLootingRulePacket() : GamePacket(CSOffsets.CSChangeLootingRulePacket, 1)
 {
-    public CSChangeLootingRulePacket() : base(CSOffsets.CSChangeLootingRulePacket, 1)
-    {
-    }
-
     public override void Read(PacketStream stream)
     {
         var teamId = stream.ReadUInt32();

--- a/AAEmu.Game/Core/Packets/C2G/CSLootCloseBagPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSLootCloseBagPacket.cs
@@ -1,5 +1,6 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.Game.Items.Loots;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
@@ -11,8 +12,12 @@ public class CSLootCloseBagPacket : GamePacket
 
     public override void Read(PacketStream stream)
     {
-        var iid = stream.ReadUInt64();
+        var itemIndex = stream.ReadUInt16();
+        var ownerType = (LootOwnerType)stream.ReadUInt16();
+        var ownerObjId = stream.ReadBc();
+        var b = stream.ReadByte();
+        // var iid = stream.ReadUInt64();
 
-        Logger.Warn("LootCloseBag, IId: {0}", iid);
+        Logger.Warn($"LootCloseBag, itemIndex: {itemIndex}, LootOwner: {ownerType}:{ownerObjId}, b: {b}");
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSLootCloseBagPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSLootCloseBagPacket.cs
@@ -1,15 +1,12 @@
 ﻿using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Models.Game.Items.Loots;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
-public class CSLootCloseBagPacket : GamePacket
+public class CSLootCloseBagPacket() : GamePacket(CSOffsets.CSLootCloseBagPacket, 1)
 {
-    public CSLootCloseBagPacket() : base(CSOffsets.CSLootCloseBagPacket, 1)
-    {
-    }
-
     public override void Read(PacketStream stream)
     {
         var itemIndex = stream.ReadUInt16();
@@ -19,5 +16,8 @@ public class CSLootCloseBagPacket : GamePacket
         // var iid = stream.ReadUInt64();
 
         Logger.Warn($"LootCloseBag, itemIndex: {itemIndex}, LootOwner: {ownerType}:{ownerObjId}, b: {b}");
+        
+        var lootOwner = WorldManager.Instance.GetBaseUnit(ownerObjId);
+        lootOwner?.LootingContainer.CloseBag(Connection.ActiveChar, itemIndex, ownerType, ownerObjId, b);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSLootCloseBagPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSLootCloseBagPacket.cs
@@ -5,6 +5,9 @@ using AAEmu.Game.Models.Game.Items.Loots;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
+/// <summary>
+/// Player closed a loot container
+/// </summary>
 public class CSLootCloseBagPacket() : GamePacket(CSOffsets.CSLootCloseBagPacket, 1)
 {
     public override void Read(PacketStream stream)
@@ -13,7 +16,6 @@ public class CSLootCloseBagPacket() : GamePacket(CSOffsets.CSLootCloseBagPacket,
         var ownerType = (LootOwnerType)stream.ReadUInt16();
         var ownerObjId = stream.ReadBc();
         var b = stream.ReadByte();
-        // var iid = stream.ReadUInt64();
 
         Logger.Warn($"LootCloseBag, itemIndex: {itemIndex}, LootOwner: {ownerType}:{ownerObjId}, b: {b}");
         

--- a/AAEmu.Game/Core/Packets/C2G/CSLootDicePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSLootDicePacket.cs
@@ -1,9 +1,14 @@
 ﻿using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Models.Game.Items.Loots;
+using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
+/// <summary>
+/// Player does a dice roll response
+/// </summary>
 public class CSLootDicePacket() : GamePacket(CSOffsets.CSLootDicePacket, 1)
 {
     public override void Read(PacketStream stream)
@@ -12,12 +17,32 @@ public class CSLootDicePacket() : GamePacket(CSOffsets.CSLootDicePacket, 1)
         var lootOwnerType = (LootOwnerType)stream.ReadUInt16();
         var lootOwnerObjId = stream.ReadBc();
         var b = stream.ReadByte();
-        // var iid = stream.ReadUInt64();
-        var roll = stream.ReadBoolean();
+        var rollRequest = stream.ReadBoolean(); // this might be a byte instead?
+
+        byte[] remainingBytes = [];
+        if (stream.Pos < stream.Count)
+        {
+            remainingBytes = stream.ReadBytes(stream.Count - stream.Pos);
+        }
         
-        Logger.Warn($"LootDice, ItemIndex: {itemIndex}, LootOwner: {lootOwnerType}:{lootOwnerObjId}, b: {b}, Roll: {roll}");
-        
-        // TODO: Validate lootOwner
-        // TODO: Handle dice rolls
+        Logger.Warn($"CSLootDice, ItemIndex: {itemIndex}, LootOwner: {lootOwnerType}:{lootOwnerObjId}, b: {b}, Roll: {rollRequest}, remainingBytes: {remainingBytes.Length}");
+
+        BaseUnit lootOwner = null;
+        switch (lootOwnerType)
+        {
+            case LootOwnerType.Npc:
+                lootOwner = WorldManager.Instance.GetNpc(lootOwnerObjId);
+                break;
+            case LootOwnerType.Doodad:
+                lootOwner = WorldManager.Instance.GetDoodad(lootOwnerObjId);
+                break;
+        }
+
+        if (lootOwner == null)
+        {
+            Logger.Warn($"CSLootDice, LootOwner not found: {lootOwnerType}:{lootOwnerObjId} by {Connection.ActiveChar.Name}");
+            return;
+        }
+        lootOwner.LootingContainer.DoPlayerRoll(Connection.ActiveChar, itemIndex, rollRequest);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSLootDicePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSLootDicePacket.cs
@@ -1,5 +1,6 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.Game.Items.Loots;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
@@ -11,9 +12,16 @@ public class CSLootDicePacket : GamePacket
 
     public override void Read(PacketStream stream)
     {
-        var iid = stream.ReadUInt64();
+        var itemIndex = stream.ReadUInt16();
+        var lootOwnerType = (LootOwnerType)stream.ReadUInt16();
+        var lootOwnerObjId = stream.ReadBc();
+        var b = stream.ReadByte();
+        // var iid = stream.ReadUInt64();
         var roll = stream.ReadBoolean();
-
-        Logger.Warn("LootDice, IId: {0}, Roll: {1}", iid, roll);
+        
+        Logger.Warn($"LootDice, ItemIndex: {itemIndex}, LootOwner: {lootOwnerType}:{lootOwnerObjId}, b: {b}, Roll: {roll}");
+        
+        // TODO: Validate lootOwner
+        // TODO: Handle dice rolls
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSLootDicePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSLootDicePacket.cs
@@ -7,7 +7,7 @@ using AAEmu.Game.Models.Game.Units;
 namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
-/// Player does a dice roll response
+/// Player does a die roll response
 /// </summary>
 public class CSLootDicePacket() : GamePacket(CSOffsets.CSLootDicePacket, 1)
 {

--- a/AAEmu.Game/Core/Packets/C2G/CSLootDicePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSLootDicePacket.cs
@@ -4,12 +4,8 @@ using AAEmu.Game.Models.Game.Items.Loots;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
-public class CSLootDicePacket : GamePacket
+public class CSLootDicePacket() : GamePacket(CSOffsets.CSLootDicePacket, 1)
 {
-    public CSLootDicePacket() : base(CSOffsets.CSLootDicePacket, 1)
-    {
-    }
-
     public override void Read(PacketStream stream)
     {
         var itemIndex = stream.ReadUInt16();

--- a/AAEmu.Game/Core/Packets/C2G/CSLootItemPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSLootItemPacket.cs
@@ -18,11 +18,12 @@ public class CSLootItemPacket : GamePacket
     {
         var itemIndex = stream.ReadUInt16();
         var ownerType = (LootOwnerType)stream.ReadUInt16();
-        var ownerObjId = stream.ReadUInt32();
+        var ownerObjId = stream.ReadBc();
+        var b = stream.ReadByte();
         // var iid = stream.ReadUInt64();
         var count = stream.ReadInt32();
         
-        Logger.Warn($"LootItem, itemIndex: {itemIndex}, LootOwner: {ownerType}:{ownerObjId}, Count: {count}");
+        Logger.Warn($"LootItem, itemIndex: {itemIndex}, LootOwner: {ownerType}:{ownerObjId}, b: {b}, Count: {count}");
 
         var owner = WorldManager.Instance.GetBaseUnit(ownerObjId);
         if (owner == null)

--- a/AAEmu.Game/Core/Packets/C2G/CSLootItemPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSLootItemPacket.cs
@@ -1,8 +1,10 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
+using AAEmu.Game.Models.Game.Items.Loots;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
@@ -14,14 +16,23 @@ public class CSLootItemPacket : GamePacket
 
     public override void Read(PacketStream stream)
     {
-        var iid = stream.ReadUInt64();
+        var itemIndex = stream.ReadUInt16();
+        var ownerType = (LootOwnerType)stream.ReadUInt16();
+        var ownerObjId = stream.ReadUInt32();
+        // var iid = stream.ReadUInt64();
         var count = stream.ReadInt32();
+        
+        Logger.Warn($"LootItem, itemIndex: {itemIndex}, LootOwner: {ownerType}:{ownerObjId}, Count: {count}");
 
-        Logger.Warn("LootItem, IId: {0}, Count: {1}", iid, count);
-
-        var objId = (uint)(iid >> 32);
-        var lootDropItems = ItemManager.Instance.GetLootDropItems(objId);
-        var lootDropItem = lootDropItems.Find(a => a.Id == iid);
+        var owner = WorldManager.Instance.GetBaseUnit(ownerObjId);
+        if (owner == null)
+            ownerType = LootOwnerType.None;
+        
+        // TODO: Validate arguments
+        
+        var lootDropItems = ItemManager.Instance.GetLootDropItems(ownerObjId);
+        // var lootDropItem = lootDropItems.Find(a => a.Id == iid);
+        var lootDropItem = lootDropItems.Find(a => a.Count > 0);
         if (lootDropItem != null)
         {
             var freeSpace = Connection.ActiveChar.Inventory.Bag.SpaceLeftForItem(lootDropItem, out _);
@@ -30,14 +41,14 @@ public class CSLootItemPacket : GamePacket
                 Connection.ActiveChar.SendErrorMessage(ErrorMessageType.BagFull);
                 return;
             }
-            ItemManager.Instance.TookLootDropItem(Connection.ActiveChar, lootDropItems, lootDropItem, count);
+            ItemManager.Instance.TookLootDropItem(Connection.ActiveChar, ownerType, ownerObjId, lootDropItems, lootDropItem, count);
         }
         else
         {
             if (lootDropItems.Count <= 0)
             {
-                ItemManager.Instance.RemoveLootDropItems(objId);
-                Connection.ActiveChar.BroadcastPacket(new SCLootableStatePacket(objId, false), true);
+                ItemManager.Instance.RemoveLootDropItems(ownerObjId);
+                Connection.ActiveChar.BroadcastPacket(new SCLootableStatePacket(ownerType, ownerObjId, false), true);
             }
         }
     }

--- a/AAEmu.Game/Core/Packets/C2G/CSLootItemPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSLootItemPacket.cs
@@ -1,19 +1,12 @@
 ﻿using AAEmu.Commons.Network;
-using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Network.Game;
-using AAEmu.Game.Core.Packets.G2C;
-using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Items.Loots;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
-public class CSLootItemPacket : GamePacket
+public class CSLootItemPacket() : GamePacket(CSOffsets.CSLootItemPacket, 1)
 {
-    public CSLootItemPacket() : base(CSOffsets.CSLootItemPacket, 1)
-    {
-    }
-
     public override void Read(PacketStream stream)
     {
         var itemIndex = stream.ReadUInt16();
@@ -26,31 +19,13 @@ public class CSLootItemPacket : GamePacket
         Logger.Warn($"LootItem, itemIndex: {itemIndex}, LootOwner: {ownerType}:{ownerObjId}, b: {b}, Count: {count}");
 
         var owner = WorldManager.Instance.GetBaseUnit(ownerObjId);
-        if (owner == null)
-            ownerType = LootOwnerType.None;
         
         // TODO: Validate arguments
-        
-        var lootDropItems = ItemManager.Instance.GetLootDropItems(ownerObjId);
-        // var lootDropItem = lootDropItems.Find(a => a.Id == iid);
-        var lootDropItem = lootDropItems.Find(a => a.Count > 0);
-        if (lootDropItem != null)
+
+        if (owner?.LootingContainer.TryTakeLoot(Connection.ActiveChar, itemIndex, null, count) ?? false)
         {
-            var freeSpace = Connection.ActiveChar.Inventory.Bag.SpaceLeftForItem(lootDropItem, out _);
-            if (freeSpace < lootDropItem.Count)
-            {
-                Connection.ActiveChar.SendErrorMessage(ErrorMessageType.BagFull);
-                return;
-            }
-            ItemManager.Instance.TookLootDropItem(Connection.ActiveChar, ownerType, ownerObjId, lootDropItems, lootDropItem, count);
-        }
-        else
-        {
-            if (lootDropItems.Count <= 0)
-            {
-                ItemManager.Instance.RemoveLootDropItems(ownerObjId);
-                Connection.ActiveChar.BroadcastPacket(new SCLootableStatePacket(ownerType, ownerObjId, false), true);
-            }
+            if (owner.LootingContainer.Items.Count <= 0)
+                owner.LootingContainer.UpdateLootState();
         }
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSLootItemPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSLootItemPacket.cs
@@ -12,20 +12,13 @@ public class CSLootItemPacket() : GamePacket(CSOffsets.CSLootItemPacket, 1)
         var itemIndex = stream.ReadUInt16();
         var ownerType = (LootOwnerType)stream.ReadUInt16();
         var ownerObjId = stream.ReadBc();
-        var b = stream.ReadByte();
-        // var iid = stream.ReadUInt64();
-        var count = stream.ReadInt32();
+        var u1 = stream.ReadUInt16(); // also item index?
+        var u2 = stream.ReadUInt16();
         
-        Logger.Warn($"LootItem, itemIndex: {itemIndex}, LootOwner: {ownerType}:{ownerObjId}, b: {b}, Count: {count}");
+        Logger.Warn($"LootItem, itemIndex: {itemIndex}, LootOwner: {ownerType}:{ownerObjId}, u1: {u1}, u2: {u2}");
 
         var owner = WorldManager.Instance.GetBaseUnit(ownerObjId);
-        
-        // TODO: Validate arguments
 
-        if (owner?.LootingContainer.TryTakeLoot(Connection.ActiveChar, itemIndex, null, count) ?? false)
-        {
-            if (owner.LootingContainer.Items.Count <= 0)
-                owner.LootingContainer.UpdateLootState();
-        }
+        owner?.LootingContainer.TryTakeLoot(Connection.ActiveChar, itemIndex, null);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSLootItemPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSLootItemPacket.cs
@@ -19,6 +19,6 @@ public class CSLootItemPacket() : GamePacket(CSOffsets.CSLootItemPacket, 1)
 
         var owner = WorldManager.Instance.GetBaseUnit(ownerObjId);
 
-        owner?.LootingContainer.TryTakeLoot(Connection.ActiveChar, itemIndex, null);
+        owner?.LootingContainer.TryTakeLoot(Connection.ActiveChar, itemIndex, null, false);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSLootOpenBagPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSLootOpenBagPacket.cs
@@ -1,22 +1,22 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
-public class CSLootOpenBagPacket : GamePacket
+public class CSLootOpenBagPacket() : GamePacket(CSOffsets.CSLootOpenBagPacket, 1)
 {
-    public CSLootOpenBagPacket() : base(CSOffsets.CSLootOpenBagPacket, 1)
-    {
-    }
-
     public override void Read(PacketStream stream)
     {
         var objId = stream.ReadBc();
         var obj2Id = stream.ReadBc();
         var lootAll = stream.ReadBoolean();
 
-        ItemManager.Instance.TookLootDropItems(Connection.ActiveChar, objId, lootAll);
-
+        var lootOwner = WorldManager.Instance.GetBaseUnit(objId);
+        var object2 = WorldManager.Instance.GetBaseUnit(obj2Id);
+        
+        lootOwner?.LootingContainer.OpenBag(Connection.ActiveChar, object2, lootAll);
+        // ItemManager.Instance.TookLootDropItems(Connection.ActiveChar, objId, lootAll);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSLootOpenBagPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSLootOpenBagPacket.cs
@@ -17,6 +17,5 @@ public class CSLootOpenBagPacket() : GamePacket(CSOffsets.CSLootOpenBagPacket, 1
         var object2 = WorldManager.Instance.GetBaseUnit(obj2Id);
         
         lootOwner?.LootingContainer.OpenBag(Connection.ActiveChar, object2, lootAll);
-        // ItemManager.Instance.TookLootDropItems(Connection.ActiveChar, objId, lootAll);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSLootOpenBagPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSLootOpenBagPacket.cs
@@ -1,5 +1,4 @@
 ﻿using AAEmu.Commons.Network;
-using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Network.Game;
 

--- a/AAEmu.Game/Core/Packets/C2G/CSRollDicePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSRollDicePacket.cs
@@ -15,6 +15,5 @@ public class CSRollDicePacket : GamePacket
 
         var max = stream.ReadUInt32();
         CharacterManager.PlayerRoll(Connection.ActiveChar, int.Parse(max.ToString()));
-
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCLootBagDataPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCLootBagDataPacket.cs
@@ -5,25 +5,16 @@ using AAEmu.Game.Models.Game.Items;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCLootBagDataPacket : GamePacket
+public class SCLootBagDataPacket(List<Item> items, bool lootAll) : GamePacket(SCOffsets.SCLootBagDataPacket, 1)
 {
-    private readonly List<Item> _items;
-    private readonly bool _lootAll;
-
-    public SCLootBagDataPacket(List<Item> items, bool lootAll) : base(SCOffsets.SCLootBagDataPacket, 1)
-    {
-        _items = items;
-        _lootAll = lootAll;
-    }
-
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write((byte)_items.Count);
+        stream.Write((byte)items.Count);
 
-        foreach (var item in _items)
+        foreach (var item in items)
             item.Write(stream);
 
-        stream.Write(_lootAll);
+        stream.Write(lootAll);
         return stream;
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCLootDiceNotifyPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCLootDiceNotifyPacket.cs
@@ -7,7 +7,7 @@ namespace AAEmu.Game.Core.Packets.G2C;
 public class SCLootDiceNotifyPacket : GamePacket
 {
     private readonly string _charName;
-    private Item _item;
+    private readonly Item _item;
     private readonly sbyte _dice;
 
     /// <summary>

--- a/AAEmu.Game/Core/Packets/G2C/SCLootDiceNotifyPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCLootDiceNotifyPacket.cs
@@ -1,21 +1,31 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.Game.Items;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
 public class SCLootDiceNotifyPacket : GamePacket
 {
     private readonly string _charName;
+    private Item _item;
     private readonly sbyte _dice;
 
-    public SCLootDiceNotifyPacket(string charName, sbyte dice) : base(SCOffsets.SCLootDiceNotifyPacket, 1)
+    /// <summary>
+    /// Notify player of a roll result of any eligible players for a given item
+    /// </summary>
+    /// <param name="charName"></param>
+    /// <param name="item"></param>
+    /// <param name="dice"></param>
+    public SCLootDiceNotifyPacket(string charName, Item item, sbyte dice) : base(SCOffsets.SCLootDiceNotifyPacket, 1)
     {
         _charName = charName;
+        _item = item;
         _dice = dice;
     }
     public override PacketStream Write(PacketStream stream)
     {
         stream.Write(_charName);
+        stream.Write(_item);
         stream.Write(_dice);
         return stream;
     }

--- a/AAEmu.Game/Core/Packets/G2C/SCLootDicePacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCLootDicePacket.cs
@@ -8,6 +8,10 @@ public class SCLootDicePacket : GamePacket
 {
     private readonly Item _item;
 
+    /// <summary>
+    /// Send a roll request for a given loot item
+    /// </summary>
+    /// <param name="item">Loot item to roll for, can be identified by its fictional itemId</param>
     public SCLootDicePacket(Item item) : base(SCOffsets.SCLootDicePacket, 1)
     {
         _item = item;

--- a/AAEmu.Game/Core/Packets/G2C/SCLootDiceSummaryPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCLootDiceSummaryPacket.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Items.Loots;
 
 namespace AAEmu.Game.Core.Packets.G2C;
@@ -11,9 +12,9 @@ public class SCLootDiceSummaryPacket : GamePacket
     private readonly LootOwnerType _lootOwnerType;
     private readonly uint _lootOwnerObjId;
     //private readonly ulong _iId;
-    private readonly Dictionary<uint, sbyte> _diceList;
+    private readonly Dictionary<Character, sbyte> _diceList;
 
-    public SCLootDiceSummaryPacket(LootOwnerType lootOwnerType, uint lootOwner, ushort itemIndex, Dictionary<uint,sbyte> diceList) : base(SCOffsets.SCLootDiceSummaryPacket, 1)
+    public SCLootDiceSummaryPacket(LootOwnerType lootOwnerType, uint lootOwner, ushort itemIndex, Dictionary<Character,sbyte> diceList) : base(SCOffsets.SCLootDiceSummaryPacket, 1)
     {
         _itemIndex = itemIndex;
         _lootOwnerType = lootOwnerType;
@@ -30,7 +31,7 @@ public class SCLootDiceSummaryPacket : GamePacket
         stream.Write(_diceList.Count);
         foreach (var (player, dice) in _diceList)
         {
-            stream.Write(player);
+            stream.Write(player.Id);
             stream.Write(dice);
         }
         return stream;

--- a/AAEmu.Game/Core/Packets/G2C/SCLootDiceSummaryPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCLootDiceSummaryPacket.cs
@@ -1,29 +1,37 @@
-﻿using AAEmu.Commons.Network;
+﻿using System.Collections.Generic;
+using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.Game.Items.Loots;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
 public class SCLootDiceSummaryPacket : GamePacket
 {
-    private readonly ulong _iId;
-    private readonly int _count;
-    private readonly uint _id;
-    private readonly sbyte _diceValue;
+    private readonly ushort _itemIndex;
+    private readonly LootOwnerType _lootOwnerType;
+    private readonly uint _lootOwnerObjId;
+    //private readonly ulong _iId;
+    private readonly Dictionary<uint, sbyte> _diceList;
 
-    public SCLootDiceSummaryPacket(ulong iId, int count, uint id, sbyte diceValue) : base(SCOffsets.SCLootDiceSummaryPacket, 1)
+    public SCLootDiceSummaryPacket(LootOwnerType lootOwnerType, uint lootOwner, ushort itemIndex, Dictionary<uint,sbyte> diceList) : base(SCOffsets.SCLootDiceSummaryPacket, 1)
     {
-        _iId = iId;
-        _count = count;
-        _id = id;
-        _diceValue = diceValue;
+        _itemIndex = itemIndex;
+        _lootOwnerType = lootOwnerType;
+        _lootOwnerObjId = lootOwner;
+        _diceList = diceList;
     }
 
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(_iId);
-        stream.Write(_count);
-        stream.Write(_id);
-        stream.Write(_diceValue);
+        stream.Write(_itemIndex);
+        stream.Write((ushort)_lootOwnerType);
+        stream.Write(_lootOwnerObjId);
+        stream.Write(_diceList.Count);
+        foreach (var (player, dice) in _diceList)
+        {
+            stream.Write(player);
+            stream.Write(dice);
+        }
         return stream;
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCLootDiceSummaryPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCLootDiceSummaryPacket.cs
@@ -25,7 +25,8 @@ public class SCLootDiceSummaryPacket : GamePacket
     {
         stream.Write(_itemIndex);
         stream.Write((ushort)_lootOwnerType);
-        stream.Write(_lootOwnerObjId);
+        stream.WriteBc(_lootOwnerObjId);
+        stream.Write((byte)0);
         stream.Write(_diceList.Count);
         foreach (var (player, dice) in _diceList)
         {

--- a/AAEmu.Game/Core/Packets/G2C/SCLootDiceSummaryPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCLootDiceSummaryPacket.cs
@@ -6,30 +6,16 @@ using AAEmu.Game.Models.Game.Items.Loots;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCLootDiceSummaryPacket : GamePacket
+public class SCLootDiceSummaryPacket(LootOwnerType lootOwnerType, uint lootOwner, ushort itemIndex, Dictionary<Character, sbyte> diceList) : GamePacket(SCOffsets.SCLootDiceSummaryPacket, 1)
 {
-    private readonly ushort _itemIndex;
-    private readonly LootOwnerType _lootOwnerType;
-    private readonly uint _lootOwnerObjId;
-    //private readonly ulong _iId;
-    private readonly Dictionary<Character, sbyte> _diceList;
-
-    public SCLootDiceSummaryPacket(LootOwnerType lootOwnerType, uint lootOwner, ushort itemIndex, Dictionary<Character,sbyte> diceList) : base(SCOffsets.SCLootDiceSummaryPacket, 1)
-    {
-        _itemIndex = itemIndex;
-        _lootOwnerType = lootOwnerType;
-        _lootOwnerObjId = lootOwner;
-        _diceList = diceList;
-    }
-
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(_itemIndex);
-        stream.Write((ushort)_lootOwnerType);
-        stream.WriteBc(_lootOwnerObjId);
+        stream.Write(itemIndex);
+        stream.Write((ushort)lootOwnerType);
+        stream.WriteBc(lootOwner);
         stream.Write((byte)0);
-        stream.Write(_diceList.Count);
-        foreach (var (player, dice) in _diceList)
+        stream.Write(diceList.Count);
+        foreach (var (player, dice) in diceList)
         {
             stream.Write(player.Id);
             stream.Write(dice);

--- a/AAEmu.Game/Core/Packets/G2C/SCLootItemFailedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCLootItemFailedPacket.cs
@@ -5,31 +5,18 @@ using AAEmu.Game.Models.Game.Items.Loots;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCLootItemFailedPacket : GamePacket
+public class SCLootItemFailedPacket(ErrorMessageType errorMessage, LootOwnerType lootOwnerType, uint lootOwnerObjId, ushort itemIndex, uint itemTemplateId) : GamePacket(SCOffsets.SCLootItemFailedPacket, 1)
 {
-    private readonly int _errorMessage;
-    private readonly ushort _itemIndex;
-    private readonly LootOwnerType _lootOwnerType;
-    private readonly uint _lootOwnerObjId;
-    private readonly uint _itemTemplateId;
-
-    public SCLootItemFailedPacket(ErrorMessageType errorMessage, LootOwnerType lootOwnerType, uint lootOwnerObjId, ushort itemIndex, uint itemTemplateId) : base(SCOffsets.SCLootItemFailedPacket, 1)
-    {
-        _errorMessage = (int)errorMessage;
-        _lootOwnerType = lootOwnerType;
-        _lootOwnerObjId = lootOwnerObjId;
-        _itemIndex = itemIndex;
-        _itemTemplateId = itemTemplateId;
-    }
+    private readonly int _errorMessage = (int)errorMessage;
 
     public override PacketStream Write(PacketStream stream)
     {
         stream.Write(_errorMessage);
-        stream.Write(_itemIndex);
-        stream.Write((ushort)_lootOwnerType);
-        stream.WriteBc(_lootOwnerObjId);
+        stream.Write(itemIndex);
+        stream.Write((ushort)lootOwnerType);
+        stream.WriteBc(lootOwnerObjId);
         stream.Write((byte)0);
-        stream.Write(_itemTemplateId);
+        stream.Write(itemTemplateId);
         return stream;
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCLootItemFailedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCLootItemFailedPacket.cs
@@ -1,27 +1,34 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Models.Game;
+using AAEmu.Game.Models.Game.Items.Loots;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
 public class SCLootItemFailedPacket : GamePacket
 {
     private readonly int _errorMessage;
-    private readonly ulong _iId;
-    private readonly uint _id;
+    private readonly ushort _itemIndex;
+    private readonly LootOwnerType _lootOwnerType;
+    private readonly uint _lootOwnerObjId;
+    private readonly uint _itemTemplateId;
 
-    public SCLootItemFailedPacket(ErrorMessageType errorMessage, ulong iId, uint id) : base(SCOffsets.SCLootItemFailedPacket, 1)
+    public SCLootItemFailedPacket(ErrorMessageType errorMessage, LootOwnerType lootOwnerType, uint lootOwnerObjId, ushort itemIndex, uint itemTemplateId) : base(SCOffsets.SCLootItemFailedPacket, 1)
     {
         _errorMessage = (int)errorMessage;
-        _iId = iId;
-        _id = id;
+        _lootOwnerType = lootOwnerType;
+        _lootOwnerObjId = lootOwnerObjId;
+        _itemIndex = itemIndex;
+        _itemTemplateId = itemTemplateId;
     }
 
     public override PacketStream Write(PacketStream stream)
     {
         stream.Write(_errorMessage);
-        stream.Write(_iId);
-        stream.Write(_id);
+        stream.Write(_itemIndex);
+        stream.Write((ushort)_lootOwnerType);
+        stream.Write(_lootOwnerObjId);
+        stream.Write(_itemTemplateId);
         return stream;
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCLootItemFailedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCLootItemFailedPacket.cs
@@ -27,7 +27,8 @@ public class SCLootItemFailedPacket : GamePacket
         stream.Write(_errorMessage);
         stream.Write(_itemIndex);
         stream.Write((ushort)_lootOwnerType);
-        stream.Write(_lootOwnerObjId);
+        stream.WriteBc(_lootOwnerObjId);
+        stream.Write((byte)0);
         stream.Write(_itemTemplateId);
         return stream;
     }

--- a/AAEmu.Game/Core/Packets/G2C/SCLootItemTookPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCLootItemTookPacket.cs
@@ -26,7 +26,8 @@ public class SCLootItemTookPacket : GamePacket
         stream.Write(_itemTemplateId);
         stream.Write(_itemIndex);
         stream.Write((ushort)_lootOwnerType);
-        stream.Write(_lootOwnerId);
+        stream.WriteBc(_lootOwnerId);
+        stream.Write((byte)0);
         stream.Write(_count);
         return stream;
     }

--- a/AAEmu.Game/Core/Packets/G2C/SCLootItemTookPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCLootItemTookPacket.cs
@@ -1,25 +1,32 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.Game.Items.Loots;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
 public class SCLootItemTookPacket : GamePacket
 {
-    private readonly uint _id;
-    private readonly ulong _iId;
+    private readonly uint _itemTemplateId;
+    private readonly ushort _itemIndex;
+    private readonly LootOwnerType _lootOwnerType;
+    private readonly uint _lootOwnerId;
     private readonly int _count;
 
-    public SCLootItemTookPacket(uint id, ulong iId, int count) : base(SCOffsets.SCLootItemTookPacket, 1)
+    public SCLootItemTookPacket(uint itemTemplateId, ushort itemIndex, LootOwnerType lootOwnerType, uint lootOwnerId, ulong iId, int count) : base(SCOffsets.SCLootItemTookPacket, 1)
     {
-        _id = id;
-        _iId = iId;
+        _itemTemplateId = itemTemplateId;
+        _itemIndex = itemIndex;
+        _lootOwnerType = lootOwnerType;
+        _lootOwnerId = lootOwnerId;
         _count = count;
     }
 
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(_id);
-        stream.Write(_iId);
+        stream.Write(_itemTemplateId);
+        stream.Write(_itemIndex);
+        stream.Write((ushort)_lootOwnerType);
+        stream.Write(_lootOwnerId);
         stream.Write(_count);
         return stream;
     }

--- a/AAEmu.Game/Core/Packets/G2C/SCLootItemTookPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCLootItemTookPacket.cs
@@ -4,31 +4,16 @@ using AAEmu.Game.Models.Game.Items.Loots;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCLootItemTookPacket : GamePacket
+public class SCLootItemTookPacket(uint itemTemplateId, ushort itemIndex, LootOwnerType lootOwnerType, uint lootOwnerId, int count) : GamePacket(SCOffsets.SCLootItemTookPacket, 1)
 {
-    private readonly uint _itemTemplateId;
-    private readonly ushort _itemIndex;
-    private readonly LootOwnerType _lootOwnerType;
-    private readonly uint _lootOwnerId;
-    private readonly int _count;
-
-    public SCLootItemTookPacket(uint itemTemplateId, ushort itemIndex, LootOwnerType lootOwnerType, uint lootOwnerId, ulong iId, int count) : base(SCOffsets.SCLootItemTookPacket, 1)
-    {
-        _itemTemplateId = itemTemplateId;
-        _itemIndex = itemIndex;
-        _lootOwnerType = lootOwnerType;
-        _lootOwnerId = lootOwnerId;
-        _count = count;
-    }
-
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(_itemTemplateId);
-        stream.Write(_itemIndex);
-        stream.Write((ushort)_lootOwnerType);
-        stream.WriteBc(_lootOwnerId);
+        stream.Write(itemTemplateId);
+        stream.Write(itemIndex);
+        stream.Write((ushort)lootOwnerType);
+        stream.WriteBc(lootOwnerId);
         stream.Write((byte)0);
-        stream.Write(_count);
+        stream.Write(count);
         return stream;
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCLootableStatePacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCLootableStatePacket.cs
@@ -27,7 +27,8 @@ public class SCLootableStatePacket : GamePacket
     {
         stream.Write((ushort)0); // unused itemIndex?
         stream.Write((ushort)_lootOwnerType);
-        stream.Write(_lootOwnerObjId);
+        stream.WriteBc(_lootOwnerObjId);
+        stream.Write((byte)0);
         stream.Write(_hasLoot);
         return stream;
     }

--- a/AAEmu.Game/Core/Packets/G2C/SCLootableStatePacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCLootableStatePacket.cs
@@ -1,23 +1,34 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.Game.Items.Loots;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
 public class SCLootableStatePacket : GamePacket
 {
-    private readonly uint _iId;
-    private readonly bool _isLootable;
+    private readonly LootOwnerType _lootOwnerType; // Might be the same as QuestAcceptorType
+    private readonly uint _lootOwnerObjId;
+    private readonly bool _hasLoot;
 
-    public SCLootableStatePacket(uint unitId, bool isLootable) : base(SCOffsets.SCLootableStatePacket, 1)
+    /// <summary>
+    /// Sends the loot-able state of an object or unit
+    /// </summary>
+    /// <param name="lootOwnerType">What type of object has the loot state set</param>
+    /// <param name="lootOwnerObjId">ObjectId to set the state for</param>
+    /// <param name="hasLoot"></param>
+    public SCLootableStatePacket(LootOwnerType lootOwnerType, uint lootOwnerObjId, bool hasLoot) : base(SCOffsets.SCLootableStatePacket, 1)
     {
-        _iId = unitId;
-        _isLootable = isLootable;
+        _lootOwnerType = lootOwnerType;
+        _lootOwnerObjId = lootOwnerObjId;
+        _hasLoot = hasLoot;
     }
 
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(((ulong)_iId << 32) + 65536);
-        stream.Write(_isLootable);
+        stream.Write((ushort)0); // unused itemIndex?
+        stream.Write((ushort)_lootOwnerType);
+        stream.Write(_lootOwnerObjId);
+        stream.Write(_hasLoot);
         return stream;
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCTeamLootingRuleChangedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCTeamLootingRuleChangedPacket.cs
@@ -4,24 +4,13 @@ using AAEmu.Game.Models.Game.Team;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCTeamLootingRuleChangedPacket : GamePacket
+public class SCTeamLootingRuleChangedPacket(uint teamId, LootingRule lootingRule, byte changeFlags) : GamePacket(SCOffsets.SCTeamLootingRuleChangedPacket, 1)
 {
-    private readonly uint _teamId;
-    private readonly LootingRule _lootingRule;
-    private readonly byte _changeFlags;
-
-    public SCTeamLootingRuleChangedPacket(uint teamId, LootingRule lootingRule, byte changeFlags) : base(SCOffsets.SCTeamLootingRuleChangedPacket, 1)
-    {
-        _teamId = teamId;
-        _lootingRule = lootingRule;
-        _changeFlags = changeFlags;
-    }
-
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(_teamId);
-        stream.Write(_lootingRule);
-        stream.Write(_changeFlags);
+        stream.Write(teamId);
+        stream.Write(lootingRule);
+        stream.Write(changeFlags);
         return stream;
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCUnitLootingStatePacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCUnitLootingStatePacket.cs
@@ -5,17 +5,22 @@ namespace AAEmu.Game.Core.Packets.G2C;
 
 public class SCUnitLootingStatePacket : GamePacket
 {
-    private readonly byte _bc;
+    private readonly uint _unitObjId;
     private readonly byte _looting;
 
-    public SCUnitLootingStatePacket(byte bc, byte looting) : base(SCOffsets.SCUnitLootingStatePacket, 1)
+    /// <summary>
+    /// Sets the state of a unit if they are busy looting or not
+    /// </summary>
+    /// <param name="unitObjId"></param>
+    /// <param name="looting">Looting state, 2 seems to be "done looting"</param>
+    public SCUnitLootingStatePacket(uint unitObjId, byte looting) : base(SCOffsets.SCUnitLootingStatePacket, 1)
     {
-        _bc = bc;
+        _unitObjId = unitObjId;
         _looting = looting;
     }
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(_bc);
+        stream.WriteBc(_unitObjId);
         stream.Write(_looting);
         return stream;
     }

--- a/AAEmu.Game/Core/Packets/G2C/SCUnitLootingStatePacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCUnitLootingStatePacket.cs
@@ -18,6 +18,7 @@ public class SCUnitLootingStatePacket : GamePacket
         _unitObjId = unitObjId;
         _looting = looting;
     }
+
     public override PacketStream Write(PacketStream stream)
     {
         stream.WriteBc(_unitObjId);

--- a/AAEmu.Game/Models/Game/Items/Containers/LootingContainer.cs
+++ b/AAEmu.Game/Models/Game/Items/Containers/LootingContainer.cs
@@ -37,7 +37,7 @@ public class LootingContainer(IBaseUnit owner)
     /// <summary>
     /// Time before loot goes to public in seconds
     /// </summary>
-    public const float MakeLootPublicTime = 180f;
+    private const float MakeLootPublicTime = 180f;
 
     /// <summary>
     /// When loot has been generated, extend the despawn timer by this amount (in seconds)
@@ -71,7 +71,7 @@ public class LootingContainer(IBaseUnit owner)
     /// <summary>
     /// List of item entries (itemIndex, LootItemEntry)
     /// </summary>
-    public Dictionary<ushort, LootingContainerItemEntry> Items { get; init; } = new();
+    public Dictionary<ushort, LootingContainerItemEntry> Items { get; } = new();
     private bool AlreadyGenerated { get; set; }
     private HashSet<Character> EligiblePlayers { get; } = [];
     private HashSet<Character> OpenedBy { get; } = [];
@@ -305,7 +305,7 @@ public class LootingContainer(IBaseUnit owner)
             var lootedItems = new List<ushort>();
             foreach (var (itemIndex, itemEntry) in Items)
             {
-                if (TryTakeLoot(player, itemIndex, itemEntry))
+                if (TryTakeLoot(player, itemIndex, itemEntry, true))
                     lootedItems.Add(itemIndex);
             }
             // Remove actually looted items
@@ -337,8 +337,9 @@ public class LootingContainer(IBaseUnit owner)
     /// <param name="player"></param>
     /// <param name="itemIndex"></param>
     /// <param name="itemEntry"></param>
+    /// <param name="didLootAll"></param>
     /// <returns>Returns true if the item was granted to the player</returns>
-    public bool TryTakeLoot(Character player, ushort itemIndex, LootingContainerItemEntry itemEntry)
+    public bool TryTakeLoot(Character player, ushort itemIndex, LootingContainerItemEntry itemEntry, bool didLootAll)
     {
         var lootTarget = player;
         // If itemEntry not specified, grab it from its index
@@ -372,7 +373,7 @@ public class LootingContainer(IBaseUnit owner)
         // Check if we already have looting right, if so, try to loot again
         if (itemEntry.HighestRoller == player.Id)
         {
-            return TryDistributeLootToPlayer(player, itemEntry);
+            return TryDistributeLootToPlayer(player, itemEntry, didLootAll);
         }
 
         // Check if rolls in progress (for more than one player only)
@@ -405,7 +406,7 @@ public class LootingContainer(IBaseUnit owner)
 
                     if (itemEntry.HighestRoller > 0)
                     {
-                        var res = TryDistributeLootToPlayer(winner, itemEntry);
+                        var res = TryDistributeLootToPlayer(winner, itemEntry, didLootAll);
                         return winner == player && res;
                     }
                 }
@@ -456,7 +457,7 @@ public class LootingContainer(IBaseUnit owner)
 
         // TODO: Handle pickup limit, not sure if we should prevent looting/rolling in the first place, or just prevent adding to inventory
 
-        return TryDistributeLootToPlayer(lootTarget, itemEntry);
+        return TryDistributeLootToPlayer(lootTarget, itemEntry, didLootAll);
     }
 
     /// <summary>
@@ -497,10 +498,19 @@ public class LootingContainer(IBaseUnit owner)
         if (itemEntry.PlayerRolls.Any(m => m.Value == 0))
             return;
         
+        FinishRolling(itemEntry);
+    }
+
+    /// <summary>
+    /// Handle the distribution when all rolls are finished
+    /// </summary>
+    /// <param name="itemEntry"></param>
+    private void FinishRolling(LootingContainerItemEntry itemEntry)
+    {
         // All done? Send summary as well to all
         foreach (var (targetPlayer, _) in itemEntry.PlayerRolls)
         {
-            targetPlayer.SendPacket(new SCLootDiceSummaryPacket(LootOwnerType, LootOwner.ObjId, itemEntry.ItemIndex, itemEntry.PlayerRolls));
+            targetPlayer?.SendPacket(new SCLootDiceSummaryPacket(LootOwnerType, LootOwner.ObjId, itemEntry.ItemIndex, itemEntry.PlayerRolls));
         }
 
         // Find the highest rolled value
@@ -509,7 +519,7 @@ public class LootingContainer(IBaseUnit owner)
             .OrderBy(x => x.Value)
             .Select(x => x.Value)
             .FirstOrDefault();
-        
+
         // Find highest roller(s)
         var highestEntries = itemEntry.PlayerRolls
             .Where(x => x.Value >= highestResult)
@@ -523,16 +533,16 @@ public class LootingContainer(IBaseUnit owner)
             return;
         }
 
-        // Select random winner (if multiple people roll the same
+        // Select random winner (if multiple people roll the same)
         var pickIndex = Random.Shared.Next(highestEntries.Count);
         var highestEntry = highestEntries[pickIndex];
 
         // Mark winner
         itemEntry.HighestRoller = highestEntry.Key.Id;
-        TryDistributeLootToPlayer(highestEntry.Key, itemEntry);
+        TryDistributeLootToPlayer(highestEntry.Key, itemEntry, false);
     }
 
-    private bool TryDistributeLootToPlayer(Character player, LootingContainerItemEntry itemEntry)
+    private bool TryDistributeLootToPlayer(Character player, LootingContainerItemEntry itemEntry, bool didLootAll)
     {
         var freeSpace = player.Inventory.Bag.SpaceLeftForItem(itemEntry.Item, out _);
         if (freeSpace < itemEntry.Item.Count)
@@ -554,7 +564,7 @@ public class LootingContainer(IBaseUnit owner)
             // On a loot attempt, it's probably safe to try and assign it a real itemId
             itemEntry.Item.Id = ItemIdManager.Instance.GetNextId();
             // Try to add the new item
-            if (!player.Inventory.Bag.AcquireDefaultItem(ItemTaskType.Loot, itemEntry.Item.TemplateId, itemEntry.Item.Count, itemEntry.Item.Grade))
+            if (!player.Inventory.Bag.AcquireDefaultItem(didLootAll ? ItemTaskType.LootAll : ItemTaskType.Loot, itemEntry.Item.TemplateId, itemEntry.Item.Count, itemEntry.Item.Grade))
             {
                 // Free the Id again if failed
                 ItemIdManager.Instance.ReleaseId((uint)itemEntry.Item.Id);
@@ -573,5 +583,56 @@ public class LootingContainer(IBaseUnit owner)
         if (Items.Count <= 0)
             UpdateLootState();
         return true;
+    }
+
+    /// <summary>
+    /// Forces any ongoing loot rolls to end by making the remaining players auto-pass
+    /// </summary>
+    private void ForceLootRollToFinish()
+    {
+        foreach (var (_, itemEntry) in Items)
+        {
+            if (itemEntry.PlayerRolls.All(m => m.Value != 0))
+                continue;
+
+            foreach (var (player, roll) in itemEntry.PlayerRolls)
+            {
+                if (roll == 0)
+                {
+                    itemEntry.PlayerRolls[player] = -1;
+                    // Notify the others of this roll result (not sure if we should add this)
+                    // foreach (var targetPlayer in itemEntry.PlayerRolls.Keys)
+                    // {
+                    //     targetPlayer.SendPacket(new SCLootDiceNotifyPacket(player.Name, itemEntry.Item, -1));
+                    // }
+                }
+            }
+            
+            FinishRolling(itemEntry);
+        }
+    }
+
+    public void MakeLootPublic()
+    {
+        ForceLootRollToFinish();
+        if (Items.Count <= 0)
+            return;
+
+        // Force full public looting for all non-claimed items
+        TeamLootingRule.LootMethod = LootingRuleMethod.Public;
+        TeamLootingRule.MinimumGrade = 0;
+        TeamLootingRule.RollForBindOnPickup = false;
+
+        // Broadcast the new state it to everybody nearby
+        LootOwner?.BroadcastPacket(new SCLootableStatePacket(LootOwnerType, LootOwner.ObjId, true), false);
+    }
+
+    public bool CanMakePublic()
+    {
+        return ((TeamLootingRule != null) &&
+            (TeamLootingRule.LootMethod != LootingRuleMethod.Public) &&
+            (Items.Count > 0) &&
+            (CreationTime > DateTime.MinValue) &&
+            (CreationTime.AddSeconds(MakeLootPublicTime) <= DateTime.UtcNow));
     }
 }

--- a/AAEmu.Game/Models/Game/Items/Containers/LootingContainer.cs
+++ b/AAEmu.Game/Models/Game/Items/Containers/LootingContainer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using AAEmu.Commons.Utils;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.Id;
 using AAEmu.Game.Core.Managers.World;
@@ -25,6 +24,8 @@ namespace AAEmu.Game.Models.Game.Items.Containers;
 /// </summary>
 public class LootingContainer(IBaseUnit owner)
 {
+    // ReSharper disable once FieldCanBeMadeReadOnly.Local
+    // ReSharper disable once InconsistentNaming
     private static Logger Logger = LogManager.GetCurrentClassLogger();
 
     // TODO: Make loot range and timing settings configurable
@@ -46,7 +47,7 @@ public class LootingContainer(IBaseUnit owner)
     /// <summary>
     /// Minimum time that a corpse should remain after it has been looted for all items (if it had items)
     /// </summary>
-    public const float PostLootMinimumDespawnTime = 2f;
+    private const float PostLootMinimumDespawnTime = 2f;
 
     /// <summary>
     /// Unit this looting container is attached to
@@ -57,9 +58,10 @@ public class LootingContainer(IBaseUnit owner)
     /// <summary>
     /// Unit that dealt the killing blow
     /// </summary>
-    public IBaseUnit Killer { get; private set; }
-    public Team.Team KillerTeam { get; private set; }
-    public LootingRule TeamLootingRule { get; private set; }
+    private IBaseUnit Killer { get; set; }
+
+    private Team.Team KillerTeam { get; set; }
+    private LootingRule TeamLootingRule { get; set; }
 
     /// <summary>
     /// Time this loot was generated
@@ -151,7 +153,7 @@ public class LootingContainer(IBaseUnit owner)
                 {
                     LootMethod = LootingRuleMethod.FreeForAll,
                     MinimumGrade = 0,
-                    LootMaster = (killer as Character)?.Id ?? 0
+                    LootMaster = (Killer as Character)?.Id ?? 0
                 };
                 // A player has tag rights
                 EligiblePlayers.Add(npc.CharacterTagging.Tagger);
@@ -260,7 +262,7 @@ public class LootingContainer(IBaseUnit owner)
     /// <summary>
     /// Sends the SCLootableStatePacket to all involved players and updates despawn times if needed
     /// </summary>
-    public void UpdateLootState()
+    private void UpdateLootState()
     {
         SendPacketToPlayers(EligiblePlayers, new SCLootableStatePacket(LootOwnerType, LootOwner.ObjId, Items.Count > 0));
         // If no items left, then reduce the despawn timer if needed
@@ -398,8 +400,7 @@ public class LootingContainer(IBaseUnit owner)
                 else if (KillerTeam != null)
                 {
                     // Kill credits go to a team, pick a winner at random
-                    var winner = KillerTeam.GetNextLootWinner(EligiblePlayers, itemEntry.Owner.LootOwner,
-                        MaxLootingRange);
+                    var winner = KillerTeam.GetNextLootWinner(EligiblePlayers, itemEntry.Owner.LootOwner);
                     itemEntry.HighestRoller = winner?.Id ?? 0;
 
                     if (itemEntry.HighestRoller > 0)
@@ -497,12 +498,12 @@ public class LootingContainer(IBaseUnit owner)
             return;
         
         // All done? Send summary as well to all
-        foreach (var (targetPlayer, roll) in itemEntry.PlayerRolls)
+        foreach (var (targetPlayer, _) in itemEntry.PlayerRolls)
         {
             targetPlayer.SendPacket(new SCLootDiceSummaryPacket(LootOwnerType, LootOwner.ObjId, itemEntry.ItemIndex, itemEntry.PlayerRolls));
         }
 
-        // Find highest rolled value
+        // Find the highest rolled value
         var highestResult = itemEntry.PlayerRolls
             .Where(x => x.Value > 0)
             .OrderBy(x => x.Value)
@@ -566,7 +567,7 @@ public class LootingContainer(IBaseUnit owner)
             }
         }
         // TODO: check what packet this sends to others
-        player.SendPacket(new SCLootItemTookPacket(itemEntry.Item.TemplateId, itemEntry.ItemIndex, LootOwnerType, LootOwner.ObjId, fullOldItemId, itemEntry.Item.Count));
+        player.SendPacket(new SCLootItemTookPacket(itemEntry.Item.TemplateId, itemEntry.ItemIndex, LootOwnerType, LootOwner.ObjId, itemEntry.Item.Count));
         Items.Remove(itemEntry.ItemIndex);
 
         if (Items.Count <= 0)

--- a/AAEmu.Game/Models/Game/Items/Containers/LootingContainer.cs
+++ b/AAEmu.Game/Models/Game/Items/Containers/LootingContainer.cs
@@ -1,0 +1,369 @@
+﻿using System;
+using System.Collections.Generic;
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.Id;
+using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.GameData;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.DoodadObj;
+using AAEmu.Game.Models.Game.Items.Actions;
+using AAEmu.Game.Models.Game.Items.Loots;
+using AAEmu.Game.Models.Game.NPChar;
+using AAEmu.Game.Models.Game.Team;
+using AAEmu.Game.Models.Game.Units;
+using NLog;
+
+namespace AAEmu.Game.Models.Game.Items.Containers;
+
+/// <summary>
+/// Unlike other item containers this one is not an actual ItemContainer
+/// </summary>
+public class LootingContainer(IBaseUnit owner)
+{
+    private static Logger Logger = LogManager.GetCurrentClassLogger();
+    /// <summary>
+    /// Unit this looting container is attached to
+    /// </summary>
+    private IBaseUnit LootOwner { get; } = owner;
+    private LootOwnerType LootOwnerType { get; set; } = LootOwnerType.None;
+
+    /// <summary>
+    /// Unit that dealt the killing blow
+    /// </summary>
+    public IBaseUnit Killer { get; private set; }
+    public Team.Team KillerTeam { get; private set; }
+    public LootingRule TeamLootingRule { get; private set; }
+
+    private DateTime CreationTime { get; set; } = DateTime.MinValue;
+    private DateTime ExpireTime { get; set; } = DateTime.MaxValue;
+
+    /// <summary>
+    /// List of item entries (itemIndex, LootItemEntry)
+    /// </summary>
+    public Dictionary<ushort, LootingContainerItemEntry> Items { get; init; } = new();
+    private bool AlreadyGenerated { get; set; }
+    private HashSet<Character> EligiblePlayers { get; } = [];
+    private HashSet<Character> OpenedBy { get; } = [];
+
+    /// <summary>
+    /// Generate appropriate loot
+    /// </summary>
+    /// <param name="killer"></param>
+    public void GenerateLoot(IBaseUnit killer)
+    {
+        // Do not allow multiple generations of loot 
+        if (AlreadyGenerated)
+            return;
+        AlreadyGenerated = true;
+        
+        // Initialize some things
+        LootOwnerType = LootOwner switch
+        {
+            Npc => LootOwnerType.Npc,
+            Doodad => LootOwnerType.Doodad,
+            _ => LootOwnerType.None
+        };
+        Killer = killer;
+        CreationTime = DateTime.UtcNow;
+        ExpireTime = CreationTime + TimeSpan.FromMinutes(5);
+        Items.Clear();
+
+        // NPC Loot handling
+        if (LootOwnerType == LootOwnerType.Npc && LootOwner is Npc npc)
+        {
+            // Get drop list for this NPC
+            var lootPackDroppingNpcs = ItemManager.Instance.GetLootPackIdByNpcId(npc.TemplateId);
+            if (lootPackDroppingNpcs.Count <= 0)
+            {
+                return;
+            }
+
+            // Calculate loot rates
+            var lootDropRate = 1f;
+            var lootGoldRate = 1f;
+
+            // Check all people with a claim on the NPC
+            EligiblePlayers.Clear();
+            KillerTeam = TeamManager.Instance.GetActiveTeam(npc.CharacterTagging.TagTeam);
+            TeamLootingRule = KillerTeam.LootingRule.Clone();
+            
+            if (npc.CharacterTagging.TagTeam != 0)
+            {
+                // A team has tagging rights
+                if (KillerTeam != null)
+                {
+                    foreach (var member in KillerTeam.Members)
+                    {
+                        if (member == null || member.Character == null)
+                            continue;
+
+                        var distance = member.Character.Transform.World.Position - npc.Transform.World.Position;
+                        if (distance.Length() <= 200)
+                        {
+                            //This player is in range of the mob and in a group with tagging rights.
+                            EligiblePlayers.Add(member.Character);
+                        }
+                    }
+                }
+                else if (npc.CharacterTagging.Tagger != null)
+                {
+                    //A player has tag rights
+                    EligiblePlayers.Add(npc.CharacterTagging.Tagger);
+                }
+
+            }
+            else if (npc.CharacterTagging.Tagger != null)
+            {
+                // Set to FreeForAll when only the tagger has rights
+                TeamLootingRule = new LootingRule
+                {
+                    LootMethod = LootingRuleMethod.FreeForAll,
+                    MinimumGrade = 0xFF,
+                    LootMaster = (killer as Character)?.Id ?? 0
+                };
+                // A player has tag rights
+                EligiblePlayers.Add(npc.CharacterTagging.Tagger);
+            }
+
+            if (EligiblePlayers.Count > 0)
+            {
+                var maxDropRateMul = -100f;
+                var maxLootGoldMul = -100f;
+
+                foreach (var pl in EligiblePlayers)
+                {
+                    var aggroDropMul = (100f + pl.DropRateMul) / 100f;
+                    var aggroGoldMul = (100f + pl.LootGoldMul) / 100f;
+                    if (aggroDropMul > maxDropRateMul)
+                        maxDropRateMul = aggroDropMul;
+                    if (aggroGoldMul > maxLootGoldMul)
+                        maxLootGoldMul = aggroGoldMul;
+
+                }
+
+                lootDropRate = maxDropRateMul;
+                lootGoldRate = maxLootGoldMul;
+            }
+            else if (killer is Character player)
+            {
+                lootDropRate *= (100f + player.DropRateMul) / 100f;
+                lootGoldRate *= (100f + player.LootGoldMul) / 100f;
+                Logger.Info($"Unit killed without aggro: {npc.ObjId} ({npc.TemplateId}) by {player.Name}");
+            }
+
+            // Base ID used for identifying the loot
+            var baseId = ((ulong)LootOwner.ObjId << 32) + ((ulong)LootOwnerType << 16) + 1;
+
+            // Generate the actual loot
+            foreach (var lootPackDropping in lootPackDroppingNpcs)
+            {
+                var lootPack = LootGameData.Instance.GetPack(lootPackDropping.LootPackId);
+                if (lootPack == null)
+                    continue;
+                var items = lootPack.GenerateNpcPackItems(ref baseId, killer, lootDropRate, lootGoldRate);
+
+                RegisterItems(items);
+            }
+
+            UpdateLootState();
+        }
+        else
+        if (LootOwnerType == LootOwnerType.Doodad && LootOwner is Doodad doodad)
+        {
+            // TODO: LootOwnerType.Doodad
+            Logger.Warn($"Not yet implemented for doodads, LootOwner: {LootOwnerType}:{doodad.ObjId}");
+        }
+        else
+        {
+            // TODO: Either loot generated for a not supported type or it no longer exists 
+            Logger.Warn($"Unsupported LootOwner: {LootOwnerType}:{LootOwner.ObjId}");
+        }
+    }
+
+    /// <summary>
+    /// Add generated loot to the loot container
+    /// </summary>
+    /// <param name="items">Loot</param>
+    private void RegisterItems(List<Item> items)
+    {
+        foreach (var item in items)
+        {
+            var newItem = new LootingContainerItemEntry
+            {
+                Owner = this,
+                Item = item,
+                ItemIndex = (ushort)(Items.Count + 1),
+                HighestRoller = 0
+            };
+            // Update ItemId to what is expected to be used
+            // Note that the actual Item.Id needs to be updated upon actual looting
+            newItem.Item.Id = ((ulong)LootOwner.ObjId << 32) + ((ulong)LootOwnerType << 16) + newItem.ItemIndex;
+
+            // Add roll settings for everybody
+            foreach (var player in EligiblePlayers)
+            {
+                newItem.PlayerRolls.TryAdd(player.Id, -1);
+            }
+
+            // Add the actual entry
+            Items.Add(newItem.ItemIndex, newItem);
+        }
+    }
+
+    /// <summary>
+    /// Returns true if all items are looted, or if loot time has expired
+    /// </summary>
+    /// <returns></returns>
+    public bool AllowDespawn()
+    {
+        return Items.Count <= 0 || ExpireTime <= DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Broadcasts packet to all players in the list of targets
+    /// </summary>
+    /// <param name="players"></param>
+    /// <param name="packet"></param>
+    private void SendPacketToPlayers(HashSet<Character> players, GamePacket packet)
+    {
+        foreach (var target in players)
+        {
+            target.SendPacket(packet);
+        }
+    }
+
+    /// <summary>
+    /// Sends the SCLootableStatePacket to all involved players
+    /// </summary>
+    public void UpdateLootState()
+    {
+        SendPacketToPlayers(EligiblePlayers, new SCLootableStatePacket(LootOwnerType, LootOwner.ObjId, Items.Count > 0));
+    }
+
+    /// <summary>
+    /// Player opens the loot bag
+    /// </summary>
+    /// <param name="player"></param>
+    /// <param name="object2"></param>
+    /// <param name="lootAll"></param>
+    public void OpenBag(Character player, BaseUnit object2, bool lootAll)
+    {
+        OpenedBy.Add(player);
+
+        // If LootAll is set, try to loot all items immediately
+        if (lootAll)
+        {
+            // Try to loot all items
+            var lootedItems = new List<ushort>();
+            foreach (var (itemIndex, itemEntry) in Items)
+            {
+                if (TryTakeLoot(player, itemIndex, itemEntry, itemEntry.Item.Count))
+                    lootedItems.Add(itemIndex);
+            }
+            // Remove actually looted items
+            foreach(var lootedItemIndex in lootedItems)
+                Items.Remove(lootedItemIndex);
+        }
+        // Send packet update of remaining items, or loot state if all has been looted already
+        if (Items.Count <= 0)
+        {
+            UpdateLootState();
+        }
+        else
+        {
+            var remainingItems = new List<Item>();
+            foreach (var (_, itemEntry) in Items)
+            {
+                remainingItems.Add(itemEntry.Item);
+            }
+
+            SendPacketToPlayers(OpenedBy, new SCLootBagDataPacket(remainingItems, lootAll));
+        }
+    }
+
+    /// <summary>
+    /// Tries to add a LootingContainerItemEntry's item to the player's Bag, does not actually remove the itemEntry
+    /// </summary>
+    /// <param name="player"></param>
+    /// <param name="itemIndex"></param>
+    /// <param name="itemEntry"></param>
+    /// <param name="count"></param>
+    /// <returns>Returns true if the item was granted to the player</returns>
+    public bool TryTakeLoot(Character player, ushort itemIndex, LootingContainerItemEntry itemEntry, int count)
+    {
+        // If itemEntry not specified, grab it from its index
+        itemEntry ??= Items.GetValueOrDefault(itemIndex);
+
+        // Invalid item?
+        if (itemEntry == null)
+            return false;
+
+        // First check for quest items eligibility
+        if (itemEntry.Item.Template.LootQuestId > 0)
+        {
+            if (!player.Quests.HasQuest(itemEntry.Item.Template.LootQuestId))
+            {
+                player.SendPacket(new SCLootItemFailedPacket(ErrorMessageType.NeedQuestToInteract, LootOwnerType, LootOwner.ObjId, itemEntry.ItemIndex, itemEntry.Item.TemplateId));
+                return false;
+            }
+        }
+        
+        // Check party/raid loot settings (if applicable)
+        
+        
+        // TODO: Handle pickup limit
+
+        var freeSpace = player.Inventory.Bag.SpaceLeftForItem(itemEntry.Item, out _);
+        if (freeSpace < itemEntry.Item.Count)
+        {
+            // player.SendErrorMessage(ErrorMessageType.BagFull);
+            player.SendPacket(new SCLootItemFailedPacket(ErrorMessageType.BagFull, LootOwnerType, LootOwner.ObjId, itemEntry.ItemIndex, itemEntry.Item.TemplateId));
+            return false;
+        }
+
+        var fullOldItemId = itemEntry.Item.Id;
+
+        // var objId = (uint)(lootDropItem.Id >> 32);
+        if (itemEntry.Item.TemplateId == Item.Coins)
+        {
+            player.AddMoney(SlotType.Inventory, itemEntry.Item.Count);
+        }
+        else
+        {
+            // On a loot attempt, it's probably safe to try and assign it a real itemId
+            itemEntry.Item.Id = ItemIdManager.Instance.GetNextId();
+            // Try to add the new item
+            if (!player.Inventory.Bag.AcquireDefaultItem(ItemTaskType.Loot, itemEntry.Item.TemplateId,
+                    count > itemEntry.Item.Count ? itemEntry.Item.Count : count, itemEntry.Item.Grade))
+            {
+                // Free the Id again if failed
+                ItemIdManager.Instance.ReleaseId((uint)itemEntry.Item.Id);
+                // Re-assign the original loot bag id 
+                itemEntry.Item.Id = fullOldItemId;
+                // Send a bag full fail message
+                // player.SendErrorMessage(ErrorMessageType.BagFull);
+                player.SendPacket(new SCLootItemFailedPacket(ErrorMessageType.BagFull, LootOwnerType, LootOwner.ObjId, itemEntry.ItemIndex, itemEntry.Item.TemplateId));
+                return false;
+            }
+        }
+        // TODO: check what packet this sends to others
+        player.SendPacket(new SCLootItemTookPacket(itemEntry.Item.TemplateId, itemEntry.ItemIndex, LootOwnerType, LootOwner.ObjId, fullOldItemId, itemEntry.Item.Count));
+        Items.Remove(itemEntry.ItemIndex);
+        
+        return true;
+    }
+
+    /// <summary>
+    /// Player manually closes the loot bag
+    /// </summary>
+    /// <param name="player"></param>
+    /// <param name="itemIndex"></param>
+    /// <param name="ownerType"></param>
+    /// <param name="ownerObjId"></param>
+    /// <param name="b"></param>
+    public void CloseBag(Character player, ushort itemIndex, LootOwnerType ownerType, uint ownerObjId, byte b)
+    {
+        OpenedBy.Remove(player);
+    }
+}

--- a/AAEmu.Game/Models/Game/Items/Containers/LootingContainer.cs
+++ b/AAEmu.Game/Models/Game/Items/Containers/LootingContainer.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using AAEmu.Commons.Utils;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.Id;
+using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.GameData;
@@ -9,6 +12,7 @@ using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.Items.Actions;
 using AAEmu.Game.Models.Game.Items.Loots;
+using AAEmu.Game.Models.Game.Items.Templates;
 using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Team;
 using AAEmu.Game.Models.Game.Units;
@@ -22,6 +26,28 @@ namespace AAEmu.Game.Models.Game.Items.Containers;
 public class LootingContainer(IBaseUnit owner)
 {
     private static Logger Logger = LogManager.GetCurrentClassLogger();
+
+    // TODO: Make loot range and timing settings configurable
+    /// <summary>
+    /// Maximum range from owner to be permitted to loot (don't allow looting by far away people)
+    /// </summary>
+    public const float MaxLootingRange = 200f;
+
+    /// <summary>
+    /// Time before loot goes to public in seconds
+    /// </summary>
+    public const float MakeLootPublicTime = 180f;
+
+    /// <summary>
+    /// When loot has been generated, extend the despawn timer by this amount (in seconds)
+    /// </summary>
+    public const float LootDespawnExtensionTime = 300f;
+
+    /// <summary>
+    /// Minimum time that a corpse should remain after it has been looted for all items (if it had items)
+    /// </summary>
+    public const float PostLootMinimumDespawnTime = 2f;
+
     /// <summary>
     /// Unit this looting container is attached to
     /// </summary>
@@ -35,8 +61,10 @@ public class LootingContainer(IBaseUnit owner)
     public Team.Team KillerTeam { get; private set; }
     public LootingRule TeamLootingRule { get; private set; }
 
+    /// <summary>
+    /// Time this loot was generated
+    /// </summary>
     private DateTime CreationTime { get; set; } = DateTime.MinValue;
-    private DateTime ExpireTime { get; set; } = DateTime.MaxValue;
 
     /// <summary>
     /// List of item entries (itemIndex, LootItemEntry)
@@ -66,7 +94,6 @@ public class LootingContainer(IBaseUnit owner)
         };
         Killer = killer;
         CreationTime = DateTime.UtcNow;
-        ExpireTime = CreationTime + TimeSpan.FromMinutes(5);
         Items.Clear();
 
         // NPC Loot handling
@@ -86,7 +113,10 @@ public class LootingContainer(IBaseUnit owner)
             // Check all people with a claim on the NPC
             EligiblePlayers.Clear();
             KillerTeam = TeamManager.Instance.GetActiveTeam(npc.CharacterTagging.TagTeam);
-            TeamLootingRule = KillerTeam.LootingRule.Clone();
+            TeamLootingRule = KillerTeam?.LootingRule.Clone() ?? new LootingRule()
+            {
+                LootMethod = LootingRuleMethod.FreeForAll,
+            };
             
             if (npc.CharacterTagging.TagTeam != 0)
             {
@@ -97,9 +127,11 @@ public class LootingContainer(IBaseUnit owner)
                     {
                         if (member == null || member.Character == null)
                             continue;
+                        
+                        //if (member.HasGoneRoundRobin)
+                        //    continue;
 
-                        var distance = member.Character.Transform.World.Position - npc.Transform.World.Position;
-                        if (distance.Length() <= 200)
+                        if (member.Character.GetDistanceTo(npc) <= MaxLootingRange)
                         {
                             //This player is in range of the mob and in a group with tagging rights.
                             EligiblePlayers.Add(member.Character);
@@ -108,10 +140,9 @@ public class LootingContainer(IBaseUnit owner)
                 }
                 else if (npc.CharacterTagging.Tagger != null)
                 {
-                    //A player has tag rights
+                    // If a team tag, but no valid team found then use the tagger
                     EligiblePlayers.Add(npc.CharacterTagging.Tagger);
                 }
-
             }
             else if (npc.CharacterTagging.Tagger != null)
             {
@@ -119,13 +150,14 @@ public class LootingContainer(IBaseUnit owner)
                 TeamLootingRule = new LootingRule
                 {
                     LootMethod = LootingRuleMethod.FreeForAll,
-                    MinimumGrade = 0xFF,
+                    MinimumGrade = 0,
                     LootMaster = (killer as Character)?.Id ?? 0
                 };
                 // A player has tag rights
                 EligiblePlayers.Add(npc.CharacterTagging.Tagger);
             }
 
+            // Calculate required drop-rate multipliers
             if (EligiblePlayers.Count > 0)
             {
                 var maxDropRateMul = -100f;
@@ -147,9 +179,11 @@ public class LootingContainer(IBaseUnit owner)
             }
             else if (killer is Character player)
             {
+                // If no eligible players defined, then try to use the killer's loot rates and mark it as the sole valid option
                 lootDropRate *= (100f + player.DropRateMul) / 100f;
                 lootGoldRate *= (100f + player.LootGoldMul) / 100f;
                 Logger.Info($"Unit killed without aggro: {npc.ObjId} ({npc.TemplateId}) by {player.Name}");
+                EligiblePlayers.Add(player);
             }
 
             // Base ID used for identifying the loot
@@ -164,6 +198,11 @@ public class LootingContainer(IBaseUnit owner)
                 var items = lootPack.GenerateNpcPackItems(ref baseId, killer, lootDropRate, lootGoldRate);
 
                 RegisterItems(items);
+            }
+
+            if (Items.Count <= 0)
+            {
+                return;
             }
 
             UpdateLootState();
@@ -200,24 +239,9 @@ public class LootingContainer(IBaseUnit owner)
             // Note that the actual Item.Id needs to be updated upon actual looting
             newItem.Item.Id = ((ulong)LootOwner.ObjId << 32) + ((ulong)LootOwnerType << 16) + newItem.ItemIndex;
 
-            // Add roll settings for everybody
-            foreach (var player in EligiblePlayers)
-            {
-                newItem.PlayerRolls.TryAdd(player.Id, -1);
-            }
-
             // Add the actual entry
             Items.Add(newItem.ItemIndex, newItem);
         }
-    }
-
-    /// <summary>
-    /// Returns true if all items are looted, or if loot time has expired
-    /// </summary>
-    /// <returns></returns>
-    public bool AllowDespawn()
-    {
-        return Items.Count <= 0 || ExpireTime <= DateTime.UtcNow;
     }
 
     /// <summary>
@@ -234,19 +258,40 @@ public class LootingContainer(IBaseUnit owner)
     }
 
     /// <summary>
-    /// Sends the SCLootableStatePacket to all involved players
+    /// Sends the SCLootableStatePacket to all involved players and updates despawn times if needed
     /// </summary>
     public void UpdateLootState()
     {
         SendPacketToPlayers(EligiblePlayers, new SCLootableStatePacket(LootOwnerType, LootOwner.ObjId, Items.Count > 0));
+        // If no items left, then reduce the despawn timer if needed
+        if (Items.Count <= 0)
+        {
+            var minimumDespawnTime = CreationTime;
+            switch (LootOwnerType)
+            {
+                case LootOwnerType.Npc:
+                    if (LootOwner is Npc npc)
+                    {
+                        if (npc.Spawner != null)
+                            minimumDespawnTime = CreationTime.AddSeconds(npc.Spawner.DespawnTime);
+                        if (minimumDespawnTime < DateTime.UtcNow)
+                            minimumDespawnTime = DateTime.UtcNow.AddSeconds(PostLootMinimumDespawnTime);
+                        npc.Despawn = minimumDespawnTime;
+                    }
+                    break;
+                default:
+                    Logger.Warn($"UpdateLootState, Unsupported LootOwnerType: {LootOwnerType} after looting");
+                    break;
+            }
+        }
     }
 
     /// <summary>
     /// Player opens the loot bag
     /// </summary>
-    /// <param name="player"></param>
-    /// <param name="object2"></param>
-    /// <param name="lootAll"></param>
+    /// <param name="player">Player opening the loot container</param>
+    /// <param name="object2">unused</param>
+    /// <param name="lootAll">True when the player opened the loot using (G) to loot all</param>
     public void OpenBag(Character player, BaseUnit object2, bool lootAll)
     {
         OpenedBy.Add(player);
@@ -258,19 +303,21 @@ public class LootingContainer(IBaseUnit owner)
             var lootedItems = new List<ushort>();
             foreach (var (itemIndex, itemEntry) in Items)
             {
-                if (TryTakeLoot(player, itemIndex, itemEntry, itemEntry.Item.Count))
+                if (TryTakeLoot(player, itemIndex, itemEntry))
                     lootedItems.Add(itemIndex);
             }
             // Remove actually looted items
             foreach(var lootedItemIndex in lootedItems)
                 Items.Remove(lootedItemIndex);
         }
+
         // Send packet update of remaining items, or loot state if all has been looted already
-        if (Items.Count <= 0)
-        {
-            UpdateLootState();
-        }
-        else
+        // if (Items.Count <= 0)
+        // {
+        //     UpdateLootState();
+        // }
+        // else
+        if (Items.Count > 0)
         {
             var remainingItems = new List<Item>();
             foreach (var (_, itemEntry) in Items)
@@ -288,10 +335,10 @@ public class LootingContainer(IBaseUnit owner)
     /// <param name="player"></param>
     /// <param name="itemIndex"></param>
     /// <param name="itemEntry"></param>
-    /// <param name="count"></param>
     /// <returns>Returns true if the item was granted to the player</returns>
-    public bool TryTakeLoot(Character player, ushort itemIndex, LootingContainerItemEntry itemEntry, int count)
+    public bool TryTakeLoot(Character player, ushort itemIndex, LootingContainerItemEntry itemEntry)
     {
+        var lootTarget = player;
         // If itemEntry not specified, grab it from its index
         itemEntry ??= Items.GetValueOrDefault(itemIndex);
 
@@ -299,7 +346,18 @@ public class LootingContainer(IBaseUnit owner)
         if (itemEntry == null)
             return false;
 
-        // First check for quest items eligibility
+        // Check if it's already claimed by somebody else
+        if ((itemEntry.HighestRoller > 0) && (itemEntry.HighestRoller != player.Id))
+        {
+            if (itemEntry.HighestRoller > 0)
+            {
+                player.SendErrorMessage(ErrorMessageType.NoPermissionToLoot, itemEntry.HighestRoller);
+            }
+            player.SendPacket(new SCLootItemFailedPacket(ErrorMessageType.NoPermissionToLoot, LootOwnerType, LootOwner.ObjId, itemEntry.ItemIndex, itemEntry.Item.TemplateId));
+            return false;
+        }
+        
+        // Check for quest items eligibility
         if (itemEntry.Item.Template.LootQuestId > 0)
         {
             if (!player.Quests.HasQuest(itemEntry.Item.Template.LootQuestId))
@@ -308,12 +366,173 @@ public class LootingContainer(IBaseUnit owner)
                 return false;
             }
         }
-        
-        // Check party/raid loot settings (if applicable)
-        
-        
-        // TODO: Handle pickup limit
 
+        // Check if we already have looting right, if so, try to loot again
+        if (itemEntry.HighestRoller == player.Id)
+        {
+            return TryDistributeLootToPlayer(player, itemEntry);
+        }
+
+        // Check if rolls in progress (for more than one player only)
+        if (itemEntry.PlayerRolls.Count > 1)
+        {
+            return false;
+        }
+
+        // Do the Team looting rules require us to do a manual roll?
+        var rollMandatory = (TeamLootingRule.MinimumGrade > 0 && itemEntry.Item.Grade >= TeamLootingRule.MinimumGrade) || (TeamLootingRule.RollForBindOnPickup && itemEntry.Item.Template.BindType.HasFlag(ItemBindType.BindOnPickup));
+
+        // Check the other party/raid loot settings (if applicable)
+        var allowLootingNow = false;
+        switch (TeamLootingRule.LootMethod)
+        {
+            case LootingRuleMethod.FreeForAll:
+                allowLootingNow = true;
+                break;
+            case LootingRuleMethod.RotateWinner:
+                if (EligiblePlayers.Count <= 1)
+                {
+                    // Only one possible player, so always allow 
+                    allowLootingNow = true;
+                }
+                else if (KillerTeam != null)
+                {
+                    // Kill credits go to a team, pick a winner at random
+                    var winner = KillerTeam.GetNextLootWinner(EligiblePlayers, itemEntry.Owner.LootOwner,
+                        MaxLootingRange);
+                    itemEntry.HighestRoller = winner?.Id ?? 0;
+
+                    if (itemEntry.HighestRoller > 0)
+                    {
+                        var res = TryDistributeLootToPlayer(winner, itemEntry);
+                        return winner == player && res;
+                    }
+                }
+                else
+                {
+                    Logger.Warn($"TryTakeLoot, We have no valid Team to apply {TeamLootingRule.LootMethod} to. Reverting it to public as a failsafe");
+                    allowLootingNow = true;
+                    rollMandatory = false;
+                    TeamLootingRule.LootMethod = LootingRuleMethod.Public;
+                }
+
+                // TODO: Handle edge-case where party is removed before rolls are executed
+                break;
+            case LootingRuleMethod.LootMaster:
+                allowLootingNow = true;
+                lootTarget = WorldManager.Instance.GetCharacterById(TeamLootingRule.LootMaster) ?? player;
+                // TODO: verify if looting range matters
+                break;
+            case LootingRuleMethod.Public:
+                allowLootingNow = true;
+                rollMandatory = false;
+                break;
+        }
+
+        if (allowLootingNow == false)
+        {
+            return false;
+        }
+
+        // If a roll is required, then add all eligible players to the roll pool
+        if (rollMandatory && itemEntry.HighestRoller <= 0)
+        {
+            foreach (var eligiblePlayer in EligiblePlayers)
+            {
+                itemEntry.PlayerRolls.TryAdd(eligiblePlayer, 0);
+            }
+        }
+
+        //  If more than one person needs to roll, send out rolls to all players
+        if (itemEntry.PlayerRolls.Count > 1)
+        {
+            foreach (var (character, _) in itemEntry.PlayerRolls)
+            {
+                character.SendPacket(new SCLootDicePacket(itemEntry.Item));
+            }
+            return false;
+        }
+
+        // TODO: Handle pickup limit, not sure if we should prevent looting/rolling in the first place, or just prevent adding to inventory
+
+        return TryDistributeLootToPlayer(lootTarget, itemEntry);
+    }
+
+    /// <summary>
+    /// Player manually closes the loot bag
+    /// </summary>
+    /// <param name="player"></param>
+    /// <param name="itemIndex"></param>
+    /// <param name="ownerType"></param>
+    /// <param name="ownerObjId"></param>
+    /// <param name="b"></param>
+    public void CloseBag(Character player, ushort itemIndex, LootOwnerType ownerType, uint ownerObjId, byte b)
+    {
+        OpenedBy.Remove(player);
+    }
+
+    /// <summary>
+    /// Apply a player roll to loot
+    /// </summary>
+    /// <param name="player"></param>
+    /// <param name="itemIndex"></param>
+    /// <param name="rollRequest"></param>
+    public void DoPlayerRoll(Character player, ushort itemIndex, bool rollRequest)
+    {
+        var itemEntry = Items.GetValueOrDefault(itemIndex);
+        if (itemEntry == null)
+            return;
+
+        var rollResult = rollRequest ? (sbyte)Random.Shared.Next(1, 100) : (sbyte)-1;
+        itemEntry.PlayerRolls[player] = rollResult;
+
+        // Notify the others of this roll result
+        foreach (var targetPlayer in itemEntry.PlayerRolls.Keys)
+        {
+            targetPlayer.SendPacket(new SCLootDiceNotifyPacket(player.Name, itemEntry.Item, rollResult));
+        }
+
+        // Check if everybody has rolled
+        if (itemEntry.PlayerRolls.Any(m => m.Value == 0))
+            return;
+        
+        // All done? Send summary as well to all
+        foreach (var (targetPlayer, roll) in itemEntry.PlayerRolls)
+        {
+            targetPlayer.SendPacket(new SCLootDiceSummaryPacket(LootOwnerType, LootOwner.ObjId, itemEntry.ItemIndex, itemEntry.PlayerRolls));
+        }
+
+        // Find highest rolled value
+        var highestResult = itemEntry.PlayerRolls
+            .Where(x => x.Value > 0)
+            .OrderBy(x => x.Value)
+            .Select(x => x.Value)
+            .FirstOrDefault();
+        
+        // Find highest roller(s)
+        var highestEntries = itemEntry.PlayerRolls
+            .Where(x => x.Value >= highestResult)
+            .OrderBy(x => x.Value)
+            .ToList();
+
+        if (highestEntries.Count <= 0)
+        {
+            // Everybody passed or didn't roll, set it to public
+            itemEntry.PlayerRolls.Clear();
+            return;
+        }
+
+        // Select random winner (if multiple people roll the same
+        var pickIndex = Random.Shared.Next(highestEntries.Count);
+        var highestEntry = highestEntries[pickIndex];
+
+        // Mark winner
+        itemEntry.HighestRoller = highestEntry.Key.Id;
+        TryDistributeLootToPlayer(highestEntry.Key, itemEntry);
+    }
+
+    private bool TryDistributeLootToPlayer(Character player, LootingContainerItemEntry itemEntry)
+    {
         var freeSpace = player.Inventory.Bag.SpaceLeftForItem(itemEntry.Item, out _);
         if (freeSpace < itemEntry.Item.Count)
         {
@@ -334,8 +553,7 @@ public class LootingContainer(IBaseUnit owner)
             // On a loot attempt, it's probably safe to try and assign it a real itemId
             itemEntry.Item.Id = ItemIdManager.Instance.GetNextId();
             // Try to add the new item
-            if (!player.Inventory.Bag.AcquireDefaultItem(ItemTaskType.Loot, itemEntry.Item.TemplateId,
-                    count > itemEntry.Item.Count ? itemEntry.Item.Count : count, itemEntry.Item.Grade))
+            if (!player.Inventory.Bag.AcquireDefaultItem(ItemTaskType.Loot, itemEntry.Item.TemplateId, itemEntry.Item.Count, itemEntry.Item.Grade))
             {
                 // Free the Id again if failed
                 ItemIdManager.Instance.ReleaseId((uint)itemEntry.Item.Id);
@@ -350,20 +568,9 @@ public class LootingContainer(IBaseUnit owner)
         // TODO: check what packet this sends to others
         player.SendPacket(new SCLootItemTookPacket(itemEntry.Item.TemplateId, itemEntry.ItemIndex, LootOwnerType, LootOwner.ObjId, fullOldItemId, itemEntry.Item.Count));
         Items.Remove(itemEntry.ItemIndex);
-        
-        return true;
-    }
 
-    /// <summary>
-    /// Player manually closes the loot bag
-    /// </summary>
-    /// <param name="player"></param>
-    /// <param name="itemIndex"></param>
-    /// <param name="ownerType"></param>
-    /// <param name="ownerObjId"></param>
-    /// <param name="b"></param>
-    public void CloseBag(Character player, ushort itemIndex, LootOwnerType ownerType, uint ownerObjId, byte b)
-    {
-        OpenedBy.Remove(player);
+        if (Items.Count <= 0)
+            UpdateLootState();
+        return true;
     }
 }

--- a/AAEmu.Game/Models/Game/Items/Loots/LootOwnerType.cs
+++ b/AAEmu.Game/Models/Game/Items/Loots/LootOwnerType.cs
@@ -1,0 +1,8 @@
+﻿namespace AAEmu.Game.Models.Game.Items.Loots;
+
+public enum LootOwnerType : ushort
+{
+    None = 0,
+    Npc = 1,
+    Doodad = 2,
+}

--- a/AAEmu.Game/Models/Game/Items/Loots/LootPack.cs
+++ b/AAEmu.Game/Models/Game/Items/Loots/LootPack.cs
@@ -116,7 +116,6 @@ public class LootPack
             }
             else
             {
-
                 selected.AddRange(loots.Where(loot => loot.AlwaysDrop || loot.DropRate == 10000000 || alwaysDropGroup).ToList());
 
                 foreach (var loot in loots.Where(loot => !(loot.AlwaysDrop || loot.DropRate == 10000000 || alwaysDropGroup)))
@@ -132,7 +131,7 @@ public class LootPack
                         continue;
                     }
 
-                    // itemStackingRoll += loot.DropRate;
+                    itemStackingRoll += loot.DropRate;
 
                     selected.Add(loot);
                     break;
@@ -173,7 +172,7 @@ public class LootPack
     /// <param name="killer">Unit doing the killing blow</param>
     /// <returns></returns>
 #pragma warning disable CA1859
-    private ICharacter GetPlayerUsingKiller(BaseUnit killer)
+    private ICharacter GetPlayerUsingKiller(IBaseUnit killer)
 #pragma warning restore CA1859
     {
         if (killer is Character character)
@@ -203,7 +202,7 @@ public class LootPack
         return null;
     }
 
-    public List<Item> GenerateNpcPackItems(ref ulong baseId, BaseUnit killer, float lootDropRate = 1.0f, float lootGoldRate = 1.0f)
+    public List<Item> GenerateNpcPackItems(ref ulong baseId, IBaseUnit killer, float lootDropRate = 1.0f, float lootGoldRate = 1.0f)
     {
         var player = GetPlayerUsingKiller(killer);
         // TODO: handle raid-wide checks and individual loot

--- a/AAEmu.Game/Models/Game/Items/Loots/LootingContainerItemEntry.cs
+++ b/AAEmu.Game/Models/Game/Items/Loots/LootingContainerItemEntry.cs
@@ -12,18 +12,21 @@ public class LootingContainerItemEntry
     /// <summary>
     /// LootingContainer owning this entry
     /// </summary>
-    public LootingContainer Owner { get; set; }
+    public LootingContainer Owner { get; init; }
     /// <summary>
     /// Item index within the LootingContainer
     /// </summary>
-    public ushort ItemIndex { get; set; }
+    public ushort ItemIndex { get; init; }
     /// <summary>
     /// List of the current roll results of all eligible player (PlayerId, RollResult), roll results: 0=not rolled, -1=pass 
     /// </summary>
-    public Dictionary<Character, sbyte> PlayerRolls { get; set; } = new();
+    public Dictionary<Character, sbyte> PlayerRolls { get; } = [];
     /// <summary>
     /// PlayerId of the highest roller (or the person that claimed this loot entry)
     /// </summary>
     public uint HighestRoller { get; set; }
-    public Item Item { get; set; }
+    /// <summary>
+    /// The generated Item
+    /// </summary>
+    public Item Item { get; init; }
 }

--- a/AAEmu.Game/Models/Game/Items/Loots/LootingContainerItemEntry.cs
+++ b/AAEmu.Game/Models/Game/Items/Loots/LootingContainerItemEntry.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using AAEmu.Game.Models.Game.Items.Containers;
+
+namespace AAEmu.Game.Models.Game.Items.Loots;
+
+/// <summary>
+/// A single item entry of a looting container
+/// </summary>
+public class LootingContainerItemEntry
+{
+    /// <summary>
+    /// LootingContainer owning this entry
+    /// </summary>
+    public LootingContainer Owner { get; set; }
+    /// <summary>
+    /// Item index within the LootingContainer
+    /// </summary>
+    public ushort ItemIndex { get; set; }
+    /// <summary>
+    /// List of the current roll results of all eligible player (PlayerId, RollResult) 
+    /// </summary>
+    public Dictionary<uint, sbyte> PlayerRolls { get; set; } = new();
+    /// <summary>
+    /// PlayerId of the highest roller (or the person that claimed this loot entry)
+    /// </summary>
+    public uint HighestRoller { get; set; }
+    public Item Item { get; set; }
+}

--- a/AAEmu.Game/Models/Game/Items/Loots/LootingContainerItemEntry.cs
+++ b/AAEmu.Game/Models/Game/Items/Loots/LootingContainerItemEntry.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Items.Containers;
 
 namespace AAEmu.Game.Models.Game.Items.Loots;
@@ -17,9 +18,9 @@ public class LootingContainerItemEntry
     /// </summary>
     public ushort ItemIndex { get; set; }
     /// <summary>
-    /// List of the current roll results of all eligible player (PlayerId, RollResult) 
+    /// List of the current roll results of all eligible player (PlayerId, RollResult), roll results: 0=not rolled, -1=pass 
     /// </summary>
-    public Dictionary<uint, sbyte> PlayerRolls { get; set; } = new();
+    public Dictionary<Character, sbyte> PlayerRolls { get; set; } = new();
     /// <summary>
     /// PlayerId of the highest roller (or the person that claimed this loot entry)
     /// </summary>

--- a/AAEmu.Game/Models/Game/NPChar/NpcSpawner.cs
+++ b/AAEmu.Game/Models/Game/NPChar/NpcSpawner.cs
@@ -9,6 +9,7 @@ using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.Id;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.GameData;
+using AAEmu.Game.Models.Game.Items.Containers;
 using AAEmu.Game.Models.Game.Skills.Effects;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.World;
@@ -111,6 +112,7 @@ public class NpcSpawner : Spawner<Npc>
     {
         _spawnCount = 0;
     }
+
     public void DecreaseCount(Npc npc)
     {
         npc.Spawner._spawnCount--;
@@ -123,6 +125,11 @@ public class NpcSpawner : Spawner<Npc>
         }
 
         npc.Despawn = DateTime.UtcNow.AddSeconds(npc.Spawner.DespawnTime);
+        // If it has loot, extend the time
+        if (npc.LootingContainer?.Items.Count > 0)
+        {
+            npc.Despawn += TimeSpan.FromSeconds(LootingContainer.LootDespawnExtensionTime);
+        }
         SpawnManager.Instance.AddDespawn(npc);
     }
 

--- a/AAEmu.Game/Models/Game/NPChar/Tagging.cs
+++ b/AAEmu.Game/Models/Game/NPChar/Tagging.cs
@@ -3,6 +3,7 @@ using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.World;
 using System.Collections.Generic;
+using AAEmu.Game.Models.Game.Items.Containers;
 
 namespace AAEmu.Game.Models.Game.NPChar;
 
@@ -31,6 +32,7 @@ public class Tagging
             }
         }
     }
+
     public uint TagTeam
     {
         get
@@ -41,6 +43,7 @@ public class Tagging
             }
         }
     }
+
     public void ClearAllTaggers()
     {
         _taggers = [];
@@ -48,79 +51,65 @@ public class Tagging
         _tagTeam = 0;
         // _totalDamage = 0;
     }
+
     public void AddTagger(Unit checkUnit, int damage)
     {
         lock (_lock)
         {
-            // Check if the character is a pet
-
-            if (checkUnit is Units.Mate pm)
+            // Check if the character is a pet, if so, propagate its user
+            if (checkUnit is Units.Mate mate)
             {
-                checkUnit = WorldManager.Instance.GetCharacterByObjId(pm.OwnerObjId) ?? checkUnit;
+                checkUnit = WorldManager.Instance.GetCharacterByObjId(mate.OwnerObjId) ?? checkUnit;
             }
 
-            if (checkUnit is Character pl)
+            if (checkUnit is Character player)
             {
-
-                if (!_taggers.ContainsKey(pl))
+                if (_taggers.TryAdd(player, damage))
                 {
-                    _taggers[pl] = damage;
-                    if (_tagger == null)
-                    {
-                        _tagger = pl;
-                    }
+                    _tagger ??= player;
                 }
                 else
                 {
-                    _taggers[pl] += damage;
+                    _taggers[player] += damage;
                 }
 
                 // _totalDamage += damage;
 
                 // Check if the character is in a party
-                if (pl.InParty)
+                if (player.InParty)
                 {
-                    var checkTeam = TeamManager.Instance.GetTeamByObjId(pl.ObjId);
+                    var checkTeam = TeamManager.Instance.GetTeamByObjId(player.ObjId);
                     var partyDamage = 0;
                     foreach (var member in checkTeam.Members)
                     {
-                        if (member != null && member.Character != null)
-                        {
-                            if (member.Character is Character tm)
-                            {
-                                var distance = tm.Transform.World.Position - Owner.Transform.World.Position;
-                                if (distance.Length() <= 200)
-                                {
-                                    //tm is an eligible party member
-                                    if (_taggers.TryGetValue(tm, out var value))
-                                    {
-                                        //Tagger is already in the list
-                                        partyDamage += value;
+                        if (member == null || member.Character == null)
+                            continue;
 
-                                    }
-                                }
+                        if (member.Character.GetDistanceTo(Owner, true) <= LootingContainer.MaxLootingRange)
+                        {
+                            // tm is an eligible party member
+                            if (_taggers.TryGetValue(member.Character, out var value))
+                            {
+                                // Tagger is already in the list
+                                partyDamage += value;
                             }
                         }
                     }
-                    //Did the party do more than 50% of the total HP in damage?
+                    // Did the party do more than 50% of the total HP in damage?
                     if (partyDamage > Owner.MaxHp * 0.5)
                     {
-
                         _tagTeam = checkTeam.Id;
-
                     }
                 }
                 else
                 {
-                    if (_taggers[pl] > Owner.MaxHp * 0.5)
+                    if (_taggers[player] > Owner.MaxHp * 0.5)
                     {
-
-                        _tagger = pl;
+                        _tagger = player;
                     }
                 }
             }
-            //TODO: packet to set red-but-not-aggro HP bar for taggers, "dull red" HP bar for not-taggers
-
+            // TODO: packet to set red-but-not-aggro HP bar for taggers, "dull red" HP bar for not-taggers
         }
     }
 }

--- a/AAEmu.Game/Models/Game/Team/LootingRule.cs
+++ b/AAEmu.Game/Models/Game/Team/LootingRule.cs
@@ -4,34 +4,41 @@ namespace AAEmu.Game.Models.Game.Team;
 
 public class LootingRule : PacketMarshaler
 {
-    public byte LootMethod { get; set; }
-    public byte Type { get; set; }
-    public uint Id { get; set; }
-    public bool RollForBop { get; set; }
-
-    public LootingRule()
-    {
-        // TODO - MAKE IT CONFIGURABLE (config.json)
-        LootMethod = 1;
-        Type = 2;
-        Id = 0;
-        RollForBop = true;
-    }
+    // TODO: Make default party loot settings configurable or remember player's last settings 
+    public LootingRuleMethod LootMethod { get; set; } = LootingRuleMethod.RotateWinner;
+    public byte MinimumGrade { get; set; } = 2; // Grand+
+    public uint LootMaster { get; set; }
+    public bool RollForBindOnPickup { get; set; } = true;
 
     public override void Read(PacketStream stream)
     {
-        LootMethod = stream.ReadByte();
-        Type = stream.ReadByte();
-        Id = stream.ReadUInt32();
-        RollForBop = stream.ReadBoolean();
+        LootMethod = (LootingRuleMethod)stream.ReadByte();
+        MinimumGrade = stream.ReadByte();
+        LootMaster = stream.ReadUInt32();
+        RollForBindOnPickup = stream.ReadBoolean();
     }
 
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(LootMethod);
-        stream.Write(Type);
-        stream.Write(Id);
-        stream.Write(RollForBop);
+        stream.Write((byte)LootMethod);
+        stream.Write(MinimumGrade);
+        stream.Write(LootMaster);
+        stream.Write(RollForBindOnPickup);
         return stream;
+    }
+
+    /// <summary>
+    /// Returns a new instance of this LootingRule with exactly the same settings
+    /// </summary>
+    /// <returns></returns>
+    public LootingRule Clone()
+    {
+        return new LootingRule
+        {
+            LootMethod = LootMethod,
+            MinimumGrade = MinimumGrade,
+            LootMaster = LootMaster,
+            RollForBindOnPickup = RollForBindOnPickup
+        };
     }
 }

--- a/AAEmu.Game/Models/Game/Team/LootingRule.cs
+++ b/AAEmu.Game/Models/Game/Team/LootingRule.cs
@@ -4,7 +4,7 @@ namespace AAEmu.Game.Models.Game.Team;
 
 public class LootingRule : PacketMarshaler
 {
-    // TODO: Make default party loot settings configurable or remember player's last settings 
+    // TODO: Make default party loot settings configurable or remember player's last settings?
     public LootingRuleMethod LootMethod { get; set; } = LootingRuleMethod.RotateWinner;
     public byte MinimumGrade { get; set; } = 2; // Grand+
     public uint LootMaster { get; set; }

--- a/AAEmu.Game/Models/Game/Team/LootingRuleMethod.cs
+++ b/AAEmu.Game/Models/Game/Team/LootingRuleMethod.cs
@@ -5,4 +5,5 @@ public enum LootingRuleMethod : byte
     FreeForAll = 0,
     RotateWinner = 1,
     LootMaster = 2,
+    Public = 0xFF // used internally
 }

--- a/AAEmu.Game/Models/Game/Team/LootingRuleMethod.cs
+++ b/AAEmu.Game/Models/Game/Team/LootingRuleMethod.cs
@@ -1,0 +1,8 @@
+﻿namespace AAEmu.Game.Models.Game.Team;
+
+public enum LootingRuleMethod : byte
+{
+    FreeForAll = 0,
+    RotateWinner = 1,
+    LootMaster = 2,
+}

--- a/AAEmu.Game/Models/Game/Team/Team.cs
+++ b/AAEmu.Game/Models/Game/Team/Team.cs
@@ -21,6 +21,7 @@ public class Team : PacketMarshaler
         Members = new TeamMember[50];
         ResetMarks();
         PingPosition = new WorldSpawnPosition();
+        LootingRule = new LootingRule();
     }
 
     public void ResetMarks()

--- a/AAEmu.Game/Models/Game/Team/Team.cs
+++ b/AAEmu.Game/Models/Game/Team/Team.cs
@@ -1,7 +1,11 @@
-﻿using AAEmu.Commons.Network;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.World.Transform;
 
 namespace AAEmu.Game.Models.Game.Team;
@@ -191,6 +195,48 @@ public class Team : PacketMarshaler
 
         return result;
     }
+
+    /// <summary>
+    /// Gets the next "winner" for loot
+    /// </summary>
+    /// <param name="eligiblePlayer">Only Characters in this list allowed to be returned</param>
+    /// <param name="referenceLootOwner">BaseUnit used for location reference to check range</param>
+    /// <param name="maxRange">If greater than 0, this range will be used to check range</param>
+    /// <returns></returns>
+    public Character GetNextLootWinner(HashSet<Character> eligiblePlayer, IBaseUnit referenceLootOwner, float maxRange = 200f)
+    {
+        // Match the eligible player list with the team members list
+        var eligibleMembers = Members
+            .Where(member => member is { Character: not null } &&
+                             eligiblePlayer.Contains(member.Character))
+            .ToList();
+
+        // If every eligible player has got a winning roll, reset all of their win flags
+        if (eligibleMembers.All(x => x.HasGoneRoundRobin))
+        {
+            foreach (var teamMember in eligibleMembers)
+            {
+                teamMember.HasGoneRoundRobin = false;
+            }
+        }
+        
+        // Grab a list of all remaining characters using only those provided from the members list
+        var tempPlayerList = eligibleMembers.Where(member => member is { HasGoneRoundRobin: false }).ToList();
+
+        // Somehow no results?
+        if (tempPlayerList.Count <= 0)
+        {
+            // If somehow no results even after re-filling the list, return null
+            Logger.Warn($"Was unable to generate a new random looting order list for team {Id} with leader {OwnerId}, ReferenceLootOwner: {referenceLootOwner}, MaxRange: {maxRange}");
+            return null;
+        }
+
+        // Pick a random
+        var rngPos = Random.Shared.Next(tempPlayerList.Count);
+        tempPlayerList[rngPos].HasGoneRoundRobin = true;
+        return tempPlayerList[rngPos].Character;
+    }
+    
 
     public override PacketStream Write(PacketStream stream)
     {

--- a/AAEmu.Game/Models/Game/Units/BaseUnit.cs
+++ b/AAEmu.Game/Models/Game/Units/BaseUnit.cs
@@ -7,6 +7,7 @@ using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Faction;
 using AAEmu.Game.Models.Game.Housing;
+using AAEmu.Game.Models.Game.Items.Containers;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Skills.Static;
 using AAEmu.Game.Models.Game.Skills.Templates;
@@ -32,12 +33,18 @@ public class BaseUnit : GameObject, IBaseUnit
     public CombatBuffs CombatBuffs { get; set; }
     public object ChargeLock { get; set; }
 
+    /// <summary>
+    /// The loot container for items dropped by this unit
+    /// </summary>
+    public LootingContainer LootingContainer { get; init; }
+
     public BaseUnit()
     {
         Buffs = new Buffs(this);
         SkillModifiersCache = new SkillModifiers();
         BuffModifiersCache = new BuffModifiers();
         CombatBuffs = new CombatBuffs(this);
+        LootingContainer = new LootingContainer(this);
     }
 
     /// <summary>

--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -445,23 +445,20 @@ public class Unit : BaseUnit, IUnit
         {
             switch (this)
             {
-                //case Npc:
-                //    break;
                 case Mate mate:
                     DespawnMate(WorldManager.Instance.GetCharacterByObjId(mate.OwnerObjId));
                     break;
                 case Character character:
                     DespawnMate(character);
                     break;
-                    //default:
-                    //    break;
             }
             return;
         }
 
-        // Generate the loot for this Npc 
+        // Generate the loot for this Npc
         LootingContainer.GenerateLoot(killer);
 
+        // Cleanup targeting and aggro packets
         if (CurrentTarget != null)
         {
             killer.SendPacketToPlayers([this, killer], new SCAiAggroPacket(killer.ObjId, 0));

--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -459,82 +459,8 @@ public class Unit : BaseUnit, IUnit
             return;
         }
 
-        var lootDropItems = ItemManager.Instance.CreateLootDropItems(ObjId, killer);
-        // Without moving the tagging into the root of unit, we need to do some work for loot distribution:
-        if (lootDropItems.Count > 0)
-        {
-            // Logger.Info($"Loot item count is {lootDropItems.Count}");
-            var unit = WorldManager.Instance.GetNpc(ObjId);
-            if (unit == null)
-            {
-                // Defaulting to the original code if this isn't an NPC
-                // Logger.Info($"Not an NPC for {ObjId}");
-
-                killer.BroadcastPacket(new SCLootableStatePacket(LootOwnerType.Npc, ObjId, true), true);
-
-            }
-            else
-            {
-                // it's an NPC, and we have a thing for this!
-                var eligiblePlayers = new HashSet<Character>();
-                if (unit.CharacterTagging.TagTeam != 0)
-                {
-                    // A team has tagging rights.
-                    // TODO: Master Looter
-                    var activeTeam = TeamManager.Instance.GetActiveTeam(unit.CharacterTagging.TagTeam);
-                    if (activeTeam.LootingRule.LootMethod == 0)
-                    {
-                        // FFA Loot
-                        foreach (var member in activeTeam.Members)
-                        {
-                            if (member?.Character == null)
-                                continue;
-
-                            if (GetDistanceTo(member.Character) <= 200)
-                            {
-                                eligiblePlayers.Add(member.Character);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        // RoundRobin
-                        // TODO: Master Looter
-                        var nextEligibleLooter = TeamManager.Instance.GetNextEligibleLooter(unit.CharacterTagging.TagTeam, unit);
-                        if (nextEligibleLooter != null)
-                        {
-                            eligiblePlayers.Add(nextEligibleLooter);
-                            Logger.Warn($"Eligible team, adding {nextEligibleLooter}");
-                        }
-                        else
-                        {
-                            Logger.Warn("Next eligible looter was null");
-                        }
-                    }
-                }
-                else if (unit.CharacterTagging.Tagger != null)
-                {
-                    //A player has tag rights
-                    eligiblePlayers.Add(unit.CharacterTagging.Tagger);
-                    Logger.Warn($"Added tagger {unit.CharacterTagging.Tagger}");
-                }
-                if (eligiblePlayers.Count > 0)
-                {
-                    foreach (var eligible in eligiblePlayers)
-                    {
-                        if (eligible != null)
-                        {
-                            eligible.SendPacket(new SCLootableStatePacket(LootOwnerType.Npc, ObjId, true));
-                        }
-                        else
-                        {
-                            Logger.Warn($"Eligible player was null, eligible player count was {eligiblePlayers.Count}");
-                        }
-                    }
-                }
-            }
-
-        }
+        // Generate the loot for this Npc 
+        LootingContainer.GenerateLoot(killer);
 
         if (CurrentTarget != null)
         {

--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -14,6 +14,7 @@ using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Expeditions;
 using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Items.Containers;
+using AAEmu.Game.Models.Game.Items.Loots;
 using AAEmu.Game.Models.Game.Items.Templates;
 using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Skills;
@@ -469,7 +470,7 @@ public class Unit : BaseUnit, IUnit
                 // Defaulting to the original code if this isn't an NPC
                 // Logger.Info($"Not an NPC for {ObjId}");
 
-                killer.BroadcastPacket(new SCLootableStatePacket(ObjId, true), true);
+                killer.BroadcastPacket(new SCLootableStatePacket(LootOwnerType.Npc, ObjId, true), true);
 
             }
             else
@@ -523,7 +524,7 @@ public class Unit : BaseUnit, IUnit
                     {
                         if (eligible != null)
                         {
-                            eligible.SendPacket(new SCLootableStatePacket(ObjId, true));
+                            eligible.SendPacket(new SCLootableStatePacket(LootOwnerType.Npc, ObjId, true));
                         }
                         else
                         {


### PR DESCRIPTION
- Changed how loot from NPCs is implemented.
- Implemented **Free-For-All**, **Rotate-Winner** and **LootMaster** looting rules for parties and raids.
- Implemented functionality of making untouched loot public after 3 minutes.
- Extended despawn times when the NPC has loot (up to 5 minutes).