### PR TITLE
[Game] Fix for respawn locations during war time

### DIFF
--- a/AAEmu.Game/Core/Managers/PortalManager.cs
+++ b/AAEmu.Game/Core/Managers/PortalManager.cs
@@ -471,7 +471,7 @@ public class PortalManager : Singleton<PortalManager>
 
     public Portal GetClosestReturnPortal(Character character)
     {
-        var cxyz = character.Transform.World.Position;
+        var currentPosition = character.Transform.World.Position;
         var distance = 999999f;
         var portal = new Portal();
 
@@ -486,8 +486,8 @@ public class PortalManager : Singleton<PortalManager>
                 }
             }
             //if (!value.Name.ToLower().Contains("respawn")) { continue; }
-            var pxyz = new Vector3(value.X, value.Y, value.Z);
-            var dist = MathUtil.CalculateDistance(cxyz, pxyz);
+            var portalXyz = new Vector3(value.X, value.Y, value.Z);
+            var dist = MathUtil.CalculateDistance(currentPosition, portalXyz);
             if (!(dist < distance)) { continue; }
             distance = dist;
             portal = value;

--- a/AAEmu.Game/Core/Packets/C2G/CSResurrectCharacterPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSResurrectCharacterPacket.cs
@@ -7,6 +7,8 @@ using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Units.Static;
+using AAEmu.Game.Models.Game.World.Zones;
+using AAEmu.Game.Models.StaticValues;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
@@ -25,7 +27,8 @@ public class CSResurrectCharacterPacket : GamePacket
         var portal = new Portal();
 
         // поищем сначала "UnitId": 502, "Title": "Temple Priestess",
-        if (Connection.ActiveChar.Transform.WorldId > 0)
+        // Inside dungeons or other instances, just respawn at the nearest Priestess
+        if (Connection.ActiveChar.Transform.WorldId != WorldManager.DefaultWorldId)
         {
             var npcs = WorldManager.Instance.GetAllNpcsFromWorld(Connection.ActiveChar.Transform.WorldId);
             foreach (var npc in npcs.Where(npc => npc.TemplateId == 502))
@@ -41,7 +44,37 @@ public class CSResurrectCharacterPacket : GamePacket
         }
         else
         {
-            portal = PortalManager.Instance.GetClosestReturnPortal(Connection.ActiveChar);
+            // Check if the current zone is at War and if it has special respawn areas for factions
+            var usePortalId = 0u;
+            var currentZone = ZoneManager.Instance.GetZoneByKey(Connection.ActiveChar.Transform.ZoneId);
+            if (currentZone != null)
+            {
+                var conflictData = ZoneManager.Instance.GetConflicts()?.FirstOrDefault(c => c.ZoneGroupId == currentZone.GroupId);
+                if (conflictData?.CurrentZoneState == ZoneConflictType.War)
+                {
+                    switch (Connection.ActiveChar.Faction.MotherId)
+                    {
+                        case FactionsEnum.NuiaAlliance:
+                            usePortalId = conflictData.NuiaReturnPointId;
+                            break;
+                        case FactionsEnum.HaranyaAlliance:
+                            usePortalId = conflictData.HariharaReturnPointId;
+                            break;
+                    }
+                }
+            }
+
+            // Try to get a faction specific respawn
+            if (usePortalId > 0)
+            {
+                portal = PortalManager.Instance.GetRespawnById(usePortalId);
+            }
+            
+            // Find the closest return portal (in the world) for the player if none has been found yet
+            if ((usePortalId == 0) || (portal == null))
+            {
+                portal = PortalManager.Instance.GetClosestReturnPortal(Connection.ActiveChar);
+            }
         }
 
         if (inPlace)


### PR DESCRIPTION
Players of the Nuian and Haranyan faction will now spawn correctly at their pre-defined locations if the zone is in War state.
