### PR TITLE
[Game] Implemented CleanupLookConvert special effect

### DIFF
--- a/AAEmu.Game/Models/Game/Items/Actions/ItemTaskType.cs
+++ b/AAEmu.Game/Models/Game/Items/Actions/ItemTaskType.cs
@@ -116,7 +116,7 @@ public enum ItemTaskType : byte
     ChangeAutoUseAaPoint = 110,
     ConvertItemLook = 111,
     ChangeExpertLimit = 112,
-    Sknize = 113,
+    Skinize = 113,
     ItemTaskThistimeUnpack = 114,
     BuyPremiumService = 115,
     BuyAaPoint = 116

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/CleanupLookConvert.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/CleanupLookConvert.cs
@@ -1,12 +1,16 @@
 ﻿using System;
-
+using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Items;
+using AAEmu.Game.Models.Game.Items.Actions;
 using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects.SpecialEffects;
 
 public class CleanupLookConvert : SpecialEffectAction
 {
+    protected override SpecialType SpecialEffectActionType => SpecialType.CleanupLookConvert;
+
     public override void Execute(BaseUnit caster,
         SkillCaster casterObj,
         BaseUnit target,
@@ -20,7 +24,61 @@ public class CleanupLookConvert : SpecialEffectAction
         int value3,
         int value4)
     {
-        // TODO ...
-        if (caster is Character) { Logger.Debug("Special effects: CleanupLookConvert value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4); }
+        if (caster is Character)
+        {
+            Logger.Debug("Special effects: CleanupLookConvert value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4);
+        }
+
+        if (caster is not Character character)
+        {
+            skill.Cancelled = true;
+            return;
+        }
+
+        if (targetObj is not SkillCastItemTarget itemTarget)
+        {
+            skill.Cancelled = true;
+            return;
+        }
+
+        var itemWithImage = character.Inventory.GetItemById(itemTarget.Id);
+        if (itemWithImage == null)
+        {
+            skill.Cancelled = true;
+            return;
+        }
+
+        if (itemWithImage.ImageItemTemplateId <= 0)
+        {
+            // Is not an item with an image on it
+            skill.Cancelled = true;
+            // TODO: Get the correct error message
+            character.SendErrorMessage(ErrorMessageType.ItemLookConvertAsInvalidCombination);
+            // character.SendErrorMessage(ErrorMessageType.FailedToChangeItemLook);
+            return;
+        }
+
+        if (casterObj is not SkillItem powderSkillItem)
+        {
+            skill.Cancelled = true;
+            return;
+        }
+
+        var powderItem = character.Inventory.GetItemById(powderSkillItem.ItemId);
+        if (powderItem == null)
+        {
+            skill.Cancelled = true;
+            return;
+        }
+
+        if (powderItem.Count < 1)
+        {
+            skill.Cancelled = true;
+            return;
+        }
+
+        itemWithImage.ImageItemTemplateId = 0;
+        character.SendPacket(new SCItemTaskSuccessPacket(ItemTaskType.ConvertItemLook, [new ItemUpdate(itemWithImage)], []));
+        powderItem._holdingContainer.ConsumeItem(ItemTaskType.ConvertItemLook, powderItem.TemplateId, 1, powderItem);
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/Skinize.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/Skinize.cs
@@ -25,52 +25,60 @@ public class Skinize : SpecialEffectAction
         int value3,
         int value4)
     {
-        // TODO ...
         if (caster is Character)
         {
             Logger.Debug("Special effects: Skinize value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4);
         }
 
-        if (caster is not Character character || character is null)
+        if (caster is not Character character)
         {
+            skill.Cancelled = true;
             return;
         }
 
-        if (targetObj is not SkillCastItemTarget itemTarget || itemTarget is null)
+        if (targetObj is not SkillCastItemTarget itemTarget)
         {
+            skill.Cancelled = true;
             return;
         }
 
         var itemToImage = character.Inventory.GetItemById(itemTarget.Id);
         if (itemToImage == null)
         {
+            skill.Cancelled = true;
             return;
         }
 
         if (itemToImage.HasFlag(ItemFlag.Skinized))
         {
-            // Already a image item
+            // Already an image item
+            skill.Cancelled = true;
+            // TODO: Get the correct error as this is likely not correct
+            character.SendErrorMessage(ErrorMessageType.ItemLookConvertAsNotUseAsSkin);
             return;
         }
 
-        if (casterObj is not SkillItem powderSkillItem || powderSkillItem is null)
+        if (casterObj is not SkillItem powderSkillItem)
         {
+            skill.Cancelled = true;
             return;
         }
 
-        Item powderItem = character.Inventory.GetItemById(powderSkillItem.ItemId);
+        var powderItem = character.Inventory.GetItemById(powderSkillItem.ItemId);
         if (powderItem == null)
         {
+            skill.Cancelled = true;
             return;
         }
 
         if (powderItem.Count < 1)
         {
+            skill.Cancelled = true;
             return;
         }
 
         itemToImage.SetFlag(ItemFlag.Skinized);
-        character.SendPacket(new SCItemTaskSuccessPacket(ItemTaskType.Sknize, [new ItemUpdateBits(itemToImage)], []));
-        powderItem._holdingContainer.ConsumeItem(ItemTaskType.Sknize, powderItem.TemplateId, 1, powderItem);
+        character.SendPacket(new SCItemTaskSuccessPacket(ItemTaskType.Skinize, [new ItemUpdateBits(itemToImage)], []));
+        powderItem._holdingContainer.ConsumeItem(ItemTaskType.Skinize, powderItem.TemplateId, 1, powderItem);
     }
 }

--- a/AAEmu.sln.DotSettings
+++ b/AAEmu.sln.DotSettings
@@ -51,6 +51,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=qtype/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Recalc/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Recv/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=skinize/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=socketing/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Spawner/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Spawners/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
- Implemented functionality for item `29704 - Shatigon's Pocket Watch` that removes a image from a imaged item.
- Also added better error handling for other actions related to the `Fusion Alembic` item that allows gear imaging.
