### PR TITLE
[Game] Workaround for ship skills targetting more than the ship

### DIFF
--- a/AAEmu.Game/Core/Packets/C2G/CSStartSkillPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSStartSkillPacket.cs
@@ -81,7 +81,7 @@ public class CSStartSkillPacket : GamePacket
 
             if ((mate != null) || (slave != null))
             {
-                // check if it's a mate or slave skill and return it's rider/operator related skill
+                // check if it's a mate or slave skill and return its rider/operator related skill
                 mountAttachedSkill = MateManager.Instance.GetMountAttachedSkills(skillId, Connection.ActiveChar.AttachedPoint);
             }
 

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -832,10 +832,17 @@ public class Skill
         var player = caster as Character;
         var possibleTargets = new List<BaseUnit>(); // TODO crutches
         // Get a list of all possible targets
+        if (Template.TargetSiege && Template.TargetSelection == SkillTargetSelection.Source && caster is Slave)
+        {
+            // Hack for ship skills, only TargetSiege or possibly CombatDice seem to be different from other AoE skills
+            possibleTargets.Add(targetSelf);
+        }
+        else
         if (Template.TargetAreaRadius > 0)
         {
             var units = WorldManager.GetAround<BaseUnit>(targetSelf, Template.TargetAreaRadius, true);
-            units.Add(targetSelf); // Add main target as well
+            if (Template.TargetSelection == SkillTargetSelection.Source)
+                units.Add(targetSelf); // Add main target as well
             units = FilterAoeUnits(caster, units).ToList();
 
             possibleTargets.AddRange(units);


### PR DESCRIPTION
Added a check for source and siege target properties of skill to single out skill of ships that need to apply buffs to itself.
We are likely missing some other way where skill targeting is not producing the intended results. But `siege_target` seems to be the only property where this is different from other skills with radius set.

Fixes #1137