### PR TITLE
[Game] Fixes to NPCSpawner to resolve daily spawns, and DoodadFuncFishSchool

### DIFF
--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncFishSchool.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncFishSchool.cs
@@ -45,8 +45,7 @@ public class DoodadFuncFishSchool : DoodadPhaseFuncTemplate
         //spawnPos.World.AddDistanceToFront(3f);
         //spawnPos.World.SetHeight(WorldManager.Instance.GetHeight(spawnPos));
         spawner[0].Position = spawnPos.CloneAsSpawnPosition();
-        var npc = spawner[0].Spawn(0);
-        npc.Spawner.RespawnTime = 0; // запретим респавн
+        //No initial spawn, fish spawn are triggered by fishing.
 
         return false;
     }

--- a/AAEmu.Game/Models/Game/NPChar/NpcSpawner.cs
+++ b/AAEmu.Game/Models/Game/NPChar/NpcSpawner.cs
@@ -59,7 +59,8 @@ public class NpcSpawner : Spawner<Npc>
         {
             return null; // if npcs are delayed to show later
         }
-        DoSpawn(true, beginning); // show all Npc, first start server
+
+       DoSpawn(true, beginning); // show all Npc, first start server
 
         return _spawned;
     }
@@ -78,7 +79,6 @@ public class NpcSpawner : Spawner<Npc>
         DoSpawn(); // show one Npc
         return _lastSpawn;
     }
-
     public override void Despawn(Npc npc)
     {
         npc.UnregisterNpcEvents();
@@ -387,13 +387,13 @@ public class NpcSpawner : Spawner<Npc>
                         Logger.Trace("Период еще не начался.");
                         // есть в расписании, надо запланировать спавн
                         // is on the schedule, needs to be scheduled
-                        var cronExpression = GameScheduleManager.Instance.GetCronRemainingTime((int)UnitId, true);
+                        var cronExpression = GameScheduleManager.Instance.GetCronRemainingTime((int)Template.Id, true);
                         if (cronExpression is "" or "0 0 0 0 0 ?")
                         {
                             Logger.Trace($"DoSpawnSchedule: Can't schedule spawn Npc templateId={UnitId} from spawnerId={Template.Id}");
                             Logger.Trace($"DoSpawnSchedule: cronExpression {cronExpression}");
                             _isScheduled = false;
-                            return false;
+                            return true;//It's scheduled, but we can't spawn it.
                         }
 
                         try
@@ -405,10 +405,10 @@ public class NpcSpawner : Spawner<Npc>
                         }
                         catch (Exception)
                         {
-                            Logger.Trace($"DoSpawnSchedule: Can't schedule spawn Npc templateId={UnitId} from spawnerId={Template.Id}");
+                            Logger.Trace($"DoSpawnSchedule: Can't schedule spawn Npc templateId={UnitId} from spawnerId={Template.Id} on exception.");
                             Logger.Trace($"DoSpawnSchedule: cronExpression {cronExpression}");
                             _isScheduled = false;
-                            return false;
+                            return true;//Cannot schedule
                         }
                     }
                     else if (status == GameScheduleManager.PeriodStatus.InProgress)
@@ -424,7 +424,7 @@ public class NpcSpawner : Spawner<Npc>
                         //Logger.Warn("Период завершился.");
                         Logger.Trace($"DoSpawnSchedule: Can't spawn. The period has ended. Npc templateId={UnitId} from spawnerId={Template.Id}");
                         _isScheduled = false;
-                        return false;
+                        return true;//It's scheduled, but we can't spawn it.
                     }
                 }
             }


### PR DESCRIPTION
* [Game] Fixes to NPCSpawner to resolve a bug with daily spawns:
Description of changes:
- Changed a variable being passed to the NPC cron check from Unit ID to Spawner ID in a single instance.
- Changed DoSpawnSchedule to reurn true consistently in every instance where an NPC is on the spawner but should NOT be spawned, and false in every other instance, to be consistent with the spawn checks.

[Game] Fixes to DoodadFuncFishSchool:
Description of changes:
- Removed the immediate spawn of fish. This doesn't happen when a pool is chummed, and chumming a pool is what calls this function.