### PR TITLE
[Game] Implement mate level cap

### DIFF
--- a/AAEmu.Game/Core/Managers/ExperienceManager.cs
+++ b/AAEmu.Game/Core/Managers/ExperienceManager.cs
@@ -1,7 +1,11 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+
 using AAEmu.Commons.Utils;
 using AAEmu.Game.Models.Game;
-using AAEmu.Game.Utils.DB;
+
 using NLog;
 
 namespace AAEmu.Game.Core.Managers;
@@ -10,67 +14,195 @@ public class ExperienceManager : Singleton<ExperienceManager>
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
-    private Dictionary<byte, ExperienceLevelTemplate> _levels;
+    /// <summary>List of experience templates, indexed by zero-based level (level 1 is index 0).</summary>
+    private readonly List<ExperienceLevelTemplate> _levelTemplatesByLevel = [];
+    /// <summary>Sorted list of total experience amounts from lowest level to highest level, indexed by zero-based level (level 1 is index 0).</summary>
+    private readonly List<int> _expByLevel = [];
+    /// <summary>Sorted list of total mate experience amounts from lowest level to highest level, indexed by zero-based mate level (level 1 is index 0).</summary>
+    private readonly List<int> _mateExpByLevel = [];
 
     // TODO: Put this in the configuration files
-    public static byte MaxPlayerLevel => 55;
-    public static byte MaxMateLevel => 50;
+    /// <summary>Artificial level cap for players. If database contains more levels than this, they will be ignored.</summary>
+    private static byte PlayerLevelCap => 55;
+    /// <summary>Artificial level cap for mates (mounts, pets). If database contains more levels than this, they will be ignored.</summary>
+    private static byte MateLevelCap => 50;
 
+    /// <summary>
+    /// Gets the maximum level for players.
+    /// </summary>
+    public byte MaxPlayerLevel { get; private set; }
+
+    /// <summary>
+    /// Gets the maximum level for mates (mounts, pets).
+    /// </summary>
+    public byte MaxMateLevel { get; private set; }
+
+    /// <summary>
+    /// Gets the total experience required to reach the given level.
+    /// </summary>
+    /// <param name="level">The level to reach.</param>
+    /// <param name="mate"><c>true</c> to get the experience for a mate (mount, pet); <c>false</c> to get the experience for a player.</param>
+    /// <returns>The total experience required to reach the given level, or 0 if the level is invalid.</returns>
     public int GetExpForLevel(byte level, bool mate = false)
     {
-        var levelTemplate = _levels.GetValueOrDefault(level);
-        return mate ? levelTemplate?.TotalMateExp ?? 0 : levelTemplate?.TotalExp ?? 0;
-    }
+        if (GetTemplateForLevel(level) is { } levelTemplate)
+            return mate ? levelTemplate.TotalMateExp : levelTemplate.TotalExp;
 
-    public byte GetLevelFromExp(int exp, bool mate = false)
-    {
-        // Loop the levels to find the level for a given exp value
-        foreach (var (level, levelTemplate) in _levels)
-        {
-            if (exp < (mate ? levelTemplate.TotalMateExp : levelTemplate.TotalExp))
-                return (byte)(level - 1);
-        }
         return 0;
     }
 
+    /// <summary>
+    /// Gets the level that corresponds to the given experience amount.
+    /// </summary>
+    /// <param name="exp">The amount of experience.</param>
+    /// <param name="overflow">The amount of experience that exceeds the level.</param>
+    /// <param name="mate"><c>true</c> to get the level for a mate (mount, pet); <c>false</c> to get the level for a player.</param>
+    /// <returns>The level that corresponds to the given experience amount, or the maximum level if the experience exceeds that of the maximum level.</returns>
+    /// <remarks>Prefer the <see cref="GetLevelFromExp(int, byte, out int, bool)"/> overload if the current level is known.</remarks>
+    /// <seealso cref="GetLevelFromExp(int, byte, out int, bool)"/>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="exp"/> is negative.</exception>
+    public byte GetLevelFromExp(int exp, out int overflow, bool mate = false)
+        => GetLevelFromExp(exp, mate, out overflow, minLevel: 0);
+
+    /// <summary>
+    /// Gets the level that corresponds to the given experience amount.
+    /// </summary>
+    /// <param name="exp">The amount of experience.</param>
+    /// <param name="currentLevel">The current level of the unit.</param>
+    /// <param name="overflow">The amount of experience that exceeds the level.</param>
+    /// <param name="mate"><c>true</c> to get the level for a mate (mount, pet); <c>false</c> to get the level for a player.</param>
+    /// <returns>The level that corresponds to the given experience amount, or the maximum level if the experience exceeds that of the maximum level.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="exp"/> is negative.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="currentLevel"/> is zero.</exception>
+    public byte GetLevelFromExp(int exp, byte currentLevel, out int overflow, bool mate = false)
+    {
+        ArgumentOutOfRangeException.ThrowIfZero(currentLevel);
+        return GetLevelFromExp(exp, mate, out overflow, minLevel: currentLevel);
+    }
+
+    /// <summary>
+    /// Gets the level that corresponds to the given experience amount.
+    /// </summary>
+    /// <param name="exp">The amount of experience.</param>
+    /// <param name="mate"><c>true</c> to get the level for a mate (mount, pet); <c>false</c> to get the level for a player.</param>
+    /// <param name="minLevel">The minimum level of the unit to consider. Should usually be the current level of the unit.</param>
+    /// <param name="overflow">The amount of experience that exceeds the level.</param>
+    /// <returns>The level that corresponds to the given experience amount, or the maximum level if the experience exceeds that of the maximum level.</returns>
+    /// <remarks>The <paramref name="minLevel"/> parameter is an optimization to speed up locating the level for a given experience value, by excluding certain levels.</remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="exp"/> is negative.</exception>
+    private byte GetLevelFromExp(int exp, bool mate, out int overflow, byte minLevel = 0)
+    {
+        // This method relies on units being unable to lose levels (experience can be lost, but not causing de-levelling).
+        ArgumentOutOfRangeException.ThrowIfNegative(exp);
+
+        var expByLevel = mate ? _mateExpByLevel : _expByLevel;
+        var maxLevel = mate ? MaxMateLevel : MaxPlayerLevel;
+
+        // Check if minLevel is already at or beyond the maximum level.
+        // This prevents out of bounds indexing below (or indexing into values beyond the max level, when the db contains more rows than needed)
+        if (minLevel >= maxLevel)
+        {
+            overflow = Math.Max(0, exp - GetExpForLevel(maxLevel, mate));
+            return maxLevel;
+        }
+
+        // Limit the binary search to the range between the min possible level and the max level of the unit (better for mates which have a lower max level)
+        var count = Math.Min(expByLevel.Count - minLevel, maxLevel);
+        var index = expByLevel.BinarySearch(minLevel, count, exp, null);
+
+        // Found the exact exp value - add 1 to turn 0-based index into level
+        if (index >= 0)
+        {
+            overflow = 0;
+            return (byte)(index + 1);
+        }
+
+        // Get the index of the next-largest exp value
+        var nextLargestIndex = ~index; // Will equal list.Count if the exp value is larger than all levels
+        if (nextLargestIndex < expByLevel.Count)
+        {
+            var level = (byte)nextLargestIndex;
+            overflow = exp - GetExpForLevel(level, mate);
+            return level;
+        }
+
+        // Exp is greater than the largest level's exp.
+        // We still provide overflow exp, even though this shouldn't be applied to the character.
+        overflow = Math.Max(0, exp - GetExpForLevel(maxLevel, mate));
+        return maxLevel;
+    }
+
+    /// <summary>
+    /// Gets the experience needed to reach the given level from the current experience amount.
+    /// </summary>
+    /// <param name="currentExp">The current amount of experience.</param>
+    /// <param name="targetLevel">The target level to reach.</param>
+    /// <param name="mate"><c>true</c> to get the level for a mate (mount, pet); <c>false</c> to get the level for a player.</param>
+    /// <returns>The amount of experience needed to reach the given level, or 0 if the target level is invalid or already reached.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="currentExp"/> is negative.</exception>
     public int GetExpNeededToGivenLevel(int currentExp, byte targetLevel, bool mate = false)
     {
+        ArgumentOutOfRangeException.ThrowIfNegative(currentExp);
         var targetExp = GetExpForLevel(targetLevel, mate);
         var diff = targetExp - currentExp;
-        return (diff <= 0) ? 0 : diff;
+        return Math.Max(0, diff);
     }
 
+    /// <summary>
+    /// Gets the total number of skill points for the given level.
+    /// </summary>
+    /// <param name="level">The level of the player.</param>
+    /// <returns>The total number of skill points for the given level, or 0 if the level is invalid.</returns>
     public int GetSkillPointsForLevel(byte level)
+        => GetTemplateForLevel(level)?.SkillPoints ?? 0;
+
+    /// <summary>
+    /// Loads the experience level templates from the default loader (Sqlite).
+    /// </summary>
+    public void Load()
+        => Load(new SqliteExperienceLevelTemplateLoader(Logger), PlayerLevelCap, MateLevelCap);
+
+    /// <summary>
+    /// Loads the experience level templates from the given loader.
+    /// </summary>
+    /// <param name="loader">The loader for the experience level templates.</param>
+    /// <param name="playerLevelCap">The maximum level for players.</param>
+    /// <param name="mateLevelCap">The maximum level for mates (mounts, pets).</param>
+    /// <remarks>
+    /// The maximum levels for players and mates will be the lower of the number of levels loaded
+    /// from <paramref name="loader"/>, and the corresponding level cap.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="playerLevelCap"/> is zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="mateLevelCap"/> is zero.</exception>
+    public void Load(IExperienceLevelTemplateLoader loader, byte playerLevelCap, byte mateLevelCap)
     {
-        return _levels.GetValueOrDefault(level)?.SkillPoints ?? 0;
+        ArgumentOutOfRangeException.ThrowIfZero(playerLevelCap);
+        ArgumentOutOfRangeException.ThrowIfZero(mateLevelCap);
+
+        _levelTemplatesByLevel.Clear();
+        _expByLevel.Clear();
+        _mateExpByLevel.Clear();
+
+        Logger.Info("Loading experience data...");
+
+        foreach (var levelTemplate in loader.Load())
+        {
+            _levelTemplatesByLevel.Add(levelTemplate);
+            _expByLevel.Add(levelTemplate.TotalExp);
+            _mateExpByLevel.Add(levelTemplate.TotalMateExp);
+        }
+
+        // Set the maximum levels for players and mates to either the number of levels in the database, or the configured level cap, whichever is lower
+        MaxPlayerLevel = (byte)Math.Min(_levelTemplatesByLevel.Count, playerLevelCap);
+        MaxMateLevel = (byte)Math.Min(_levelTemplatesByLevel.Count, mateLevelCap);
+
+        Logger.Info("Experience data loaded");
     }
 
-    public void Load()
+    private ExperienceLevelTemplate? GetTemplateForLevel(byte level)
     {
-        _levels = [];
-        using (var connection = SQLite.CreateConnection())
-        {
-            Logger.Info("Loading experience data...");
-            using (var command = connection.CreateCommand())
-            {
-                command.CommandText = "SELECT * FROM levels";
-                command.Prepare();
-                using (var sqliteDataReader = command.ExecuteReader())
-                using (var reader = new SQLiteWrapperReader(sqliteDataReader))
-                {
-                    while (reader.Read())
-                    {
-                        var level = new ExperienceLevelTemplate();
-                        level.Level = reader.GetByte("id");
-                        level.TotalExp = reader.GetInt32("total_exp");
-                        level.TotalMateExp = reader.GetInt32("total_mate_exp");
-                        level.SkillPoints = reader.GetInt32("skill_points");
-                        _levels.Add(level.Level, level);
-                    }
-                }
-            }
-
-            Logger.Info("Experience data loaded");
-        }
+        if (level <= 0 || level > _levelTemplatesByLevel.Count)
+            return null;
+        return _levelTemplatesByLevel[level - 1];
     }
 }

--- a/AAEmu.Game/Core/Managers/FeaturesManager.cs
+++ b/AAEmu.Game/Core/Managers/FeaturesManager.cs
@@ -16,8 +16,8 @@ public class FeaturesManager : Singleton<FeaturesManager>
         Logger.Info("Initializing Features ...");
         Fsets = new FeatureSet();
 
-        Fsets.PlayerLevelLimit = ExperienceManager.MaxPlayerLevel;
-        Fsets.MateLevelLimit = ExperienceManager.MaxMateLevel;
+        Fsets.PlayerLevelLimit = ExperienceManager.Instance.MaxPlayerLevel;
+        Fsets.MateLevelLimit = ExperienceManager.Instance.MaxMateLevel;
 
         // Allow House sales
         Fsets.Set(Feature.houseSale, true);

--- a/AAEmu.Game/Core/Managers/IExperienceLevelTemplateLoader.cs
+++ b/AAEmu.Game/Core/Managers/IExperienceLevelTemplateLoader.cs
@@ -1,0 +1,22 @@
+﻿#nullable enable
+
+using System.Collections.Generic;
+using System.IO;
+
+using AAEmu.Game.Models.Game;
+
+namespace AAEmu.Game.Core.Managers;
+
+/// <summary>
+/// Defines a loader for experience level templates.
+/// </summary>
+public interface IExperienceLevelTemplateLoader
+{
+    /// <summary>
+    /// Loads the experience level templates from a data source.
+    /// </summary>
+    /// <returns>An enumerable containing the experience level templates.</returns>
+    /// <exception cref="InvalidDataException">Thrown when data in the underlying data source is invalid.</exception>
+    /// <remarks>The experience level templates must be returned in order, from lowest level to highest level.</remarks>
+    IEnumerable<ExperienceLevelTemplate> Load();
+}

--- a/AAEmu.Game/Core/Managers/SqliteExperienceLevelTemplateLoader.cs
+++ b/AAEmu.Game/Core/Managers/SqliteExperienceLevelTemplateLoader.cs
@@ -1,0 +1,64 @@
+﻿#nullable enable
+
+using System.Collections.Generic;
+using System.IO;
+
+using AAEmu.Game.Models.Game;
+using AAEmu.Game.Utils.DB;
+
+using NLog;
+
+namespace AAEmu.Game.Core.Managers;
+
+/// <summary>
+/// Loads experience level templates from a SQLite database.
+/// </summary>
+public sealed class SqliteExperienceLevelTemplateLoader(ILogger logger) : IExperienceLevelTemplateLoader
+{
+    public IEnumerable<ExperienceLevelTemplate> Load()
+    {
+        using var connection = SQLite.CreateConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT * FROM levels ORDER BY id ASC";
+        command.Prepare();
+        using var sqliteDataReader = command.ExecuteReader();
+        using var reader = new SQLiteWrapperReader(sqliteDataReader);
+
+        // Validate the data, must start at level 1, and have increasing experience
+        var expectedLevel = 1;
+        var lastExp = -1;
+        var lastMateExp = -1;
+        while (reader.Read())
+        {
+            var levelTemplate = new ExperienceLevelTemplate();
+            levelTemplate.Level = reader.GetByte("id");
+            levelTemplate.TotalExp = reader.GetInt32("total_exp");
+            levelTemplate.TotalMateExp = reader.GetInt32("total_mate_exp");
+            levelTemplate.SkillPoints = reader.GetInt32("skill_points");
+
+            if (levelTemplate.Level != expectedLevel)
+            {
+                logger.Error("Experience data is missing level {0}", expectedLevel);
+                throw new InvalidDataException($"Experience data is missing level {expectedLevel}");
+            }
+
+            if (levelTemplate.TotalExp <= lastExp)
+            {
+                logger.Error("Experience data is not sorted by total_exp");
+                throw new InvalidDataException("Experience data is not sorted by total_exp");
+            }
+
+            if (levelTemplate.TotalMateExp <= lastMateExp)
+            {
+                logger.Error("Experience data is not sorted by total_mate_exp");
+                throw new InvalidDataException("Experience data is not sorted by total_mate_exp");
+            }
+
+            yield return levelTemplate;
+
+            expectedLevel++;
+            lastExp = levelTemplate.TotalExp;
+            lastMateExp = levelTemplate.TotalMateExp;
+        }
+    }
+}

--- a/AAEmu.Game/GameService.cs
+++ b/AAEmu.Game/GameService.cs
@@ -63,6 +63,7 @@ public sealed class GameService : IHostedService, IDisposable
 
         WorldManager.Instance.Load();
         WorldIdManager.Instance.Initialize();
+        ExperienceManager.Instance.Load();
         FeaturesManager.Initialize();
 
         LocalizationManager.Instance.Load();
@@ -112,7 +113,6 @@ public sealed class GameService : IHostedService, IDisposable
         SphereQuestManager.Instance.Initialize();
 
         FormulaManager.Instance.Load();
-        ExperienceManager.Instance.Load();
         AiPathsManager.Instance.Load();
 
         TlIdManager.Instance.Initialize();

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -1345,21 +1345,39 @@ public partial class Character : Unit, ICharacter
         return false;
     }
 
-    public void AddExp(int exp, bool shouldAddAbilityExp)
+    public void AddExp(int expDelta, bool shouldAddAbilityExp)
     {
-        if (exp == 0)
+        if (expDelta == 0)
             return;
 
-        if (exp > 0)
+        if (expDelta > 0)
         {
-            var totalExp = exp * AppConfiguration.Instance.World.ExpRate;
-            exp = (int)totalExp;
+            expDelta = (int)(expDelta * AppConfiguration.Instance.World.ExpRate);
         }
-        Experience = Math.Min(Experience + exp, ExperienceManager.Instance.GetExpForLevel(55));
+        
+        var newExperience = Experience + expDelta;
+        var newLevel = ExperienceManager.Instance.GetLevelFromExp(newExperience, Level, out var overflow);
+        var leveledUp = newLevel > Level;
+        
+        // Prevent overflow - cap the experience at the amount for the highest level
+        if (newLevel >= ExperienceManager.Instance.MaxPlayerLevel)
+        {
+            newExperience -= overflow;
+        }
+        
+        Experience = newExperience;
+        Level = newLevel;
+        
         if (shouldAddAbilityExp)
-            Abilities.AddActiveExp(exp); // TODO ... or all?
-        SendPacket(new SCExpChangedPacket(ObjId, exp, shouldAddAbilityExp));
-        CheckLevelUp();
+            Abilities.AddActiveExp(expDelta); // TODO ... or all?
+        
+        SendPacket(new SCExpChangedPacket(ObjId, expDelta, shouldAddAbilityExp));
+
+        if (leveledUp)
+        {
+            Expedition?.OnCharacterRefresh(this);
+            BroadcastPacket(new SCLevelChangedPacket(ObjId, Level), true);
+        }
 
         //Quests.OnLevelUp(); // TODO added for quest Id=5967
         // инициируем событие
@@ -1370,34 +1388,30 @@ public partial class Character : Unit, ICharacter
         }
     }
 
-    public void CheckLevelUp()
+    private void ValidateAndFixExpAndLevel()
     {
-        var needExp = ExperienceManager.Instance.GetExpForLevel((byte)(Level + 1));
-        var change = false;
-        while (Experience >= needExp)
-        {
-            change = true;
-            Level++;
-            needExp = ExperienceManager.Instance.GetExpForLevel((byte)(Level + 1));
-            Expedition?.OnCharacterRefresh(this);
-        }
-
-        if (change)
-        {
-            BroadcastPacket(new SCLevelChangedPacket(ObjId, Level), true);
-        }
-    }
-
-    public void CheckExp()
-    {
+        // Check if player has too little exp to be at their current level, and give them enough to maintain it
         var needExp = ExperienceManager.Instance.GetExpForLevel(Level);
         if (Experience < needExp)
-            Experience = needExp;
-        needExp = ExperienceManager.Instance.GetExpForLevel((byte)(Level + 1));
-        while (Experience >= needExp)
         {
-            Level++;
-            needExp = ExperienceManager.Instance.GetExpForLevel((byte)(Level + 1));
+            Experience = needExp;
+            return;
+        }
+
+        // Check if player has enough exp to be at a higher level, and grant them the new level
+        var newLevel = ExperienceManager.Instance.GetLevelFromExp(Experience, Level, out var overflow);
+        var leveledUp = newLevel > Level;
+        
+        // Prevent overflow - cap the experience at the amount for the highest level
+        if (newLevel >= ExperienceManager.Instance.MaxPlayerLevel)
+        {
+            Experience -= overflow;
+        }
+        
+        Level = newLevel;
+        
+        if (leveledUp)
+        {
             Expedition?.OnCharacterRefresh(this);
         }
     }
@@ -2097,7 +2111,7 @@ public partial class Character : Unit, ICharacter
                         character.Hp = character.MaxHp;
                     if (character.Mp > character.MaxMp)
                         character.Mp = character.MaxMp;
-                    character.CheckExp();
+                    character.ValidateAndFixExpAndLevel();
                     character.PostUpdateCurrentHp(character, 0, character.Hp, KillReason.Unknown);
                 }
             }
@@ -2214,7 +2228,7 @@ public partial class Character : Unit, ICharacter
                         character.Hp = character.MaxHp;
                     if (character.Mp > character.MaxMp)
                         character.Mp = character.MaxMp;
-                    character.CheckExp();
+                    character.ValidateAndFixExpAndLevel();
                     character.PostUpdateCurrentHp(character, 0, character.Hp, KillReason.Unknown);
                 }
             }

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -1512,7 +1512,7 @@ public partial class Character : Unit, ICharacter
     public override int GetAbLevel(AbilityType type)
     {
         if (type == AbilityType.General) return Level;
-        return ExperienceManager.Instance.GetLevelFromExp(Abilities.Abilities[type].Exp);
+        return ExperienceManager.Instance.GetLevelFromExp(Abilities.Abilities[type].Exp, out _);
     }
 
     public void ResetSkillCooldown(uint skillId, bool gcd)

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -119,7 +119,7 @@ public partial class Character : Unit, ICharacter
     public int PrevPoint { get; set; }
     public int Point { get; set; }
     public int Gift { get; set; }
-    public int Experience { get; set; }
+    public int Experience { get; private set; }
     public int RecoverableExp { get; set; }
     public DateTime Created { get; set; } // время создания персонажа
     public DateTime Updated { get; set; } // время внесения изменений

--- a/AAEmu.Game/Models/Game/Char/CharacterAbilities.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterAbilities.cs
@@ -52,12 +52,13 @@ public class CharacterAbilities
     public void AddActiveExp(int exp)
     {
         // TODO SCExpChangedPacket
+        var maxLevelExp = ExperienceManager.Instance.GetExpForLevel(ExperienceManager.Instance.MaxPlayerLevel);
         if (Owner.Ability1 != AbilityType.None)
-            Abilities[Owner.Ability1].Exp = Math.Min(Abilities[Owner.Ability1].Exp + exp, ExperienceManager.Instance.GetExpForLevel(55));
+            Abilities[Owner.Ability1].Exp = Math.Min(Abilities[Owner.Ability1].Exp + exp, maxLevelExp);
         if (Owner.Ability2 != AbilityType.None)
-            Abilities[Owner.Ability2].Exp = Math.Min(Abilities[Owner.Ability2].Exp + exp, ExperienceManager.Instance.GetExpForLevel(55));
+            Abilities[Owner.Ability2].Exp = Math.Min(Abilities[Owner.Ability2].Exp + exp, maxLevelExp);
         if (Owner.Ability3 != AbilityType.None)
-            Abilities[Owner.Ability3].Exp = Math.Min(Abilities[Owner.Ability3].Exp + exp, ExperienceManager.Instance.GetExpForLevel(55));
+            Abilities[Owner.Ability3].Exp = Math.Min(Abilities[Owner.Ability3].Exp + exp, maxLevelExp);
     }
 
     public void Swap(AbilityType oldAbilityId, AbilityType abilityId)

--- a/AAEmu.Game/Models/Game/Char/CharacterAbilities.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterAbilities.cs
@@ -153,6 +153,6 @@ public class CharacterAbilities
 
     public byte GetAbilityLevel(AbilityType abilityType)
     {
-        return Abilities.TryGetValue(abilityType, out var ability) ? ExperienceManager.Instance.GetLevelFromExp(ability.Exp) : (byte)0;
+        return Abilities.TryGetValue(abilityType, out var ability) ? ExperienceManager.Instance.GetLevelFromExp(ability.Exp, out _) : (byte)0;
     }
 }

--- a/AAEmu.Game/Models/Game/Char/ICharacter.cs
+++ b/AAEmu.Game/Models/Game/Char/ICharacter.cs
@@ -28,7 +28,7 @@ public interface ICharacter : IUnit
     void SendMessage(string message);
     void SendErrorMessage(ErrorMessageType errorMsgType, uint type = 0, bool isNotify = true);
     void ChangeLabor(short change, int actabilityId);
-    void AddExp(int exp, bool shouldAddAbilityExp);
+    void AddExp(int expDelta, bool shouldAddAbilityExp);
     public bool ChangeMoney(SlotType typeFrom, SlotType typeTo, int amount, ItemTaskType itemTaskType = ItemTaskType.DepositMoney);
     public void ChangeGamePoints(GamePointKind kind, int change);
     public void SetGrowthRate(float value);

--- a/AAEmu.Game/Models/Game/Quests/Acts/QuestActObjAbilityLevel.cs
+++ b/AAEmu.Game/Models/Game/Quests/Acts/QuestActObjAbilityLevel.cs
@@ -27,7 +27,7 @@ public class QuestActObjAbilityLevel(QuestComponentTemplate parentComponent) : Q
         {
             // Single Ability check
             var ability = quest.Owner.Abilities.Abilities[AbilityId];
-            int abLevel = ExperienceManager.Instance.GetLevelFromExp(ability.Exp);
+            int abLevel = ExperienceManager.Instance.GetLevelFromExp(ability.Exp, out _);
             return abLevel >= Level;
         }
 
@@ -35,7 +35,7 @@ public class QuestActObjAbilityLevel(QuestComponentTemplate parentComponent) : Q
         for (var i = AbilityType.General + 1; i < AbilityType.None; i++)
         {
             var ability = quest.Owner.Abilities.Abilities[i];
-            int abLevel = ExperienceManager.Instance.GetLevelFromExp(ability.Exp);
+            int abLevel = ExperienceManager.Instance.GetLevelFromExp(ability.Exp, out _);
             if (abLevel < Level)
                 return false; // Fail check if any of the Abilities is below the required level
         }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/AddExp.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/AddExp.cs
@@ -27,7 +27,7 @@ public class AddExp : SpecialEffectAction
     {
         if (caster is Character) { Logger.Debug("Special effects: AddExp value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4); }
 
-        if (!(target is Unit unit))
+        if (target is not Unit unit)
         {
             return;
         }
@@ -45,7 +45,17 @@ public class AddExp : SpecialEffectAction
         switch (target)
         {
             case Units.Mate mate:
-                mate.AddExp(expToAdd);
+                if (mate.IsMaxLevel)
+                {
+                    // Cancel the skill and don't consume the item/reagent (e.g. Companion Crust)
+                    skill.Cancelled = true;
+                    ((Unit)caster).SendErrorMessage(ErrorMessageType.InvalidTarget);
+                    // TODO: This doesn't stop the skill on the client, so it still performs the animation
+                }
+                else
+                {
+                    mate.AddExp(expToAdd);
+                }
                 break;
             case Character character:
                 character.AddExp(expToAdd, true);

--- a/AAEmu.Game/Models/Game/Skills/Plots/PlotCondition.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/PlotCondition.cs
@@ -262,7 +262,7 @@ public class PlotCondition
         if (caster is Character character)
         {
             var ability = character.Abilities.Abilities[(AbilityType)abilityType];
-            int abLevel = ExperienceManager.Instance.GetLevelFromExp(ability.Exp);
+            int abLevel = ExperienceManager.Instance.GetLevelFromExp(ability.Exp, out _);
             return abLevel >= min && abLevel <= max;
         }
         //Should this ever not be a character using this condition?

--- a/AAEmu.Game/Scripts/Commands/ChangeLevel.cs
+++ b/AAEmu.Game/Scripts/Commands/ChangeLevel.cs
@@ -110,7 +110,7 @@ public class ChangeLevel : ICommand
                 }
             }
 
-            var expForLevel = ExperienceManager.Instance.GetExpForLevel(level) - targetPlayer.Experience;
+            var expForLevel = ExperienceManager.Instance.GetExpNeededToGivenLevel(targetPlayer.Experience, level);
             if (expForLevel > maxExpToAdd)
             {
                 maxExpToAdd = expForLevel;
@@ -122,16 +122,11 @@ public class ChangeLevel : ICommand
                 targetPlayer.AddExp(maxExpToAdd, true);
             }
 
-            // If the target level is bigger than player's current level, refill HP/MP and send level-up packet
+            // If the target level is bigger than player's current level, refill HP/MP
             if (level > targetPlayer.Level)
             {
-                targetPlayer.Level = level;
-                targetPlayer.Experience = expForLevel;
-
                 targetPlayer.Hp = targetPlayer.MaxHp;
                 targetPlayer.Mp = targetPlayer.MaxMp;
-
-                targetPlayer.BroadcastPacket(new SCLevelChangedPacket(targetPlayer.ObjId, level), true);
             }
         }
     }

--- a/AAEmu.Game/Scripts/Commands/ChangeLevel.cs
+++ b/AAEmu.Game/Scripts/Commands/ChangeLevel.cs
@@ -26,7 +26,7 @@ public class ChangeLevel : ICommand
     public string GetCommandHelpText()
     {
         return $"Adds experience points needed to reach target <level>\n" +
-               $"Allowed range is 2-{ExperienceManager.MaxPlayerLevel} and {ExperienceManager.MaxMateLevel} for pets\n";
+               $"Allowed range is 2-{ExperienceManager.Instance.MaxPlayerLevel} and {ExperienceManager.Instance.MaxMateLevel} for pets\n";
     }
 
     public void Execute(Character character, string[] args, IMessageOutput messageOutput)
@@ -48,10 +48,10 @@ public class ChangeLevel : ICommand
 
         if (character.CurrentTarget is Mate mate)
         {
-            if (level <= 1 || level > ExperienceManager.MaxMateLevel)
+            if (level <= 1 || level > ExperienceManager.Instance.MaxMateLevel)
             {
                 CommandManager.SendErrorText(this, messageOutput,
-                    $"Allowed level range: 2-{ExperienceManager.MaxMateLevel}|r");
+                    $"Allowed level range: 2-{ExperienceManager.Instance.MaxMateLevel}|r");
                 return;
             }
 
@@ -68,10 +68,10 @@ public class ChangeLevel : ICommand
         }
         else
         {
-            if (level <= 1 || level > ExperienceManager.MaxPlayerLevel)
+            if (level <= 1 || level > ExperienceManager.Instance.MaxPlayerLevel)
             {
                 CommandManager.SendErrorText(this, messageOutput,
-                    $"Allowed level range: 2-{ExperienceManager.MaxPlayerLevel}|r");
+                    $"Allowed level range: 2-{ExperienceManager.Instance.MaxPlayerLevel}|r");
                 return;
             }
 

--- a/AAEmu.UnitTests/Game/Core/Managers/ExperienceManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/ExperienceManagerTests.cs
@@ -1,0 +1,322 @@
+﻿using System;
+using System.Linq;
+
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.Game;
+
+using Moq;
+
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class ExperienceManagerTests
+{
+    private readonly ExperienceManager _cut = ExperienceManager.Instance;
+    private const int maxPlayerExp = 200;
+    private const int maxMateExp = 100;
+
+    public ExperienceManagerTests()
+    {
+        SetupExperienceManager([
+            new ExperienceLevelTemplate { Level = 1, TotalExp = 0, TotalMateExp = 0, SkillPoints = 1 },
+            new ExperienceLevelTemplate { Level = 2, TotalExp = 100, TotalMateExp = 50, SkillPoints = 2 },
+            new ExperienceLevelTemplate { Level = 3, TotalExp = 200, TotalMateExp = 100, SkillPoints = 3 }
+        ]);
+    }
+
+    [Fact]
+    public void MaxPlayerLevelGreaterThanZero()
+    {
+        Assert.True(_cut.MaxPlayerLevel > 0);
+    }
+
+    [Fact]
+    public void MaxMateLevelGreaterThanZero()
+    {
+        Assert.True(_cut.MaxMateLevel > 0);
+    }
+
+    [Theory]
+    // Character
+    [InlineData(0, false, 0)] // Level 0 is invalid for character, so should return 0 exp
+    [InlineData(1, false, 0)]
+    [InlineData(2, false, 100)]
+    [InlineData(3, false, 200)]
+    [InlineData(4, false, 0)] // Level 3 is invalid for character, so should return 0 exp
+    // Mate
+    [InlineData(0, true, 0)] // Level 0 is invalid for mate, so should return 0 exp
+    [InlineData(1, true, 0)]
+    [InlineData(2, true, 50)]
+    [InlineData(3, true, 100)]
+    [InlineData(4, true, 0)] // Level 3 is invalid for mate, so should return 0 exp
+    public void GetExpForLevel(byte level, bool mate, int expectedExp)
+    {
+        var exp = _cut.GetExpForLevel(level, mate);
+        Assert.Equal(expectedExp, exp);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    public void GetLevelFromExp_Invalid_TooSmall_Throws(int exp)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => _cut.GetLevelFromExp(exp, out _));
+    }
+
+    [Theory]
+    // Characters
+    [InlineData(201, false)]
+    [InlineData(300, false)]
+    [InlineData(int.MaxValue, false)]
+    // Mates
+    [InlineData(101, true)]
+    [InlineData(300, true)]
+    [InlineData(int.MaxValue, true)]
+    public void GetLevelFromExp_Invalid_TooBig_ReturnsMaxLevel(int exp, bool mate)
+    {
+        var level = _cut.GetLevelFromExp(exp, out var overflow, mate);
+
+        var expectedLevel = mate ? _cut.MaxMateLevel : _cut.MaxPlayerLevel;
+        var expectedOverflow = exp - (mate ? maxMateExp : maxPlayerExp);
+
+        Assert.Equal(expectedLevel, level);
+        Assert.Equal(expectedOverflow, overflow);
+    }
+
+    [Theory]
+    // Character
+    [InlineData(0, false, 1, 0)]
+    [InlineData(1, false, 1, 1)]
+    [InlineData(99, false, 1, 99)]
+    [InlineData(100, false, 2, 0)]
+    [InlineData(101, false, 2, 1)]
+    [InlineData(199, false, 2, 99)]
+    [InlineData(200, false, 3, 0)]
+    // Mate
+    [InlineData(0, true, 1, 0)]
+    [InlineData(1, true, 1, 1)]
+    [InlineData(49, true, 1, 49)]
+    [InlineData(50, true, 2, 0)]
+    [InlineData(51, true, 2, 1)]
+    [InlineData(99, true, 2, 49)]
+    [InlineData(100, true, 3, 0)]
+    public void GetLevelFromExp_Valid(int exp, bool mate, int expectedLevel, int expectedOverflow)
+    {
+        var level = _cut.GetLevelFromExp(exp, out var overflow, mate);
+        Assert.Equal(expectedLevel, level);
+        Assert.Equal(expectedOverflow, overflow);
+    }
+
+    [Fact]
+    public void GetLevelFromExp_CurrentLevel_Zero_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => _cut.GetLevelFromExp(1, 0, out _));
+    }
+
+    [Theory]
+    [InlineData(-1, 1)]
+    [InlineData(int.MinValue, 1)]
+    public void GetLevelFromExp_CurrentLevel_Invalid_TooSmall_Throws(int exp, byte currentLevel)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => _cut.GetLevelFromExp(exp, currentLevel, out _));
+    }
+
+    [Theory]
+    // Characters
+    [InlineData(201, 1, false, 1)]
+    [InlineData(300, 1, false, 100)]
+    [InlineData(int.MaxValue, 1, false, int.MaxValue - maxPlayerExp)]
+    [InlineData(201, 2, false, 1)]
+    [InlineData(300, 2, false, 100)]
+    [InlineData(int.MaxValue, 2, false, int.MaxValue - maxPlayerExp)]
+    [InlineData(201, 3, false, 1)]
+    [InlineData(300, 3, false, 100)]
+    [InlineData(int.MaxValue, 3, false, int.MaxValue - maxPlayerExp)]
+    // Mates
+    [InlineData(101, 1, true, 1)]
+    [InlineData(300, 1, true, 200)]
+    [InlineData(int.MaxValue, 1, true, int.MaxValue - maxMateExp)]
+    [InlineData(101, 2, true, 1)]
+    [InlineData(300, 2, true, 200)]
+    [InlineData(int.MaxValue, 2, true, int.MaxValue - maxMateExp)]
+    [InlineData(101, 3, true, 1)]
+    [InlineData(300, 3, true, 200)]
+    [InlineData(int.MaxValue, 3, true, int.MaxValue - maxMateExp)]
+    public void GetLevelFromExp_CurrentLevel_Invalid_TooBig_ReturnsMaxLevel(int exp, byte currentLevel, bool mate, int expectedOverflow)
+    {
+        var level = _cut.GetLevelFromExp(exp, currentLevel, out var overflow, mate);
+        var expectedLevel = mate ? _cut.MaxMateLevel : _cut.MaxPlayerLevel;
+        Assert.Equal(expectedLevel, level);
+        Assert.Equal(expectedOverflow, overflow);
+    }
+
+    [Theory]
+    // Character
+    [InlineData(0, false, 1, 1)]
+    [InlineData(1, false, 1, 1)]
+    [InlineData(99, false, 1, 1)]
+    [InlineData(100, false, 1, 2)]
+    [InlineData(101, false, 1, 2)]
+    [InlineData(199, false, 1, 2)]
+    [InlineData(200, false, 1, 3)]
+
+    [InlineData(0, false, 2, 2)] // If you're currently level 2 and have 0 exp, it's expected this will return level 2, because it doesn't check lower than the current level
+    [InlineData(1, false, 2, 2)]
+    [InlineData(99, false, 2, 2)]
+    [InlineData(100, false, 2, 2)]
+    [InlineData(101, false, 2, 2)]
+    [InlineData(199, false, 2, 2)]
+    [InlineData(200, false, 2, 3)]
+    // Mate
+    [InlineData(0, true, 1, 1)]
+    [InlineData(1, true, 1, 1)]
+    [InlineData(49, true, 1, 1)]
+    [InlineData(50, true, 1, 2)]
+    [InlineData(51, true, 1, 2)]
+    [InlineData(99, true, 1, 2)]
+    [InlineData(100, true, 1, 3)]
+
+    [InlineData(0, true, 2, 2)]
+    [InlineData(1, true, 2, 2)]
+    [InlineData(49, true, 2, 2)]
+    [InlineData(50, true, 2, 2)]
+    [InlineData(51, true, 2, 2)]
+    [InlineData(99, true, 2, 2)]
+    [InlineData(100, true, 2, 3)]
+    public void GetLevelFromExp_CurrentLevel_Valid(int exp, bool mate, byte currentLevel, int expectedLevel)
+    {
+        var level = _cut.GetLevelFromExp(exp, currentLevel, out _, mate);
+        Assert.Equal(expectedLevel, level);
+    }
+
+    [Theory]
+    // Characters
+    [InlineData(0, 1, false, 0)]
+    [InlineData(5, 1, false, 0)]
+    [InlineData(500, 1, false, 0)]
+    [InlineData(0, 2, false, 100)]
+    [InlineData(0, 3, false, 200)]
+    // Mates
+    [InlineData(0, 1, true, 0)]
+    [InlineData(0, 2, true, 50)]
+    [InlineData(0, 3, true, 100)]
+    public void GetExpNeededToGivenLevel_Valid(int currentExp, byte targetLevel, bool mate, int expectedExp)
+    {
+        var exp = _cut.GetExpNeededToGivenLevel(currentExp, targetLevel, mate);
+        Assert.Equal(expectedExp, exp);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void GetExpNeededToGivenLevel_Invalid_NegativeExpThrows(bool mate)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => _cut.GetExpNeededToGivenLevel(-1, 1, mate));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void GetExpNeededToGivenLevel_Invalid_TargetLevelTooHigh(bool mate)
+    {
+        var exp = _cut.GetExpNeededToGivenLevel(0, 100, mate);
+        Assert.Equal(0, exp);
+    }
+
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(2, 2)]
+    [InlineData(3, 3)]
+    public void GetSkillPointsForLevel_Valid(byte level, int expectedSkillPoints)
+    {
+        var skillPoints = _cut.GetSkillPointsForLevel(level);
+        Assert.Equal(expectedSkillPoints, skillPoints);
+    }
+
+    [Theory]
+    [InlineData(4)]
+    [InlineData(50)]
+    [InlineData(byte.MaxValue)]
+    public void GetSkillPointsForLevel_Invalid_ReturnsZero(byte level)
+    {
+        var skillPoints = _cut.GetSkillPointsForLevel(level);
+        Assert.Equal(0, skillPoints);
+    }
+
+    [Fact]
+    public void Load_CallsLoader()
+    {
+        var mockLoader = new Mock<IExperienceLevelTemplateLoader>(MockBehavior.Strict);
+        mockLoader.Setup(l => l.Load())
+            .Returns(Enumerable.Empty<ExperienceLevelTemplate>())
+            .Verifiable(Times.Once);
+
+        _cut.Load(mockLoader.Object, 1, 1);
+        mockLoader.Verify();
+    }
+
+    [Fact]
+    public void Load_ResetsState()
+    {
+        // arrange
+        var mockLoader1 = new Mock<IExperienceLevelTemplateLoader>(MockBehavior.Strict);
+        mockLoader1.Setup(l => l.Load())
+            .Returns([
+                new ExperienceLevelTemplate { Level = 1, TotalExp = 0, TotalMateExp = 0 },
+                new ExperienceLevelTemplate { Level = 2, TotalExp = 100, TotalMateExp = 100 }
+            ])
+            .Verifiable(Times.Once);
+
+        var mockLoader2 = new Mock<IExperienceLevelTemplateLoader>(MockBehavior.Strict);
+        mockLoader2.Setup(l => l.Load())
+            .Returns([
+                new ExperienceLevelTemplate { Level = 1, TotalExp = 0, TotalMateExp = 0 }
+            ])
+            .Verifiable(Times.Once);
+
+        _cut.Load(mockLoader1.Object, 2, 2);
+
+        // act
+        _cut.Load(mockLoader2.Object, 1, 1);
+        var level = _cut.GetLevelFromExp(100, out _, false);
+
+        // assert
+        Assert.Equal(1, level); // should be level 1 if the second loader overwrote the first
+        Assert.Equal(1, _cut.MaxPlayerLevel);
+        Assert.Equal(1, _cut.MaxMateLevel);
+        mockLoader1.Verify();
+        mockLoader2.Verify();
+    }
+
+    [Theory]
+    [InlineData(1, 1, 1, 1)]
+    [InlineData(2, 2, 2, 2)]
+    [InlineData(3, 3, 2, 2)]
+    [InlineData(1, 2, 1, 2)]
+    [InlineData(2, 1, 2, 1)]
+    [InlineData(3, 1, 2, 1)]
+    public void Load_SetsMaxLevel(byte playerLevelCap, byte mateLevelCap, byte expectedMaxPlayerLevel, byte expectedMaxMateLevel)
+    {
+        var mockLoader = new Mock<IExperienceLevelTemplateLoader>(MockBehavior.Strict);
+        mockLoader.Setup(l => l.Load())
+            .Returns([
+                new ExperienceLevelTemplate { Level = 1, TotalExp = 0, TotalMateExp = 0 },
+                new ExperienceLevelTemplate { Level = 2, TotalExp = 100, TotalMateExp = 100 }
+            ])
+            .Verifiable(Times.Once);
+
+        _cut.Load(mockLoader.Object, playerLevelCap, mateLevelCap);
+
+        mockLoader.Verify();
+        Assert.Equal(expectedMaxPlayerLevel, _cut.MaxPlayerLevel);
+        Assert.Equal(expectedMaxMateLevel, _cut.MaxMateLevel);
+    }
+
+    private void SetupExperienceManager(ExperienceLevelTemplate[] levelTemplates)
+    {
+        var mockLoader = new Mock<IExperienceLevelTemplateLoader>(MockBehavior.Strict);
+        mockLoader.Setup(x => x.Load()).Returns(levelTemplates);
+        _cut.Load(mockLoader.Object, (byte)levelTemplates.Length, (byte)levelTemplates.Length);
+    }
+}


### PR DESCRIPTION
Implements the level cap for mates, preventing them from levelling above the max level.

https://github.com/AAEmu/AAEmu/commit/f0afbf4d1520878199f16dd340a2abc8a0304d80 is still a work in progress to avoid consuming [Companion Crust](https://archeagecodex.com/us/item/29040/) when the pet/mount is already max level. In its current form, it cancels the skill and this prevents the item from being consumed on the server, but the client still performs the animation as if the skill was successful. Is there a better place to do this kind of check that would prevent the client animation entirely?