### PR TITLE
[Game] Fix inability to use glider skills while targetting a unit that isn't gliding

### DIFF
--- a/AAEmu.Game/GameData/UnitRequirementsGameData.cs
+++ b/AAEmu.Game/GameData/UnitRequirementsGameData.cs
@@ -169,6 +169,12 @@ public class UnitRequirementsGameData : Singleton<UnitRequirementsGameData>, IGa
         }
         // TODO: check if there are any other skill types that required to be used in a specific area of multiple quest spheres
 
+        // Needed to fix skills that can only target self (i.e. that don't apply to the target, for example glider skills),
+        // even though they use UnitReqsKindType.TargetBuffTag
+        var target = skillTemplate.TargetType == SkillTargetType.Self
+            ? ownerUnit
+            : (ownerUnit as Unit)?.CurrentTarget ?? ownerUnit;
+        
         var res = !skillTemplate.OrUnitReqs;
         var lastFailedCheckResult = new UnitReqsValidationResult(SkillResultKeys.skill_failure, 0, 0);
         foreach (var unitReq in reqs)
@@ -190,7 +196,7 @@ public class UnitRequirementsGameData : Singleton<UnitRequirementsGameData>, IGa
             }
             else
             {
-                var lastCheckResult = unitReq.Validate(ownerUnit);
+                var lastCheckResult = unitReq.Validate(ownerUnit, target);
                 reqRes = lastCheckResult.ResultKey == SkillResultKeys.ok;
                 if (lastCheckResult.ResultKey != SkillResultKeys.ok)
                     lastFailedCheckResult = lastCheckResult;
@@ -214,10 +220,13 @@ public class UnitRequirementsGameData : Singleton<UnitRequirementsGameData>, IGa
         var reqs = GetSphereRequirements(sphere.Id);
         if (reqs.Count == 0)
             return true; // No requirements, we're good
+        
+        var target = (ownerUnit as Unit)?.CurrentTarget ?? ownerUnit;
+        
         var res = !sphere.OrUnitReqs;
         foreach (var unitReq in reqs)
         {
-            var validateRes = unitReq.Validate(ownerUnit);
+            var validateRes = unitReq.Validate(ownerUnit, target);
             var reqRes = validateRes.ResultKey == SkillResultKeys.ok;
 
             if (sphere.OrUnitReqs)
@@ -237,10 +246,11 @@ public class UnitRequirementsGameData : Singleton<UnitRequirementsGameData>, IGa
         var reqs = GetQuestComponentRequirements(questComponent.Id);
         if (reqs.Count == 0)
             return true; // No requirements, we're good
+        var target = (ownerUnit as Unit)?.CurrentTarget ?? ownerUnit;
         var res = !questComponent.OrUnitReqs;
         foreach (var unitReq in reqs)
         {
-            var validateRes = unitReq.Validate(ownerUnit);
+            var validateRes = unitReq.Validate(ownerUnit, target);
             var reqRes = validateRes.ResultKey == SkillResultKeys.ok;
 
             if (questComponent.OrUnitReqs)

--- a/AAEmu.Game/Models/Game/Units/UnitReqs.cs
+++ b/AAEmu.Game/Models/Game/Units/UnitReqs.cs
@@ -29,7 +29,7 @@ public class UnitReqs
     public uint Value1 { get; set; }
     public uint Value2 { get; set; }
 
-    public UnitReqsValidationResult Validate(BaseUnit owner)
+    public UnitReqsValidationResult Validate(BaseUnit owner, BaseUnit target)
     {
         UnitReqsValidationResult Ret(SkillResultKeys errorKey, bool success)
         {
@@ -46,7 +46,7 @@ public class UnitReqs
         }
 
         var unit = owner as Unit;
-        var targetUnit = unit?.CurrentTarget as Unit;
+        var targetUnit = target as Unit;
         var player = owner as Character;
         switch (KindType)
         {


### PR DESCRIPTION
Trying to use glider skills while targetting a unit that isn't gliding (e.g. a mount or house) would prevent the skills from being used, with an error message that the target must be gliding.

This happens because the unit_reqs for the skills use `UnitReqsKindType.TargetBuffTag`, and the player's current target is evaluated.

The skills themselves are marked as self-only target (`SkillTargetType.Self`), so the fix is to use the player themselves as the target for these skills.