### PR TITLE
[Game] Adding FinishChanneling functionality to plots.

### DIFF
--- a/AAEmu.Game/Core/Packets/G2C/SCPlotEventPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCPlotEventPacket.cs
@@ -60,7 +60,7 @@ public class SCPlotEventPacket : GamePacket
         stream.Write(_flag);
         if (((_flag >> 3) & 1) != 1)
         {
-            return stream;           // flag = 2 | 6
+            return stream;           // We had a note here that flag = 2 | 6, but it can also be 0. It defaults to 2, it seems.
         }
         for (var i = 0; i < 13; i++) // flag = 8
         {

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpawnFishEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpawnFishEffect.cs
@@ -17,6 +17,7 @@ public class SpawnFishEffect : EffectTemplate
         CastAction castObj, EffectSource source, SkillObject skillObject, DateTime time,
         CompressedGamePackets packetBuilder = null)
     {
-        Logger.Trace("SpawnFishEffect");
+        Logger.Info($"SpawnFishEffect:");
+        //Process: Spawn the fish, add it to the world at the correct location, then: combat engaged, target, aggro target before starting fish AI.
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/FinishChanneling.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/FinishChanneling.cs
@@ -20,7 +20,13 @@ public class FinishChanneling : SpecialEffectAction
         int value3,
         int value4)
     {
-        // TODO ...
         if (caster is Character) { Logger.Debug("Special effects: FinishChanneling value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4); }
+
+        if (target is Unit unit)
+        {
+            unit.ActivePlotState?.FinishChanneling();
+
+        }
+
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Plots/PlotEventEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/PlotEventEffect.cs
@@ -23,7 +23,7 @@ public class PlotEventEffect
 
         var buffEffect = template as BuffEffect;
         if (buffEffect != null)
-            flag = 6; //idk what this does?  
+            flag = 2; //We still don't know what this does, but we had it as 6, and it's 2 in our packet sniffing. 
 
         BaseUnit source;
         switch (SourceId)

--- a/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotNode.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotNode.cs
@@ -76,8 +76,13 @@ public class PlotNode
 
         if (castTime > 0)
             state.IsCasting = true;
-        if ((ParentNextEvent?.Casting ?? false) || (ParentNextEvent?.Casting ?? false))
+        if (ParentNextEvent?.Casting ?? false)
             state.IsCasting = false;
+
+        if (ParentNextEvent?.Channeling ?? false)
+            state.IsChanneling = false;
+        else
+            state.IsChanneling = true;
 
         if (Event.HasSpecialEffects() || castTime > 0 || Event.Conditions.Count > 0)
         {

--- a/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotState.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotState.cs
@@ -8,10 +8,12 @@ namespace AAEmu.Game.Models.Game.Skills.Plots.Tree;
 public class PlotState
 {
     private bool _cancellationRequest;
+    private bool _finishChanneling;
     public Dictionary<uint, int> Tickets { get; set; }
     public int[] Variables { get; set; }
     public byte CombatDiceRoll { get; set; }
     public bool IsCasting { get; set; }
+    public bool IsChanneling { get; set; }
 
     public Skill ActiveSkill { get; set; }
     public Unit Caster { get; set; }
@@ -26,6 +28,7 @@ public class PlotState
     public PlotState(BaseUnit caster, SkillCaster casterCaster, BaseUnit target, SkillCastTarget targetCaster, SkillObject skillObject, Skill skill)
     {
         _cancellationRequest = false;
+        _finishChanneling = false;
 
         Caster = caster as Unit;
         CasterCaster = casterCaster;
@@ -42,4 +45,7 @@ public class PlotState
 
     public bool CancellationRequested() => _cancellationRequest;
     public bool RequestCancellation() => _cancellationRequest = true;
+    public bool ChannelingFinishRequested() => _finishChanneling;
+    public bool FinishChanneling() => _finishChanneling = true;
+    public bool PermitChanneling() => _finishChanneling = false;
 }


### PR DESCRIPTION
[Game]
- FinishChanneling fast-tracks to the end of the currently channeling node, moving to the node that follows it once channeling ends -  which is different from EndChanneling, which interrupts it.
- Also changed some flags in related files (with comments) based on packet captures.