### PR TITLE
[All] Added process related information when starting a server

### DIFF
--- a/AAEmu.Game/AAEmu.Game.csproj
+++ b/AAEmu.Game/AAEmu.Game.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UserSecretsId>426ad5c3-9a72-44e9-88f5-4b5940b98c28</UserSecretsId>
     <ApplicationIcon>Resources\icon_game.ico</ApplicationIcon>
+    <Copyright>Copyright (c) 2019 - 2025 the AAEmu contributors</Copyright>
   </PropertyGroup>
 
   <ItemGroup>
@@ -91,6 +92,7 @@
     <PackageReference Include="NCrontab" Version="3.3.3" />
     <PackageReference Include="NLog" Version="5.3.4" />
     <PackageReference Include="NLua" Version="1.7.3" />
+    <PackageReference Include="OSVersionExt.NetStd" Version="3.0.1" />
     <PackageReference Include="System.Drawing.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.6.0" />
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />

--- a/AAEmu.Game/Program.cs
+++ b/AAEmu.Game/Program.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Hosting;
 
 using NLog;
 using NLog.Config;
+using OSVersionExtension;
 
 namespace AAEmu.Game;
 
@@ -124,9 +125,14 @@ public static class Program
 
     private static void Initialization()
     {
-        Logger.Info($"{Name} version {Version}");
         _thread.Name = "AA.Game Base Thread";
         _startTime = DateTime.UtcNow;
+        Logger.Info($"{Name} version {Version}");
+        Logger.Info($"Running as {(Environment.Is64BitProcess ? "64" : "32")}-bits on {(Environment.Is64BitOperatingSystem ? "64" : "32")}-bits {OSVersion.GetOperatingSystem()} ({Environment.OSVersion})");
+        if (!Environment.Is64BitProcess)
+        {
+            Logger.Warn($"Running in 32-bits mode is not recommended to do memory constraints");
+        }
     }
 
     public static bool LoadConfiguration()

--- a/AAEmu.Login/AAEmu.Login.csproj
+++ b/AAEmu.Login/AAEmu.Login.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
     <PackageReference Include="NLog" Version="5.3.4" />
+    <PackageReference Include="OSVersionExt.NetStd" Version="3.0.1" />
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/AAEmu.Login/Program.cs
+++ b/AAEmu.Login/Program.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NLog;
 using NLog.Config;
+using OSVersionExtension;
 
 namespace AAEmu.Login;
 
@@ -30,8 +31,6 @@ public static class Program
         Initialization();
 
         LoadConfiguration(args);
-
-        Logger.Info($"{Name} version {Version}");
 
         // Apply MySQL Configuration
         MySQL.SetConfiguration(AppConfiguration.Instance.Connections.MySQLProvider);
@@ -95,6 +94,12 @@ public static class Program
     {
         _thread.Name = "AA.LoginServer Base Thread";
         _startTime = DateTime.UtcNow;
+        Logger.Info($"{Name} version {Version}");
+        Logger.Info($"Running as {(Environment.Is64BitProcess ? "64" : "32")}-bits on {(Environment.Is64BitOperatingSystem ? "64" : "32")}-bits {OSVersion.GetOperatingSystem()} ({Environment.OSVersion})");
+        if (!Environment.Is64BitProcess)
+        {
+            Logger.Warn($"Running in 32-bits mode is not recommended to do memory constraints");
+        }
     }
 
     private static void Configuration(string[] args, string mainConfigJson)


### PR DESCRIPTION
- Added a line that adds information about how and in what environment the server was started.
- Added a warning log if it's running as a 32-bits process (instead of right out refusing)
