### PR TITLE
[Game] Pet spawn packet delay

### DIFF
--- a/AAEmu.Game/Core/Managers/MateManager.cs
+++ b/AAEmu.Game/Core/Managers/MateManager.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-
+using System.Threading;
 using AAEmu.Commons.Utils;
 using AAEmu.Game.Core.Managers.Id;
 using AAEmu.Game.Core.Managers.World;
@@ -205,6 +205,7 @@ public class MateManager : Singleton<MateManager>
         owner.SendPacket(new SCItemTaskSuccessPacket(ItemTaskType.UpdateSummonMateItem, [new ItemUpdate(item)],
             [])); // TODO - maybe update details
         owner.SendPacket(new SCMateSpawnedPacket(mate));
+        Thread.Sleep(50);
         mate.Spawn();
 
         Logger.Debug("Mount spawned. ownerObjId: {0}, tlId: {1}, mateObjId: {2}", owner.ObjId, mate.TlId, mate.ObjId);


### PR DESCRIPTION
- Added a small sleep between the Mate spawn packed and  normal packets send for spawning like UnitState, MateState and UnitPoints. This fixes (or mitigates) the issue people are having that a newly spawned pet's skill are not usable (the client thinks it's still level 1)

This is far from a ideal solution, but it does highlight that we need a more tick-base packet system at the least.
