### PR TITLE
[Game] fixes duplicated npc spawn due to NpcSpawnerSpawnEffect

### DIFF
--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -96,7 +96,7 @@ public class Skill
         var character = caster as Character;
 
         unit.ConditionChance = true;
-        
+
         var requirementResult = UnitRequirementsGameData.Instance.CanUseSkill(Template, caster, casterCaster);
         if (requirementResult.ResultKey != SkillResultKeys.ok)
         {
@@ -860,7 +860,7 @@ public class Skill
         {
             possibleTargets.Add(caster);
         }
-        
+
         foreach (var target in possibleTargets)
         {
             if (target is Unit targetUnit && Template.TargetType == SkillTargetType.Hostile)
@@ -999,6 +999,15 @@ public class Skill
 
                 // Dice
                 if (effect.Chance < 100 && Rand.Next(100) > effect.Chance)
+                {
+                    continue;
+                }
+
+                // prevents an NPC Spawn Skill to be duplicated 
+                if (lastAppliedEffect != null &&
+                    effect.Template is NpcSpawnerSpawnEffect &&
+                    effect.EffectId == lastAppliedEffect.EffectId &&
+                    ((effect.Template as NpcSpawnerSpawnEffect).SpawnerId == (lastAppliedEffect.Template as NpcSpawnerSpawnEffect).SpawnerId))
                 {
                     continue;
                 }
@@ -1155,7 +1164,7 @@ public class Skill
 
                     if (player is { SkillCancelled: true }) { Cancelled = true; }
                 }
-                
+
                 // Implement consumption of item sets
                 if (effect.ItemSetId > 0)
                 {
@@ -1256,7 +1265,7 @@ public class Skill
             // Lower cap at 1
             if ((Template.ConsumeLaborPower > 0) && (laborCost < 1))
                 laborCost = 1;
-            
+
             if (laborCost > 0 && !Cancelled && character.LaborPower >= laborCost)
             {
                 // Consume labor only if there is enough of it
@@ -1364,7 +1373,7 @@ public class Skill
             }
         }
 
-AlwaysHit:
+    AlwaysHit:
         switch (damageType)
         {
             case DamageType.Melee:


### PR DESCRIPTION
I found a bug in quest Under Dahuta's Veil (3990) that was duplicating the mob that was spawned from NpcSpawnerSpawnEffect

It seems that the skill was being cast multiple times, for each one of the targets around it

This check prevents it

![Screenshot_1](https://github.com/user-attachments/assets/ed32ac6f-7f45-4a00-bd72-ca87ceceafb7)
