### PR TITLE
[Game] Fix wrong Character HP/MP on login

### DIFF
--- a/AAEmu.Game/Core/Packets/C2G/CSSelectCharacterPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSSelectCharacterPacket.cs
@@ -104,6 +104,9 @@ public class CSSelectCharacterPacket : GamePacket
                 character.Buffs.AddBuff(new Buff(character, character, casterObj, buffTemplate, null, DateTime.UtcNow) { Passive = true });
             }
 
+            character.UpdateGearBonuses(null, null);
+            character.RestoreSavedHpMp();
+
             character.Breath = character.LungCapacity;
 
             Connection.ActiveChar.OnZoneChange(0, Connection.ActiveChar.Transform.ZoneId);

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -229,6 +229,8 @@ public partial class Character : Unit, ICharacter
 
     // Set to true when character has finished loading for this instance
     private bool FinishedLoading { get; set; } = false;
+    private int _savedHp;
+    private int _savedMp;
 
     #region Attributes
 
@@ -2054,6 +2056,8 @@ public partial class Character : Unit, ICharacter
                     character.RecoverableExp = reader.GetInt32("recoverable_exp");
                     character.Hp = reader.GetInt32("hp");
                     character.Mp = reader.GetInt32("mp");
+                    character._savedHp = character.Hp; // save for later
+                    character._savedMp = character.Mp;
                     // character.LaborPower = reader.GetInt16("labor_power");
                     // character.LaborPowerModified = reader.GetDateTime("labor_power_modified");
                     character.InitializeLaborCache(accountDetails.Labor, accountDetails.LastUpdated);
@@ -2170,6 +2174,8 @@ public partial class Character : Unit, ICharacter
                     character.RecoverableExp = reader.GetInt32("recoverable_exp");
                     character.Hp = reader.GetInt32("hp");
                     character.Mp = reader.GetInt32("mp");
+                    character._savedHp = character.Hp; // save for later
+                    character._savedMp = character.Mp;
                     character.InitializeLaborCache(accountDetails.Labor, accountDetails.LastUpdated);
                     // character.LaborPower = reader.GetInt16("labor_power");
                     // character.LaborPowerModified = reader.GetDateTime("labor_power_modified");
@@ -2670,6 +2676,15 @@ public partial class Character : Unit, ICharacter
             return;
         FinishedLoading = true;
         SendMessage(ChatType.System, AppConfiguration.Instance.World.MOTD);
+    }
+
+    /// <summary>
+    /// Restores HP/MP back to their loaded values
+    /// </summary>
+    public void RestoreSavedHpMp()
+    {
+        Hp = Math.Min(_savedHp, MaxHp);
+        Mp = Math.Min(_savedMp, MaxMp);
     }
 
     public override string DebugName()


### PR DESCRIPTION
- Added temporary variables to store HP/MP from the DB in until all buffs and equipment bonuses can get applied. After that restores them to the saved values.
