### PR TITLE
[Game] Fixes dead new characters bug

### DIFF
--- a/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
@@ -551,6 +551,7 @@ public class CharacterManager : Singleton<CharacterManager>
 
         character.Hp = character.MaxHp;
         character.Mp = character.MaxMp;
+        character.RestoreSavedHpMp();
 
         if (character.SaveDirectlyToDatabase())
         {

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -229,8 +229,8 @@ public partial class Character : Unit, ICharacter
 
     // Set to true when character has finished loading for this instance
     private bool FinishedLoading { get; set; } = false;
-    private int _savedHp;
-    private int _savedMp;
+    private int _savedHp = 99999999;
+    private int _savedMp = 99999999;
 
     #region Attributes
 


### PR DESCRIPTION
- Forgot to handle the code for newly created characters where the _savedHp/Mp values would not be set, resulting in a dead character if it was just created and the user didn't log out before using it.
