### PR TITLE
[UnitTests] Adding xUnit tests for the AccessLevelManager class:

### DIFF
--- a/AAEmu.UnitTests/Game/Core/Managers/AccessLevelManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/AccessLevelManagerTests.cs
@@ -1,0 +1,93 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models;
+
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers
+{
+    public class AccessLevelManagerTests
+    {
+        private readonly AccessLevelManager _manager;
+
+        public AccessLevelManagerTests()
+        {
+            _manager = AccessLevelManager.Instance;
+            ResetManagerState();
+            ResetAppConfiguration();
+        }
+
+        private void ResetManagerState()
+        {
+            var cmdField = typeof(AccessLevelManager).GetField("CMD",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            cmdField.SetValue(_manager, new List<Command>());
+        }
+
+        private void ResetAppConfiguration()
+        {
+            var config = AppConfiguration.Instance;
+            var accessLevelProperty = config.GetType().GetProperty("AccessLevel");
+            accessLevelProperty.SetValue(config, new Dictionary<string, int>());
+        }
+
+        [Fact]
+        public void GetLevel_WhenCommandNotExists_ShouldReturnDefaultLevel()
+        {
+            _manager.Load();
+            var result = _manager.GetLevel("non_existent_command");
+            Assert.Equal(100, result);
+        }
+
+        [Fact]
+        public void GetLevel_WhenCommandExists_ShouldReturnCorrectLevel()
+        {
+            var config = AppConfiguration.Instance;
+            var accessLevel = config.AccessLevel as Dictionary<string, int>;
+
+            accessLevel.Add("test_command", 5);
+
+            _manager.Load();
+            var result = _manager.GetLevel("test_command");
+            Assert.Equal(5, result);
+        }
+
+        [Fact]
+        public void Load_ShouldLoadMultipleCommandsCorrectly()
+        {
+            var config = AppConfiguration.Instance;
+            var accessLevel = config.AccessLevel as Dictionary<string, int>;
+
+            accessLevel["cmd1"] = 1;
+            accessLevel["cmd2"] = 2;
+            accessLevel["cmd3"] = 3;
+
+            _manager.Load();
+            Assert.Equal(1, _manager.GetLevel("cmd1"));
+            Assert.Equal(2, _manager.GetLevel("cmd2"));
+            Assert.Equal(3, _manager.GetLevel("cmd3"));
+        }
+
+        [Fact]
+        public void Load_WhenDuplicateCommands_ShouldOverwriteLevel()
+        {
+            var config = AppConfiguration.Instance;
+            var accessLevel = config.AccessLevel as Dictionary<string, int>;
+
+            accessLevel["duplicate"] = 5;
+            accessLevel["duplicate"] = 10;
+
+            _manager.Load();
+            Assert.Equal(10, _manager.GetLevel("duplicate"));
+        }
+
+        [Fact]
+        public void Load_WhenEmptyConfig_ShouldNotLoadCommands()
+        {
+            _manager.Load();
+            Assert.Equal(100, _manager.GetLevel("any_command"));
+        }
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/AccessLevelManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/AccessLevelManagerTests.cs
@@ -20,9 +20,7 @@ namespace AAEmu.UnitTests.Game.Core.Managers
 
         private void ResetAppConfiguration()
         {
-            var config = AppConfiguration.Instance;
-            var accessLevelProperty = config.GetType().GetProperty("AccessLevel");
-            accessLevelProperty.SetValue(config, new Dictionary<string, int>());
+            AppConfiguration.Instance.AccessLevel?.Clear();
         }
 
         [Fact]

--- a/AAEmu.UnitTests/Game/Core/Managers/AccessLevelManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/AccessLevelManagerTests.cs
@@ -14,16 +14,8 @@ namespace AAEmu.UnitTests.Game.Core.Managers
 
         public AccessLevelManagerTests()
         {
-            _manager = AccessLevelManager.Instance;
-            ResetManagerState();
+            _manager = new AccessLevelManager();
             ResetAppConfiguration();
-        }
-
-        private void ResetManagerState()
-        {
-            var cmdField = typeof(AccessLevelManager).GetField("CMD",
-                BindingFlags.NonPublic | BindingFlags.Instance);
-            cmdField.SetValue(_manager, new List<Command>());
         }
 
         private void ResetAppConfiguration()


### PR DESCRIPTION
- Implementation Notes:

1. Reflection: Used to reset the internal state of the singleton between tests. This is necessary because:
- CMD command list is private;
- AccessLevelManager is implemented as a singleton;

2. Configuration assumptions:
- AppConfiguration.Instance.AccessLevel is available for modification;
- It is assumed to be a List<KeyValuePair<string, int>>>;

3. Test Isolation:
- Each test is run with a clean state;
- Resets manager and configuration state before each test;

4. Basic Scenario Coverage:
- The command is not present in the configuration;
- Single commands;
- Several commands;
- Duplicate commands;
- Empty configuration;

Made with DeepSeek.