### PR TITLE
[Game] Sports Fishing

### DIFF
--- a/AAEmu.Game/Core/Managers/TaskManager2.cs
+++ b/AAEmu.Game/Core/Managers/TaskManager2.cs
@@ -151,7 +151,18 @@ public class TaskManager : Singleton<TaskManager>, ITaskManager
 
         return res;
     }
-
+    public void RemoveTasks(Func<Task, bool> predicate)
+    {
+        // Take a snapshot of the current tasks to avoid modifying the collection while iterating.
+        foreach (var kvp in _queue.ToArray())
+        {
+            if (predicate(kvp.Value))
+            {
+                _queue.Remove(kvp.Key, out _);
+                ReleaseId(kvp.Key);
+            }
+        }
+    }
     private uint NextId()
     {
         lock (_taskIdLock)

--- a/AAEmu.Game/Models/Game/AI/v2/Behaviors/BaseCombatBehavior.cs
+++ b/AAEmu.Game/Models/Game/AI/v2/Behaviors/BaseCombatBehavior.cs
@@ -52,6 +52,72 @@ public abstract class BaseCombatBehavior : Behavior
         if ((Ai.Owner.ActiveSkillController?.State ?? SkillController.SCState.Ended) == SkillController.SCState.Running)
             return;
 
+        var speed = Ai.GetRealMovementSpeed(Ai.Owner.BaseMoveSpeed);
+        var moveFlags = Ai.GetRealMovementFlags(speed);
+        speed *= (delta.Milliseconds / 1000.0);
+
+        if (Ai.Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId(1025)))
+        {
+            // Sports fish movement logic
+            // Halve the speed for the sports fish movement logic
+            speed *= 0.5;
+
+            // Buff 1021: Move left (i.e. as far left as possible)
+            if (Ai.Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId(1021)))
+            {
+                var currentPosition = Ai.Owner.Transform.World.Position;
+                // Define a target far to the left (assuming X axis; adjust the value as needed)
+                var leftTarget = new Vector3(currentPosition.X - 10000, currentPosition.Y, currentPosition.Z);
+                Ai.Owner.LookTowards(leftTarget);
+                Ai.Owner.MoveTowards(leftTarget, (float)speed, moveFlags);
+                return;
+            }
+
+            // Buff 1020: Move right
+            if (Ai.Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId(1020)))
+            {
+                var currentPosition = Ai.Owner.Transform.World.Position;
+                var rightTarget = new Vector3(currentPosition.X + 10000, currentPosition.Y, currentPosition.Z);
+                Ai.Owner.LookTowards(rightTarget);
+                Ai.Owner.MoveTowards(rightTarget, (float)speed, moveFlags);
+                return;
+            }
+
+            // Buff 1023: Run away from the player's location (i.e. the target)
+            if (Ai.Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId(1023)))
+            {
+                var currentPosition = Ai.Owner.Transform.World.Position;
+                var playerPosition = target.Transform.World.Position;
+                // Calculate the opposite direction from the player
+                var runDirection = currentPosition - playerPosition;
+                if (runDirection.Length() == 0)
+                {
+                    // Fallback in case we're exactly on top of the player: default to right
+                    runDirection = new Vector3(1, 0, 0);
+                }
+                runDirection = Vector3.Normalize(runDirection);
+                // Create a target far away in that direction
+                var runTarget = currentPosition + runDirection * 10000;
+                Ai.Owner.LookTowards(runTarget);
+                Ai.Owner.MoveTowards(runTarget, (float)speed, moveFlags);
+                return;
+            }
+
+            // Buff 1022: Descend (move downward)
+            if (Ai.Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId(1022)))
+            {
+                var currentPosition = Ai.Owner.Transform.World.Position;
+                // Assuming Y is the vertical axis (adjust if your engine uses a different axis)
+                var descendTarget = new Vector3(currentPosition.X, currentPosition.Y - 10000, currentPosition.Z);
+                Ai.Owner.LookTowards(descendTarget);
+                Ai.Owner.MoveTowards(descendTarget, (float)speed, moveFlags);
+                return;
+            }
+
+            // If no specific fish buff is active, remain still.
+            Ai.Owner.StopMovement();
+            return;
+        }
         //Ai.Owner.Template.AttackStartRangeScale * 4,
         //var range = 2f;// Ai.Owner.Template.AttackStartRangeScale * 6;
         var range = Ai.Owner.Template.AttackStartRangeScale;
@@ -65,9 +131,7 @@ public abstract class BaseCombatBehavior : Behavior
         {
             range -= 1f; // Fix that ID=7927, Plateau Earth Elemental can hit with a melee attack
         }
-        var speed = Ai.GetRealMovementSpeed(Ai.Owner.BaseMoveSpeed);
-        var moveFlags = Ai.GetRealMovementFlags(speed);
-        speed *= (delta.Milliseconds / 1000.0);
+
         var distanceToTarget = Ai.Owner.GetDistanceTo(target, true);
 
         if (AppConfiguration.Instance.World.GeoDataMode && Ai.Owner.Transform.WorldId > 0)

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncRecoverItem.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncRecoverItem.cs
@@ -77,7 +77,27 @@ public class DoodadFuncRecoverItem : DoodadFuncTemplate
         }
         else if (owner?.ItemTemplateId > 0)
         {
-            addedItem = character.Inventory.Bag.AcquireDefaultItem(ItemTaskType.RecoverDoodadItem, owner.ItemTemplateId, 1);
+            // Check if the item qualifies as an auto-equip trade pack.
+            if (ItemManager.Instance.IsAutoEquipTradePack(owner.ItemTemplateId))
+            {
+                // Create a new instance of the trade pack item.
+                var packItem = ItemManager.Instance.Create(owner.ItemTemplateId, 1, 0);
+
+                // Attempt to remove any existing instance of the trade pack from the backpack.
+                if (character.Inventory.TakeoffBackpack(ItemTaskType.RecoverDoodadItem, true))
+                {
+                    // Add the new trade pack item to the Equipment's backpack slot.
+                    if (character.Inventory.Equipment.AddOrMoveExistingItem(ItemTaskType.RecoverDoodadItem, packItem, (int)EquipmentItemSlot.Backpack))
+                    {
+                        addedItem = true;
+                    }
+                }
+            }
+            else
+            {
+                // For non-trade pack items, attempt to acquire the default item into the bag.
+                addedItem = character.Inventory.Bag.AcquireDefaultItem(ItemTaskType.RecoverDoodadItem, owner.ItemTemplateId, 1);
+            }
         }
         else
         {

--- a/AAEmu.Game/Models/Game/Items/Containers/LootingContainer.cs
+++ b/AAEmu.Game/Models/Game/Items/Containers/LootingContainer.cs
@@ -86,7 +86,7 @@ public class LootingContainer(IBaseUnit owner)
         if (AlreadyGenerated)
             return;
         AlreadyGenerated = true;
-        
+
         // Initialize some things
         LootOwnerType = LootOwner switch
         {
@@ -119,7 +119,7 @@ public class LootingContainer(IBaseUnit owner)
             {
                 LootMethod = LootingRuleMethod.FreeForAll,
             };
-            
+
             if (npc.CharacterTagging.TagTeam != 0)
             {
                 // A team has tagging rights
@@ -129,7 +129,7 @@ public class LootingContainer(IBaseUnit owner)
                     {
                         if (member == null || member.Character == null)
                             continue;
-                        
+
                         //if (member.HasGoneRoundRobin)
                         //    continue;
 
@@ -198,11 +198,11 @@ public class LootingContainer(IBaseUnit owner)
                 var lootPack = LootGameData.Instance.GetPack(lootPackDropping.LootPackId);
                 if (lootPack == null)
                     continue;
-                lootPackResults.AddRange(lootPack.GeneratePackNew(lootDropRate, lootGoldRate, killer as Character, ActabilityType.None, true)); 
+                lootPackResults.AddRange(lootPack.GeneratePackNew(lootDropRate, lootGoldRate, killer as Character, ActabilityType.None, true));
                 // var items = lootPack.GenerateNpcPackItems(ref baseId, killer, lootDropRate, lootGoldRate);
                 // RegisterItems(items);
             }
-            
+
             // Make Group list to enumerate with
             var groups = lootPackResults.GroupBy(x => x.lootGroupOrigin).Select(x => x.Key).ToList();
 
@@ -230,7 +230,7 @@ public class LootingContainer(IBaseUnit owner)
                         resultsToAdd.Add(item);
                     }
                 }
-                
+
                 RegisterItems(resultsToAdd);
             }
 
@@ -341,7 +341,7 @@ public class LootingContainer(IBaseUnit owner)
                     lootedItems.Add(itemIndex);
             }
             // Remove actually looted items
-            foreach(var lootedItemIndex in lootedItems)
+            foreach (var lootedItemIndex in lootedItems)
                 Items.Remove(lootedItemIndex);
         }
 
@@ -391,7 +391,7 @@ public class LootingContainer(IBaseUnit owner)
             player.SendPacket(new SCLootItemFailedPacket(ErrorMessageType.NoPermissionToLoot, LootOwnerType, LootOwner.ObjId, itemEntry.ItemIndex, itemEntry.Item.TemplateId));
             return false;
         }
-        
+
         // Check for quest items eligibility
         if (itemEntry.Item.Template.LootQuestId > 0)
         {
@@ -529,7 +529,7 @@ public class LootingContainer(IBaseUnit owner)
         // Check if everybody has rolled
         if (itemEntry.PlayerRolls.Any(m => m.Value == 0))
             return;
-        
+
         FinishRolling(itemEntry);
     }
 
@@ -591,6 +591,36 @@ public class LootingContainer(IBaseUnit owner)
         {
             player.AddMoney(SlotType.Inventory, itemEntry.Item.Count);
         }
+        else if (ItemManager.Instance.IsAutoEquipTradePack(itemEntry.Item.TemplateId))
+        {
+            // Auto-equip tradepack item branch.
+            // Create a new item instance (non-binding on creation).
+            var item = ItemManager.Instance.Create(itemEntry.Item.TemplateId, itemEntry.Item.Count, itemEntry.Item.Grade, false);
+
+            // Attempt to remove the current backpack item to free up the slot.
+            if (player.Inventory.TakeoffBackpack(ItemTaskType.RecoverDoodadItem, true))
+            {
+                // Try to add the new item to the Equipment container's Backpack slot.
+                if (!player.Inventory.Equipment.AddOrMoveExistingItem(ItemTaskType.RecoverDoodadItem, item, (int)EquipmentItemSlot.Backpack))
+                {
+                    // If adding fails, release the item ID and restore original.
+                    ItemIdManager.Instance.ReleaseId((uint)item.Id);
+                    itemEntry.Item.Id = fullOldItemId;
+                    player.SendPacket(new SCLootItemFailedPacket(ErrorMessageType.BagFull, LootOwnerType, LootOwner.ObjId, itemEntry.ItemIndex, itemEntry.Item.TemplateId));
+                    return false;
+                }
+                else
+                {
+                    Logger.Trace("AutoEquipTradePack: Tradepack item added to Equipment container successfully.");
+                }
+            }
+            else
+            {
+                Logger.Warn("AutoEquipTradePack: Failed to take off backpack for auto-equip tradepack item TemplateId={0}.", itemEntry.Item.TemplateId);
+                player.SendPacket(new SCLootItemFailedPacket(ErrorMessageType.BagFull, LootOwnerType, LootOwner.ObjId, itemEntry.ItemIndex, itemEntry.Item.TemplateId));
+                return false;
+            }
+        }
         else
         {
             // On a loot attempt, it's probably safe to try and assign it a real itemId
@@ -639,7 +669,7 @@ public class LootingContainer(IBaseUnit owner)
                     // }
                 }
             }
-            
+
             FinishRolling(itemEntry);
         }
     }

--- a/AAEmu.Game/Models/Game/Skills/Buff.cs
+++ b/AAEmu.Game/Models/Game/Skills/Buff.cs
@@ -7,6 +7,7 @@ using AAEmu.Game.Models.Game.Skills.Buffs;
 using AAEmu.Game.Models.Game.Skills.Templates;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.StaticValues;
+using AAEmu.Game.Models.Tasks.Skills;
 using NLog;
 
 namespace AAEmu.Game.Models.Game.Skills;
@@ -160,7 +161,51 @@ public class Buff
             StopEffectTask(replace);
         }
     }
+    public void OverwriteWith(Buff newBuff)
+    {
+        lock (_lock)
+        {
+            // Capture the remaining time before we update the StartTime.
+            var remaining = GetTimeLeft();
 
+            // Update buff properties from the new buff.
+            this.Charge = newBuff.Charge;
+            this.AbLevel = newBuff.AbLevel;
+            this.Caster = newBuff.Caster;
+            this.SkillCaster = newBuff.SkillCaster;
+
+            // Set StartTime to now.
+            var now = DateTime.UtcNow;
+            StartTime = now;
+
+            // Update Duration based on the stack rule:
+            if (Template.StackRule == BuffStackRule.Extend)
+            {
+                // Extend: new Duration = remaining time (from old timer) + newBuff.Duration.
+                Duration = newBuff.Duration + (int)remaining;
+            }
+            else
+            {
+                // Refresh: new Duration = newBuff.Duration.
+                Duration = newBuff.Duration;
+            }
+
+            // Recalculate EndTime based on the new StartTime and Duration.
+            EndTime = StartTime.AddMilliseconds(Duration);
+
+            // Remove any tasks associated with this buff using a predicate.
+            TaskManager.Instance.RemoveTasks(task =>
+            {
+                if (task is DispelTask dt && dt.Effect.Target is Buff buff)
+                {
+                    // Remove tasks if they are for this buff.
+                    return buff == this;
+                }
+                return false;
+            });
+            SetInUse(true, true);
+        }
+    }
     public void Exit(bool replace = false)
     {
         if (State == EffectState.Finished)

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpawnFishEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpawnFishEffect.cs
@@ -85,7 +85,7 @@ public class SpawnFishEffect : EffectTemplate
     }
     public uint GetFishSpawnerId(Character player)
     {
-        var doodads = WorldManager.GetAround<Doodad>(player, 20);
+        var doodads = WorldManager.GetAround<Doodad>(player, 100);
         for (var i = 0; i < doodads.Count; i++)
         {
             if (doodads[i].Template.GroupId == 65)

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -1156,7 +1156,18 @@ public class Skill
                     // для квеста 3478, требуется чтобы caster был Npc
                     // для квеста 3993 должен выполняться эффект, а он прерывался из-за неправильного сравнения!
                     var npc = WorldManager.Instance.GetNpcByTemplateId(nsse.NpcId);
-                    effect.Template.Apply(npc ?? caster, casterCaster, target, thisTargetCaster, new CastSkill(Template.Id, TlId), new EffectSource(this), skillObject, DateTime.UtcNow, packets);
+                    var effectiveNpc = npc ?? (target as Npc);
+
+                    // If we have an effective NPC and it is dead, skip the effect.
+                    if (effectiveNpc != null && effectiveNpc.IsDead)
+                    {
+                        //  Logger.Warn("Effective NPC is dead, skipping KillNpcWithoutCorpseEffect.");
+                    }
+                    else
+                    {
+                        effect.Template.Apply(npc ?? caster, casterCaster, target, thisTargetCaster, new CastSkill(Template.Id, TlId),
+                            new EffectSource(this), skillObject, DateTime.UtcNow, packets);
+                    }
                 }
                 else
                 {
@@ -1373,7 +1384,7 @@ public class Skill
             }
         }
 
-    AlwaysHit:
+AlwaysHit:
         switch (damageType)
         {
             case DamageType.Melee:


### PR DESCRIPTION
- Completed Sports Fishing functionality.

- Changed the way the system handles overwriting buffs to stop them triggering removal/timeout.

- Basic support for buff extension (First Round In New Morning, for example)

- Changed KillNpcWithoutCorpseEffect to not trigger after the death of the NPC

- Added the ability to loot TradePacks from Npc Loot

- Basic SportsFish movement AI for the minigame