### PR TITLE
[Game] Sports Fishing

### DIFF
--- a/AAEmu.Game/Core/Managers/TaskManager2.cs
+++ b/AAEmu.Game/Core/Managers/TaskManager2.cs
@@ -151,7 +151,18 @@ public class TaskManager : Singleton<TaskManager>, ITaskManager
 
         return res;
     }
-
+    public void RemoveTasks(Func<Task, bool> predicate)
+    {
+        // Take a snapshot of the current tasks to avoid modifying the collection while iterating.
+        foreach (var kvp in _queue.ToArray())
+        {
+            if (predicate(kvp.Value))
+            {
+                if (_queue.TryRemove(kvp))
+                    ReleaseId(kvp.Key);
+            }
+        }
+    }
     private uint NextId()
     {
         lock (_taskIdLock)

--- a/AAEmu.Game/Models/Game/AI/v2/Behaviors/BaseCombatBehavior.cs
+++ b/AAEmu.Game/Models/Game/AI/v2/Behaviors/BaseCombatBehavior.cs
@@ -14,6 +14,8 @@ using AAEmu.Game.Models.Game.AI.v2.Params.Almighty;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Skills.SkillControllers;
 using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.StaticValues;
+
 using AAEmu.Game.Utils;
 
 namespace AAEmu.Game.Models.Game.AI.v2.Behaviors;
@@ -52,6 +54,71 @@ public abstract class BaseCombatBehavior : Behavior
         if ((Ai.Owner.ActiveSkillController?.State ?? SkillController.SCState.Ended) == SkillController.SCState.Running)
             return;
 
+        var speed = Ai.GetRealMovementSpeed(Ai.Owner.BaseMoveSpeed);
+        var moveFlags = Ai.GetRealMovementFlags(speed);
+        speed *= (delta.Milliseconds / 1000.0);
+
+        if (Ai.Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId((uint)TagsEnum.Fish)))
+        {
+            // Sports fish movement logic
+            // Halve the speed for the sports fish movement logic
+            speed *= 0.5;
+
+            // Buff 1021: Move left (i.e. as far left as possible)
+            if (Ai.Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId((uint)TagsEnum.Left)))
+            {
+                var currentPosition = Ai.Owner.Transform.World.Position;
+                // Define a target far to the left 
+                var leftTarget = new Vector3(currentPosition.X - 10000, currentPosition.Y, currentPosition.Z);
+                Ai.Owner.LookTowards(leftTarget);
+                Ai.Owner.MoveTowards(leftTarget, (float)speed, moveFlags);
+                return;
+            }
+
+            // Buff 1020: Move right
+            if (Ai.Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId((uint)TagsEnum.Right)))
+            {
+                var currentPosition = Ai.Owner.Transform.World.Position;
+                var rightTarget = new Vector3(currentPosition.X + 10000, currentPosition.Y, currentPosition.Z);
+                Ai.Owner.LookTowards(rightTarget);
+                Ai.Owner.MoveTowards(rightTarget, (float)speed, moveFlags);
+                return;
+            }
+
+            // Buff 1023: Run away from the player's location (i.e. the target)
+            if (Ai.Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId((uint)TagsEnum.Back)))
+            {
+                var currentPosition = Ai.Owner.Transform.World.Position;
+                var playerPosition = target.Transform.World.Position;
+                // Calculate the opposite direction from the player
+                var runDirection = currentPosition - playerPosition;
+                if (runDirection.Length() == 0)
+                {
+                    // Fallback in case we're exactly on top of the player: default to right
+                    runDirection = new Vector3(1, 0, 0);
+                }
+                runDirection = Vector3.Normalize(runDirection);
+                // Create a target far away in that direction
+                var runTarget = currentPosition + runDirection * 10000;
+                Ai.Owner.LookTowards(runTarget);
+                Ai.Owner.MoveTowards(runTarget, (float)speed, moveFlags);
+                return;
+            }
+
+            // Buff 1022: Descend (move downward)
+            if (Ai.Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId((uint)TagsEnum.Descend)))
+            {
+                var currentPosition = Ai.Owner.Transform.World.Position;
+                var descendTarget = new Vector3(currentPosition.X, currentPosition.Y - 10000, currentPosition.Z);
+                Ai.Owner.LookTowards(descendTarget);
+                Ai.Owner.MoveTowards(descendTarget, (float)speed, moveFlags);
+                return;
+            }
+
+            // If no specific fish buff is active, remain still.
+            Ai.Owner.StopMovement();
+            return;
+        }
         //Ai.Owner.Template.AttackStartRangeScale * 4,
         //var range = 2f;// Ai.Owner.Template.AttackStartRangeScale * 6;
         var range = Ai.Owner.Template.AttackStartRangeScale;
@@ -65,9 +132,7 @@ public abstract class BaseCombatBehavior : Behavior
         {
             range -= 1f; // Fix that ID=7927, Plateau Earth Elemental can hit with a melee attack
         }
-        var speed = Ai.GetRealMovementSpeed(Ai.Owner.BaseMoveSpeed);
-        var moveFlags = Ai.GetRealMovementFlags(speed);
-        speed *= (delta.Milliseconds / 1000.0);
+
         var distanceToTarget = Ai.Owner.GetDistanceTo(target, true);
 
         if (AppConfiguration.Instance.World.GeoDataMode && Ai.Owner.Transform.WorldId > 0)

--- a/AAEmu.Game/Models/Game/Skills/Buff.cs
+++ b/AAEmu.Game/Models/Game/Skills/Buff.cs
@@ -7,6 +7,7 @@ using AAEmu.Game.Models.Game.Skills.Buffs;
 using AAEmu.Game.Models.Game.Skills.Templates;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.StaticValues;
+using AAEmu.Game.Models.Tasks.Skills;
 using NLog;
 
 namespace AAEmu.Game.Models.Game.Skills;
@@ -160,7 +161,51 @@ public class Buff
             StopEffectTask(replace);
         }
     }
+    public void OverwriteWith(Buff newBuff)
+    {
+        lock (_lock)
+        {
+            // Capture the remaining time before we update the StartTime.
+            var remaining = GetTimeLeft();
 
+            // Update buff properties from the new buff.
+            this.Charge = newBuff.Charge;
+            this.AbLevel = newBuff.AbLevel;
+            this.Caster = newBuff.Caster;
+            this.SkillCaster = newBuff.SkillCaster;
+
+            // Set StartTime to now.
+            var now = DateTime.UtcNow;
+            StartTime = now;
+
+            // Update Duration based on the stack rule:
+            if (Template.StackRule == BuffStackRule.Extend)
+            {
+                // Extend: new Duration = remaining time (from old timer) + newBuff.Duration.
+                Duration = newBuff.Duration + (int)remaining;
+            }
+            else
+            {
+                // Refresh: new Duration = newBuff.Duration.
+                Duration = newBuff.Duration;
+            }
+
+            // Recalculate EndTime based on the new StartTime and Duration.
+            EndTime = StartTime.AddMilliseconds(Duration);
+
+            // Remove any tasks associated with this buff using a predicate.
+            TaskManager.Instance.RemoveTasks(task =>
+            {
+                if (task is DispelTask dt && dt.Effect.Target is Buff buff)
+                {
+                    // Remove tasks if they are for this buff.
+                    return buff == this;
+                }
+                return false;
+            });
+            SetInUse(true, true);
+        }
+    }
     public void Exit(bool replace = false)
     {
         if (State == EffectState.Finished)

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpawnFishEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpawnFishEffect.cs
@@ -1,16 +1,15 @@
 ﻿using System;
-
+using AAEmu.Game.Core.Managers.UnitManagers;
+using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Packets;
 using AAEmu.Game.Core.Packets.G2C;
-using AAEmu.Game.Models.Game.Skills.Templates;
-using AAEmu.Game.Models.Game.Units;
-using AAEmu.Game.Models.Game.NPChar;
-using AAEmu.Game.Core.Managers.World;
-using AAEmu.Game.Core.Managers.UnitManagers;
 using AAEmu.Game.GameData;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.DoodadObj.Funcs;
+using AAEmu.Game.Models.Game.NPChar;
+using AAEmu.Game.Models.Game.Skills.Templates;
+using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects;
 
@@ -85,7 +84,7 @@ public class SpawnFishEffect : EffectTemplate
     }
     public uint GetFishSpawnerId(Character player)
     {
-        var doodads = WorldManager.GetAround<Doodad>(player, 20);
+        var doodads = WorldManager.GetAround<Doodad>(player, 100);
         for (var i = 0; i < doodads.Count; i++)
         {
             if (doodads[i].Template.GroupId == 65)

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -1156,7 +1156,18 @@ public class Skill
                     // для квеста 3478, требуется чтобы caster был Npc
                     // для квеста 3993 должен выполняться эффект, а он прерывался из-за неправильного сравнения!
                     var npc = WorldManager.Instance.GetNpcByTemplateId(nsse.NpcId);
-                    effect.Template.Apply(npc ?? caster, casterCaster, target, thisTargetCaster, new CastSkill(Template.Id, TlId), new EffectSource(this), skillObject, DateTime.UtcNow, packets);
+                    var effectiveNpc = npc ?? (target as Npc);
+
+                    // If we have an effective NPC and it is dead, skip the effect - KillNPCWithoutCorpse happens before death
+                    if (effectiveNpc != null && effectiveNpc.IsDead)
+                    {
+                        // Logger.Warn("Effective NPC is dead, skipping KillNpcWithoutCorpseEffect.");
+                    }
+                    else
+                    {
+                        effect.Template.Apply(npc ?? caster, casterCaster, target, thisTargetCaster, new CastSkill(Template.Id, TlId),
+                            new EffectSource(this), skillObject, DateTime.UtcNow, packets);
+                    }
                 }
                 else
                 {
@@ -1373,7 +1384,7 @@ public class Skill
             }
         }
 
-    AlwaysHit:
+AlwaysHit:
         switch (damageType)
         {
             case DamageType.Melee:

--- a/AAEmu.Game/Models/StaticValues/TagsEnum.cs
+++ b/AAEmu.Game/Models/StaticValues/TagsEnum.cs
@@ -5,5 +5,11 @@ public enum TagsEnum : uint
     Stealth = 100,
     Returning = 148, // NPC returning home
     NoFight = 345, // Nui statue's protection
+    Right = 1020, //Sports fishing move right
+    Left = 1021, //Sports fishing move left
+    Descend = 1022, //Sports fishing move down
+    Back = 1023, //Sports fishing run away
+    Fish = 1025, // Sports Fishing fish
     PlaySong = 1155,
+
 }


### PR DESCRIPTION
- Completed Sports Fishing functionality.

- Changed the way the system handles overwriting buffs to stop them triggering removal/timeout.

- Basic support for buff extension (First Round In New Morning, for example)

- Changed KillNpcWithoutCorpseEffect to not trigger after the death of the NPC. Once the NPC has been killed, this stops being relevant.

- Added the ability to loot TradePacks from Npc Loot

- Basic SportsFish movement AI for the minigame