### PR TITLE
 - Fix for the LootRate issue #1191

### DIFF
--- a/AAEmu.Game/Models/Game/Items/Containers/LootingContainer.cs
+++ b/AAEmu.Game/Models/Game/Items/Containers/LootingContainer.cs
@@ -87,6 +87,13 @@ public class LootingContainer(IBaseUnit owner)
             return;
         AlreadyGenerated = true;
 
+        // Add a global loot bag chance that's affected by loot rate
+        // A higher loot rate should make it LESS likely to drop, not more
+        var baseLootChance = 1.0f;
+        var lootRoll = Random.Shared.NextSingle();
+        if (lootRoll > baseLootChance / AppConfiguration.Instance.World.LootRate)
+            return;
+
         // Initialize some things
         LootOwnerType = LootOwner switch
         {


### PR DESCRIPTION
 - Fix for the LootRate issue #1191
 
Steps to reproduce

    Configure the server with a LootRate of 4.0.
    Kill any mob.
    Observe that a loot bag (with items to open) always drops.
