### PR TITLE
[Game] Fix Evenstones destroying whole stacks

### DIFF
--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/ItemConversion.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/ItemConversion.cs
@@ -84,7 +84,7 @@ public class ItemConversion : SpecialEffectAction
             }
         }
 
-        // destroy item
-        targetItem._holdingContainer.RemoveItem(ItemTaskType.Conversion, targetItem, true);
+        // consumes target item from stack or if there is only 1, destroy item
+        targetItem._holdingContainer.ConsumeItem(ItemTaskType.Conversion, targetItem.TemplateId, 1, targetItem);
     }
 }


### PR DESCRIPTION
Using Evenstones on a stackable item like lunagems destroyed the entire stack. This fixes the interaction to reduce the item stack count by 1 instead.

Note: From my testing I couldn't find anything broken by this fix but it was very limited.