### PR TITLE
[Game] Fixed XP bar bug

### DIFF
--- a/AAEmu.Game/GameService.cs
+++ b/AAEmu.Game/GameService.cs
@@ -67,12 +67,12 @@ public sealed class GameService : IHostedService, IDisposable
         WorldManager.Instance.Load();
 
         // Feature Sets 
+        ExperienceManager.Instance.Load();
         FeaturesManager.Initialize();
         LocalizationManager.Instance.Load();
 
         ObjectIdManager.Instance.Initialize();
         TradeIdManager.Instance.Initialize();
-        ExperienceManager.Instance.Load();
 
         ZoneManager.Instance.Load();
         // TODO: Implement lazy loading for heightmaps


### PR DESCRIPTION
- Fixes the XP bar not updating because FSets was reporting a max-level of 0 to the client. Changed loading order to fix this.
