### PR TITLE
[Game] Fix transform/housing position and rotation

### DIFF
--- a/AAEmu.Game/Core/Managers/HousingManager.cs
+++ b/AAEmu.Game/Core/Managers/HousingManager.cs
@@ -478,7 +478,17 @@ public class HousingManager : Singleton<HousingManager>
 
         house.Id = HousingIdManager.Instance.GetNextId();
         house.Transform.Local.SetPosition(posX, posY, posZ);
-        house.Transform.Local.SetZRotation(zRot);
+        // In 1.2 the rotation in SCUnitStatePacket is sent as X, Y, Z using 1 byte each.
+        // This limits us to 256 unique rotations around Z (up) that can be represented.
+        // When placing the house with the preview and then finalizing it, this causes the actual rotation to be different from the preview.
+        // 3.0 sends a full 32-bit float for the Z-rotation for BaseUnitType.Housing, so this seems to have been fixed in later versions.
+        // The fact the server has a more accurate view of the rotation than the client means positions of objects (doodads) placed in the house
+        // can be offset.
+        // To make the server and client agree on the rotation, we convert the float zRot to a sbyte, then back to a float.
+        // The server then knows the rotation as one of the 256 unique rotations that the client can be sent.
+        var (_, _, yaw) = PositionAndRotation.ToRollPitchYawSBytes(new Vector3(0, 0, zRot));
+        zRot = PositionAndRotation.FromRollPitchYawSBytes(0, 0, yaw).Z;
+        house.Transform.Local.SetRotation(0, 0, zRot);
 
         if (house.Template.BuildSteps.Count > 0)
             house.CurrentStep = 0;

--- a/AAEmu.Game/Core/Managers/UnitManagers/DoodadManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/DoodadManager.cs
@@ -2995,7 +2995,7 @@ public class DoodadManager : Singleton<DoodadManager>
         doodad.Transform = character.Transform.CloneDetached(doodad);
         doodad.Transform.InstanceId = character.ParentWorld.Id;
         doodad.Transform.Local.SetPosition(x, y, z);
-        doodad.Transform.Local.SetZRotation(zRot);
+        doodad.Transform.Local.SetRotation(0, 0, zRot);
         // doodad.Transform.WorldId = world.Template.Id;
         doodad.ItemId = itemId;
         doodad.PlantTime = DateTime.UtcNow;
@@ -3008,7 +3008,6 @@ public class DoodadManager : Singleton<DoodadManager>
             doodad.ParentObj = targetHouse;
             doodad.ParentObjId = targetHouse.ObjId;
             doodad.Transform.Parent = targetHouse.Transform;
-            doodad.Transform.Local.Rotate(targetHouse.Transform.Local.Rotation);
         }
         else
         {

--- a/AAEmu.Game/Models/Game/World/Transform/PositionAndRotation.cs
+++ b/AAEmu.Game/Models/Game/World/Transform/PositionAndRotation.cs
@@ -74,17 +74,40 @@ public class PositionAndRotation
         var q = ToQuaternion();
         // var q = Quaternion.CreateFromYawPitchRoll(Rotation.X, Rotation.Y, Rotation.Z);
         // q = Quaternion.Normalize(q);
+        return ToRollPitchYawShorts(q);
+    }
+    
+    public static (short, short, short) ToRollPitchYawShorts(Quaternion q)
+    {
         return ((short)(q.X * short.MaxValue), (short)(q.Y * short.MaxValue), (short)(q.Z * short.MaxValue));
     }
 
-    public (sbyte, sbyte, sbyte) ToRollPitchYawSBytes()
+    public (sbyte, sbyte, sbyte) ToRollPitchYawSBytes() => ToRollPitchYawSBytes(Rotation);
+
+    public static (sbyte Roll, sbyte Pitch, sbyte Yaw) ToRollPitchYawSBytes(Quaternion q)
     {
-        var roll = (sbyte)(Rotation.X / TwoPi / ToSByteDivider);
-        var pitch = (sbyte)(Rotation.Y / TwoPi / ToSByteDivider);
-        var yaw = (sbyte)(Rotation.Z / TwoPi / ToSByteDivider);
+        var euler = FromQuaternion(q);
+        return ToRollPitchYawSBytes(euler);
+    }
+    
+    public static (sbyte Roll, sbyte Pitch, sbyte Yaw) ToRollPitchYawSBytes(Vector3 v)
+    {
+        // MathF.Round is used to round the float to the nearest integer to avoid issues with floating point precision
+        // and round-tripping.
+        var roll = (sbyte)MathF.Round(v.X / TwoPi / ToSByteDivider);
+        var pitch = (sbyte)MathF.Round(v.Y / TwoPi / ToSByteDivider);
+        var yaw = (sbyte)MathF.Round(v.Z / TwoPi / ToSByteDivider);
         return (roll, pitch, yaw);
     }
-
+    
+    public static Vector3 FromRollPitchYawSBytes(sbyte roll, sbyte pitch, sbyte yaw)
+    {
+        var x = roll * ToSByteDivider * TwoPi;
+        var y = pitch * ToSByteDivider * TwoPi;
+        var z = yaw * ToSByteDivider * TwoPi;
+        return new Vector3(x, y, z); // Rotation.X/Y/Z in radians
+    }
+    
     public (sbyte, sbyte, sbyte) ToRollPitchYawSBytesMovement()
     {
         sbyte roll = MathUtil.ConvertRadianToDirection(Rotation.X - TwoPi);

--- a/AAEmu.Game/Models/Game/World/Transform/Transform.cs
+++ b/AAEmu.Game/Models/Game/World/Transform/Transform.cs
@@ -335,15 +335,17 @@ public class Transform : IDisposable
         if (!_children.Contains(child))
         {
             _children.Add(child);
-            // TODO: This needs better handling and take into account rotations
-            //child.Local.SubDistance(World.Position);
-            //child.Local.Position -= World.Position;
-            //child.Local.Rotation -= World.Rotation;
+
+            var inverseParentRotation = Quaternion.Inverse(World.ToQuaternion());
 
             // NLObP version of transformations
-            child.Local.Position -= World.Position;
-            var rot = Quaternion.CreateFromAxisAngle(Vector3.UnitZ, -World.Rotation.Z);
-            child.Local.Position = Vector3.Transform(child.Local.Position, rot);
+            child.Local.Position = Vector3.Transform(child.Local.Position - World.Position, inverseParentRotation);
+
+            // Child has no parent, so child.Local == child.World
+            var childWorldRotation = child.Local.ToQuaternion();
+            // Transform the child's world rotation to the local space of the parent, using the parent's inverse rotation
+            var localRotation = inverseParentRotation * childWorldRotation;
+            child.Local.ApplyFromQuaternion(localRotation);
 
             if (child.GameObject != null)
                 child.GameObject.ParentObj = this.GameObject;
@@ -354,10 +356,16 @@ public class Transform : IDisposable
     {
         if (_children.Remove(child))
         {
-            // TODO: This needs better handling and take into account rotations
-            child.Local.Rotation += World.Rotation;
-            child.Local.Position += World.Position;
-            //child.Local.AddDistance(World.Position);
+            var parentRotation = World.ToQuaternion();
+
+            // NLObP version of transformations
+            child.Local.Position = Vector3.Transform(child.Local.Position, parentRotation) + World.Position;
+
+            var childLocalRotation = child.Local.ToQuaternion();
+            // Transform the child's local rotation relative to the parent to world space, using the parent's rotation
+            var worldRotation = parentRotation * childLocalRotation;
+            child.Local.ApplyFromQuaternion(worldRotation);
+            
             if (child.GameObject != null)
                 child.GameObject.ParentObj = null;
         }
@@ -374,14 +382,15 @@ public class Transform : IDisposable
         var res = _parentTransform.GetWorldPosition().Clone();
 
         // Use parent rotation to translate child coordinates
-        Quaternion parentQuatRotation = res.ToQuaternion();
-        Quaternion localQuatPos = new Quaternion(Local.Position, 0);
-        Quaternion localTranslatedPos = Quaternion.Inverse(parentQuatRotation) * localQuatPos * parentQuatRotation;
-        res.Translate(new Vector3(localTranslatedPos.X, localTranslatedPos.Y, localTranslatedPos.Z));
+        var parentQuatRotation = res.ToQuaternion();
+        res.Translate(Vector3.Transform(Local.Position, parentQuatRotation));
 
-        res.Rotate(Local.Rotation);
-        // Is this even correct ?
-
+        // Child has no parent, so child.Local == child.World
+        var localRotation = Local.ToQuaternion();
+        // Transform the child's local rotation to world space, using the parent's rotation
+        var worldRotation = parentQuatRotation * localRotation;
+        res.ApplyFromQuaternion(worldRotation);
+        
         res.IsLocal = false;
         return res;
     }


### PR DESCRIPTION
This makes the server use the same rotation for houses as the client will (for newly placed houses, already-placed ones will remain slightly buggy with a minor offset to placed doodads). Due to `SCUnitStatePacket` only using a byte to send Z rotation to the client, placed houses can only have one of 256 possible rotations. In 3.0 the same packet [uses a 32-bit float](https://github.com/AAEmu/AAEmu/blame/bf919bf8f07d547592412a3f3ede1935e9eb3396/AAEmu.Game/Core/Packets/G2C/SCUnitStatePacket.cs#L457) for Z rotation for houses, so this fix is specific to 1.2.

By forcing the server to use the less-precise rotation (one of 256 rotations) instead of the full one that the client originally requested when building the house, all local positions and rotations relative to the house are now the same between client and server.

Crops/livestock and housing decor all have the correct position and rotation when placed on a rotated house.

Supersedes https://github.com/AAEmu/AAEmu/pull/1252