### PR TITLE
Fix SonarQube token param

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -42,6 +42,6 @@ jobs:
         shell: powershell
         run: |
           dotnet restore
-          .\.sonar\scanner\dotnet-sonarscanner begin /k:"AAEmu_AAEmu" /o:"aaemu" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+          .\.sonar\scanner\dotnet-sonarscanner begin /k:"AAEmu_AAEmu" /o:"aaemu" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
           dotnet build --configuration Release --no-restore
-          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"


### PR DESCRIPTION
`sonar.login` has been replaced by `sonar.token`