### PR TITLE
[Login] Tidying and nullable reference types

### DIFF
--- a/AAEmu.Login/AAEmu.Login.csproj
+++ b/AAEmu.Login/AAEmu.Login.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <UserSecretsId>68f0c4f8-94e8-45b8-b1a0-03a4ccf61ed2</UserSecretsId>
     <ApplicationIcon>Resources\icon_login.ico</ApplicationIcon>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/AAEmu.Login/Core/Controllers/GameController.cs
+++ b/AAEmu.Login/Core/Controllers/GameController.cs
@@ -1,4 +1,6 @@
-﻿using System.Net;
+﻿using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
 using AAEmu.Commons.Utils;
 using AAEmu.Commons.Utils.DB;
 using AAEmu.Login.Core.Network.Connections;
@@ -13,21 +15,10 @@ namespace AAEmu.Login.Core.Controllers;
 public class GameController : Singleton<GameController>
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
-    private Dictionary<byte, GameServer> _gameServers;
-    private Dictionary<byte, byte> _mirrorsId;
+    private readonly ConcurrentDictionary<GameServerId, GameServer> _gameServers = [];
+    private readonly Dictionary<GameServerId, GameServerId> _mirrorsId = [];
 
-    public byte? GetParentId(byte gsId)
-    {
-        if (_mirrorsId.TryGetValue(gsId, out var id))
-            return id;
-        return null;
-    }
-
-    protected GameController()
-    {
-        _gameServers = [];
-        _mirrorsId = [];
-    }
+    public bool TryGetParentId(GameServerId gsId, out GameServerId id) => _mirrorsId.TryGetValue(gsId, out id);
 
     private static async Task SendPacketWithDelay(InternalConnection connection, int delay, InternalPacket message)
     {
@@ -40,17 +31,12 @@ public class GameController : Singleton<GameController>
         try
         {
             var parsedHost = Dns.GetHostEntry(host);
-            foreach (var ipAddress in parsedHost.AddressList)
+            var firstIPv4Address =
+                parsedHost.AddressList.FirstOrDefault(ip => ip.AddressFamily == AddressFamily.InterNetwork);
+            if (firstIPv4Address != null)
             {
-                // For whatever reason, we can't just access the IsIPv4 property here
-                // if (ipAddress.IsIPv4)
-                //     return ipAddress.ToString();
-                var ipString = ipAddress.ToString();
-                if (ipString.Split('.').Length == 4)
-                {
-                    Logger.Debug($"Resolved {host} to {ipString}");
-                    return ipString;
-                }
+                Logger.Debug($"Resolved {host} to {firstIPv4Address}");
+                return firstIPv4Address.ToString();
             }
             Logger.Warn($"Unable to resolved {host}");
             return host;
@@ -65,42 +51,38 @@ public class GameController : Singleton<GameController>
 
     public void Load()
     {
-        using (var connection = MySQL.CreateConnection())
+        using var connection = MySQL.CreateConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT * FROM game_servers WHERE hidden = 0";
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
         {
-            using (var command = connection.CreateCommand())
+            var id = new GameServerId(reader.GetByte("id"));
+            var name = reader.GetString("name");
+            var loadedHost = reader.GetString("host");
+            var host = AppConfiguration.Instance.SkipHostResolve ? loadedHost : ResolveHostName(loadedHost);
+            var port = reader.GetUInt16("port");
+            var gameServer = new GameServer(id, name, host, port);
+            if (!_gameServers.TryAdd(gameServer.Id, gameServer))
             {
-                command.CommandText = "SELECT * FROM game_servers WHERE hidden = 0";
-                command.Prepare();
-                using (var reader = command.ExecuteReader())
-                {
-                    while (reader.Read())
-                    {
-                        var id = reader.GetByte("id");
-                        var name = reader.GetString("name");
-                        var loadedHost = reader.GetString("host");
-                        var host = AppConfiguration.Instance.SkipHostResolve ? loadedHost : ResolveHostName(loadedHost);
-                        var port = reader.GetUInt16("port");
-                        var gameServer = new GameServer(id, name, host, port);
-                        _gameServers.Add(gameServer.Id, gameServer);
-
-                        var extraInfo = host != loadedHost ? "from " + loadedHost :
-                            AppConfiguration.Instance.SkipHostResolve ? " (unresolved)" : "";
-                        Logger.Info($"Game Server {id}: {name} -> {host}:{port} {extraInfo}");
-                    }
-                }
+                Logger.Error("Game Server {id} ({name}) already exists in the game_servers table!", gameServer.Id.Value, gameServer.Name);
             }
 
-            if (_gameServers.Count <= 0)
-            {
-                Logger.Fatal("No servers have been defined in the game_servers table!");
-                return;
-            }
+            var extraInfo = host != loadedHost ? "from " + loadedHost :
+                AppConfiguration.Instance.SkipHostResolve ? " (unresolved)" : "";
+            Logger.Info($"Game Server {id.Value}: {name} -> {host}:{port} {extraInfo}");
+        }
+
+        if (_gameServers.IsEmpty)
+        {
+            Logger.Fatal("No servers have been defined in the game_servers table!");
+            return;
         }
 
         Logger.Info($"Loaded {_gameServers.Count} game server(s)");
     }
 
-    public void Add(byte gsId, List<byte> mirrorsId, InternalConnection connection)
+    public void Add(GameServerId gsId, List<GameServerId> mirrorsId, InternalConnection connection)
     {
         if (!_gameServers.TryGetValue(gsId, out var gameServer))
         {
@@ -125,7 +107,7 @@ public class GameController : Singleton<GameController>
         Logger.Info($"Registered GameServer {gameServer.Id} ({gameServer.Name}) from {connection.Ip}");
     }
 
-    public void Remove(byte gsId)
+    public void Remove(GameServerId gsId)
     {
         if (!_gameServers.TryGetValue(gsId, out var gameServer))
             return;
@@ -175,15 +157,12 @@ public class GameController : Singleton<GameController>
         connection.SendPacket(new ACWorldListPacket(gameServers, connection.GetCharacters()));
     }
 
-    public void SetLoad(byte gsId, byte load)
+    public void SetLoad(GameServerId gsId, byte load)
     {
-        lock (_gameServers)
-        {
-            _gameServers[gsId].Load = (GSLoad)load;
-        }
+        _gameServers[gsId].Load = (GSLoad)load;
     }
 
-    public void RequestEnterWorld(LoginConnection connection, byte gsId)
+    public void RequestEnterWorld(LoginConnection connection, GameServerId gsId)
     {
         if (!_gameServers.TryGetValue(gsId, out var gs))
             return;
@@ -192,26 +171,22 @@ public class GameController : Singleton<GameController>
         gs.SendPacket(new LGPlayerEnterPacket(connection.AccountId, connection.Id));
     }
 
-    public void EnterWorld(LoginConnection connection, byte gsId, byte result)
+    public void EnterWorld(LoginConnection connection, GameServerId gsId, byte result)
     {
-        if (result == 0)
+        switch (result)
         {
-            if (_gameServers.TryGetValue(gsId, out var server))
-            {
+            case 0 when _gameServers.TryGetValue(gsId, out var server):
                 connection.SendPacket(new ACWorldCookiePacket(connection, server));
-            }
-            else
-            {
+                break;
+            case 0:
                 // TODO ...
-            }
-        }
-        else if (result == 1)
-        {
-            connection.SendPacket(new ACEnterWorldDeniedPacket(0)); // TODO change reason
-        }
-        else
-        {
-            // TODO ...
+                break;
+            case 1:
+                connection.SendPacket(new ACEnterWorldDeniedPacket(0)); // TODO change reason
+                break;
+            default:
+                // TODO ...
+                break;
         }
     }
 }

--- a/AAEmu.Login/Core/Controllers/LoginController.cs
+++ b/AAEmu.Login/Core/Controllers/LoginController.cs
@@ -49,7 +49,7 @@ public class LoginController : Singleton<LoginController>
         #region update account
         command.Parameters.Clear();
         command.CommandText = "UPDATE `users` SET last_ip = @last_ip, last_login = @last_login, updated_at = @updated_at WHERE id = @id";
-        command.Parameters.AddWithValue("@id", connection.AccountId);
+        command.Parameters.AddWithValue("@id", connection.AccountId.Value);
         command.Parameters.AddWithValue("@last_ip", connection.LastIp.ToString());
         command.Parameters.AddWithValue("@last_login", ((DateTimeOffset)connection.LastLogin).ToUnixTimeSeconds());
         command.Parameters.AddWithValue("@updated_at", ((DateTimeOffset)connection.LastLogin).ToUnixTimeSeconds());
@@ -118,7 +118,7 @@ public class LoginController : Singleton<LoginController>
         #region update account
         command.Parameters.Clear();
         command.CommandText = "UPDATE `users` SET last_ip = @last_ip, last_login = @last_login, updated_at = @updated_at WHERE id = @id";
-        command.Parameters.AddWithValue("@id", connection.AccountId);
+        command.Parameters.AddWithValue("@id", connection.AccountId.Value);
         command.Parameters.AddWithValue("@last_ip", connection.LastIp.ToString());
         command.Parameters.AddWithValue("@last_login", ((DateTimeOffset)connection.LastLogin).ToUnixTimeSeconds());
         command.Parameters.AddWithValue("@updated_at", ((DateTimeOffset)connection.LastLogin).ToUnixTimeSeconds());

--- a/AAEmu.Login/Core/Controllers/LoginController.cs
+++ b/AAEmu.Login/Core/Controllers/LoginController.cs
@@ -1,4 +1,5 @@
-﻿using AAEmu.Commons.Utils;
+﻿using System.Collections.Concurrent;
+using AAEmu.Commons.Utils;
 using AAEmu.Commons.Utils.DB;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.Packets.L2C;
@@ -11,14 +12,9 @@ namespace AAEmu.Login.Core.Controllers;
 
 public class LoginController : Singleton<LoginController>
 {
-    private Dictionary<byte, Dictionary<uint, uint>> _tokens; // gsId, [token, accountId]
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
-    private static bool _autoAccount = AppConfiguration.Instance.AutoAccount;
-
-    protected LoginController()
-    {
-        _tokens = [];
-    }
+    private static readonly bool _autoAccount = AppConfiguration.Instance.AutoAccount;
+    private readonly ConcurrentDictionary<GameServerId, ConcurrentDictionary<uint, AccountId>> _tokens = []; // gsId, [token, accountId]
 
     /// <summary>
     /// Kr Method Auth
@@ -27,50 +23,42 @@ public class LoginController : Singleton<LoginController>
     /// <param name="username"></param>
     public static void Login(LoginConnection connection, string username)
     {
-        using (var connect = MySQL.CreateConnection())
+        using var connect = MySQL.CreateConnection();
+        using var command = connect.CreateCommand();
+        command.CommandText = "SELECT * FROM users where username=@username";
+        command.Parameters.AddWithValue("@username", username);
+        using var reader = command.ExecuteReader();
+        if (!reader.Read())
         {
-            using (var command = connect.CreateCommand())
-            {
-                command.CommandText = "SELECT * FROM users where username=@username";
-                command.Parameters.AddWithValue("@username", username);
-                command.Prepare();
-                using (var reader = command.ExecuteReader())
-                {
-                    if (!reader.Read())
-                    {
-                        connection.SendPacket(new ACLoginDeniedPacket(2));
-                        return;
-                    }
-
-                    // TODO ... validation password
-
-                    connection.AccountId = reader.GetUInt32("id");
-                    connection.AccountName = username;
-                    connection.LastLogin = DateTime.UtcNow;
-                    connection.LastIp = connection.Ip;
-
-                    connection.SendPacket(new ACJoinResponsePacket(0, 6));
-                    connection.SendPacket(new ACAuthResponsePacket(connection.AccountId, 6));
-
-                    reader.Close();
-
-                    #region update account
-                    command.Parameters.Clear();
-                    command.CommandText = "UPDATE `users` SET last_ip = @last_ip, last_login = @last_login, updated_at = @updated_at WHERE id = @id";
-                    command.Parameters.AddWithValue("@id", connection.AccountId);
-                    command.Parameters.AddWithValue("@last_ip", connection.LastIp.ToString());
-                    command.Parameters.AddWithValue("@last_login", ((DateTimeOffset)connection.LastLogin).ToUnixTimeSeconds());
-                    command.Parameters.AddWithValue("@updated_at", ((DateTimeOffset)connection.LastLogin).ToUnixTimeSeconds());
-                    command.Prepare();
-
-                    if (command.ExecuteNonQuery() != 1)
-                    {
-                        Logger.Warn("Database update failed, error occurred while updating account login IP and time");
-                    }
-                    # endregion
-                }
-            }
+            connection.SendPacket(new ACLoginDeniedPacket(2));
+            return;
         }
+
+        // TODO ... validation password
+
+        connection.AccountId = new AccountId(reader.GetUInt32("id"));
+        connection.AccountName = username;
+        connection.LastLogin = DateTime.UtcNow;
+        connection.LastIp = connection.Ip;
+
+        connection.SendPacket(new ACJoinResponsePacket(0, 6));
+        connection.SendPacket(new ACAuthResponsePacket(connection.AccountId, 6));
+
+        reader.Close();
+
+        #region update account
+        command.Parameters.Clear();
+        command.CommandText = "UPDATE `users` SET last_ip = @last_ip, last_login = @last_login, updated_at = @updated_at WHERE id = @id";
+        command.Parameters.AddWithValue("@id", connection.AccountId);
+        command.Parameters.AddWithValue("@last_ip", connection.LastIp.ToString());
+        command.Parameters.AddWithValue("@last_login", ((DateTimeOffset)connection.LastLogin).ToUnixTimeSeconds());
+        command.Parameters.AddWithValue("@updated_at", ((DateTimeOffset)connection.LastLogin).ToUnixTimeSeconds());
+
+        if (command.ExecuteNonQuery() != 1)
+        {
+            Logger.Warn("Database update failed, error occurred while updating account login IP and time");
+        }
+        # endregion
     }
 
     /// <summary>
@@ -79,121 +67,107 @@ public class LoginController : Singleton<LoginController>
     /// <param name="connection"></param>
     /// <param name="username"></param>
     /// <param name="password"></param>
-    public static void Login(LoginConnection connection, string username, IEnumerable<byte> password)
+    public static void Login(LoginConnection connection, string username, ReadOnlySpan<byte> password)
     {
-        using (var connect = MySQL.CreateConnection())
+        using var connect = MySQL.CreateConnection();
+        using var command = connect.CreateCommand();
+        command.CommandText = "SELECT * FROM users where username=@username";
+        command.Parameters.AddWithValue("@username", username);
+        using var reader = command.ExecuteReader();
+        if (!reader.Read())
         {
-            using (var command = connect.CreateCommand())
+            if (_autoAccount)
             {
-                command.CommandText = "SELECT * FROM users where username=@username";
-                command.Parameters.AddWithValue("@username", username);
-                command.Prepare();
-                using (var reader = command.ExecuteReader())
-                {
-                    if (!reader.Read())
-                    {
-                        if (_autoAccount)
-                        {
-                            reader.Close();
-                            CreateAndLoginInvalid(connection, username, password, connect);
-                        }
-                        else
-                        {
-                            connection.SendPacket(new ACLoginDeniedPacket(2));
-                        }
-
-                        return;
-                    }
-
-                    var pass = Convert.FromBase64String(reader.GetString("password"));
-                    if (!pass.SequenceEqual(password))
-                    {
-                        connection.SendPacket(new ACLoginDeniedPacket(2));
-                        return;
-                    }
-
-                    var banned = reader.GetBoolean("banned");
-                    if (banned)
-                    {
-                        var banReason = (byte)reader.GetUInt32("ban_reason");
-                        connection.SendPacket(new ACLoginDeniedPacket(banReason));
-                        return;
-                    }
-
-                    connection.AccountId = reader.GetUInt32("id");
-                    connection.AccountName = username;
-                    connection.LastLogin = DateTime.UtcNow;
-                    connection.LastIp = connection.Ip;
-
-                    Logger.Info("{0} connected.", connection.AccountName);
-                    connection.SendPacket(new ACJoinResponsePacket(0, 6));
-                    connection.SendPacket(new ACAuthResponsePacket(connection.AccountId, 6));
-
-                    reader.Close();
-
-                    #region update account
-                    command.Parameters.Clear();
-                    command.CommandText = "UPDATE `users` SET last_ip = @last_ip, last_login = @last_login, updated_at = @updated_at WHERE id = @id";
-                    command.Parameters.AddWithValue("@id", connection.AccountId);
-                    command.Parameters.AddWithValue("@last_ip", connection.LastIp.ToString());
-                    command.Parameters.AddWithValue("@last_login", ((DateTimeOffset)connection.LastLogin).ToUnixTimeSeconds());
-                    command.Parameters.AddWithValue("@updated_at", ((DateTimeOffset)connection.LastLogin).ToUnixTimeSeconds());
-                    command.Prepare();
-
-                    if (command.ExecuteNonQuery() != 1)
-                    {
-                        Logger.Warn("Database update failed, error occurred while updating account login IP and time");
-                    }
-                    # endregion
-                }
+                reader.Close();
+                CreateAndLoginInvalid(connection, username, password, connect);
             }
-        }
-    }
-
-    public static void CreateAndLoginInvalid(LoginConnection connection, string username, IEnumerable<byte> password, MySqlConnection connect)
-    {
-        var pass = Convert.ToBase64String(password.ToArray());
-
-        using (var command = connect.CreateCommand())
-        {
-            command.CommandText =
-                "INSERT into users (username, password, email, last_ip, last_login, created_at, updated_at) VALUES (@username, @password, @email, @last_ip, @last_login, @created_at, @updated_at)";
-            command.Parameters.AddWithValue("@username", username);
-            command.Parameters.AddWithValue("@password", pass);
-            command.Parameters.AddWithValue("@email", "");
-            command.Parameters.AddWithValue("@last_ip", connection.Ip.ToString());
-            command.Parameters.AddWithValue("@last_login", ((DateTimeOffset)DateTime.UtcNow).ToUnixTimeSeconds());
-            command.Parameters.AddWithValue("@created_at", ((DateTimeOffset)DateTime.UtcNow).ToUnixTimeSeconds());
-            command.Parameters.AddWithValue("@updated_at", ((DateTimeOffset)DateTime.UtcNow).ToUnixTimeSeconds());
-            command.Prepare();
-
-            if (command.ExecuteNonQuery() != 1)
+            else
             {
                 connection.SendPacket(new ACLoginDeniedPacket(2));
-                return;
             }
 
-            Logger.Debug("Created account from invalid username login with value:" + username);
-            Login(connection, username, password);
+            return;
         }
+
+        var expectedPassword = Convert.FromBase64String(reader.GetString("password"));
+        if (!password.SequenceEqual(expectedPassword))
+        {
+            connection.SendPacket(new ACLoginDeniedPacket(2));
+            return;
+        }
+
+        var banned = reader.GetBoolean("banned");
+        if (banned)
+        {
+            var banReason = (byte)reader.GetUInt32("ban_reason");
+            connection.SendPacket(new ACLoginDeniedPacket(banReason));
+            return;
+        }
+
+        connection.AccountId = new AccountId(reader.GetUInt32("id"));
+        connection.AccountName = username;
+        connection.LastLogin = DateTime.UtcNow;
+        connection.LastIp = connection.Ip;
+
+        Logger.Info("{0} connected.", connection.AccountName);
+        connection.SendPacket(new ACJoinResponsePacket(0, 6));
+        connection.SendPacket(new ACAuthResponsePacket(connection.AccountId, 6));
+
+        reader.Close();
+
+        #region update account
+        command.Parameters.Clear();
+        command.CommandText = "UPDATE `users` SET last_ip = @last_ip, last_login = @last_login, updated_at = @updated_at WHERE id = @id";
+        command.Parameters.AddWithValue("@id", connection.AccountId);
+        command.Parameters.AddWithValue("@last_ip", connection.LastIp.ToString());
+        command.Parameters.AddWithValue("@last_login", ((DateTimeOffset)connection.LastLogin).ToUnixTimeSeconds());
+        command.Parameters.AddWithValue("@updated_at", ((DateTimeOffset)connection.LastLogin).ToUnixTimeSeconds());
+
+        if (command.ExecuteNonQuery() != 1)
+        {
+            Logger.Warn("Database update failed, error occurred while updating account login IP and time");
+        }
+        # endregion
     }
 
-    public void AddReconnectionToken(InternalConnection connection, byte gsId, uint accountId, uint token)
+    public static void CreateAndLoginInvalid(LoginConnection connection, string username, ReadOnlySpan<byte> password, MySqlConnection connect)
     {
-        if (!_tokens.ContainsKey(gsId))
-            _tokens.Add(gsId, []);
+        var pass = Convert.ToBase64String(password);
 
-        _tokens[gsId].Add(token, accountId);
+        using var command = connect.CreateCommand();
+        command.CommandText =
+            "INSERT into users (username, password, email, last_ip, last_login, created_at, updated_at) VALUES (@username, @password, @email, @last_ip, @last_login, @created_at, @updated_at)";
+        command.Parameters.AddWithValue("@username", username);
+        command.Parameters.AddWithValue("@password", pass);
+        command.Parameters.AddWithValue("@email", "");
+        command.Parameters.AddWithValue("@last_ip", connection.Ip.ToString());
+        command.Parameters.AddWithValue("@last_login", ((DateTimeOffset)DateTime.UtcNow).ToUnixTimeSeconds());
+        command.Parameters.AddWithValue("@created_at", ((DateTimeOffset)DateTime.UtcNow).ToUnixTimeSeconds());
+        command.Parameters.AddWithValue("@updated_at", ((DateTimeOffset)DateTime.UtcNow).ToUnixTimeSeconds());
+
+        if (command.ExecuteNonQuery() != 1)
+        {
+            connection.SendPacket(new ACLoginDeniedPacket(2));
+            return;
+        }
+
+        Logger.Debug("Created account from invalid username login with value:" + username);
+        Login(connection, username, password);
+    }
+
+    public void AddReconnectionToken(InternalConnection connection, GameServerId gsId, AccountId accountId, uint token)
+    {
+        var tokensForGameServer = _tokens.GetOrAdd(gsId, static _ => []);
+        tokensForGameServer.TryAdd(token, accountId);
         connection.SendPacket(new LGPlayerReconnectPacket(token));
     }
 
-    public void Reconnect(LoginConnection connection, byte gsId, uint accountId, uint token)
+    public void Reconnect(LoginConnection connection, GameServerId gsId, AccountId accountId, uint token)
     {
         if (!_tokens.ContainsKey(gsId))
         {
-            var parentId = GameController.Instance.GetParentId(gsId);
-            if (parentId != null)
-                gsId = (byte)parentId;
+            if (GameController.Instance.TryGetParentId(gsId, out var parentId))
+                gsId = parentId;
             else
             {
                 // TODO ...

--- a/AAEmu.Login/Core/Controllers/RequestController.cs
+++ b/AAEmu.Login/Core/Controllers/RequestController.cs
@@ -3,20 +3,15 @@ using AAEmu.Login.Utils;
 
 namespace AAEmu.Login.Core.Controllers;
 
-public class RequestController : IdManager
+public class RequestController() : IdManager("RequestController", firstId, lastId, objTables, exclude)
 {
     private static RequestController _instance;
     private const uint firstId = 0x00000001;
     private const uint lastId = 0x00FFFFFF;
-    private static uint[] exclude = System.Array.Empty<uint>();
-    private static string[,] objTables = { { } };
-    private readonly ConcurrentDictionary<uint, TaskCompletionSource<bool>> _requests;
-    public static RequestController Instance => _instance ?? (_instance = new RequestController());
-
-    public RequestController() : base("RequestController", firstId, lastId, objTables, exclude)
-    {
-        _requests = new ConcurrentDictionary<uint, TaskCompletionSource<bool>>();
-    }
+    private static readonly uint[] exclude = [];
+    private static readonly string[,] objTables = { { } };
+    private readonly ConcurrentDictionary<uint, TaskCompletionSource<bool>> _requests = new();
+    public static RequestController Instance => _instance ??= new RequestController();
 
     public (uint[] requestIds, Task result) Create(int count, int timeout)
     {
@@ -24,7 +19,7 @@ public class RequestController : IdManager
         var tasks = new Task[count];
         for (var i = 0; i < count; i++)
         {
-            var task = new TaskCompletionSource<bool>();
+            var task = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             _requests.TryAdd(requestIds[i], task);
             tasks[i] = Task.WhenAny(task.Task, Task.Delay(timeout));
         }

--- a/AAEmu.Login/Core/Controllers/RequestController.cs
+++ b/AAEmu.Login/Core/Controllers/RequestController.cs
@@ -5,7 +5,7 @@ namespace AAEmu.Login.Core.Controllers;
 
 public class RequestController() : IdManager("RequestController", firstId, lastId, objTables, exclude)
 {
-    private static RequestController _instance;
+    private static RequestController? _instance;
     private const uint firstId = 0x00000001;
     private const uint lastId = 0x00FFFFFF;
     private static readonly uint[] exclude = [];

--- a/AAEmu.Login/Core/Network/Connections/InternalConnection.cs
+++ b/AAEmu.Login/Core/Network/Connections/InternalConnection.cs
@@ -10,9 +10,9 @@ public class InternalConnection(ISession session)
 {
     public uint Id => session.SessionId;
     public IPAddress Ip => session.Ip;
-    public GameServer GameServer { get; set; }
+    public GameServer? GameServer { get; set; }
     public bool Block { get; set; }
-    public PacketStream LastPacket { get; set; }
+    public PacketStream? LastPacket { get; set; }
 
     public static void OnConnect()
     {

--- a/AAEmu.Login/Core/Network/Connections/InternalConnection.cs
+++ b/AAEmu.Login/Core/Network/Connections/InternalConnection.cs
@@ -6,20 +6,13 @@ using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Network.Connections;
 
-public class InternalConnection
+public class InternalConnection(ISession session)
 {
-    private ISession _session;
-
-    public uint Id => _session.SessionId;
-    public IPAddress Ip => _session.Ip;
+    public uint Id => session.SessionId;
+    public IPAddress Ip => session.Ip;
     public GameServer GameServer { get; set; }
     public bool Block { get; set; }
     public PacketStream LastPacket { get; set; }
-
-    public InternalConnection(ISession session)
-    {
-        _session = session;
-    }
 
     public static void OnConnect()
     {
@@ -31,11 +24,11 @@ public class InternalConnection
             return;
         packet.Connection = this;
         byte[] buf = packet.Encode();
-        _session.SendPacket(buf);
+        session.SendPacket(buf);
     }
 
     public void AddAttribute(string name, object value)
     {
-        _session.AddAttribute(name, value);
+        session.AddAttribute(name, value);
     }
 }

--- a/AAEmu.Login/Core/Network/Connections/InternalConnectionTable.cs
+++ b/AAEmu.Login/Core/Network/Connections/InternalConnectionTable.cs
@@ -7,18 +7,11 @@ public class InternalConnectionTable : Singleton<InternalConnectionTable>
 {
     private readonly ConcurrentDictionary<uint, InternalConnection> _connections = [];
 
-    public void AddConnection(InternalConnection con)
-    {
-        _connections.TryAdd(con.Id, con);
-    }
+    public void AddConnection(InternalConnection con) => _connections.TryAdd(con.Id, con);
 
-    public InternalConnection GetConnection(uint id)
-    {
-        _connections.TryGetValue(id, out var con);
-        return con;
-    }
+    public InternalConnection? GetConnection(uint id) => _connections.GetValueOrDefault(id);
 
-    public InternalConnection RemoveConnection(uint id)
+    public InternalConnection? RemoveConnection(uint id)
     {
         _connections.TryRemove(id, out var con);
         return con;

--- a/AAEmu.Login/Core/Network/Connections/InternalConnectionTable.cs
+++ b/AAEmu.Login/Core/Network/Connections/InternalConnectionTable.cs
@@ -5,12 +5,7 @@ namespace AAEmu.Login.Core.Network.Connections;
 
 public class InternalConnectionTable : Singleton<InternalConnectionTable>
 {
-    private ConcurrentDictionary<uint, InternalConnection> _connections;
-
-    private InternalConnectionTable()
-    {
-        _connections = new ConcurrentDictionary<uint, InternalConnection>();
-    }
+    private readonly ConcurrentDictionary<uint, InternalConnection> _connections = [];
 
     public void AddConnection(InternalConnection con)
     {

--- a/AAEmu.Login/Core/Network/Connections/LoginConnection.cs
+++ b/AAEmu.Login/Core/Network/Connections/LoginConnection.cs
@@ -13,13 +13,13 @@ public class LoginConnection
 
     public ConnectionId Id => new ConnectionId(_session.SessionId);
     public IPAddress Ip => _session.Ip;
-    public InternalConnection InternalConnection { get; set; }
-    public PacketStream LastPacket { get; set; }
+    public InternalConnection? InternalConnection { get; set; }
+    public PacketStream? LastPacket { get; set; }
 
     public AccountId AccountId { get; set; }
-    public string AccountName { get; set; }
+    public string? AccountName { get; set; }
     public DateTime LastLogin { get; set; }
-    public IPAddress LastIp { get; set; }
+    public IPAddress? LastIp { get; set; }
     public bool IsLocallyConnected { get; private set; }
 
     public Dictionary<GameServerId, List<LoginCharacterInfo>> Characters { get; }
@@ -45,7 +45,7 @@ public class LoginConnection
 
     public void SendPacket(byte[] packet)
     {
-        _session?.SendPacket(packet);
+        _session.SendPacket(packet);
     }
 
     public static void OnConnect()
@@ -54,15 +54,16 @@ public class LoginConnection
 
     public void Shutdown()
     {
-        _session?.Close();
+        _session.Close();
     }
 
     public List<LoginCharacterInfo> GetCharacters()
     {
         var res = new List<LoginCharacterInfo>();
         foreach (var characters in Characters.Values)
-            if (characters != null)
-                res.AddRange(characters);
+        {
+            res.AddRange(characters);
+        }
         return res;
     }
 

--- a/AAEmu.Login/Core/Network/Connections/LoginConnection.cs
+++ b/AAEmu.Login/Core/Network/Connections/LoginConnection.cs
@@ -3,25 +3,26 @@ using AAEmu.Commons.Models;
 using AAEmu.Commons.Network;
 using AAEmu.Commons.Network.Core;
 using AAEmu.Login.Core.Network.Login;
+using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Network.Connections;
 
 public class LoginConnection
 {
-    private ISession _session;
+    private readonly ISession _session;
 
-    public uint Id => _session.SessionId;
+    public ConnectionId Id => new ConnectionId(_session.SessionId);
     public IPAddress Ip => _session.Ip;
     public InternalConnection InternalConnection { get; set; }
     public PacketStream LastPacket { get; set; }
 
-    public uint AccountId { get; set; }
+    public AccountId AccountId { get; set; }
     public string AccountName { get; set; }
     public DateTime LastLogin { get; set; }
     public IPAddress LastIp { get; set; }
     public bool IsLocallyConnected { get; private set; }
 
-    public Dictionary<byte, List<LoginCharacterInfo>> Characters;
+    public Dictionary<GameServerId, List<LoginCharacterInfo>> Characters { get; }
 
     public LoginConnection(ISession session)
     {
@@ -30,8 +31,8 @@ public class LoginConnection
         // checks if a connection is from the same machine
         var localIp = session?.Socket?.LocalEndPoint?.ToString() ?? "local:0";
         var remoteIp = session?.Socket?.RemoteEndPoint?.ToString() ?? "remote:0";
-        localIp = localIp.Substring(0, localIp.IndexOf(':'));
-        remoteIp = remoteIp.Substring(0, remoteIp.IndexOf(':'));
+        localIp = localIp[..localIp.IndexOf(':')];
+        remoteIp = remoteIp[..remoteIp.IndexOf(':')];
         IsLocallyConnected = localIp == remoteIp;
 
         Characters = [];
@@ -65,10 +66,10 @@ public class LoginConnection
         return res;
     }
 
-    public void AddCharacters(byte gsId, List<LoginCharacterInfo> characterInfos)
+    public void AddCharacters(GameServerId gsId, List<LoginCharacterInfo> characterInfos)
     {
         foreach (var character in characterInfos)
-            character.GsId = gsId;
+            character.GsId = gsId.Value;
         Characters.Add(gsId, characterInfos);
     }
 }

--- a/AAEmu.Login/Core/Network/Connections/LoginConnectionTable.cs
+++ b/AAEmu.Login/Core/Network/Connections/LoginConnectionTable.cs
@@ -13,13 +13,13 @@ public class LoginConnectionTable : Singleton<LoginConnectionTable>
         _connections.TryAdd(con.Id, con);
     }
 
-    public LoginConnection GetConnection(ConnectionId id)
+    public LoginConnection? GetConnection(ConnectionId id)
     {
         _connections.TryGetValue(id, out var con);
         return con;
     }
 
-    public LoginConnection RemoveConnection(ConnectionId id)
+    public LoginConnection? RemoveConnection(ConnectionId id)
     {
         _connections.TryRemove(id, out var con);
         return con;

--- a/AAEmu.Login/Core/Network/Connections/LoginConnectionTable.cs
+++ b/AAEmu.Login/Core/Network/Connections/LoginConnectionTable.cs
@@ -1,29 +1,25 @@
 ﻿using System.Collections.Concurrent;
 using AAEmu.Commons.Utils;
+using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Network.Connections;
 
 public class LoginConnectionTable : Singleton<LoginConnectionTable>
 {
-    private ConcurrentDictionary<uint, LoginConnection> _connections;
-
-    private LoginConnectionTable()
-    {
-        _connections = new ConcurrentDictionary<uint, LoginConnection>();
-    }
+    private readonly ConcurrentDictionary<ConnectionId, LoginConnection> _connections = [];
 
     public void AddConnection(LoginConnection con)
     {
         _connections.TryAdd(con.Id, con);
     }
 
-    public LoginConnection GetConnection(uint id)
+    public LoginConnection GetConnection(ConnectionId id)
     {
         _connections.TryGetValue(id, out var con);
         return con;
     }
 
-    public LoginConnection RemoveConnection(uint id)
+    public LoginConnection RemoveConnection(ConnectionId id)
     {
         _connections.TryRemove(id, out var con);
         return con;

--- a/AAEmu.Login/Core/Network/Internal/InternalNetwork.cs
+++ b/AAEmu.Login/Core/Network/Internal/InternalNetwork.cs
@@ -12,7 +12,7 @@ public class InternalNetwork : Singleton<InternalNetwork>
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
     private Server _server;
-    private InternalProtocolHandler _handler;
+    private readonly InternalProtocolHandler _handler;
 
     public InternalNetwork()
     {

--- a/AAEmu.Login/Core/Network/Internal/InternalNetwork.cs
+++ b/AAEmu.Login/Core/Network/Internal/InternalNetwork.cs
@@ -11,7 +11,7 @@ public class InternalNetwork : Singleton<InternalNetwork>
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
-    private Server _server;
+    private Server? _server;
     private readonly InternalProtocolHandler _handler;
 
     public InternalNetwork()
@@ -39,7 +39,7 @@ public class InternalNetwork : Singleton<InternalNetwork>
 
     public void Stop()
     {
-        if (_server.IsStarted)
+        if (_server?.IsStarted == true)
             _server.Stop();
 
         Logger.Info("InternalNetwork stoped");

--- a/AAEmu.Login/Core/Network/Internal/InternalPacket.cs
+++ b/AAEmu.Login/Core/Network/Internal/InternalPacket.cs
@@ -3,12 +3,8 @@ using AAEmu.Login.Core.Network.Connections;
 
 namespace AAEmu.Login.Core.Network.Internal;
 
-public abstract class InternalPacket : PacketBase<InternalConnection>
+public abstract class InternalPacket(ushort typeId) : PacketBase<InternalConnection>(typeId)
 {
-    protected InternalPacket(ushort typeId) : base(typeId)
-    {
-    }
-
     public override PacketStream Encode()
     {
         var ps = new PacketStream();

--- a/AAEmu.Login/Core/Network/Internal/InternalProtocolHandler.cs
+++ b/AAEmu.Login/Core/Network/Internal/InternalProtocolHandler.cs
@@ -6,6 +6,7 @@ using AAEmu.Commons.Network;
 using AAEmu.Commons.Network.Core;
 using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Models;
 using NLog;
 
 namespace AAEmu.Login.Core.Network.Internal;
@@ -14,12 +15,7 @@ public class InternalProtocolHandler : BaseProtocolHandler
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
-    private ConcurrentDictionary<uint, Type> _packets;
-
-    public InternalProtocolHandler()
-    {
-        _packets = new ConcurrentDictionary<uint, Type>();
-    }
+    private readonly ConcurrentDictionary<uint, Type> _packets = [];
 
     public override void OnConnect(ISession session)
     {
@@ -35,7 +31,7 @@ public class InternalProtocolHandler : BaseProtocolHandler
         Logger.Info("GameServer from {0} disconnected", session.Ip.ToString());
         var gsId = session.GetAttribute("gsId");
         if (gsId != null)
-            GameController.Instance.Remove((byte)gsId);
+            GameController.Instance.Remove((GameServerId)gsId);
         InternalConnectionTable.Instance.RemoveConnection(session.SessionId);
     }
 
@@ -50,7 +46,7 @@ public class InternalProtocolHandler : BaseProtocolHandler
         }
 
         stream.Insert(stream.Count, buf, offset, bytes);
-        while (stream != null && stream.Count > 0)
+        while (stream is { Count: > 0 })
         {
             ushort len;
             try

--- a/AAEmu.Login/Core/Network/Internal/InternalProtocolHandler.cs
+++ b/AAEmu.Login/Core/Network/Internal/InternalProtocolHandler.cs
@@ -38,6 +38,12 @@ public class InternalProtocolHandler : BaseProtocolHandler
     public override void OnReceive(ISession session, byte[] buf, int offset, int bytes)
     {
         var connection = InternalConnectionTable.Instance.GetConnection(session.SessionId);
+        if (connection == null)
+        {
+            Logger.Error("Connection not found for session {0}", session.SessionId);
+            return;
+        }
+        
         var stream = new PacketStream();
         if (connection.LastPacket != null)
         {
@@ -88,7 +94,7 @@ public class InternalProtocolHandler : BaseProtocolHandler
                 {
                     try
                     {
-                        var packet = (InternalPacket)Activator.CreateInstance(classType);
+                        var packet = (InternalPacket)Activator.CreateInstance(classType)!;
                         packet.Connection = connection;
                         packet.Decode(stream2);
                     }

--- a/AAEmu.Login/Core/Network/Login/LoginNetwork.cs
+++ b/AAEmu.Login/Core/Network/Login/LoginNetwork.cs
@@ -11,7 +11,7 @@ public class LoginNetwork : Singleton<LoginNetwork>
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
-    private Server _server;
+    private Server? _server;
     private readonly LoginProtocolHandler _handler;
 
     private LoginNetwork()

--- a/AAEmu.Login/Core/Network/Login/LoginNetwork.cs
+++ b/AAEmu.Login/Core/Network/Login/LoginNetwork.cs
@@ -12,7 +12,7 @@ public class LoginNetwork : Singleton<LoginNetwork>
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
     private Server _server;
-    private LoginProtocolHandler _handler;
+    private readonly LoginProtocolHandler _handler;
 
     private LoginNetwork()
     {
@@ -45,7 +45,7 @@ public class LoginNetwork : Singleton<LoginNetwork>
 
     public void Stop()
     {
-        if ((_server != null) && (_server.IsStarted))
+        if (_server is { IsStarted: true })
             _server.Stop();
 
         Logger.Info("Network stopped");

--- a/AAEmu.Login/Core/Network/Login/LoginPacket.cs
+++ b/AAEmu.Login/Core/Network/Login/LoginPacket.cs
@@ -3,12 +3,8 @@ using AAEmu.Login.Core.Network.Connections;
 
 namespace AAEmu.Login.Core.Network.Login;
 
-public abstract class LoginPacket : PacketBase<LoginConnection>
+public abstract class LoginPacket(ushort typeId) : PacketBase<LoginConnection>(typeId)
 {
-    protected LoginPacket(ushort typeId) : base(typeId)
-    {
-    }
-
     public override PacketStream Encode()
     {
         var ps = new PacketStream();

--- a/AAEmu.Login/Core/Network/Login/LoginProtocolHandler.cs
+++ b/AAEmu.Login/Core/Network/Login/LoginProtocolHandler.cs
@@ -82,7 +82,7 @@ public class LoginProtocolHandler : BaseProtocolHandler
             }
 
             stream.Insert(stream.Count, buf, 0, bytes);
-            while (stream != null && stream.Count > 0)
+            while (stream is { Count: > 0 })
             {
                 ushort len;
                 try
@@ -122,7 +122,7 @@ public class LoginProtocolHandler : BaseProtocolHandler
                     }
                     else
                     {
-                        var packet = (LoginPacket)Activator.CreateInstance(classType);
+                        var packet = (LoginPacket)Activator.CreateInstance(classType)!;
                         packet.Connection = connection;
                         packet.Decode(stream2);
                     }

--- a/AAEmu.Login/Core/Network/Login/LoginProtocolHandler.cs
+++ b/AAEmu.Login/Core/Network/Login/LoginProtocolHandler.cs
@@ -5,7 +5,7 @@ using AAEmu.Commons.Exceptions;
 using AAEmu.Commons.Network;
 using AAEmu.Commons.Network.Core;
 using AAEmu.Login.Core.Network.Connections;
-
+using AAEmu.Login.Models;
 using NLog;
 
 namespace AAEmu.Login.Core.Network.Login;
@@ -14,12 +14,7 @@ public class LoginProtocolHandler : BaseProtocolHandler
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
-    private ConcurrentDictionary<uint, Type> _packets;
-
-    public LoginProtocolHandler()
-    {
-        _packets = new ConcurrentDictionary<uint, Type>();
-    }
+    private readonly ConcurrentDictionary<uint, Type> _packets = [];
 
     public override void OnConnect(ISession session)
     {
@@ -46,9 +41,9 @@ public class LoginProtocolHandler : BaseProtocolHandler
         }
         try
         {
-            var con = LoginConnectionTable.Instance.GetConnection(session.SessionId);
+            var con = LoginConnectionTable.Instance.GetConnection(new ConnectionId(session.SessionId));
             if (con != null)
-                LoginConnectionTable.Instance.RemoveConnection(session.SessionId);
+                LoginConnectionTable.Instance.RemoveConnection(new ConnectionId(session.SessionId));
         }
         catch (Exception e)
         {
@@ -63,7 +58,7 @@ public class LoginProtocolHandler : BaseProtocolHandler
     {
         try
         {
-            var connection = LoginConnectionTable.Instance.GetConnection(session.SessionId);
+            var connection = LoginConnectionTable.Instance.GetConnection(new ConnectionId(session.SessionId));
             if (connection == null)
                 return;
             OnReceive(connection, buf, offset, bytes);
@@ -159,7 +154,7 @@ public class LoginProtocolHandler : BaseProtocolHandler
     {
         var dump = new StringBuilder();
         for (var i = stream.Pos; i < stream.Count; i++)
-            dump.AppendFormat("{0:x2} ", stream.Buffer[i]);
+            dump.Append($"{stream.Buffer[i]:x2} ");
         Logger.Error("Unknown packet 0x{0:x2} from {1}:\n{2}", (object)type, (object)connection.Ip, (object)dump);
     }
 }

--- a/AAEmu.Login/Core/Packets/C2L/CACancelEnterWorldPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CACancelEnterWorldPacket.cs
@@ -3,12 +3,8 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CACancelEnterWorldPacket : LoginPacket
+public class CACancelEnterWorldPacket() : LoginPacket(CLOffsets.CACancelEnterWorldPacket)
 {
-    public CACancelEnterWorldPacket() : base(CLOffsets.CACancelEnterWorldPacket)
-    {
-    }
-
     public override void Read(PacketStream stream)
     {
         var wId = stream.ReadByte(); // diw -> world id

--- a/AAEmu.Login/Core/Packets/C2L/CAChallengeResponse2Packet.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAChallengeResponse2Packet.cs
@@ -4,12 +4,8 @@ using AAEmu.Login.Core.Packets.L2C;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CAChallengeResponse2Packet : LoginPacket
+public class CAChallengeResponse2Packet() : LoginPacket(CLOffsets.CAChallengeResponse2Packet)
 {
-    public CAChallengeResponse2Packet() : base(CLOffsets.CAChallengeResponse2Packet)
-    {
-    }
-
     public override void Read(PacketStream stream)
     {
         for (var i = 0; i < 8; i++)

--- a/AAEmu.Login/Core/Packets/C2L/CAChallengeResponsePacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAChallengeResponsePacket.cs
@@ -4,12 +4,8 @@ using AAEmu.Login.Core.Packets.L2C;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CAChallengeResponsePacket : LoginPacket
+public class CAChallengeResponsePacket() : LoginPacket(CLOffsets.CAChallengeResponsePacket)
 {
-    public CAChallengeResponsePacket() : base(CLOffsets.CAChallengeResponsePacket)
-    {
-    }
-
     public override void Read(PacketStream stream)
     {
         for (var i = 0; i < 4; i++)

--- a/AAEmu.Login/Core/Packets/C2L/CAEnterWorldPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAEnterWorldPacket.cs
@@ -1,19 +1,16 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Login;
+using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CAEnterWorldPacket : LoginPacket
+public class CAEnterWorldPacket() : LoginPacket(CLOffsets.CAEnterWorldPacket)
 {
-    public CAEnterWorldPacket() : base(CLOffsets.CAEnterWorldPacket)
-    {
-    }
-
     public override void Read(PacketStream stream)
     {
         var flag = stream.ReadUInt64();
-        var gsId = stream.ReadByte();
+        var gsId = new GameServerId(stream.ReadByte());
 
         GameController.Instance.RequestEnterWorld(Connection, gsId);
     }

--- a/AAEmu.Login/Core/Packets/C2L/CAListWorldPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAListWorldPacket.cs
@@ -4,13 +4,8 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CAListWorldPacket : LoginPacket
+public class CAListWorldPacket() : LoginPacket(CLOffsets.CAListWorldPacket)
 {
-    public CAListWorldPacket() : base(CLOffsets.CAListWorldPacket)
-    {
-        // Nothing
-    }
-
     public override void Read(PacketStream stream)
     {
         var flag = stream.ReadUInt64();

--- a/AAEmu.Login/Core/Packets/C2L/CAOtpNumberPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAOtpNumberPacket.cs
@@ -3,12 +3,8 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CAOtpNumberPacket : LoginPacket
+public class CAOtpNumberPacket() : LoginPacket(CLOffsets.CAOtpNumberPacket)
 {
-    public CAOtpNumberPacket() : base(CLOffsets.CAOtpNumberPacket)
-    {
-    }
-
     public override void Read(PacketStream stream)
     {
         var num = stream.ReadString(); // TODO but on old client length const 8

--- a/AAEmu.Login/Core/Packets/C2L/CAPcCertNumberPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAPcCertNumberPacket.cs
@@ -3,12 +3,8 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CAPcCertNumberPacket : LoginPacket
+public class CAPcCertNumberPacket() : LoginPacket(CLOffsets.CAPcCertNumberPacket)
 {
-    public CAPcCertNumberPacket() : base(CLOffsets.CAPcCertNumberPacket)
-    {
-    }
-
     public override void Read(PacketStream stream)
     {
         var num = stream.ReadString(); // TODO but on old client length const 8

--- a/AAEmu.Login/Core/Packets/C2L/CARequestAuthGameOnPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CARequestAuthGameOnPacket.cs
@@ -3,12 +3,8 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CARequestAuthGameOnPacket : LoginPacket
+public class CARequestAuthGameOnPacket() : LoginPacket(CLOffsets.CARequestAuthGameOnPacket)
 {
-    public CARequestAuthGameOnPacket() : base(CLOffsets.CARequestAuthGameOnPacket)
-    {
-    }
-
     public override void Read(PacketStream stream)
     {
         var pFrom = stream.ReadUInt32();

--- a/AAEmu.Login/Core/Packets/C2L/CARequestAuthMailRuPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CARequestAuthMailRuPacket.cs
@@ -4,12 +4,8 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CARequestAuthMailRuPacket : LoginPacket
+public class CARequestAuthMailRuPacket() : LoginPacket(CLOffsets.CARequestAuthMailRuPacket)
 {
-    public CARequestAuthMailRuPacket() : base(CLOffsets.CARequestAuthMailRuPacket)
-    {
-    }
-
     public override void Read(PacketStream stream)
     {
         var pFrom = stream.ReadUInt32();

--- a/AAEmu.Login/Core/Packets/C2L/CARequestAuthPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CARequestAuthPacket.cs
@@ -4,12 +4,8 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CARequestAuthPacket : LoginPacket
+public class CARequestAuthPacket() : LoginPacket(CLOffsets.CARequestAuthPacket)
 {
-    public CARequestAuthPacket() : base(CLOffsets.CARequestAuthPacket)
-    {
-    }
-
     public override void Read(PacketStream stream)
     {
         var pFrom = stream.ReadUInt32();

--- a/AAEmu.Login/Core/Packets/C2L/CARequestAuthTencentPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CARequestAuthTencentPacket.cs
@@ -3,12 +3,8 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CARequestAuthTencentPacket : LoginPacket
+public class CARequestAuthTencentPacket() : LoginPacket(CLOffsets.CARequestAuthTencentPacket)
 {
-    public CARequestAuthTencentPacket() : base(CLOffsets.CARequestAuthTencentPacket)
-    {
-    }
-
     public override void Read(PacketStream stream)
     {
         var pFrom = stream.ReadUInt32();

--- a/AAEmu.Login/Core/Packets/C2L/CARequestAuthTrionPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CARequestAuthTrionPacket.cs
@@ -6,12 +6,8 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CARequestAuthTrionPacket : LoginPacket
+public class CARequestAuthTrionPacket() : LoginPacket(CLOffsets.CARequestAuthTrionPacket)
 {
-    public CARequestAuthTrionPacket() : base(CLOffsets.CARequestAuthTrionPacket)
-    {
-    }
-
     public override void Read(PacketStream stream)
     {
         var pFrom = stream.ReadUInt32();

--- a/AAEmu.Login/Core/Packets/C2L/CARequestReconnectPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CARequestReconnectPacket.cs
@@ -1,20 +1,18 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Login;
+using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CARequestReconnectPacket : LoginPacket
+public class CARequestReconnectPacket() : LoginPacket(CLOffsets.CARequestReconnectPacket)
 {
-    public CARequestReconnectPacket() : base(CLOffsets.CARequestReconnectPacket)
-    { }
-
     public override void Read(PacketStream stream)
     {
         var pFrom = stream.ReadUInt32();
         var pTo = stream.ReadUInt32();
-        var accountId = stream.ReadUInt32();
-        var gsId = stream.ReadByte();
+        var accountId = new AccountId(stream.ReadUInt32());
+        var gsId = new GameServerId(stream.ReadByte());
         var cookie = stream.ReadUInt32();
         var macLength = stream.ReadUInt16();
         var mac = stream.ReadBytes(macLength);

--- a/AAEmu.Login/Core/Packets/G2L/GLGameServerLoadPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLGameServerLoadPacket.cs
@@ -8,6 +8,6 @@ public class GLGameServerLoadPacket() : InternalPacket(GLOffsets.GLGameServerLoa
 {
     public override void Read(PacketStream stream)
     {
-        Connection.GameServer.Load = (GSLoad)stream.ReadByte();
+        Connection.GameServer!.Load = (GSLoad)stream.ReadByte();
     }
 }

--- a/AAEmu.Login/Core/Packets/G2L/GLGameServerLoadPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLGameServerLoadPacket.cs
@@ -1,5 +1,6 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Login.Core.Network.Internal;
+using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Packets.G2L;
 
@@ -7,6 +8,6 @@ public class GLGameServerLoadPacket() : InternalPacket(GLOffsets.GLGameServerLoa
 {
     public override void Read(PacketStream stream)
     {
-        Connection.GameServer.SetLoad(stream.ReadByte());
+        Connection.GameServer.Load = (GSLoad)stream.ReadByte();
     }
 }

--- a/AAEmu.Login/Core/Packets/G2L/GLPlayerEnterPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLPlayerEnterPacket.cs
@@ -2,19 +2,16 @@
 using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.Network.Internal;
+using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Packets.G2L;
 
-public class GLPlayerEnterPacket : InternalPacket
+public class GLPlayerEnterPacket() : InternalPacket(GLOffsets.GLPlayerEnterPacket)
 {
-    public GLPlayerEnterPacket() : base(GLOffsets.GLPlayerEnterPacket)
-    {
-    }
-
     public override void Read(PacketStream stream)
     {
-        var connectionId = stream.ReadUInt32();
-        var gsId = stream.ReadByte();
+        var connectionId = new ConnectionId(stream.ReadUInt32());
+        var gsId = new GameServerId(stream.ReadByte());
         var result = stream.ReadByte();
 
         var connection = LoginConnectionTable.Instance.GetConnection(connectionId);

--- a/AAEmu.Login/Core/Packets/G2L/GLPlayerEnterPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLPlayerEnterPacket.cs
@@ -15,6 +15,6 @@ public class GLPlayerEnterPacket() : InternalPacket(GLOffsets.GLPlayerEnterPacke
         var result = stream.ReadByte();
 
         var connection = LoginConnectionTable.Instance.GetConnection(connectionId);
-        GameController.Instance.EnterWorld(connection, gsId, result);
+        GameController.Instance.EnterWorld(connection!, gsId, result);
     }
 }

--- a/AAEmu.Login/Core/Packets/G2L/GLPlayerReconnectPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLPlayerReconnectPacket.cs
@@ -1,19 +1,16 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Internal;
+using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Packets.G2L;
 
-public class GLPlayerReconnectPacket : InternalPacket
+public class GLPlayerReconnectPacket() : InternalPacket(GLOffsets.GLPlayerReconnectPacket)
 {
-    public GLPlayerReconnectPacket() : base(GLOffsets.GLPlayerReconnectPacket)
-    {
-    }
-
     public override void Read(PacketStream stream)
     {
-        var gsId = stream.ReadByte();
-        var accountId = stream.ReadUInt32();
+        var gsId = new GameServerId(stream.ReadByte());
+        var accountId = new AccountId(stream.ReadUInt32());
         var token = stream.ReadUInt32();
 
         LoginController.Instance.AddReconnectionToken(Connection, gsId, accountId, token);

--- a/AAEmu.Login/Core/Packets/G2L/GLRegisterGameServerPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLRegisterGameServerPacket.cs
@@ -6,12 +6,8 @@ using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Packets.G2L;
 
-public class GLRegisterGameServerPacket : InternalPacket
+public class GLRegisterGameServerPacket() : InternalPacket(GLOffsets.GLRegisterGameServerPacket)
 {
-    public GLRegisterGameServerPacket() : base(GLOffsets.GLRegisterGameServerPacket)
-    {
-    }
-
     private async Task SendPacketWithDelay(int delay, InternalPacket message)
     {
         await Task.Delay(delay);
@@ -23,11 +19,11 @@ public class GLRegisterGameServerPacket : InternalPacket
         var secretKey = stream.ReadString();
         if (secretKey == AppConfiguration.Instance.SecretKey)
         {
-            var gsId = stream.ReadByte();
+            var gsId = new GameServerId(stream.ReadByte());
             var additionalesCount = stream.ReadInt32();
-            var mirrors = new List<byte>();
+            var mirrors = new List<GameServerId>();
             for (var i = 0; i < additionalesCount; i++)
-                mirrors.Add(stream.ReadByte());
+                mirrors.Add(new GameServerId(stream.ReadByte()));
 
             GameController.Instance.Add(gsId, mirrors, Connection);
         }

--- a/AAEmu.Login/Core/Packets/G2L/GLRequestInfoPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLRequestInfoPacket.cs
@@ -3,18 +3,16 @@ using AAEmu.Commons.Network;
 using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.Network.Internal;
+using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Packets.G2L;
 
-public class GLRequestInfoPacket : InternalPacket
+public class GLRequestInfoPacket() : InternalPacket(GLOffsets.GLRequestInfoPacket)
 {
-    public GLRequestInfoPacket() : base(GLOffsets.GLRequestInfoPacket)
-    {
-    }
-
     public override void Read(PacketStream stream)
     {
-        var connection = LoginConnectionTable.Instance.GetConnection(stream.ReadUInt32());
+        var connectionId = new ConnectionId(stream.ReadUInt32());
+        var connection = LoginConnectionTable.Instance.GetConnection(connectionId);
         var requestId = stream.ReadUInt32();
         var characters = stream.ReadCollection<LoginCharacterInfo>();
 

--- a/AAEmu.Login/Core/Packets/G2L/GLRequestInfoPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLRequestInfoPacket.cs
@@ -17,7 +17,7 @@ public class GLRequestInfoPacket() : InternalPacket(GLOffsets.GLRequestInfoPacke
         var characters = stream.ReadCollection<LoginCharacterInfo>();
 
         if (characters.Count > 0)
-            connection.AddCharacters(Connection.GameServer.Id, characters);
+            connection!.AddCharacters(Connection.GameServer!.Id, characters);
         RequestController.Instance.ReleaseId(requestId);
     }
 }

--- a/AAEmu.Login/Core/Packets/L2C/ACAccountWarnedPacket.cs
+++ b/AAEmu.Login/Core/Packets/L2C/ACAccountWarnedPacket.cs
@@ -3,12 +3,8 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.L2C;
 
-public class ACAccountWarnedPacket : LoginPacket
+public class ACAccountWarnedPacket() : LoginPacket(LCOffsets.ACAccountWarnedPacket)
 {
-    public ACAccountWarnedPacket() : base(LCOffsets.ACAccountWarnedPacket)
-    {
-    }
-
     public override PacketStream Write(PacketStream stream)
     {
         stream.Write((byte)0); // source

--- a/AAEmu.Login/Core/Packets/L2C/ACAuthResponsePacket.cs
+++ b/AAEmu.Login/Core/Packets/L2C/ACAuthResponsePacket.cs
@@ -1,26 +1,18 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Login.Core.Network.Login;
+using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Packets.L2C;
 
-public class ACAuthResponsePacket : LoginPacket
+public class ACAuthResponsePacket(AccountId accountId, byte slotCount) : LoginPacket(LCOffsets.ACAuthResponsePacket)
 {
-    private readonly uint _accountId;
-    private readonly byte[] _wsk;
-    private readonly byte _slotCount;
-
-    public ACAuthResponsePacket(uint accountId, byte slotCount) : base(LCOffsets.ACAuthResponsePacket)
-    {
-        _accountId = accountId;
-        _wsk = new byte[32];
-        _slotCount = slotCount;
-    }
+    private readonly byte[] _wsk = new byte[32];
 
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(_accountId);
+        stream.Write(accountId.Value);
         stream.Write(_wsk, true);
-        stream.Write(_slotCount);
+        stream.Write(slotCount);
 
         return stream;
     }

--- a/AAEmu.Login/Core/Packets/L2C/ACChallenge2Packet.cs
+++ b/AAEmu.Login/Core/Packets/L2C/ACChallenge2Packet.cs
@@ -3,13 +3,8 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.L2C;
 
-public class ACChallenge2Packet : LoginPacket
+public class ACChallenge2Packet() : LoginPacket(LCOffsets.ACChallenge2Packet)
 {
-    public ACChallenge2Packet() : base(LCOffsets.ACChallenge2Packet)
-    {
-
-    }
-
     public override PacketStream Write(PacketStream stream)
     {
         stream.Write(5000); // round

--- a/AAEmu.Login/Core/Packets/L2C/ACChallengePacket.cs
+++ b/AAEmu.Login/Core/Packets/L2C/ACChallengePacket.cs
@@ -3,12 +3,8 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.L2C;
 
-public class ACChallengePacket : LoginPacket
+public class ACChallengePacket() : LoginPacket(LCOffsets.ACChallengePacket)
 {
-    public ACChallengePacket() : base(LCOffsets.ACChallengePacket)
-    {
-    }
-
     public override PacketStream Write(PacketStream stream)
     {
         stream.Write((uint)0); // salt

--- a/AAEmu.Login/Core/Packets/L2C/ACEnterOtpPacket.cs
+++ b/AAEmu.Login/Core/Packets/L2C/ACEnterOtpPacket.cs
@@ -3,12 +3,8 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.L2C;
 
-public class ACEnterOtpPacket : LoginPacket
+public class ACEnterOtpPacket() : LoginPacket(LCOffsets.ACEnterOtpPacket)
 {
-    public ACEnterOtpPacket() : base(LCOffsets.ACEnterOtpPacket)
-    {
-    }
-
     public override PacketStream Write(PacketStream stream)
     {
         stream.Write(0); // mt

--- a/AAEmu.Login/Core/Packets/L2C/ACEnterPcCertPacket.cs
+++ b/AAEmu.Login/Core/Packets/L2C/ACEnterPcCertPacket.cs
@@ -3,12 +3,8 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.L2C;
 
-public class ACEnterPcCertPacket : LoginPacket
+public class ACEnterPcCertPacket() : LoginPacket(LCOffsets.ACEnterPcCertPacket)
 {
-    public ACEnterPcCertPacket() : base(LCOffsets.ACEnterPcCertPacket)
-    {
-    }
-
     public override PacketStream Write(PacketStream stream)
     {
         stream.Write(0); // mt

--- a/AAEmu.Login/Core/Packets/L2C/ACEnterWorldDeniedPacket.cs
+++ b/AAEmu.Login/Core/Packets/L2C/ACEnterWorldDeniedPacket.cs
@@ -3,18 +3,11 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.L2C;
 
-public class ACEnterWorldDeniedPacket : LoginPacket
+public class ACEnterWorldDeniedPacket(byte reason) : LoginPacket(LCOffsets.ACEnterWorldDeniedPacket)
 {
-    private readonly byte _reason;
-
-    public ACEnterWorldDeniedPacket(byte reason) : base(LCOffsets.ACEnterWorldDeniedPacket)
-    {
-        _reason = reason;
-    }
-
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(_reason);
+        stream.Write(reason);
 
         return stream;
     }

--- a/AAEmu.Login/Core/Packets/L2C/ACJoinResponsePacket.cs
+++ b/AAEmu.Login/Core/Packets/L2C/ACJoinResponsePacket.cs
@@ -3,21 +3,12 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.L2C;
 
-public class ACJoinResponsePacket : LoginPacket
+public class ACJoinResponsePacket(ushort reason, ulong afs) : LoginPacket(LCOffsets.ACJoinResponsePacket)
 {
-    private readonly ushort _reason;
-    private readonly ulong _afs;
-
-    public ACJoinResponsePacket(ushort reason, ulong afs) : base(LCOffsets.ACJoinResponsePacket)
-    {
-        _reason = reason;
-        _afs = afs;
-    }
-
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(_reason);
-        stream.Write(_afs);
+        stream.Write(reason);
+        stream.Write(afs);
 
         // afs[0] -> max number of characters per account
         // afs[1] -> additional number of characters per server when using the slot increase item

--- a/AAEmu.Login/Core/Packets/L2C/ACLoginDeniedPacket.cs
+++ b/AAEmu.Login/Core/Packets/L2C/ACLoginDeniedPacket.cs
@@ -3,18 +3,11 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.L2C;
 
-public class ACLoginDeniedPacket : LoginPacket
+public class ACLoginDeniedPacket(byte reason) : LoginPacket(LCOffsets.ACLoginDeniedPacket)
 {
-    private byte _reason;
-
-    public ACLoginDeniedPacket(byte reason) : base(LCOffsets.ACLoginDeniedPacket)
-    {
-        _reason = reason;
-    }
-
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(_reason);
+        stream.Write(reason);
         stream.Write(""); // vp
         stream.Write(""); // msg
 

--- a/AAEmu.Login/Core/Packets/L2C/ACShowArsPacket.cs
+++ b/AAEmu.Login/Core/Packets/L2C/ACShowArsPacket.cs
@@ -3,12 +3,8 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.L2C;
 
-public class ACShowArsPacket : LoginPacket
+public class ACShowArsPacket() : LoginPacket(LCOffsets.ACShowArsPacket)
 {
-    public ACShowArsPacket() : base(LCOffsets.ACShowArsPacket)
-    {
-    }
-
     public override PacketStream Write(PacketStream stream)
     {
         stream.Write(""); // num

--- a/AAEmu.Login/Core/Packets/L2C/ACWorldCookiePacket.cs
+++ b/AAEmu.Login/Core/Packets/L2C/ACWorldCookiePacket.cs
@@ -6,29 +6,20 @@ using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Packets.L2C;
 
-public class ACWorldCookiePacket : LoginPacket
+public class ACWorldCookiePacket(LoginConnection connection, GameServer gs) : LoginPacket(LCOffsets.ACWorldCookiePacket)
 {
-    private readonly LoginConnection _connection;
-    private readonly uint _cookie;
-    private readonly GameServer _gs;
-
-    public ACWorldCookiePacket(LoginConnection connection, GameServer gs) : base(LCOffsets.ACWorldCookiePacket)
-    {
-        _connection = connection;
-        _cookie = connection.Id;
-        _gs = gs;
-    }
+    private readonly uint _cookie = connection.Id.Value;
 
     public override PacketStream Write(PacketStream stream)
     {
-        var serverIp = _gs.Host;
-        if (_connection.IsLocallyConnected)
-            serverIp = _connection.Ip.ToString();
+        var serverIp = gs.Host;
+        if (connection.IsLocallyConnected)
+            serverIp = connection.Ip.ToString();
         stream.Write(_cookie);
         for (var i = 0; i < 4; i++)
         {
             stream.Write(Helpers.ConvertIp(serverIp));
-            stream.Write(_gs.Port);
+            stream.Write(gs.Port);
         }
 
         return stream;

--- a/AAEmu.Login/Core/Packets/L2C/ACWorldListPacket.cs
+++ b/AAEmu.Login/Core/Packets/L2C/ACWorldListPacket.cs
@@ -5,28 +5,20 @@ using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Packets.L2C;
 
-public class ACWorldListPacket : LoginPacket
+public class ACWorldListPacket(List<GameServer> gameServers, List<LoginCharacterInfo> characters)
+    : LoginPacket(LCOffsets.ACWorldListPacket)
 {
-    private readonly List<GameServer> _gs;
-    private readonly List<LoginCharacterInfo> _characters;
-
-    public ACWorldListPacket(List<GameServer> gs, List<LoginCharacterInfo> characters) : base(LCOffsets.ACWorldListPacket)
-    {
-        _gs = gs;
-        _characters = characters;
-    }
-
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write((byte)_gs.Count);
-        foreach (var gs in _gs)
+        stream.Write((byte)gameServers.Count);
+        foreach (var gs1 in gameServers)
         {
-            stream.Write(gs.Id);
-            stream.Write(gs.Name);
-            stream.Write(gs.Active);
-            if (gs.Active)
+            stream.Write(gs1.Id.Value);
+            stream.Write(gs1.Name);
+            stream.Write(gs1.Active);
+            if (gs1.Active)
             {
-                stream.Write((byte)gs.Load); // con
+                stream.Write((byte)gs1.Load); // con
                 for (var i = 0; i < 9; i++) // race
                     stream.Write((byte)0); // rcon
                 /*
@@ -53,10 +45,10 @@ public class ACWorldListPacket : LoginPacket
             }
         }
 
-        stream.Write((byte)_characters.Count);
-        if (_characters.Count > 0)
+        stream.Write((byte)characters.Count);
+        if (characters.Count > 0)
         {
-            foreach (var character in _characters)
+            foreach (var character in characters)
             {
                 stream.Write(character.AccountId);
                 stream.Write(character.GsId);

--- a/AAEmu.Login/Core/Packets/L2C/ACWorldQueuePacket.cs
+++ b/AAEmu.Login/Core/Packets/L2C/ACWorldQueuePacket.cs
@@ -3,12 +3,8 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.L2C;
 
-public class ACWorldQueuePacket : LoginPacket
+public class ACWorldQueuePacket() : LoginPacket(LCOffsets.ACWorldQueuePacket)
 {
-    public ACWorldQueuePacket() : base(LCOffsets.ACWorldQueuePacket)
-    {
-    }
-
     public override PacketStream Write(PacketStream stream)
     {
         stream.Write((byte)0); // diw -> world id

--- a/AAEmu.Login/Core/Packets/L2G/LGPlayerEnterPacket.cs
+++ b/AAEmu.Login/Core/Packets/L2G/LGPlayerEnterPacket.cs
@@ -1,23 +1,15 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Login.Core.Network.Internal;
+using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Packets.L2G;
 
-public class LGPlayerEnterPacket : InternalPacket
+public class LGPlayerEnterPacket(AccountId accountId, ConnectionId connectionId) : InternalPacket(LGOffsets.LGPlayerEnterPacket)
 {
-    private readonly uint _accountId;
-    private readonly uint _connectionId;
-
-    public LGPlayerEnterPacket(uint accountId, uint connectionId) : base(LGOffsets.LGPlayerEnterPacket)
-    {
-        _accountId = accountId;
-        _connectionId = connectionId;
-    }
-
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(_accountId);
-        stream.Write(_connectionId);
+        stream.Write(accountId.Value);
+        stream.Write(connectionId.Value);
         return stream;
     }
 }

--- a/AAEmu.Login/Core/Packets/L2G/LGPlayerReconnectPacket.cs
+++ b/AAEmu.Login/Core/Packets/L2G/LGPlayerReconnectPacket.cs
@@ -3,18 +3,11 @@ using AAEmu.Login.Core.Network.Internal;
 
 namespace AAEmu.Login.Core.Packets.L2G;
 
-public class LGPlayerReconnectPacket : InternalPacket
+public class LGPlayerReconnectPacket(uint token) : InternalPacket(LGOffsets.LGPlayerReconnectPacket)
 {
-    private readonly uint _token;
-
-    public LGPlayerReconnectPacket(uint token) : base(LGOffsets.LGPlayerReconnectPacket)
-    {
-        _token = token;
-    }
-
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(_token);
+        stream.Write(token);
         return stream;
     }
 }

--- a/AAEmu.Login/Core/Packets/L2G/LGRegisterGameServerPacket.cs
+++ b/AAEmu.Login/Core/Packets/L2G/LGRegisterGameServerPacket.cs
@@ -4,18 +4,11 @@ using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Packets.L2G;
 
-public class LGRegisterGameServerPacket : InternalPacket
+public class LGRegisterGameServerPacket(GSRegisterResult result) : InternalPacket(LGOffsets.LGRegisterGameServerPacket)
 {
-    private readonly GSRegisterResult _result;
-
-    public LGRegisterGameServerPacket(GSRegisterResult result) : base(LGOffsets.LGRegisterGameServerPacket)
-    {
-        _result = result;
-    }
-
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write((byte)_result);
+        stream.Write((byte)result);
         return stream;
     }
 }

--- a/AAEmu.Login/Core/Packets/L2G/LGRequestInfoPacket.cs
+++ b/AAEmu.Login/Core/Packets/L2G/LGRequestInfoPacket.cs
@@ -1,26 +1,17 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Login.Core.Network.Internal;
+using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Packets.L2G;
 
-public class LGRequestInfoPacket : InternalPacket
+public class LGRequestInfoPacket(ConnectionId connectionId, uint requestId, AccountId accountId)
+    : InternalPacket(LGOffsets.LGRequestInfoPacket)
 {
-    private readonly uint _connectionId;
-    private readonly uint _requestId;
-    private readonly ulong _accountId;
-
-    public LGRequestInfoPacket(uint connectionId, uint requestId, uint accountId) : base(LGOffsets.LGRequestInfoPacket)
-    {
-        _connectionId = connectionId;
-        _requestId = requestId;
-        _accountId = accountId;
-    }
-
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(_connectionId);
-        stream.Write(_requestId);
-        stream.Write(_accountId);
+        stream.Write(connectionId.Value);
+        stream.Write(requestId);
+        stream.Write((ulong)accountId.Value);
         return stream;
     }
 }

--- a/AAEmu.Login/Models/AccountId.cs
+++ b/AAEmu.Login/Models/AccountId.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Login.Models;
+
+public readonly record struct AccountId(uint Value);

--- a/AAEmu.Login/Models/AppConfiguration.cs
+++ b/AAEmu.Login/Models/AppConfiguration.cs
@@ -5,22 +5,22 @@ namespace AAEmu.Login.Models;
 
 public class AppConfiguration : Singleton<AppConfiguration>
 {
-    public string SecretKey { get; set; }
+    public required string SecretKey { get; set; }
     public bool AutoAccount { get; set; }
     public bool SkipHostResolve { get; set; }
-    public DBConnections Connections { get; set; }
-    public NetworkConfig InternalNetwork { get; set; }
-    public NetworkConfig Network { get; set; }
+    public required DBConnections Connections { get; set; }
+    public required NetworkConfig InternalNetwork { get; set; }
+    public required NetworkConfig Network { get; set; }
 
     public class NetworkConfig
     {
-        public string Host { get; set; }
-        public ushort Port { get; set; }
-        public int NumConnections { get; set; }
+        public required string Host { get; set; }
+        public required ushort Port { get; set; }
+        public required int NumConnections { get; set; }
     }
 
     public class DBConnections
     {
-        public MySqlConnectionSettings MySQLProvider { get; set; }
+        public required MySqlConnectionSettings MySQLProvider { get; set; }
     }
 }

--- a/AAEmu.Login/Models/ConnectionId.cs
+++ b/AAEmu.Login/Models/ConnectionId.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Login.Models;
+
+public readonly record struct ConnectionId(uint Value);

--- a/AAEmu.Login/Models/GSLoad.cs
+++ b/AAEmu.Login/Models/GSLoad.cs
@@ -1,0 +1,8 @@
+namespace AAEmu.Login.Models;
+
+public enum GSLoad : byte
+{
+    Low = 0,
+    Medium = 1,
+    High = 2
+}

--- a/AAEmu.Login/Models/GSRegisterResult.cs
+++ b/AAEmu.Login/Models/GSRegisterResult.cs
@@ -1,0 +1,7 @@
+namespace AAEmu.Login.Models;
+
+public enum GSRegisterResult : byte
+{
+    Success = 0,
+    Error = 1,
+}

--- a/AAEmu.Login/Models/GameServer.cs
+++ b/AAEmu.Login/Models/GameServer.cs
@@ -3,82 +3,19 @@ using AAEmu.Login.Core.Network.Internal;
 
 namespace AAEmu.Login.Models;
 
-public enum GSRegisterResult : byte
+public class GameServer(GameServerId id, string name, string host, ushort port)
 {
-    Success = 0,
-    Error = 1,
-}
-
-public enum GSLoad : byte
-{
-    Low = 0,
-    Medium = 1,
-    High = 2
-}
-
-public class GameServer
-{
-    public byte Id { get; }
-    public string Name { get; }
-    public string Host { get; set; }
-    public ushort Port { get; set; }
+    public GameServerId Id { get; } = id;
+    public string Name { get; } = name;
+    public string Host { get; } = host;
+    public ushort Port { get; } = port;
     public InternalConnection Connection { get; set; }
     public bool Active => Connection != null;
     public GSLoad Load { get; set; }
-    public List<byte> MirrorsId { get; set; }
-
-    public GameServer(byte id, string name, string host, ushort port)
-    {
-        Id = id;
-        Name = name;
-        Host = host;
-        Port = port;
-        MirrorsId = [];
-    }
+    public List<GameServerId> MirrorsId { get; } = [];
 
     public void SendPacket(InternalPacket packet)
     {
         Connection.SendPacket(packet);
     }
-
-    public override bool Equals(object obj)
-    {
-        if (ReferenceEquals(null, obj))
-            return false;
-        if (ReferenceEquals(this, obj))
-            return true;
-        if (obj.GetType() != typeof(GameServer))
-            return false;
-        return Equals((GameServer)obj);
-    }
-
-    public bool Equals(GameServer other)
-    {
-        if (ReferenceEquals(null, other))
-            return false;
-        if (ReferenceEquals(this, other))
-            return true;
-        return other.Id == Id;
-    }
-
-    public override int GetHashCode()
-    {
-        unchecked
-        {
-            var result = Id.GetHashCode();
-            result = (result * 397) ^ (Connection?.GetHashCode() ?? 0);
-            return result;
-        }
-    }
-
-    public void SetLoad(byte load)
-    {
-        Load = (GSLoad)load;
-    }
-
-    public void SetLoad(GSLoad load)
-    {
-        Load = load;
-    }
 }
-

--- a/AAEmu.Login/Models/GameServer.cs
+++ b/AAEmu.Login/Models/GameServer.cs
@@ -9,13 +9,13 @@ public class GameServer(GameServerId id, string name, string host, ushort port)
     public string Name { get; } = name;
     public string Host { get; } = host;
     public ushort Port { get; } = port;
-    public InternalConnection Connection { get; set; }
+    public InternalConnection? Connection { get; set; }
     public bool Active => Connection != null;
     public GSLoad Load { get; set; }
     public List<GameServerId> MirrorsId { get; } = [];
 
     public void SendPacket(InternalPacket packet)
     {
-        Connection.SendPacket(packet);
+        Connection?.SendPacket(packet);
     }
 }

--- a/AAEmu.Login/Models/GameServerId.cs
+++ b/AAEmu.Login/Models/GameServerId.cs
@@ -1,0 +1,3 @@
+﻿namespace AAEmu.Login.Models;
+
+public readonly record struct GameServerId(byte Value);

--- a/AAEmu.Login/Program.cs
+++ b/AAEmu.Login/Program.cs
@@ -14,9 +14,9 @@ namespace AAEmu.Login;
 public static class Program
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
-    private static Thread _thread = Thread.CurrentThread;
+    private static readonly Thread _thread = Thread.CurrentThread;
     private static DateTime _startTime;
-    private static string Name => Assembly.GetExecutingAssembly().GetName().Name;
+    private static string Name => Assembly.GetExecutingAssembly().GetName().Name ?? "AAEmu.Login";
     private static string Version => Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "???";
 
     public static int UpTime => (int)(DateTime.UtcNow - _startTime).TotalSeconds;
@@ -48,11 +48,7 @@ public static class Program
             .ConfigureAppConfiguration((hostingContext, config) =>
             {
                 config.AddEnvironmentVariables();
-
-                if (args != null)
-                {
-                    config.AddCommandLine(args);
-                }
+                config.AddCommandLine(args);
             })
             .ConfigureServices((hostContext, services) =>
             {
@@ -114,7 +110,7 @@ public static class Program
         }
     }
 
-    private static void Configuration(string[] args, string mainConfigJson)
+    private static void Configuration(string[] args, string? mainConfigJson)
     {
         var configJsonFile = Path.Combine(FileManager.AppPath, "Config.json");
         var configurationBuilder = new ConfigurationBuilder();
@@ -142,7 +138,7 @@ public static class Program
             .AddUserSecrets<LoginService>()
             .Build();
 
-        bool userSecretsDefined = config.AsEnumerable().Any();
+        var userSecretsDefined = config.AsEnumerable().Any();
         return userSecretsDefined;
     }
 }

--- a/AAEmu.Login/Utils/IdManager.cs
+++ b/AAEmu.Login/Utils/IdManager.cs
@@ -20,7 +20,7 @@ public class IdManager
     private readonly int _freeIdSize;
     private readonly string[,] _objTables;
     private readonly bool _distinct;
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
 
     public IdManager(string name, uint firstId, uint lastId, string[,] objTables, uint[] exclude, bool distinct = false)
     {
@@ -74,54 +74,48 @@ public class IdManager
     private uint[] ExtractUsedObjectIdTable()
     {
         if (_objTables.Length < 2)
-            return Array.Empty<uint>();
+            return [];
 
-        using (var connection = MySQL.CreateConnection())
+        using var connection = MySQL.CreateConnection();
+        using var command = connection.CreateCommand();
+        var query = "SELECT " + (_distinct ? "DISTINCT " : "") + _objTables[0, 1] + ", 0 AS i FROM " +
+                    _objTables[0, 0];
+        for (var i = 1; i < _objTables.Length / 2; i++)
+            query += " UNION SELECT " + (_distinct ? "DISTINCT " : "") + _objTables[i, 1] + ", " + i +
+                     " FROM " + _objTables[i, 0];
+
+        command.CommandText = "SELECT COUNT(*), COUNT(DISTINCT " + _objTables[0, 1] + ") FROM ( " + query +
+                              " ) AS all_ids";
+        int count;
+        using (var reader = command.ExecuteReader())
         {
-            using (var command = connection.CreateCommand())
-            {
-                var query = "SELECT " + (_distinct ? "DISTINCT " : "") + _objTables[0, 1] + ", 0 AS i FROM " +
-                            _objTables[0, 0];
-                for (var i = 1; i < _objTables.Length / 2; i++)
-                    query += " UNION SELECT " + (_distinct ? "DISTINCT " : "") + _objTables[i, 1] + ", " + i +
-                             " FROM " + _objTables[i, 0];
-
-                command.CommandText = "SELECT COUNT(*), COUNT(DISTINCT " + _objTables[0, 1] + ") FROM ( " + query +
-                                      " ) AS all_ids";
-                command.Prepare();
-                int count;
-                using (var reader = command.ExecuteReader())
-                {
-                    if (!reader.Read())
-                        throw new GameException("IdManager: can't extract count ids");
-                    if (reader.GetInt32(0) != reader.GetInt32(1) && !_distinct)
-                        throw new GameException("IdManager: there are duplicates in object ids");
-                    count = reader.GetInt32(0);
-                }
-
-                if (count == 0)
-                    return Array.Empty<uint>();
-
-                var result = new uint[count];
-                Logger.Info("{0}: Extracting {1} used id's from data tables...", _name, count);
-
-                command.CommandText = query;
-                command.Prepare();
-                using (var reader = command.ExecuteReader())
-                {
-                    var idx = 0;
-                    while (reader.Read())
-                    {
-                        result[idx] = reader.GetUInt32(0);
-                        idx++;
-                    }
-
-                    Logger.Info("{0}: Successfully extracted {1} used id's from data tables.", _name, idx);
-                }
-
-                return result;
-            }
+            if (!reader.Read())
+                throw new GameException("IdManager: can't extract count ids");
+            if (reader.GetInt32(0) != reader.GetInt32(1) && !_distinct)
+                throw new GameException("IdManager: there are duplicates in object ids");
+            count = reader.GetInt32(0);
         }
+
+        if (count == 0)
+            return [];
+
+        var result = new uint[count];
+        Logger.Info("{0}: Extracting {1} used id's from data tables...", _name, count);
+
+        command.CommandText = query;
+        using (var reader = command.ExecuteReader())
+        {
+            var idx = 0;
+            while (reader.Read())
+            {
+                result[idx] = reader.GetUInt32(0);
+                idx++;
+            }
+
+            Logger.Info("{0}: Successfully extracted {1} used id's from data tables.", _name, idx);
+        }
+
+        return result;
     }
 
     public virtual void ReleaseId(uint usedObjectId)

--- a/AAEmu.Login/Utils/IdManager.cs
+++ b/AAEmu.Login/Utils/IdManager.cs
@@ -1,4 +1,5 @@
-﻿using AAEmu.Commons.Exceptions;
+﻿using System.Diagnostics;
+using AAEmu.Commons.Exceptions;
 using AAEmu.Commons.Utils;
 using AAEmu.Commons.Utils.DB;
 using NLog;
@@ -9,7 +10,7 @@ public class IdManager
 {
     protected static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
-    private BitSet _freeIds;
+    private BitSet? _freeIds;
     private int _freeIdCount;
     private int _nextFreeId;
 
@@ -120,6 +121,11 @@ public class IdManager
 
     public virtual void ReleaseId(uint usedObjectId)
     {
+        if (_freeIds == null)
+        {
+            throw new InvalidOperationException("IdManager is not initialized.");
+        }
+        
         var objectId = (int)(usedObjectId - _firstId);
         if (objectId > -1)
         {
@@ -140,6 +146,11 @@ public class IdManager
 
     public uint GetNextId()
     {
+        if (_freeIds == null)
+        {
+            throw new InvalidOperationException("IdManager is not initialized.");
+        }
+        
         lock (_lock)
         {
             var newId = _nextFreeId;
@@ -175,6 +186,8 @@ public class IdManager
 
     private void IncreaseBitSetCapacity()
     {
+        Debug.Assert(_freeIds != null, "FreeIds should not be null");
+        
         var size = PrimeFinder.NextPrime(_freeIds.Count + _freeIdSize / 10);
         if (size > _freeIdSize)
             size = _freeIdSize;


### PR DESCRIPTION
- Converts using statement to [using declarations](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-8.0/using#using-declaration).
- Converts explicit constructors to [primary constructors](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/primary-constructors).
- Enables [nullable reference types](https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references).
- Introduces value type structs, for example `ConnectionId` and `GameServerId`.

There should be no functional changes - everything should work the same as before.