### PR TITLE
[Login] Separate the execution of packets from reading them

### DIFF
--- a/AAEmu.Commons/Network/PacketStream.cs
+++ b/AAEmu.Commons/Network/PacketStream.cs
@@ -795,7 +795,7 @@ public class PacketStream : ICloneable, IComparable
     public List<T> ReadCollection<T>() where T : PacketMarshaler, new()
     {
         var count = ReadInt32();
-        var collection = new List<T>();
+        var collection = new List<T>(count);
         for (var i = 0; i < count; i++)
         {
             var t = new T();

--- a/AAEmu.Login/Core/Network/Internal/InternalPacket.cs
+++ b/AAEmu.Login/Core/Network/Internal/InternalPacket.cs
@@ -35,4 +35,10 @@ public abstract class InternalPacket(ushort typeId) : PacketBase<InternalConnect
 
         return this;
     }
+    
+    /// <summary>
+    /// This is called after <see cref="Decode"/>.
+    /// The purpose is to separate packet data from packet behavior.
+    /// </summary>
+    public virtual void Execute() { }
 }

--- a/AAEmu.Login/Core/Network/Internal/InternalProtocolHandler.cs
+++ b/AAEmu.Login/Core/Network/Internal/InternalProtocolHandler.cs
@@ -97,6 +97,16 @@ public class InternalProtocolHandler : BaseProtocolHandler
                         var packet = (InternalPacket)Activator.CreateInstance(classType)!;
                         packet.Connection = connection;
                         packet.Decode(stream2);
+
+                        try
+                        {
+                            packet.Execute();
+                        }
+                        catch (Exception e)
+                        {
+                            Logger.Error("Error on execute packet {0}", type);
+                            Logger.Error(e);
+                        }
                     }
                     catch (Exception e)
                     {

--- a/AAEmu.Login/Core/Network/Login/LoginPacket.cs
+++ b/AAEmu.Login/Core/Network/Login/LoginPacket.cs
@@ -35,4 +35,10 @@ public abstract class LoginPacket(ushort typeId) : PacketBase<LoginConnection>(t
 
         return this;
     }
+    
+    /// <summary>
+    /// This is called after <see cref="Decode"/>.
+    /// The purpose is to separate packet data from packet behavior.
+    /// </summary>
+    public virtual void Execute() { }
 }

--- a/AAEmu.Login/Core/Network/Login/LoginProtocolHandler.cs
+++ b/AAEmu.Login/Core/Network/Login/LoginProtocolHandler.cs
@@ -125,6 +125,7 @@ public class LoginProtocolHandler : BaseProtocolHandler
                         var packet = (LoginPacket)Activator.CreateInstance(classType)!;
                         packet.Connection = connection;
                         packet.Decode(stream2);
+                        packet.Execute();
                     }
                 }
                 else

--- a/AAEmu.Login/Core/Packets/C2L/CAChallengeResponse2Packet.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAChallengeResponse2Packet.cs
@@ -10,7 +10,10 @@ public class CAChallengeResponse2Packet() : LoginPacket(CLOffsets.CAChallengeRes
     {
         for (var i = 0; i < 8; i++)
             stream.ReadUInt32(); // hc
+    }
 
+    public override void Execute()
+    {
         Connection.SendPacket(new ACLoginDeniedPacket(2));
     }
 }

--- a/AAEmu.Login/Core/Packets/C2L/CAChallengeResponsePacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAChallengeResponsePacket.cs
@@ -12,6 +12,10 @@ public class CAChallengeResponsePacket() : LoginPacket(CLOffsets.CAChallengeResp
             stream.ReadUInt32(); // responses
         var password = stream.ReadBytes(); // TODO or bytes? length 32
         var bytes = Convert.FromBase64String("jZae727K08KaOmKSgOaGzww/XVqGr/PKEgIMkjrcbJI=");
+    }
+
+    public override void Execute()
+    {
         Connection.SendPacket(new ACLoginDeniedPacket(3));
     }
 }

--- a/AAEmu.Login/Core/Packets/C2L/CAEnterWorldPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAEnterWorldPacket.cs
@@ -7,11 +7,16 @@ namespace AAEmu.Login.Core.Packets.C2L;
 
 public class CAEnterWorldPacket() : LoginPacket(CLOffsets.CAEnterWorldPacket)
 {
+    private GameServerId _gsId;
+    
     public override void Read(PacketStream stream)
     {
         var flag = stream.ReadUInt64();
-        var gsId = new GameServerId(stream.ReadByte());
+        _gsId = new GameServerId(stream.ReadByte());
+    }
 
-        GameController.Instance.RequestEnterWorld(Connection, gsId);
+    public override void Execute()
+    {
+        GameController.Instance.RequestEnterWorld(Connection, _gsId);
     }
 }

--- a/AAEmu.Login/Core/Packets/C2L/CAListWorldPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAListWorldPacket.cs
@@ -9,7 +9,10 @@ public class CAListWorldPacket() : LoginPacket(CLOffsets.CAListWorldPacket)
     public override void Read(PacketStream stream)
     {
         var flag = stream.ReadUInt64();
+    }
 
+    public override void Execute()
+    {
         Task.Run(() => GameController.Instance.RequestWorldListAsync(Connection));
     }
 }

--- a/AAEmu.Login/Core/Packets/C2L/CARequestAuthMailRuPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CARequestAuthMailRuPacket.cs
@@ -6,15 +6,21 @@ namespace AAEmu.Login.Core.Packets.C2L;
 
 public class CARequestAuthMailRuPacket() : LoginPacket(CLOffsets.CARequestAuthMailRuPacket)
 {
+    private string? _id;
+    private byte[]? _token;
+    
     public override void Read(PacketStream stream)
     {
         var pFrom = stream.ReadUInt32();
         var pTo = stream.ReadUInt32();
         var dev = stream.ReadBoolean();
         var mac = stream.ReadBytes();
-        var id = stream.ReadString();
-        var token = stream.ReadBytes();
+        _id = stream.ReadString();
+        _token = stream.ReadBytes();
+    }
 
-        LoginController.Login(Connection, id, token);
+    public override void Execute()
+    {
+        LoginController.Login(Connection, _id!, _token);
     }
 }

--- a/AAEmu.Login/Core/Packets/C2L/CARequestAuthPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CARequestAuthPacket.cs
@@ -6,18 +6,23 @@ namespace AAEmu.Login.Core.Packets.C2L;
 
 public class CARequestAuthPacket() : LoginPacket(CLOffsets.CARequestAuthPacket)
 {
+    private string? _account;
+    
     public override void Read(PacketStream stream)
     {
         var pFrom = stream.ReadUInt32();
         var pTo = stream.ReadUInt32();
         var svc = stream.ReadByte();
         var dev = stream.ReadBoolean();
-        var account = stream.ReadString();
+        _account = stream.ReadString();
         var mac = stream.ReadBytes();
         var mac2 = stream.ReadBytes();
         var cpu = stream.ReadUInt64();
+    }
 
-        LoginController.Login(Connection, account);
+    public override void Execute()
+    {
+        LoginController.Login(Connection, _account!);
 
         // Connection.SendPacket(new ACChallengePacket()); // TODO ...
     }

--- a/AAEmu.Login/Core/Packets/C2L/CARequestAuthTrionPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CARequestAuthTrionPacket.cs
@@ -8,6 +8,9 @@ namespace AAEmu.Login.Core.Packets.C2L;
 
 public class CARequestAuthTrionPacket() : LoginPacket(CLOffsets.CARequestAuthTrionPacket)
 {
+    private string? _username;
+    private string? _password;
+    
     public override void Read(PacketStream stream)
     {
         var pFrom = stream.ReadUInt32();
@@ -34,8 +37,14 @@ public class CARequestAuthTrionPacket() : LoginPacket(CLOffsets.CARequestAuthTri
             Logger.Error("RequestAuthTrion: username or password is empty or whitespace");
             return;
         }
+        
+        _username = username;
+        _password = password;
+    }
 
-        var token = Helpers.StringToByteArray(password);
-        LoginController.Login(Connection, username, token);
+    public override void Execute()
+    {
+        var token = Helpers.StringToByteArray(_password!);
+        LoginController.Login(Connection, _username!, token);
     }
 }

--- a/AAEmu.Login/Core/Packets/C2L/CARequestReconnectPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CARequestReconnectPacket.cs
@@ -7,16 +7,23 @@ namespace AAEmu.Login.Core.Packets.C2L;
 
 public class CARequestReconnectPacket() : LoginPacket(CLOffsets.CARequestReconnectPacket)
 {
+    private GameServerId _gsId;
+    private AccountId _accountId;
+    private uint _cookie;
+    
     public override void Read(PacketStream stream)
     {
         var pFrom = stream.ReadUInt32();
         var pTo = stream.ReadUInt32();
-        var accountId = new AccountId(stream.ReadUInt32());
-        var gsId = new GameServerId(stream.ReadByte());
-        var cookie = stream.ReadUInt32();
+        _accountId = new AccountId(stream.ReadUInt32());
+        _gsId = new GameServerId(stream.ReadByte());
+        _cookie = stream.ReadUInt32();
         var macLength = stream.ReadUInt16();
         var mac = stream.ReadBytes(macLength);
+    }
 
-        LoginController.Instance.Reconnect(Connection, gsId, accountId, cookie);
+    public override void Execute()
+    {
+        LoginController.Instance.Reconnect(Connection, _gsId, _accountId, _cookie);
     }
 }

--- a/AAEmu.Login/Core/Packets/G2L/GLGameServerLoadPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLGameServerLoadPacket.cs
@@ -6,8 +6,15 @@ namespace AAEmu.Login.Core.Packets.G2L;
 
 public class GLGameServerLoadPacket() : InternalPacket(GLOffsets.GLGameServerLoadPacket)
 {
+    private GSLoad _load;
+    
     public override void Read(PacketStream stream)
     {
-        Connection.GameServer!.Load = (GSLoad)stream.ReadByte();
+        _load = (GSLoad)stream.ReadByte();
+    }
+
+    public override void Execute()
+    {
+        Connection.GameServer!.Load = _load;
     }
 }

--- a/AAEmu.Login/Core/Packets/G2L/GLPlayerEnterPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLPlayerEnterPacket.cs
@@ -8,13 +8,20 @@ namespace AAEmu.Login.Core.Packets.G2L;
 
 public class GLPlayerEnterPacket() : InternalPacket(GLOffsets.GLPlayerEnterPacket)
 {
+    private ConnectionId _connectionId;
+    private GameServerId _gsId;
+    private byte _result;
+    
     public override void Read(PacketStream stream)
     {
-        var connectionId = new ConnectionId(stream.ReadUInt32());
-        var gsId = new GameServerId(stream.ReadByte());
-        var result = stream.ReadByte();
+        _connectionId = new ConnectionId(stream.ReadUInt32());
+        _gsId = new GameServerId(stream.ReadByte());
+        _result = stream.ReadByte();
+    }
 
-        var connection = LoginConnectionTable.Instance.GetConnection(connectionId);
-        GameController.Instance.EnterWorld(connection!, gsId, result);
+    public override void Execute()
+    {
+        var connection = LoginConnectionTable.Instance.GetConnection(_connectionId);
+        GameController.Instance.EnterWorld(connection!, _gsId, _result);
     }
 }

--- a/AAEmu.Login/Core/Packets/G2L/GLPlayerReconnectPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLPlayerReconnectPacket.cs
@@ -7,12 +7,19 @@ namespace AAEmu.Login.Core.Packets.G2L;
 
 public class GLPlayerReconnectPacket() : InternalPacket(GLOffsets.GLPlayerReconnectPacket)
 {
+    private GameServerId _gsId;
+    private AccountId _accountId;
+    private uint _token;
+    
     public override void Read(PacketStream stream)
     {
-        var gsId = new GameServerId(stream.ReadByte());
-        var accountId = new AccountId(stream.ReadUInt32());
-        var token = stream.ReadUInt32();
+        _gsId = new GameServerId(stream.ReadByte());
+        _accountId = new AccountId(stream.ReadUInt32());
+        _token = stream.ReadUInt32();
+    }
 
-        LoginController.Instance.AddReconnectionToken(Connection, gsId, accountId, token);
+    public override void Execute()
+    {
+        LoginController.Instance.AddReconnectionToken(Connection, _gsId, _accountId, _token);
     }
 }

--- a/AAEmu.Login/Core/Packets/G2L/GLRegisterGameServerPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLRegisterGameServerPacket.cs
@@ -8,6 +8,10 @@ namespace AAEmu.Login.Core.Packets.G2L;
 
 public class GLRegisterGameServerPacket() : InternalPacket(GLOffsets.GLRegisterGameServerPacket)
 {
+    private string? _secretKey;
+    private GameServerId _gsId;
+    private List<GameServerId>? _mirrors;
+    
     private async Task SendPacketWithDelay(int delay, InternalPacket message)
     {
         await Task.Delay(delay);
@@ -16,22 +20,26 @@ public class GLRegisterGameServerPacket() : InternalPacket(GLOffsets.GLRegisterG
 
     public override void Read(PacketStream stream)
     {
-        var secretKey = stream.ReadString();
-        if (secretKey == AppConfiguration.Instance.SecretKey)
-        {
-            var gsId = new GameServerId(stream.ReadByte());
-            var additionalesCount = stream.ReadInt32();
-            var mirrors = new List<GameServerId>();
-            for (var i = 0; i < additionalesCount; i++)
-                mirrors.Add(new GameServerId(stream.ReadByte()));
+        _secretKey = stream.ReadString();
+        _gsId = new GameServerId(stream.ReadByte());
+        var additionalesCount = stream.ReadInt32();
+        var mirrors = new List<GameServerId>(additionalesCount);
+        for (var i = 0; i < additionalesCount; i++)
+            mirrors.Add(new GameServerId(stream.ReadByte()));
 
-            GameController.Instance.Add(gsId, mirrors, Connection);
-        }
-        else
+        _mirrors = mirrors;
+    }
+
+    public override void Execute()
+    {
+        if (_secretKey != AppConfiguration.Instance.SecretKey)
         {
             Logger.Error($"Connection {Connection.Ip}, bad secret key");
             Task.Run(() => SendPacketWithDelay(5000, new LGRegisterGameServerPacket(GSRegisterResult.Error)));
             // Connection.SendPacket(new LGRegisterGameServerPacket(GSRegisterResult.Error));
+            return;
         }
+        
+        GameController.Instance.Add(_gsId, _mirrors!, Connection);
     }
 }

--- a/AAEmu.Login/Core/Packets/G2L/GLRequestInfoPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLRequestInfoPacket.cs
@@ -9,15 +9,22 @@ namespace AAEmu.Login.Core.Packets.G2L;
 
 public class GLRequestInfoPacket() : InternalPacket(GLOffsets.GLRequestInfoPacket)
 {
+    private ConnectionId _connectionId;
+    private uint _requestId;
+    private List<LoginCharacterInfo>? _characters;
+    
     public override void Read(PacketStream stream)
     {
-        var connectionId = new ConnectionId(stream.ReadUInt32());
-        var connection = LoginConnectionTable.Instance.GetConnection(connectionId);
-        var requestId = stream.ReadUInt32();
-        var characters = stream.ReadCollection<LoginCharacterInfo>();
+        _connectionId = new ConnectionId(stream.ReadUInt32());
+        _requestId = stream.ReadUInt32();
+        _characters = stream.ReadCollection<LoginCharacterInfo>();
+    }
 
-        if (characters.Count > 0)
-            connection!.AddCharacters(Connection.GameServer!.Id, characters);
-        RequestController.Instance.ReleaseId(requestId);
+    public override void Execute()
+    {
+        var connection = LoginConnectionTable.Instance.GetConnection(_connectionId);
+        if (_characters!.Count > 0)
+            connection!.AddCharacters(Connection.GameServer!.Id, _characters);
+        RequestController.Instance.ReleaseId(_requestId);
     }
 }


### PR DESCRIPTION
Mirrors the existing design in [GamePacket](https://github.com/AAEmu/AAEmu/blob/096f1fd61acd2eacb94601bf66143fd652e2ac82/AAEmu.Game/Core/Network/Game/GamePacket.cs#L19).

There should be no functional changes - everything should work the same as before.