### PR TITLE
[Login] Use dependency injection and separate packet handler classes

### DIFF
--- a/AAEmu.Commons/Network/BaseProtocolHandler.cs
+++ b/AAEmu.Commons/Network/BaseProtocolHandler.cs
@@ -1,22 +1,14 @@
-﻿using AAEmu.Commons.Network.Core;
+using AAEmu.Commons.Network.Core;
 
 namespace AAEmu.Commons.Network;
 
-public abstract class BaseProtocolHandler
+public abstract class BaseProtocolHandler : IBaseProtocolHandler
 {
-    public virtual void OnConnect(ISession session)
-    {
-    }
+    public virtual void OnConnect(ISession session) { }
 
-    public virtual void OnReceive(ISession session, byte[] buf, int offset, int bytes)
-    {
-    }
+    public virtual void OnReceive(ISession session, byte[] buf, int offset, int bytes) { }
 
-    public virtual void OnSend(ISession session, byte[] buf, int offset, int bytes)
-    {
-    }
+    public virtual void OnSend(ISession session, byte[] buf, int offset, int bytes) { }
 
-    public virtual void OnDisconnect(ISession session)
-    {
-    }
+    public virtual void OnDisconnect(ISession session) { }
 }

--- a/AAEmu.Commons/Network/Core/Server.cs
+++ b/AAEmu.Commons/Network/Core/Server.cs
@@ -5,19 +5,13 @@ using NLog;
 
 namespace AAEmu.Commons.Network.Core;
 
-public class Server : TcpServer
+public class Server(IPAddress address, int port, IBaseProtocolHandler protocolHandler)
+    : TcpServer(address, port)
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
-    private BaseProtocolHandler _protocolHandler;
     private readonly HashSet<Session> _sessions = [];
 
-    public BaseProtocolHandler GetHandler() => _protocolHandler;
-
-    public Server(IPAddress address, int port, BaseProtocolHandler protocolHandler)
-        : base(address, port)
-    {
-        _protocolHandler = protocolHandler;
-    }
+    public IBaseProtocolHandler GetHandler() => protocolHandler;
 
     protected override TcpSession CreateSession() => new Session(this);
 

--- a/AAEmu.Commons/Network/Core/Session.cs
+++ b/AAEmu.Commons/Network/Core/Session.cs
@@ -20,7 +20,7 @@ public class Session : TcpSession, ISession
 {
     private readonly Dictionary<string, object> _attributes = [];
 
-    public BaseProtocolHandler ProtocolHandler { get; private set; }
+    public IBaseProtocolHandler ProtocolHandler { get; private set; }
     public IPEndPoint RemoteEndPoint { get; private set; }
     public uint SessionId { get; private set; }
     public IPAddress Ip { get; private set; }

--- a/AAEmu.Commons/Network/IBaseProtocolHandler.cs
+++ b/AAEmu.Commons/Network/IBaseProtocolHandler.cs
@@ -1,0 +1,11 @@
+﻿using AAEmu.Commons.Network.Core;
+
+namespace AAEmu.Commons.Network;
+
+public interface IBaseProtocolHandler
+{
+    void OnConnect(ISession session);
+    void OnReceive(ISession session, byte[] buf, int offset, int bytes);
+    void OnSend(ISession session, byte[] buf, int offset, int bytes);
+    void OnDisconnect(ISession session);
+}

--- a/AAEmu.Login/AAEmu.Login.csproj
+++ b/AAEmu.Login/AAEmu.Login.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="NLog" />
     <PackageReference Include="OSVersionExt.NetStd" />

--- a/AAEmu.Login/Core/Controllers/GameController.cs
+++ b/AAEmu.Login/Core/Controllers/GameController.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Sockets;
-using AAEmu.Commons.Utils;
 using AAEmu.Commons.Utils.DB;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.Network.Internal;
@@ -12,7 +11,7 @@ using NLog;
 
 namespace AAEmu.Login.Core.Controllers;
 
-public class GameController : Singleton<GameController>
+public class GameController(IRequestController requestController) : IGameController
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private readonly ConcurrentDictionary<GameServerId, GameServer> _gameServers = [];
@@ -130,20 +129,20 @@ public class GameController : Singleton<GameController>
         if (_gameServers.Values.Any(x => x.Active))
         {
             var (requestIds, creationTask) =
-                RequestController.Instance.Create(gameServers.Count, 20000); // TODO Request 20s
+                requestController.Create(gameServers.Count, 20000); // TODO Request 20s
             for (var i = 0; i < gameServers.Count; i++)
             {
                 var value = gameServers[i];
                 if (!value.Active)
                 {
-                    RequestController.Instance.ReleaseId(requestIds[i]);
+                    requestController.ReleaseId(requestIds[i]);
                     continue;
                 }
 
                 var loaded = connection.Characters.ContainsKey(value.Id);
                 if (loaded)
                 {
-                    RequestController.Instance.ReleaseId(requestIds[i]);
+                    requestController.ReleaseId(requestIds[i]);
                     continue;
                 }
 

--- a/AAEmu.Login/Core/Controllers/IGameController.cs
+++ b/AAEmu.Login/Core/Controllers/IGameController.cs
@@ -1,0 +1,16 @@
+﻿using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Models;
+
+namespace AAEmu.Login.Core.Controllers;
+
+public interface IGameController
+{
+    bool TryGetParentId(GameServerId gsId, out GameServerId id);
+    void Load();
+    void Add(GameServerId gsId, List<GameServerId> mirrorsId, InternalConnection connection);
+    void Remove(GameServerId gsId);
+    Task RequestWorldListAsync(LoginConnection connection);
+    void SetLoad(GameServerId gsId, byte load);
+    void RequestEnterWorld(LoginConnection connection, GameServerId gsId);
+    void EnterWorld(LoginConnection connection, GameServerId gsId, byte result);
+}

--- a/AAEmu.Login/Core/Controllers/ILoginController.cs
+++ b/AAEmu.Login/Core/Controllers/ILoginController.cs
@@ -1,0 +1,25 @@
+﻿using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Models;
+
+namespace AAEmu.Login.Core.Controllers;
+
+public interface ILoginController
+{
+    void AddReconnectionToken(InternalConnection connection, GameServerId gsId, AccountId accountId, uint token);
+    void Reconnect(LoginConnection connection, GameServerId gsId, AccountId accountId, uint token);
+
+    /// <summary>
+    /// Kr Method Auth
+    /// </summary>
+    /// <param name="connection"></param>
+    /// <param name="username"></param>
+    void Login(LoginConnection connection, string username);
+
+    /// <summary>
+    /// Eu Method Auth
+    /// </summary>
+    /// <param name="connection"></param>
+    /// <param name="username"></param>
+    /// <param name="password"></param>
+    void Login(LoginConnection connection, string username, ReadOnlySpan<byte> password);
+}

--- a/AAEmu.Login/Core/Controllers/IRequestController.cs
+++ b/AAEmu.Login/Core/Controllers/IRequestController.cs
@@ -1,0 +1,11 @@
+namespace AAEmu.Login.Core.Controllers;
+
+public interface IRequestController
+{
+    (uint[] requestIds, Task result) Create(int count, int timeout);
+    void ReleaseId(uint usedObjectId);
+    void ReleaseId(IEnumerable<uint> usedObjectIds);
+    bool Initialize();
+    uint GetNextId();
+    uint[] GetNextId(int count);
+}

--- a/AAEmu.Login/Core/Controllers/LoginController.cs
+++ b/AAEmu.Login/Core/Controllers/LoginController.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Concurrent;
-using AAEmu.Commons.Utils;
 using AAEmu.Commons.Utils.DB;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.Packets.L2C;
@@ -10,7 +9,7 @@ using NLog;
 
 namespace AAEmu.Login.Core.Controllers;
 
-public class LoginController : Singleton<LoginController>
+public class LoginController(IGameController gameController) : ILoginController
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private static readonly bool _autoAccount = AppConfiguration.Instance.AutoAccount;
@@ -21,7 +20,7 @@ public class LoginController : Singleton<LoginController>
     /// </summary>
     /// <param name="connection"></param>
     /// <param name="username"></param>
-    public static void Login(LoginConnection connection, string username)
+    public void Login(LoginConnection connection, string username)
     {
         using var connect = MySQL.CreateConnection();
         using var command = connect.CreateCommand();
@@ -67,7 +66,7 @@ public class LoginController : Singleton<LoginController>
     /// <param name="connection"></param>
     /// <param name="username"></param>
     /// <param name="password"></param>
-    public static void Login(LoginConnection connection, string username, ReadOnlySpan<byte> password)
+    public void Login(LoginConnection connection, string username, ReadOnlySpan<byte> password)
     {
         using var connect = MySQL.CreateConnection();
         using var command = connect.CreateCommand();
@@ -130,7 +129,7 @@ public class LoginController : Singleton<LoginController>
         # endregion
     }
 
-    public static void CreateAndLoginInvalid(LoginConnection connection, string username, ReadOnlySpan<byte> password, MySqlConnection connect)
+    public void CreateAndLoginInvalid(LoginConnection connection, string username, ReadOnlySpan<byte> password, MySqlConnection connect)
     {
         var pass = Convert.ToBase64String(password);
 
@@ -166,7 +165,7 @@ public class LoginController : Singleton<LoginController>
     {
         if (!_tokens.ContainsKey(gsId))
         {
-            if (GameController.Instance.TryGetParentId(gsId, out var parentId))
+            if (gameController.TryGetParentId(gsId, out var parentId))
                 gsId = parentId;
             else
             {

--- a/AAEmu.Login/Core/Controllers/RequestController.cs
+++ b/AAEmu.Login/Core/Controllers/RequestController.cs
@@ -3,15 +3,13 @@ using AAEmu.Login.Utils;
 
 namespace AAEmu.Login.Core.Controllers;
 
-public class RequestController() : IdManager("RequestController", firstId, lastId, objTables, exclude)
+public class RequestController() : IdManager("RequestController", firstId, lastId, objTables, exclude), IRequestController
 {
-    private static RequestController? _instance;
     private const uint firstId = 0x00000001;
     private const uint lastId = 0x00FFFFFF;
     private static readonly uint[] exclude = [];
     private static readonly string[,] objTables = { { } };
     private readonly ConcurrentDictionary<uint, TaskCompletionSource<bool>> _requests = new();
-    public static RequestController Instance => _instance ??= new RequestController();
 
     public (uint[] requestIds, Task result) Create(int count, int timeout)
     {

--- a/AAEmu.Login/Core/Network/Connections/IInternalConnectionTable.cs
+++ b/AAEmu.Login/Core/Network/Connections/IInternalConnectionTable.cs
@@ -1,0 +1,8 @@
+﻿namespace AAEmu.Login.Core.Network.Connections;
+
+public interface IInternalConnectionTable
+{
+    void AddConnection(InternalConnection con);
+    InternalConnection? GetConnection(uint id);
+    InternalConnection? RemoveConnection(uint id);
+}

--- a/AAEmu.Login/Core/Network/Connections/ILoginConnectionTable.cs
+++ b/AAEmu.Login/Core/Network/Connections/ILoginConnectionTable.cs
@@ -1,0 +1,11 @@
+using AAEmu.Login.Models;
+
+namespace AAEmu.Login.Core.Network.Connections;
+
+public interface ILoginConnectionTable
+{
+    void AddConnection(LoginConnection con);
+    LoginConnection? GetConnection(ConnectionId id);
+    LoginConnection? RemoveConnection(ConnectionId id);
+    List<LoginConnection> GetConnections();
+}

--- a/AAEmu.Login/Core/Network/Connections/InternalConnectionTable.cs
+++ b/AAEmu.Login/Core/Network/Connections/InternalConnectionTable.cs
@@ -1,9 +1,8 @@
 ﻿using System.Collections.Concurrent;
-using AAEmu.Commons.Utils;
 
 namespace AAEmu.Login.Core.Network.Connections;
 
-public class InternalConnectionTable : Singleton<InternalConnectionTable>
+public class InternalConnectionTable : IInternalConnectionTable
 {
     private readonly ConcurrentDictionary<uint, InternalConnection> _connections = [];
 

--- a/AAEmu.Login/Core/Network/Connections/LoginConnectionTable.cs
+++ b/AAEmu.Login/Core/Network/Connections/LoginConnectionTable.cs
@@ -1,10 +1,9 @@
 ﻿using System.Collections.Concurrent;
-using AAEmu.Commons.Utils;
 using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Network.Connections;
 
-public class LoginConnectionTable : Singleton<LoginConnectionTable>
+public class LoginConnectionTable : ILoginConnectionTable
 {
     private readonly ConcurrentDictionary<ConnectionId, LoginConnection> _connections = [];
 

--- a/AAEmu.Login/Core/Network/Internal/IInternalNetwork.cs
+++ b/AAEmu.Login/Core/Network/Internal/IInternalNetwork.cs
@@ -1,0 +1,7 @@
+namespace AAEmu.Login.Core.Network.Internal;
+
+public interface IInternalNetwork
+{
+    void Start();
+    void Stop();
+}

--- a/AAEmu.Login/Core/Network/Internal/IInternalProtocolHandler.cs
+++ b/AAEmu.Login/Core/Network/Internal/IInternalProtocolHandler.cs
@@ -1,0 +1,10 @@
+using AAEmu.Commons.Network;
+using AAEmu.Login.Core.PacketHandlers;
+
+namespace AAEmu.Login.Core.Network.Internal;
+
+public interface IInternalProtocolHandler : IBaseProtocolHandler
+{
+    void RegisterPacket<TPacket>(uint type, IInternalPacketHandler<TPacket> packetHandler)
+        where TPacket : InternalPacket;
+}

--- a/AAEmu.Login/Core/Network/Internal/InternalNetwork.cs
+++ b/AAEmu.Login/Core/Network/Internal/InternalNetwork.cs
@@ -1,28 +1,33 @@
 ﻿using System.Net;
 using AAEmu.Commons.Network.Core;
-using AAEmu.Commons.Utils;
+using AAEmu.Login.Core.PacketHandlers;
 using AAEmu.Login.Core.Packets.G2L;
 using AAEmu.Login.Models;
 using NLog;
 
 namespace AAEmu.Login.Core.Network.Internal;
 
-public class InternalNetwork : Singleton<InternalNetwork>
+public class InternalNetwork : IInternalNetwork
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
     private Server? _server;
-    private readonly InternalProtocolHandler _handler;
+    private readonly IInternalProtocolHandler _handler;
 
-    public InternalNetwork()
+    public InternalNetwork(IInternalProtocolHandler protocolHandler,
+        IInternalPacketHandler<GLRegisterGameServerPacket> registerGameServerPacketHandler,
+        IInternalPacketHandler<GLPlayerEnterPacket> playerEnterPacketHandler,
+        IInternalPacketHandler<GLPlayerReconnectPacket> playerReconnectPacketHandler,
+        IInternalPacketHandler<GLRequestInfoPacket> requestInfoPacketHandler,
+        IInternalPacketHandler<GLGameServerLoadPacket> gameServerLoadPacketHandler)
     {
-        _handler = new InternalProtocolHandler();
+        _handler = protocolHandler;
 
-        RegisterPacket(GLOffsets.GLRegisterGameServerPacket, typeof(GLRegisterGameServerPacket));
-        RegisterPacket(GLOffsets.GLPlayerEnterPacket, typeof(GLPlayerEnterPacket));
-        RegisterPacket(GLOffsets.GLPlayerReconnectPacket, typeof(GLPlayerReconnectPacket));
-        RegisterPacket(GLOffsets.GLRequestInfoPacket, typeof(GLRequestInfoPacket));
-        RegisterPacket(GLOffsets.GLGameServerLoadPacket, typeof(GLGameServerLoadPacket));
+        RegisterPacket(GLOffsets.GLRegisterGameServerPacket, registerGameServerPacketHandler);
+        RegisterPacket(GLOffsets.GLPlayerEnterPacket, playerEnterPacketHandler);
+        RegisterPacket(GLOffsets.GLPlayerReconnectPacket, playerReconnectPacketHandler);
+        RegisterPacket(GLOffsets.GLRequestInfoPacket, requestInfoPacketHandler);
+        RegisterPacket(GLOffsets.GLGameServerLoadPacket, gameServerLoadPacketHandler);
     }
 
     public void Start()
@@ -45,8 +50,6 @@ public class InternalNetwork : Singleton<InternalNetwork>
         Logger.Info("InternalNetwork stoped");
     }
 
-    public void RegisterPacket(uint type, Type classType)
-    {
-        _handler.RegisterPacket(type, classType);
-    }
+    private void RegisterPacket<TPacket>(uint type, IInternalPacketHandler<TPacket> packetHandler)
+        where TPacket : InternalPacket => _handler.RegisterPacket(type, packetHandler);
 }

--- a/AAEmu.Login/Core/Network/Internal/InternalPacket.cs
+++ b/AAEmu.Login/Core/Network/Internal/InternalPacket.cs
@@ -35,10 +35,4 @@ public abstract class InternalPacket(ushort typeId) : PacketBase<InternalConnect
 
         return this;
     }
-    
-    /// <summary>
-    /// This is called after <see cref="Decode"/>.
-    /// The purpose is to separate packet data from packet behavior.
-    /// </summary>
-    public virtual void Execute() { }
 }

--- a/AAEmu.Login/Core/Network/Internal/InternalProtocolHandler.cs
+++ b/AAEmu.Login/Core/Network/Internal/InternalProtocolHandler.cs
@@ -6,16 +6,18 @@ using AAEmu.Commons.Network;
 using AAEmu.Commons.Network.Core;
 using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.PacketHandlers;
 using AAEmu.Login.Models;
 using NLog;
 
 namespace AAEmu.Login.Core.Network.Internal;
 
-public class InternalProtocolHandler : BaseProtocolHandler
+public class InternalProtocolHandler(IGameController gameController, IInternalConnectionTable internalConnectionTable)
+    : BaseProtocolHandler, IInternalProtocolHandler
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
-    private readonly ConcurrentDictionary<uint, Type> _packets = [];
+    private readonly ConcurrentDictionary<uint, (Type Type, IInternalPacketHandler PacketHandler)> _packets = [];
 
     public override void OnConnect(ISession session)
     {
@@ -23,21 +25,20 @@ public class InternalProtocolHandler : BaseProtocolHandler
             session.SessionId.ToString(CultureInfo.InvariantCulture));
         var con = new InternalConnection(session);
         InternalConnection.OnConnect();
-        InternalConnectionTable.Instance.AddConnection(con);
+        internalConnectionTable.AddConnection(con);
     }
 
     public override void OnDisconnect(ISession session)
     {
         Logger.Info("GameServer from {0} disconnected", session.Ip.ToString());
-        var gsId = session.GetAttribute("gsId");
-        if (gsId != null)
-            GameController.Instance.Remove((GameServerId)gsId);
-        InternalConnectionTable.Instance.RemoveConnection(session.SessionId);
+        if (session.GetAttribute("gsId") is { } gsId)
+            gameController.Remove((GameServerId)gsId);
+        internalConnectionTable.RemoveConnection(session.SessionId);
     }
 
     public override void OnReceive(ISession session, byte[] buf, int offset, int bytes)
     {
-        var connection = InternalConnectionTable.Instance.GetConnection(session.SessionId);
+        var connection = internalConnectionTable.GetConnection(session.SessionId);
         if (connection == null)
         {
             Logger.Error("Connection not found for session {0}", session.SessionId);
@@ -85,13 +86,13 @@ public class InternalProtocolHandler : BaseProtocolHandler
 
                 stream2.ReadUInt16();
                 var type = stream2.ReadUInt16();
-                _packets.TryGetValue(type, out var classType);
-                if (classType == null)
+                if (!_packets.TryGetValue(type, out var tuple))
                 {
-                    HandleUnknownPacket(session, type, stream2);
+                    HandleUnknownPacket(session, type, stream2); 
                 }
                 else
                 {
+                    var (classType, packetHandler) = tuple;
                     try
                     {
                         var packet = (InternalPacket)Activator.CreateInstance(classType)!;
@@ -100,7 +101,7 @@ public class InternalProtocolHandler : BaseProtocolHandler
 
                         try
                         {
-                            packet.Execute();
+                            packetHandler.Execute(packet, connection);
                         }
                         catch (Exception e)
                         {
@@ -124,12 +125,12 @@ public class InternalProtocolHandler : BaseProtocolHandler
         }
     }
 
-    public void RegisterPacket(uint type, Type classType)
+    public void RegisterPacket<TPacket>(uint type, IInternalPacketHandler<TPacket> packetHandler) where TPacket : InternalPacket
     {
-        if (_packets.ContainsKey(type))
-            _packets.TryRemove(type, out _);
-
-        _packets.TryAdd(type, classType);
+        _packets.AddOrUpdate(type,
+            addValueFactory: static (_, arg) => arg,
+            updateValueFactory: static (_, _, arg) => arg,
+            factoryArgument: (typeof(TPacket), packetHandler));
     }
 
     private static void HandleUnknownPacket(ISession session, uint type, PacketStream stream)

--- a/AAEmu.Login/Core/Network/Login/ILoginNetwork.cs
+++ b/AAEmu.Login/Core/Network/Login/ILoginNetwork.cs
@@ -1,0 +1,7 @@
+namespace AAEmu.Login.Core.Network.Login;
+
+public interface ILoginNetwork
+{
+    void Start();
+    void Stop();
+}

--- a/AAEmu.Login/Core/Network/Login/ILoginProtocolHandler.cs
+++ b/AAEmu.Login/Core/Network/Login/ILoginProtocolHandler.cs
@@ -1,0 +1,9 @@
+﻿using AAEmu.Commons.Network;
+using AAEmu.Login.Core.PacketHandlers;
+
+namespace AAEmu.Login.Core.Network.Login;
+
+public interface ILoginProtocolHandler : IBaseProtocolHandler
+{
+    void RegisterPacket<TPacket>(uint type, ILoginPacketHandler<TPacket> packetHandler) where TPacket : LoginPacket;
+}

--- a/AAEmu.Login/Core/Network/Login/LoginNetwork.cs
+++ b/AAEmu.Login/Core/Network/Login/LoginNetwork.cs
@@ -1,36 +1,49 @@
 ﻿using System.Net;
 using AAEmu.Commons.Network.Core;
-using AAEmu.Commons.Utils;
+using AAEmu.Login.Core.PacketHandlers;
 using AAEmu.Login.Core.Packets.C2L;
 using AAEmu.Login.Models;
 using NLog;
 
 namespace AAEmu.Login.Core.Network.Login;
 
-public class LoginNetwork : Singleton<LoginNetwork>
+public class LoginNetwork : ILoginNetwork
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
     private Server? _server;
-    private readonly LoginProtocolHandler _handler;
+    private readonly ILoginProtocolHandler _handler;
 
-    private LoginNetwork()
+    public LoginNetwork(ILoginProtocolHandler protocolHandler,
+        ILoginPacketHandler<CARequestAuthPacket> requestAuthPacketHandler,
+        ILoginPacketHandler<CARequestAuthTencentPacket> requestAuthTencentPacket,
+        ILoginPacketHandler<CARequestAuthGameOnPacket> requestAuthGameOnPacket,
+        ILoginPacketHandler<CARequestAuthTrionPacket> requestAuthTrionPacket,
+        ILoginPacketHandler<CARequestAuthMailRuPacket> requestAuthMailRuPacket,
+        ILoginPacketHandler<CAChallengeResponsePacket> challengeResponsePacket,
+        ILoginPacketHandler<CAChallengeResponse2Packet> challengeResponse2Packet,
+        ILoginPacketHandler<CAOtpNumberPacket> otpNumberPacket,
+        ILoginPacketHandler<CAPcCertNumberPacket> pcCertNumberPacket,
+        ILoginPacketHandler<CAListWorldPacket> listWorldPacket,
+        ILoginPacketHandler<CAEnterWorldPacket> enterWorldPacket,
+        ILoginPacketHandler<CACancelEnterWorldPacket> cancelEnterWorldPacket,
+        ILoginPacketHandler<CARequestReconnectPacket> requestReconnectPacket)
     {
-        _handler = new LoginProtocolHandler();
+        _handler = protocolHandler;
 
-        RegisterPacket(CLOffsets.CARequestAuthPacket, typeof(CARequestAuthPacket));
-        RegisterPacket(CLOffsets.CARequestAuthTencentPacket, typeof(CARequestAuthTencentPacket));
-        RegisterPacket(CLOffsets.CARequestAuthGameOnPacket, typeof(CARequestAuthGameOnPacket));
-        RegisterPacket(CLOffsets.CARequestAuthTrionPacket, typeof(CARequestAuthTrionPacket));
-        RegisterPacket(CLOffsets.CARequestAuthMailRuPacket, typeof(CARequestAuthMailRuPacket));
-        RegisterPacket(CLOffsets.CAChallengeResponsePacket, typeof(CAChallengeResponsePacket));
-        RegisterPacket(CLOffsets.CAChallengeResponse2Packet, typeof(CAChallengeResponse2Packet));
-        RegisterPacket(CLOffsets.CAOtpNumberPacket, typeof(CAOtpNumberPacket));
-        RegisterPacket(CLOffsets.CAPcCertNumberPacket, typeof(CAPcCertNumberPacket));
-        RegisterPacket(CLOffsets.CAListWorldPacket, typeof(CAListWorldPacket));
-        RegisterPacket(CLOffsets.CAEnterWorldPacket, typeof(CAEnterWorldPacket));
-        RegisterPacket(CLOffsets.CACancelEnterWorldPacket, typeof(CACancelEnterWorldPacket));
-        RegisterPacket(CLOffsets.CARequestReconnectPacket, typeof(CARequestReconnectPacket));
+        RegisterPacket(CLOffsets.CARequestAuthPacket, requestAuthPacketHandler);
+        RegisterPacket(CLOffsets.CARequestAuthTencentPacket, requestAuthTencentPacket);
+        RegisterPacket(CLOffsets.CARequestAuthGameOnPacket, requestAuthGameOnPacket);
+        RegisterPacket(CLOffsets.CARequestAuthTrionPacket, requestAuthTrionPacket);
+        RegisterPacket(CLOffsets.CARequestAuthMailRuPacket, requestAuthMailRuPacket);
+        RegisterPacket(CLOffsets.CAChallengeResponsePacket, challengeResponsePacket);
+        RegisterPacket(CLOffsets.CAChallengeResponse2Packet, challengeResponse2Packet);
+        RegisterPacket(CLOffsets.CAOtpNumberPacket, otpNumberPacket);
+        RegisterPacket(CLOffsets.CAPcCertNumberPacket, pcCertNumberPacket);
+        RegisterPacket(CLOffsets.CAListWorldPacket, listWorldPacket);
+        RegisterPacket(CLOffsets.CAEnterWorldPacket, enterWorldPacket);
+        RegisterPacket(CLOffsets.CACancelEnterWorldPacket, cancelEnterWorldPacket);
+        RegisterPacket(CLOffsets.CARequestReconnectPacket, requestReconnectPacket);
     }
 
     public void Start()
@@ -51,8 +64,6 @@ public class LoginNetwork : Singleton<LoginNetwork>
         Logger.Info("Network stopped");
     }
 
-    private void RegisterPacket(uint type, Type classType)
-    {
-        _handler.RegisterPacket(type, classType);
-    }
+    private void RegisterPacket<TPacket>(uint type, ILoginPacketHandler<TPacket> packetHandler)
+        where TPacket : LoginPacket => _handler.RegisterPacket(type, packetHandler);
 }

--- a/AAEmu.Login/Core/Network/Login/LoginPacket.cs
+++ b/AAEmu.Login/Core/Network/Login/LoginPacket.cs
@@ -35,10 +35,4 @@ public abstract class LoginPacket(ushort typeId) : PacketBase<LoginConnection>(t
 
         return this;
     }
-    
-    /// <summary>
-    /// This is called after <see cref="Decode"/>.
-    /// The purpose is to separate packet data from packet behavior.
-    /// </summary>
-    public virtual void Execute() { }
 }

--- a/AAEmu.Login/Core/Network/Login/LoginProtocolHandler.cs
+++ b/AAEmu.Login/Core/Network/Login/LoginProtocolHandler.cs
@@ -5,16 +5,17 @@ using AAEmu.Commons.Exceptions;
 using AAEmu.Commons.Network;
 using AAEmu.Commons.Network.Core;
 using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.PacketHandlers;
 using AAEmu.Login.Models;
 using NLog;
 
 namespace AAEmu.Login.Core.Network.Login;
 
-public class LoginProtocolHandler : BaseProtocolHandler
+public class LoginProtocolHandler(ILoginConnectionTable loginConnectionTable) : BaseProtocolHandler, ILoginProtocolHandler
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
-    private readonly ConcurrentDictionary<uint, Type> _packets = [];
+    private readonly ConcurrentDictionary<uint, (Type Type, ILoginPacketHandler PacketHandler)> _packets = [];
 
     public override void OnConnect(ISession session)
     {
@@ -23,7 +24,7 @@ public class LoginProtocolHandler : BaseProtocolHandler
         {
             var con = new LoginConnection(session);
             LoginConnection.OnConnect();
-            LoginConnectionTable.Instance.AddConnection(con);
+            loginConnectionTable.AddConnection(con);
         }
         catch (Exception e)
         {
@@ -41,9 +42,9 @@ public class LoginProtocolHandler : BaseProtocolHandler
         }
         try
         {
-            var con = LoginConnectionTable.Instance.GetConnection(new ConnectionId(session.SessionId));
+            var con = loginConnectionTable.GetConnection(new ConnectionId(session.SessionId));
             if (con != null)
-                LoginConnectionTable.Instance.RemoveConnection(new ConnectionId(session.SessionId));
+                loginConnectionTable.RemoveConnection(new ConnectionId(session.SessionId));
         }
         catch (Exception e)
         {
@@ -58,7 +59,7 @@ public class LoginProtocolHandler : BaseProtocolHandler
     {
         try
         {
-            var connection = LoginConnectionTable.Instance.GetConnection(new ConnectionId(session.SessionId));
+            var connection = loginConnectionTable.GetConnection(new ConnectionId(session.SessionId));
             if (connection == null)
                 return;
             OnReceive(connection, buf, offset, bytes);
@@ -115,17 +116,26 @@ public class LoginProtocolHandler : BaseProtocolHandler
 
                     stream2.ReadUInt16(); //len
                     var type = stream2.ReadUInt16();
-                    _packets.TryGetValue(type, out var classType);
-                    if (classType == null)
+                    if (!_packets.TryGetValue(type, out var tuple))
                     {
                         HandleUnknownPacket(connection, type, stream2);
                     }
                     else
                     {
+                        var (classType, packetHandler) = tuple;
                         var packet = (LoginPacket)Activator.CreateInstance(classType)!;
                         packet.Connection = connection;
                         packet.Decode(stream2);
-                        packet.Execute();
+                        
+                        try
+                        {
+                            packetHandler.Execute(packet, connection);
+                        }
+                        catch (Exception e)
+                        {
+                            Logger.Error("Error on execute packet {0}", type);
+                            Logger.Error(e);
+                        }
                     }
                 }
                 else
@@ -143,12 +153,12 @@ public class LoginProtocolHandler : BaseProtocolHandler
         }
     }
 
-    public void RegisterPacket(uint type, Type classType)
+    public void RegisterPacket<TPacket>(uint type, ILoginPacketHandler<TPacket> packetHandler) where TPacket : LoginPacket
     {
-        if (_packets.ContainsKey(type))
-            _packets.TryRemove(type, out _);
-
-        _packets.TryAdd(type, classType);
+        _packets.AddOrUpdate(type,
+            addValueFactory: static (_, arg) => arg,
+            updateValueFactory: static (_, _, arg) => arg,
+            factoryArgument: (typeof(TPacket), packetHandler));
     }
 
     private static void HandleUnknownPacket(LoginConnection connection, uint type, PacketStream stream)

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CACancelEnterWorldPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CACancelEnterWorldPacketHandler.cs
@@ -1,0 +1,12 @@
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Packets.C2L;
+
+namespace AAEmu.Login.Core.PacketHandlers.C2L;
+
+public class CACancelEnterWorldPacketHandler
+    : ILoginPacketHandler<CACancelEnterWorldPacket>
+{
+    public void Execute(CACancelEnterWorldPacket packet, LoginConnection connection)
+    {
+    }
+}

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponse2PacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponse2PacketHandler.cs
@@ -1,0 +1,14 @@
+﻿using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Packets.C2L;
+using AAEmu.Login.Core.Packets.L2C;
+
+namespace AAEmu.Login.Core.PacketHandlers.C2L;
+
+public class CAChallengeResponse2PacketHandler
+    : ILoginPacketHandler<CAChallengeResponse2Packet>
+{
+    public void Execute(CAChallengeResponse2Packet packet, LoginConnection connection)
+    {
+        connection.SendPacket(new ACLoginDeniedPacket(2));
+    }
+}

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponsePacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponsePacketHandler.cs
@@ -1,0 +1,14 @@
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Packets.C2L;
+using AAEmu.Login.Core.Packets.L2C;
+
+namespace AAEmu.Login.Core.PacketHandlers.C2L;
+
+public class CAChallengeResponsePacketHandler
+    : ILoginPacketHandler<CAChallengeResponsePacket>
+{
+    public void Execute(CAChallengeResponsePacket packet, LoginConnection connection)
+    {
+        connection.SendPacket(new ACLoginDeniedPacket(3));
+    }
+}

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAEnterWorldPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAEnterWorldPacketHandler.cs
@@ -1,0 +1,14 @@
+﻿using AAEmu.Login.Core.Controllers;
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Packets.C2L;
+
+namespace AAEmu.Login.Core.PacketHandlers.C2L;
+
+public class CAEnterWorldPacketHandler(IGameController gameController)
+    : ILoginPacketHandler<CAEnterWorldPacket>
+{
+    public void Execute(CAEnterWorldPacket packet, LoginConnection connection)
+    {
+        gameController.RequestEnterWorld(connection, packet.GsId);
+    }
+}

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAListWorldPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAListWorldPacketHandler.cs
@@ -1,0 +1,14 @@
+using AAEmu.Login.Core.Controllers;
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Packets.C2L;
+
+namespace AAEmu.Login.Core.PacketHandlers.C2L;
+
+public class CAListWorldPacketHandler(IGameController gameController)
+    : ILoginPacketHandler<CAListWorldPacket>
+{
+    public void Execute(CAListWorldPacket packet, LoginConnection connection)
+    {
+        Task.Run(() => gameController.RequestWorldListAsync(connection));
+    }
+}

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAOtpNumberPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAOtpNumberPacketHandler.cs
@@ -1,0 +1,12 @@
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Packets.C2L;
+
+namespace AAEmu.Login.Core.PacketHandlers.C2L;
+
+public class CAOtpNumberPacketHandler
+    : ILoginPacketHandler<CAOtpNumberPacket>
+{
+    public void Execute(CAOtpNumberPacket packet, LoginConnection connection)
+    {
+    }
+}

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAPcCertNumberPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAPcCertNumberPacketHandler.cs
@@ -1,0 +1,12 @@
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Packets.C2L;
+
+namespace AAEmu.Login.Core.PacketHandlers.C2L;
+
+public class CAPcCertNumberPacketHandler
+    : ILoginPacketHandler<CAPcCertNumberPacket>
+{
+    public void Execute(CAPcCertNumberPacket packet, LoginConnection connection)
+    {
+    }
+}

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthGameOnPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthGameOnPacketHandler.cs
@@ -1,0 +1,12 @@
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Packets.C2L;
+
+namespace AAEmu.Login.Core.PacketHandlers.C2L;
+
+public class CARequestAuthGameOnPacketHandler
+    : ILoginPacketHandler<CARequestAuthGameOnPacket>
+{
+    public void Execute(CARequestAuthGameOnPacket packet, LoginConnection connection)
+    {
+    }
+}

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthMailRuPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthMailRuPacketHandler.cs
@@ -1,0 +1,14 @@
+using AAEmu.Login.Core.Controllers;
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Packets.C2L;
+
+namespace AAEmu.Login.Core.PacketHandlers.C2L;
+
+public class CARequestAuthMailRuPacketHandler(ILoginController loginController)
+    : ILoginPacketHandler<CARequestAuthMailRuPacket>
+{
+    public void Execute(CARequestAuthMailRuPacket packet, LoginConnection connection)
+    {
+        loginController.Login(connection, packet.Id!, packet.Token);
+    }
+}

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthPacketHandler.cs
@@ -1,0 +1,16 @@
+using AAEmu.Login.Core.Controllers;
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Packets.C2L;
+
+namespace AAEmu.Login.Core.PacketHandlers.C2L;
+
+public class CARequestAuthPacketHandler(ILoginController loginController)
+    : ILoginPacketHandler<CARequestAuthPacket>
+{
+    public void Execute(CARequestAuthPacket packet, LoginConnection connection)
+    {
+        loginController.Login(connection, packet.Account!);
+
+        // Connection.SendPacket(new ACChallengePacket()); // TODO ...
+    }
+}

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthTencentPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthTencentPacketHandler.cs
@@ -1,0 +1,12 @@
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Packets.C2L;
+
+namespace AAEmu.Login.Core.PacketHandlers.C2L;
+
+public class CARequestAuthTencentPacketHandler
+    : ILoginPacketHandler<CARequestAuthTencentPacket>
+{
+    public void Execute(CARequestAuthTencentPacket packet, LoginConnection connection)
+    {
+    }
+}

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthTrionPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthTrionPacketHandler.cs
@@ -1,0 +1,16 @@
+using AAEmu.Commons.Utils;
+using AAEmu.Login.Core.Controllers;
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Packets.C2L;
+
+namespace AAEmu.Login.Core.PacketHandlers.C2L;
+
+public class CARequestAuthTrionPacketHandler(ILoginController loginController)
+    : ILoginPacketHandler<CARequestAuthTrionPacket>
+{
+    public void Execute(CARequestAuthTrionPacket packet, LoginConnection connection)
+    {
+        var token = Helpers.StringToByteArray(packet.Password!);
+        loginController.Login(connection, packet.Username!, token);
+    }
+}

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestReconnectPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestReconnectPacketHandler.cs
@@ -1,0 +1,14 @@
+using AAEmu.Login.Core.Controllers;
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Packets.C2L;
+
+namespace AAEmu.Login.Core.PacketHandlers.C2L;
+
+public class CARequestReconnectPacketHandler(ILoginController loginController)
+    : ILoginPacketHandler<CARequestReconnectPacket>
+{
+    public void Execute(CARequestReconnectPacket packet, LoginConnection connection)
+    {
+        loginController.Reconnect(connection, packet.GsId, packet.AccountId, packet.Cookie);
+    }
+}

--- a/AAEmu.Login/Core/PacketHandlers/G2L/GLGameServerLoadPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/G2L/GLGameServerLoadPacketHandler.cs
@@ -1,0 +1,13 @@
+﻿using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Packets.G2L;
+
+namespace AAEmu.Login.Core.PacketHandlers.G2L;
+
+public class GLGameServerLoadPacketHandler()
+    : IInternalPacketHandler<GLGameServerLoadPacket>
+{
+    public void Execute(GLGameServerLoadPacket packet, InternalConnection connection)
+    {
+        connection.GameServer!.Load = packet.Load;
+    }
+}

--- a/AAEmu.Login/Core/PacketHandlers/G2L/GLPlayerEnterPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/G2L/GLPlayerEnterPacketHandler.cs
@@ -1,0 +1,15 @@
+using AAEmu.Login.Core.Controllers;
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Packets.G2L;
+
+namespace AAEmu.Login.Core.PacketHandlers.G2L;
+
+public class GLPlayerEnterPacketHandler(IGameController gameController, ILoginConnectionTable loginConnectionTable)
+    : IInternalPacketHandler<GLPlayerEnterPacket>
+{
+    public void Execute(GLPlayerEnterPacket packet, InternalConnection connection)
+    {
+        var loginConnection = loginConnectionTable.GetConnection(packet.ConnectionId);
+        gameController.EnterWorld(loginConnection!, packet.GsId, packet.Result);
+    }
+}

--- a/AAEmu.Login/Core/PacketHandlers/G2L/GLPlayerReconnectPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/G2L/GLPlayerReconnectPacketHandler.cs
@@ -1,0 +1,14 @@
+using AAEmu.Login.Core.Controllers;
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Packets.G2L;
+
+namespace AAEmu.Login.Core.PacketHandlers.G2L;
+
+public class GLPlayerReconnectPacketHandler(ILoginController loginController)
+    : IInternalPacketHandler<GLPlayerReconnectPacket>
+{
+    public void Execute(GLPlayerReconnectPacket packet, InternalConnection connection)
+    {
+        loginController.AddReconnectionToken(connection, packet.GsId, packet.AccountId, packet.Token);
+    }
+}

--- a/AAEmu.Login/Core/PacketHandlers/G2L/GLRegisterGameServerPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/G2L/GLRegisterGameServerPacketHandler.cs
@@ -1,0 +1,35 @@
+﻿using AAEmu.Login.Core.Controllers;
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Network.Internal;
+using AAEmu.Login.Core.Packets.G2L;
+using AAEmu.Login.Core.Packets.L2G;
+using AAEmu.Login.Models;
+using NLog;
+
+namespace AAEmu.Login.Core.PacketHandlers.G2L;
+
+public class GLRegisterGameServerPacketHandler(IGameController gameController)
+    : IInternalPacketHandler<GLRegisterGameServerPacket>
+{
+    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
+
+    public void Execute(GLRegisterGameServerPacket packet, InternalConnection connection)
+    {
+        if (packet.SecretKey != AppConfiguration.Instance.SecretKey)
+        {
+            Logger.Error($"Connection {connection.Ip}, bad secret key");
+            Task.Run(() => SendPacketWithDelay(5000, new LGRegisterGameServerPacket(GSRegisterResult.Error)));
+            // Connection.SendPacket(new LGRegisterGameServerPacket(GSRegisterResult.Error));
+            return;
+        }
+
+        gameController.Add(packet.GsId, packet.Mirrors!, connection);
+        return;
+
+        async Task SendPacketWithDelay(int delay, InternalPacket message)
+        {
+            await Task.Delay(delay);
+            connection.SendPacket(message);
+        }
+    }
+}

--- a/AAEmu.Login/Core/PacketHandlers/G2L/GLRequestInfoPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/G2L/GLRequestInfoPacketHandler.cs
@@ -1,0 +1,19 @@
+using AAEmu.Login.Core.Controllers;
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Packets.G2L;
+
+namespace AAEmu.Login.Core.PacketHandlers.G2L;
+
+public class GLRequestInfoPacketHandler(
+    IRequestController requestController,
+    ILoginConnectionTable loginConnectionTable)
+    : IInternalPacketHandler<GLRequestInfoPacket>
+{
+    public void Execute(GLRequestInfoPacket packet, InternalConnection connection)
+    {
+        var loginConnection = loginConnectionTable.GetConnection(packet.ConnectionId);
+        if (packet.Characters!.Count > 0)
+            loginConnection!.AddCharacters(connection.GameServer!.Id, packet.Characters);
+        requestController.ReleaseId(packet.RequestId);
+    }
+}

--- a/AAEmu.Login/Core/PacketHandlers/IInternalPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/IInternalPacketHandler.cs
@@ -1,0 +1,9 @@
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Network.Internal;
+
+namespace AAEmu.Login.Core.PacketHandlers;
+
+public interface IInternalPacketHandler
+{
+    void Execute(InternalPacket packet, InternalConnection connection);
+}

--- a/AAEmu.Login/Core/PacketHandlers/IInternalPacketHandler`T.cs
+++ b/AAEmu.Login/Core/PacketHandlers/IInternalPacketHandler`T.cs
@@ -1,0 +1,13 @@
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Network.Internal;
+
+namespace AAEmu.Login.Core.PacketHandlers;
+
+public interface IInternalPacketHandler<in TPacket> : IPacketHandler<TPacket, InternalConnection>,
+    IInternalPacketHandler where TPacket : InternalPacket
+{
+    void IInternalPacketHandler.Execute(InternalPacket packet, InternalConnection connection)
+    {
+        Execute((TPacket)packet, connection);
+    }
+}

--- a/AAEmu.Login/Core/PacketHandlers/ILoginPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/ILoginPacketHandler.cs
@@ -1,0 +1,9 @@
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Network.Login;
+
+namespace AAEmu.Login.Core.PacketHandlers;
+
+public interface ILoginPacketHandler
+{
+    void Execute(LoginPacket packet, LoginConnection connection);
+}

--- a/AAEmu.Login/Core/PacketHandlers/ILoginPacketHandler`T.cs
+++ b/AAEmu.Login/Core/PacketHandlers/ILoginPacketHandler`T.cs
@@ -1,0 +1,13 @@
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Network.Login;
+
+namespace AAEmu.Login.Core.PacketHandlers;
+
+public interface ILoginPacketHandler<in TPacket> : IPacketHandler<TPacket, LoginConnection>,
+    ILoginPacketHandler where TPacket : LoginPacket
+{
+    void ILoginPacketHandler.Execute(LoginPacket packet, LoginConnection connection)
+    {
+        Execute((TPacket)packet, connection);
+    }
+}

--- a/AAEmu.Login/Core/PacketHandlers/IPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/IPacketHandler.cs
@@ -1,0 +1,6 @@
+namespace AAEmu.Login.Core.PacketHandlers;
+
+public interface IPacketHandler<in TPacket, in TConnection>
+{
+    void Execute(TPacket packet, TConnection connection);
+}

--- a/AAEmu.Login/Core/PacketHandlers/ServiceCollectionExtensions.cs
+++ b/AAEmu.Login/Core/PacketHandlers/ServiceCollectionExtensions.cs
@@ -1,0 +1,36 @@
+﻿using AAEmu.Login.Core.PacketHandlers.C2L;
+using AAEmu.Login.Core.PacketHandlers.G2L;
+using AAEmu.Login.Core.Packets.C2L;
+using AAEmu.Login.Core.Packets.G2L;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AAEmu.Login.Core.PacketHandlers;
+
+public static class ServiceCollectionExtensions
+{
+    public static void AddInternalPacketHandlers(this IServiceCollection services)
+    {
+        services.AddSingleton<IInternalPacketHandler<GLRegisterGameServerPacket>, GLRegisterGameServerPacketHandler>();
+        services.AddSingleton<IInternalPacketHandler<GLRequestInfoPacket>, GLRequestInfoPacketHandler>();
+        services.AddSingleton<IInternalPacketHandler<GLPlayerReconnectPacket>, GLPlayerReconnectPacketHandler>();
+        services.AddSingleton<IInternalPacketHandler<GLPlayerEnterPacket>, GLPlayerEnterPacketHandler>();
+        services.AddSingleton<IInternalPacketHandler<GLGameServerLoadPacket>, GLGameServerLoadPacketHandler>();
+    }
+    
+    public static void AddLoginPacketHandlers(this IServiceCollection services)
+    {
+        services.AddSingleton<ILoginPacketHandler<CACancelEnterWorldPacket>, CACancelEnterWorldPacketHandler>();
+        services.AddSingleton<ILoginPacketHandler<CAChallengeResponse2Packet>, CAChallengeResponse2PacketHandler>();
+        services.AddSingleton<ILoginPacketHandler<CAChallengeResponsePacket>, CAChallengeResponsePacketHandler>();
+        services.AddSingleton<ILoginPacketHandler<CAEnterWorldPacket>, CAEnterWorldPacketHandler>();
+        services.AddSingleton<ILoginPacketHandler<CAListWorldPacket>, CAListWorldPacketHandler>();
+        services.AddSingleton<ILoginPacketHandler<CAOtpNumberPacket>, CAOtpNumberPacketHandler>();
+        services.AddSingleton<ILoginPacketHandler<CAPcCertNumberPacket>, CAPcCertNumberPacketHandler>();
+        services.AddSingleton<ILoginPacketHandler<CARequestAuthGameOnPacket>, CARequestAuthGameOnPacketHandler>();
+        services.AddSingleton<ILoginPacketHandler<CARequestAuthMailRuPacket>, CARequestAuthMailRuPacketHandler>();
+        services.AddSingleton<ILoginPacketHandler<CARequestAuthPacket>, CARequestAuthPacketHandler>();
+        services.AddSingleton<ILoginPacketHandler<CARequestAuthTencentPacket>, CARequestAuthTencentPacketHandler>();
+        services.AddSingleton<ILoginPacketHandler<CARequestAuthTrionPacket>, CARequestAuthTrionPacketHandler>();
+        services.AddSingleton<ILoginPacketHandler<CARequestReconnectPacket>, CARequestReconnectPacketHandler>();
+    }
+}

--- a/AAEmu.Login/Core/Packets/C2L/CACancelEnterWorldPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CACancelEnterWorldPacket.cs
@@ -5,8 +5,10 @@ namespace AAEmu.Login.Core.Packets.C2L;
 
 public class CACancelEnterWorldPacket() : LoginPacket(CLOffsets.CACancelEnterWorldPacket)
 {
+    public byte WorldId { get; private set; }
+    
     public override void Read(PacketStream stream)
     {
-        var wId = stream.ReadByte(); // diw -> world id
+        WorldId = stream.ReadByte(); // diw -> world id
     }
 }

--- a/AAEmu.Login/Core/Packets/C2L/CAChallengeResponse2Packet.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAChallengeResponse2Packet.cs
@@ -1,6 +1,5 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Login.Core.Network.Login;
-using AAEmu.Login.Core.Packets.L2C;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
@@ -10,10 +9,5 @@ public class CAChallengeResponse2Packet() : LoginPacket(CLOffsets.CAChallengeRes
     {
         for (var i = 0; i < 8; i++)
             stream.ReadUInt32(); // hc
-    }
-
-    public override void Execute()
-    {
-        Connection.SendPacket(new ACLoginDeniedPacket(2));
     }
 }

--- a/AAEmu.Login/Core/Packets/C2L/CAChallengeResponsePacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAChallengeResponsePacket.cs
@@ -1,6 +1,5 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Login.Core.Network.Login;
-using AAEmu.Login.Core.Packets.L2C;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
@@ -12,10 +11,5 @@ public class CAChallengeResponsePacket() : LoginPacket(CLOffsets.CAChallengeResp
             stream.ReadUInt32(); // responses
         var password = stream.ReadBytes(); // TODO or bytes? length 32
         var bytes = Convert.FromBase64String("jZae727K08KaOmKSgOaGzww/XVqGr/PKEgIMkjrcbJI=");
-    }
-
-    public override void Execute()
-    {
-        Connection.SendPacket(new ACLoginDeniedPacket(3));
     }
 }

--- a/AAEmu.Login/Core/Packets/C2L/CAEnterWorldPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAEnterWorldPacket.cs
@@ -1,5 +1,4 @@
 ﻿using AAEmu.Commons.Network;
-using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Login;
 using AAEmu.Login.Models;
 
@@ -7,16 +6,12 @@ namespace AAEmu.Login.Core.Packets.C2L;
 
 public class CAEnterWorldPacket() : LoginPacket(CLOffsets.CAEnterWorldPacket)
 {
-    private GameServerId _gsId;
-    
+    public ulong Flag { get; private set; }
+    public GameServerId GsId { get; private set; }
+
     public override void Read(PacketStream stream)
     {
-        var flag = stream.ReadUInt64();
-        _gsId = new GameServerId(stream.ReadByte());
-    }
-
-    public override void Execute()
-    {
-        GameController.Instance.RequestEnterWorld(Connection, _gsId);
+        Flag = stream.ReadUInt64();
+        GsId = new GameServerId(stream.ReadByte());
     }
 }

--- a/AAEmu.Login/Core/Packets/C2L/CAListWorldPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAListWorldPacket.cs
@@ -1,18 +1,14 @@
 ﻿using AAEmu.Commons.Network;
-using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
 public class CAListWorldPacket() : LoginPacket(CLOffsets.CAListWorldPacket)
 {
+    public ulong Flag { get; private set; }
+    
     public override void Read(PacketStream stream)
     {
-        var flag = stream.ReadUInt64();
-    }
-
-    public override void Execute()
-    {
-        Task.Run(() => GameController.Instance.RequestWorldListAsync(Connection));
+        Flag = stream.ReadUInt64();
     }
 }

--- a/AAEmu.Login/Core/Packets/C2L/CARequestAuthMailRuPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CARequestAuthMailRuPacket.cs
@@ -1,26 +1,20 @@
 ﻿using AAEmu.Commons.Network;
-using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
 public class CARequestAuthMailRuPacket() : LoginPacket(CLOffsets.CARequestAuthMailRuPacket)
 {
-    private string? _id;
-    private byte[]? _token;
-    
+    public string? Id { get; private set; }
+    public byte[]? Token { get; private set; }
+
     public override void Read(PacketStream stream)
     {
         var pFrom = stream.ReadUInt32();
         var pTo = stream.ReadUInt32();
         var dev = stream.ReadBoolean();
         var mac = stream.ReadBytes();
-        _id = stream.ReadString();
-        _token = stream.ReadBytes();
-    }
-
-    public override void Execute()
-    {
-        LoginController.Login(Connection, _id!, _token);
+        Id = stream.ReadString();
+        Token = stream.ReadBytes();
     }
 }

--- a/AAEmu.Login/Core/Packets/C2L/CARequestAuthPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CARequestAuthPacket.cs
@@ -1,29 +1,21 @@
 ﻿using AAEmu.Commons.Network;
-using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
 public class CARequestAuthPacket() : LoginPacket(CLOffsets.CARequestAuthPacket)
 {
-    private string? _account;
-    
+    public string? Account { get; private set; }
+
     public override void Read(PacketStream stream)
     {
         var pFrom = stream.ReadUInt32();
         var pTo = stream.ReadUInt32();
         var svc = stream.ReadByte();
         var dev = stream.ReadBoolean();
-        _account = stream.ReadString();
+        Account = stream.ReadString();
         var mac = stream.ReadBytes();
         var mac2 = stream.ReadBytes();
         var cpu = stream.ReadUInt64();
-    }
-
-    public override void Execute()
-    {
-        LoginController.Login(Connection, _account!);
-
-        // Connection.SendPacket(new ACChallengePacket()); // TODO ...
     }
 }

--- a/AAEmu.Login/Core/Packets/C2L/CARequestAuthTrionPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CARequestAuthTrionPacket.cs
@@ -1,16 +1,14 @@
 ﻿using System.Xml.Linq;
 using AAEmu.Commons.Network;
-using AAEmu.Commons.Utils;
-using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
 public class CARequestAuthTrionPacket() : LoginPacket(CLOffsets.CARequestAuthTrionPacket)
 {
-    private string? _username;
-    private string? _password;
-    
+    public string? Username { get; private set; }
+    public string? Password { get; private set; }
+
     public override void Read(PacketStream stream)
     {
         var pFrom = stream.ReadUInt32();
@@ -38,13 +36,7 @@ public class CARequestAuthTrionPacket() : LoginPacket(CLOffsets.CARequestAuthTri
             return;
         }
         
-        _username = username;
-        _password = password;
-    }
-
-    public override void Execute()
-    {
-        var token = Helpers.StringToByteArray(_password!);
-        LoginController.Login(Connection, _username!, token);
+        Username = username;
+        Password = password;
     }
 }

--- a/AAEmu.Login/Core/Packets/C2L/CARequestReconnectPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CARequestReconnectPacket.cs
@@ -1,5 +1,4 @@
 ﻿using AAEmu.Commons.Network;
-using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Login;
 using AAEmu.Login.Models;
 
@@ -7,23 +6,18 @@ namespace AAEmu.Login.Core.Packets.C2L;
 
 public class CARequestReconnectPacket() : LoginPacket(CLOffsets.CARequestReconnectPacket)
 {
-    private GameServerId _gsId;
-    private AccountId _accountId;
-    private uint _cookie;
-    
+    public GameServerId GsId { get; private set; }
+    public AccountId AccountId { get; private set; }
+    public uint Cookie { get; private set; }
+
     public override void Read(PacketStream stream)
     {
         var pFrom = stream.ReadUInt32();
         var pTo = stream.ReadUInt32();
-        _accountId = new AccountId(stream.ReadUInt32());
-        _gsId = new GameServerId(stream.ReadByte());
-        _cookie = stream.ReadUInt32();
+        AccountId = new AccountId(stream.ReadUInt32());
+        GsId = new GameServerId(stream.ReadByte());
+        Cookie = stream.ReadUInt32();
         var macLength = stream.ReadUInt16();
         var mac = stream.ReadBytes(macLength);
-    }
-
-    public override void Execute()
-    {
-        LoginController.Instance.Reconnect(Connection, _gsId, _accountId, _cookie);
     }
 }

--- a/AAEmu.Login/Core/Packets/G2L/GLGameServerLoadPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLGameServerLoadPacket.cs
@@ -6,15 +6,10 @@ namespace AAEmu.Login.Core.Packets.G2L;
 
 public class GLGameServerLoadPacket() : InternalPacket(GLOffsets.GLGameServerLoadPacket)
 {
-    private GSLoad _load;
-    
+    public GSLoad Load { get; private set; }
+
     public override void Read(PacketStream stream)
     {
-        _load = (GSLoad)stream.ReadByte();
-    }
-
-    public override void Execute()
-    {
-        Connection.GameServer!.Load = _load;
+        Load = (GSLoad)stream.ReadByte();
     }
 }

--- a/AAEmu.Login/Core/Packets/G2L/GLPlayerEnterPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLPlayerEnterPacket.cs
@@ -1,6 +1,4 @@
 ﻿using AAEmu.Commons.Network;
-using AAEmu.Login.Core.Controllers;
-using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.Network.Internal;
 using AAEmu.Login.Models;
 
@@ -8,20 +6,14 @@ namespace AAEmu.Login.Core.Packets.G2L;
 
 public class GLPlayerEnterPacket() : InternalPacket(GLOffsets.GLPlayerEnterPacket)
 {
-    private ConnectionId _connectionId;
-    private GameServerId _gsId;
-    private byte _result;
-    
+    public ConnectionId ConnectionId { get; private set; }
+    public GameServerId GsId { get; private set; }
+    public byte Result { get; private set; }
+
     public override void Read(PacketStream stream)
     {
-        _connectionId = new ConnectionId(stream.ReadUInt32());
-        _gsId = new GameServerId(stream.ReadByte());
-        _result = stream.ReadByte();
-    }
-
-    public override void Execute()
-    {
-        var connection = LoginConnectionTable.Instance.GetConnection(_connectionId);
-        GameController.Instance.EnterWorld(connection!, _gsId, _result);
+        ConnectionId = new ConnectionId(stream.ReadUInt32());
+        GsId = new GameServerId(stream.ReadByte());
+        Result = stream.ReadByte();
     }
 }

--- a/AAEmu.Login/Core/Packets/G2L/GLPlayerReconnectPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLPlayerReconnectPacket.cs
@@ -1,5 +1,4 @@
 ﻿using AAEmu.Commons.Network;
-using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Internal;
 using AAEmu.Login.Models;
 
@@ -7,19 +6,14 @@ namespace AAEmu.Login.Core.Packets.G2L;
 
 public class GLPlayerReconnectPacket() : InternalPacket(GLOffsets.GLPlayerReconnectPacket)
 {
-    private GameServerId _gsId;
-    private AccountId _accountId;
-    private uint _token;
-    
+    public GameServerId GsId { get; private set; }
+    public AccountId AccountId { get; private set; }
+    public uint Token { get; private set; }
+
     public override void Read(PacketStream stream)
     {
-        _gsId = new GameServerId(stream.ReadByte());
-        _accountId = new AccountId(stream.ReadUInt32());
-        _token = stream.ReadUInt32();
-    }
-
-    public override void Execute()
-    {
-        LoginController.Instance.AddReconnectionToken(Connection, _gsId, _accountId, _token);
+        GsId = new GameServerId(stream.ReadByte());
+        AccountId = new AccountId(stream.ReadUInt32());
+        Token = stream.ReadUInt32();
     }
 }

--- a/AAEmu.Login/Core/Packets/G2L/GLRegisterGameServerPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLRegisterGameServerPacket.cs
@@ -1,45 +1,24 @@
 ﻿using AAEmu.Commons.Network;
-using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Internal;
-using AAEmu.Login.Core.Packets.L2G;
 using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Packets.G2L;
 
 public class GLRegisterGameServerPacket() : InternalPacket(GLOffsets.GLRegisterGameServerPacket)
 {
-    private string? _secretKey;
-    private GameServerId _gsId;
-    private List<GameServerId>? _mirrors;
-    
-    private async Task SendPacketWithDelay(int delay, InternalPacket message)
-    {
-        await Task.Delay(delay);
-        Connection.SendPacket(message);
-    }
+    public string? SecretKey { get; private set; }
+    public GameServerId GsId { get; private set; }
+    public List<GameServerId>? Mirrors { get; private set; }
 
     public override void Read(PacketStream stream)
     {
-        _secretKey = stream.ReadString();
-        _gsId = new GameServerId(stream.ReadByte());
+        SecretKey = stream.ReadString();
+        GsId = new GameServerId(stream.ReadByte());
         var additionalesCount = stream.ReadInt32();
         var mirrors = new List<GameServerId>(additionalesCount);
         for (var i = 0; i < additionalesCount; i++)
             mirrors.Add(new GameServerId(stream.ReadByte()));
 
-        _mirrors = mirrors;
-    }
-
-    public override void Execute()
-    {
-        if (_secretKey != AppConfiguration.Instance.SecretKey)
-        {
-            Logger.Error($"Connection {Connection.Ip}, bad secret key");
-            Task.Run(() => SendPacketWithDelay(5000, new LGRegisterGameServerPacket(GSRegisterResult.Error)));
-            // Connection.SendPacket(new LGRegisterGameServerPacket(GSRegisterResult.Error));
-            return;
-        }
-        
-        GameController.Instance.Add(_gsId, _mirrors!, Connection);
+        Mirrors = mirrors;
     }
 }

--- a/AAEmu.Login/Core/Packets/G2L/GLRequestInfoPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLRequestInfoPacket.cs
@@ -1,7 +1,5 @@
 ﻿using AAEmu.Commons.Models;
 using AAEmu.Commons.Network;
-using AAEmu.Login.Core.Controllers;
-using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.Network.Internal;
 using AAEmu.Login.Models;
 
@@ -9,22 +7,14 @@ namespace AAEmu.Login.Core.Packets.G2L;
 
 public class GLRequestInfoPacket() : InternalPacket(GLOffsets.GLRequestInfoPacket)
 {
-    private ConnectionId _connectionId;
-    private uint _requestId;
-    private List<LoginCharacterInfo>? _characters;
-    
+    public ConnectionId ConnectionId { get; private set; }
+    public uint RequestId { get; private set; }
+    public List<LoginCharacterInfo>? Characters { get; private set; }
+
     public override void Read(PacketStream stream)
     {
-        _connectionId = new ConnectionId(stream.ReadUInt32());
-        _requestId = stream.ReadUInt32();
-        _characters = stream.ReadCollection<LoginCharacterInfo>();
-    }
-
-    public override void Execute()
-    {
-        var connection = LoginConnectionTable.Instance.GetConnection(_connectionId);
-        if (_characters!.Count > 0)
-            connection!.AddCharacters(Connection.GameServer!.Id, _characters);
-        RequestController.Instance.ReleaseId(_requestId);
+        ConnectionId = new ConnectionId(stream.ReadUInt32());
+        RequestId = stream.ReadUInt32();
+        Characters = stream.ReadCollection<LoginCharacterInfo>();
     }
 }

--- a/AAEmu.Login/LoginService.cs
+++ b/AAEmu.Login/LoginService.cs
@@ -9,7 +9,11 @@ using NLog;
 
 namespace AAEmu.Login;
 
-public sealed class LoginService : IHostedService, IDisposable
+public sealed class LoginService(
+    IGameController gameController,
+    IRequestController requestController,
+    IInternalNetwork internalNetwork,
+    ILoginNetwork loginNetwork) : IHostedService, IDisposable
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
@@ -19,25 +23,27 @@ public sealed class LoginService : IHostedService, IDisposable
         // Check for updates
         using (var connection = MySQL.CreateConnection())
         {
-            if (!MySqlDatabaseUpdater.Run(connection, "aaemu_login", AppConfiguration.Instance.Connections.MySQLProvider.Database))
+            if (!MySqlDatabaseUpdater.Run(connection, "aaemu_login",
+                    AppConfiguration.Instance.Connections.MySQLProvider.Database))
             {
                 Logger.Fatal("Failed up update database !");
                 Logger.Fatal("Press Ctrl+C to quit");
                 return Task.CompletedTask;
             }
         }
-        RequestController.Instance.Initialize();
-        GameController.Instance.Load();
-        LoginNetwork.Instance.Start();
-        InternalNetwork.Instance.Start();
+
+        requestController.Initialize();
+        gameController.Load();
+        loginNetwork.Start();
+        internalNetwork.Start();
         return Task.CompletedTask;
     }
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
         Logger.Info("Stopping daemon.");
-        LoginNetwork.Instance?.Stop();
-        InternalNetwork.Instance?.Stop();
+        loginNetwork.Stop();
+        internalNetwork.Stop();
         return Task.CompletedTask;
     }
 

--- a/AAEmu.Login/Program.cs
+++ b/AAEmu.Login/Program.cs
@@ -1,6 +1,11 @@
 ﻿using System.Reflection;
 using AAEmu.Commons.IO;
 using AAEmu.Commons.Utils.DB;
+using AAEmu.Login.Core.Controllers;
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Network.Internal;
+using AAEmu.Login.Core.Network.Login;
+using AAEmu.Login.Core.PacketHandlers;
 using AAEmu.Login.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -44,19 +49,29 @@ public static class Program
             return;
         }
 
-        var builder = new HostBuilder()
-            .ConfigureAppConfiguration((hostingContext, config) =>
-            {
-                config.AddEnvironmentVariables();
-                config.AddCommandLine(args);
-            })
-            .ConfigureServices((hostContext, services) =>
-            {
-                services.AddOptions();
-                services.AddSingleton<IHostedService, LoginService>();
-            });
+        var builder = Host.CreateApplicationBuilder(args);
+        builder.Configuration.AddEnvironmentVariables();
 
-        await builder.RunConsoleAsync();
+        // Configure services
+        builder.Services.AddOptions();
+        builder.Services.AddHostedService<LoginService>();
+        
+        builder.Services.AddSingleton<IGameController, GameController>();
+        builder.Services.AddSingleton<ILoginController, LoginController>();
+        builder.Services.AddSingleton<IRequestController, RequestController>();
+
+        builder.Services.AddSingleton<IInternalProtocolHandler, InternalProtocolHandler>();
+        builder.Services.AddSingleton<IInternalConnectionTable, InternalConnectionTable>();
+        builder.Services.AddSingleton<IInternalNetwork, InternalNetwork>();
+        builder.Services.AddSingleton<ILoginProtocolHandler, LoginProtocolHandler>();
+        builder.Services.AddSingleton<ILoginConnectionTable, LoginConnectionTable>();
+        builder.Services.AddSingleton<ILoginNetwork, LoginNetwork>();
+
+        builder.Services.AddInternalPacketHandlers();
+        builder.Services.AddLoginPacketHandlers();
+        
+        var app = builder.Build();
+        await app.RunAsync();
     }
 
     private static bool LoadConfiguration(string[] args)

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="9.0.0"/>
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0"/>
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0"/>
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0"/>
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6"/>
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0"/>
     <PackageVersion Include="NCrontab" Version="3.3.3"/>
     <PackageVersion Include="NLua" Version="1.7.3"/>


### PR DESCRIPTION
Use [dependency injection](https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection) and packet handlers. The `Execute` method of packets is pulled out to a separate handler class capable of processing one type of packet.

Singletons that previously exposed a static `Instance` method are now registered in DI with singleton lifetime.