### PR TITLE
[Login] Register packets via DI

### DIFF
--- a/AAEmu.Login/Core/Network/Connections/LoginConnection.cs
+++ b/AAEmu.Login/Core/Network/Connections/LoginConnection.cs
@@ -11,7 +11,7 @@ public class LoginConnection
 {
     private readonly ISession _session;
 
-    public ConnectionId Id => new ConnectionId(_session.SessionId);
+    public ConnectionId Id => new(_session.SessionId);
     public IPAddress Ip => _session.Ip;
     public InternalConnection? InternalConnection { get; set; }
     public PacketStream? LastPacket { get; set; }

--- a/AAEmu.Login/Core/Network/Internal/IInternalPacket.cs
+++ b/AAEmu.Login/Core/Network/Internal/IInternalPacket.cs
@@ -1,0 +1,6 @@
+﻿namespace AAEmu.Login.Core.Network.Internal;
+
+public interface IInternalPacket
+{
+    static abstract ushort TypeId { get; }
+}

--- a/AAEmu.Login/Core/Network/Internal/IInternalPacketDescriptor.cs
+++ b/AAEmu.Login/Core/Network/Internal/IInternalPacketDescriptor.cs
@@ -1,0 +1,16 @@
+﻿using AAEmu.Commons.Network;
+using AAEmu.Login.Core.Network.Connections;
+
+namespace AAEmu.Login.Core.Network.Internal;
+
+public interface IInternalPacketDescriptor
+{
+    ushort TypeId { get; }
+    
+    /// <summary>
+    /// Reads the packet from the stream and dispatches it to the appropriate handler.
+    /// </summary>
+    /// <param name="stream">The stream containing the packet data.</param>
+    /// <param name="connection">The connection where the packet was received.</param>
+    void Dispatch(PacketStream stream, InternalConnection connection);
+}

--- a/AAEmu.Login/Core/Network/Internal/IInternalProtocolHandler.cs
+++ b/AAEmu.Login/Core/Network/Internal/IInternalProtocolHandler.cs
@@ -1,10 +1,5 @@
 using AAEmu.Commons.Network;
-using AAEmu.Login.Core.PacketHandlers;
 
 namespace AAEmu.Login.Core.Network.Internal;
 
-public interface IInternalProtocolHandler : IBaseProtocolHandler
-{
-    void RegisterPacket<TPacket>(uint type, IInternalPacketHandler<TPacket> packetHandler)
-        where TPacket : InternalPacket;
-}
+public interface IInternalProtocolHandler : IBaseProtocolHandler;

--- a/AAEmu.Login/Core/Network/Internal/InternalNetwork.cs
+++ b/AAEmu.Login/Core/Network/Internal/InternalNetwork.cs
@@ -1,34 +1,15 @@
 ﻿using System.Net;
 using AAEmu.Commons.Network.Core;
-using AAEmu.Login.Core.PacketHandlers;
-using AAEmu.Login.Core.Packets.G2L;
 using AAEmu.Login.Models;
 using NLog;
 
 namespace AAEmu.Login.Core.Network.Internal;
 
-public class InternalNetwork : IInternalNetwork
+public class InternalNetwork(IInternalProtocolHandler protocolHandler) : IInternalNetwork
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
     private Server? _server;
-    private readonly IInternalProtocolHandler _handler;
-
-    public InternalNetwork(IInternalProtocolHandler protocolHandler,
-        IInternalPacketHandler<GLRegisterGameServerPacket> registerGameServerPacketHandler,
-        IInternalPacketHandler<GLPlayerEnterPacket> playerEnterPacketHandler,
-        IInternalPacketHandler<GLPlayerReconnectPacket> playerReconnectPacketHandler,
-        IInternalPacketHandler<GLRequestInfoPacket> requestInfoPacketHandler,
-        IInternalPacketHandler<GLGameServerLoadPacket> gameServerLoadPacketHandler)
-    {
-        _handler = protocolHandler;
-
-        RegisterPacket(GLOffsets.GLRegisterGameServerPacket, registerGameServerPacketHandler);
-        RegisterPacket(GLOffsets.GLPlayerEnterPacket, playerEnterPacketHandler);
-        RegisterPacket(GLOffsets.GLPlayerReconnectPacket, playerReconnectPacketHandler);
-        RegisterPacket(GLOffsets.GLRequestInfoPacket, requestInfoPacketHandler);
-        RegisterPacket(GLOffsets.GLGameServerLoadPacket, gameServerLoadPacketHandler);
-    }
 
     public void Start()
     {
@@ -36,7 +17,7 @@ public class InternalNetwork : IInternalNetwork
         var host =
             new IPEndPoint(config.Host.Equals("*") ? IPAddress.Any : IPAddress.Parse(config.Host), config.Port);
 
-        _server = new Server(host.Address, host.Port, _handler);
+        _server = new Server(host.Address, host.Port, protocolHandler);
         _server.Start();
 
         Logger.Info("InternalNetwork started");
@@ -49,7 +30,4 @@ public class InternalNetwork : IInternalNetwork
 
         Logger.Info("InternalNetwork stoped");
     }
-
-    private void RegisterPacket<TPacket>(uint type, IInternalPacketHandler<TPacket> packetHandler)
-        where TPacket : InternalPacket => _handler.RegisterPacket(type, packetHandler);
 }

--- a/AAEmu.Login/Core/Network/Internal/InternalPacketDescriptor.cs
+++ b/AAEmu.Login/Core/Network/Internal/InternalPacketDescriptor.cs
@@ -1,0 +1,19 @@
+﻿using AAEmu.Commons.Network;
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.PacketHandlers;
+
+namespace AAEmu.Login.Core.Network.Internal;
+
+public class InternalPacketDescriptor<TPacket>(ushort packetId, IInternalPacketHandler<TPacket> handler)
+    : IInternalPacketDescriptor
+    where TPacket : InternalPacket, new()
+{
+    public ushort TypeId { get; } = packetId;
+
+    public void Dispatch(PacketStream stream, InternalConnection connection)
+    {
+        var packet = new TPacket { Connection = connection };
+        packet.Decode(stream);
+        handler.Execute(packet, connection);
+    }
+}

--- a/AAEmu.Login/Core/Network/Internal/InternalProtocolHandler.cs
+++ b/AAEmu.Login/Core/Network/Internal/InternalProtocolHandler.cs
@@ -6,18 +6,21 @@ using AAEmu.Commons.Network;
 using AAEmu.Commons.Network.Core;
 using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Connections;
-using AAEmu.Login.Core.PacketHandlers;
 using AAEmu.Login.Models;
 using NLog;
 
 namespace AAEmu.Login.Core.Network.Internal;
 
-public class InternalProtocolHandler(IGameController gameController, IInternalConnectionTable internalConnectionTable)
+public class InternalProtocolHandler(
+    IEnumerable<IInternalPacketDescriptor> packetDescriptors,
+    IGameController gameController,
+    IInternalConnectionTable internalConnectionTable)
     : BaseProtocolHandler, IInternalProtocolHandler
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
-    private readonly ConcurrentDictionary<uint, (Type Type, IInternalPacketHandler PacketHandler)> _packets = [];
+    private readonly ConcurrentDictionary<ushort, IInternalPacketDescriptor> _packets =
+        new(packetDescriptors.ToDictionary(d => d.TypeId));
 
     public override void OnConnect(ISession session)
     {
@@ -44,7 +47,7 @@ public class InternalProtocolHandler(IGameController gameController, IInternalCo
             Logger.Error("Connection not found for session {0}", session.SessionId);
             return;
         }
-        
+
         var stream = new PacketStream();
         if (connection.LastPacket != null)
         {
@@ -86,33 +89,19 @@ public class InternalProtocolHandler(IGameController gameController, IInternalCo
 
                 stream2.ReadUInt16();
                 var type = stream2.ReadUInt16();
-                if (!_packets.TryGetValue(type, out var tuple))
+                if (!_packets.TryGetValue(type, out var packetDescriptor))
                 {
-                    HandleUnknownPacket(session, type, stream2); 
+                    HandleUnknownPacket(session, type, stream2);
                 }
                 else
                 {
-                    var (classType, packetHandler) = tuple;
                     try
                     {
-                        var packet = (InternalPacket)Activator.CreateInstance(classType)!;
-                        packet.Connection = connection;
-                        packet.Decode(stream2);
-
-                        try
-                        {
-                            packetHandler.Execute(packet, connection);
-                        }
-                        catch (Exception e)
-                        {
-                            Logger.Error("Error on execute packet {0}", type);
-                            Logger.Error(e);
-                        }
+                        packetDescriptor.Dispatch(stream2, connection);
                     }
                     catch (Exception e)
                     {
-                        Logger.Error("Error on decode packet {0}", type);
-                        Logger.Error(e);
+                        Logger.Error(e, "Error on packet dispatch {0}", type);
                     }
                 }
             }
@@ -125,19 +114,11 @@ public class InternalProtocolHandler(IGameController gameController, IInternalCo
         }
     }
 
-    public void RegisterPacket<TPacket>(uint type, IInternalPacketHandler<TPacket> packetHandler) where TPacket : InternalPacket
-    {
-        _packets.AddOrUpdate(type,
-            addValueFactory: static (_, arg) => arg,
-            updateValueFactory: static (_, _, arg) => arg,
-            factoryArgument: (typeof(TPacket), packetHandler));
-    }
-
     private static void HandleUnknownPacket(ISession session, uint type, PacketStream stream)
     {
         var dump = new StringBuilder();
         for (var i = stream.Pos; i < stream.Count; i++)
-            dump.AppendFormat("{0:x2} ", stream.Buffer[i]);
+            dump.Append($"{stream.Buffer[i]:x2} ");
         Logger.Error("Unknown packet 0x{0:x2} from {1}:\n{2}", type, session.Ip, dump);
     }
 }

--- a/AAEmu.Login/Core/Network/Login/ILoginPacket.cs
+++ b/AAEmu.Login/Core/Network/Login/ILoginPacket.cs
@@ -1,0 +1,6 @@
+﻿namespace AAEmu.Login.Core.Network.Login;
+
+public interface ILoginPacket
+{
+    static abstract ushort TypeId { get; }
+}

--- a/AAEmu.Login/Core/Network/Login/ILoginPacketDescriptor.cs
+++ b/AAEmu.Login/Core/Network/Login/ILoginPacketDescriptor.cs
@@ -1,0 +1,16 @@
+﻿using AAEmu.Commons.Network;
+using AAEmu.Login.Core.Network.Connections;
+
+namespace AAEmu.Login.Core.Network.Login;
+
+public interface ILoginPacketDescriptor
+{
+    ushort TypeId { get; }
+    
+    /// <summary>
+    /// Reads the packet from the stream and dispatches it to the appropriate handler.
+    /// </summary>
+    /// <param name="stream">The stream containing the packet data.</param>
+    /// <param name="connection">The connection where the packet was received.</param>
+    void Dispatch(PacketStream stream, LoginConnection connection);
+}

--- a/AAEmu.Login/Core/Network/Login/ILoginProtocolHandler.cs
+++ b/AAEmu.Login/Core/Network/Login/ILoginProtocolHandler.cs
@@ -1,9 +1,5 @@
 ﻿using AAEmu.Commons.Network;
-using AAEmu.Login.Core.PacketHandlers;
 
 namespace AAEmu.Login.Core.Network.Login;
 
-public interface ILoginProtocolHandler : IBaseProtocolHandler
-{
-    void RegisterPacket<TPacket>(uint type, ILoginPacketHandler<TPacket> packetHandler) where TPacket : LoginPacket;
-}
+public interface ILoginProtocolHandler : IBaseProtocolHandler;

--- a/AAEmu.Login/Core/Network/Login/LoginNetwork.cs
+++ b/AAEmu.Login/Core/Network/Login/LoginNetwork.cs
@@ -1,56 +1,21 @@
 ﻿using System.Net;
 using AAEmu.Commons.Network.Core;
-using AAEmu.Login.Core.PacketHandlers;
-using AAEmu.Login.Core.Packets.C2L;
 using AAEmu.Login.Models;
 using NLog;
 
 namespace AAEmu.Login.Core.Network.Login;
 
-public class LoginNetwork : ILoginNetwork
+public class LoginNetwork(ILoginProtocolHandler protocolHandler) : ILoginNetwork
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
     private Server? _server;
-    private readonly ILoginProtocolHandler _handler;
-
-    public LoginNetwork(ILoginProtocolHandler protocolHandler,
-        ILoginPacketHandler<CARequestAuthPacket> requestAuthPacketHandler,
-        ILoginPacketHandler<CARequestAuthTencentPacket> requestAuthTencentPacket,
-        ILoginPacketHandler<CARequestAuthGameOnPacket> requestAuthGameOnPacket,
-        ILoginPacketHandler<CARequestAuthTrionPacket> requestAuthTrionPacket,
-        ILoginPacketHandler<CARequestAuthMailRuPacket> requestAuthMailRuPacket,
-        ILoginPacketHandler<CAChallengeResponsePacket> challengeResponsePacket,
-        ILoginPacketHandler<CAChallengeResponse2Packet> challengeResponse2Packet,
-        ILoginPacketHandler<CAOtpNumberPacket> otpNumberPacket,
-        ILoginPacketHandler<CAPcCertNumberPacket> pcCertNumberPacket,
-        ILoginPacketHandler<CAListWorldPacket> listWorldPacket,
-        ILoginPacketHandler<CAEnterWorldPacket> enterWorldPacket,
-        ILoginPacketHandler<CACancelEnterWorldPacket> cancelEnterWorldPacket,
-        ILoginPacketHandler<CARequestReconnectPacket> requestReconnectPacket)
-    {
-        _handler = protocolHandler;
-
-        RegisterPacket(CLOffsets.CARequestAuthPacket, requestAuthPacketHandler);
-        RegisterPacket(CLOffsets.CARequestAuthTencentPacket, requestAuthTencentPacket);
-        RegisterPacket(CLOffsets.CARequestAuthGameOnPacket, requestAuthGameOnPacket);
-        RegisterPacket(CLOffsets.CARequestAuthTrionPacket, requestAuthTrionPacket);
-        RegisterPacket(CLOffsets.CARequestAuthMailRuPacket, requestAuthMailRuPacket);
-        RegisterPacket(CLOffsets.CAChallengeResponsePacket, challengeResponsePacket);
-        RegisterPacket(CLOffsets.CAChallengeResponse2Packet, challengeResponse2Packet);
-        RegisterPacket(CLOffsets.CAOtpNumberPacket, otpNumberPacket);
-        RegisterPacket(CLOffsets.CAPcCertNumberPacket, pcCertNumberPacket);
-        RegisterPacket(CLOffsets.CAListWorldPacket, listWorldPacket);
-        RegisterPacket(CLOffsets.CAEnterWorldPacket, enterWorldPacket);
-        RegisterPacket(CLOffsets.CACancelEnterWorldPacket, cancelEnterWorldPacket);
-        RegisterPacket(CLOffsets.CARequestReconnectPacket, requestReconnectPacket);
-    }
 
     public void Start()
     {
         var config = AppConfiguration.Instance.Network;
         _server = new Server(
-            config.Host.Equals("*") ? IPAddress.Any : IPAddress.Parse(config.Host), config.Port, _handler);
+            config.Host.Equals("*") ? IPAddress.Any : IPAddress.Parse(config.Host), config.Port, protocolHandler);
         _server.Start();
 
         Logger.Info("Network started with Number of Connections: " + config.NumConnections);
@@ -63,7 +28,4 @@ public class LoginNetwork : ILoginNetwork
 
         Logger.Info("Network stopped");
     }
-
-    private void RegisterPacket<TPacket>(uint type, ILoginPacketHandler<TPacket> packetHandler)
-        where TPacket : LoginPacket => _handler.RegisterPacket(type, packetHandler);
 }

--- a/AAEmu.Login/Core/Network/Login/LoginPacketDescriptor.cs
+++ b/AAEmu.Login/Core/Network/Login/LoginPacketDescriptor.cs
@@ -1,0 +1,19 @@
+﻿using AAEmu.Commons.Network;
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.PacketHandlers;
+
+namespace AAEmu.Login.Core.Network.Login;
+
+public class LoginPacketDescriptor<TPacket>(ushort packetId, ILoginPacketHandler<TPacket> handler)
+    : ILoginPacketDescriptor
+    where TPacket : LoginPacket, new()
+{
+    public ushort TypeId { get; } = packetId;
+
+    public void Dispatch(PacketStream stream, LoginConnection connection)
+    {
+        var packet = new TPacket { Connection = connection };
+        packet.Decode(stream);
+        handler.Execute(packet, connection);
+    }
+}

--- a/AAEmu.Login/Core/Network/Login/LoginProtocolHandler.cs
+++ b/AAEmu.Login/Core/Network/Login/LoginProtocolHandler.cs
@@ -5,17 +5,19 @@ using AAEmu.Commons.Exceptions;
 using AAEmu.Commons.Network;
 using AAEmu.Commons.Network.Core;
 using AAEmu.Login.Core.Network.Connections;
-using AAEmu.Login.Core.PacketHandlers;
 using AAEmu.Login.Models;
 using NLog;
 
 namespace AAEmu.Login.Core.Network.Login;
 
-public class LoginProtocolHandler(ILoginConnectionTable loginConnectionTable) : BaseProtocolHandler, ILoginProtocolHandler
+public class LoginProtocolHandler(
+    IEnumerable<ILoginPacketDescriptor> packetDescriptors,
+    ILoginConnectionTable loginConnectionTable) : BaseProtocolHandler, ILoginProtocolHandler
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
-    private readonly ConcurrentDictionary<uint, (Type Type, ILoginPacketHandler PacketHandler)> _packets = [];
+    private readonly ConcurrentDictionary<ushort, ILoginPacketDescriptor> _packets =
+        new(packetDescriptors.ToDictionary(d => d.TypeId));
 
     public override void OnConnect(ISession session)
     {
@@ -40,6 +42,7 @@ public class LoginProtocolHandler(ILoginConnectionTable loginConnectionTable) : 
             Logger.Error("Unexpected null Session");
             return;
         }
+
         try
         {
             var con = loginConnectionTable.GetConnection(new ConnectionId(session.SessionId));
@@ -116,25 +119,19 @@ public class LoginProtocolHandler(ILoginConnectionTable loginConnectionTable) : 
 
                     stream2.ReadUInt16(); //len
                     var type = stream2.ReadUInt16();
-                    if (!_packets.TryGetValue(type, out var tuple))
+                    if (!_packets.TryGetValue(type, out var packetDescriptor))
                     {
                         HandleUnknownPacket(connection, type, stream2);
                     }
                     else
                     {
-                        var (classType, packetHandler) = tuple;
-                        var packet = (LoginPacket)Activator.CreateInstance(classType)!;
-                        packet.Connection = connection;
-                        packet.Decode(stream2);
-                        
                         try
                         {
-                            packetHandler.Execute(packet, connection);
+                            packetDescriptor.Dispatch(stream2, connection);
                         }
                         catch (Exception e)
                         {
-                            Logger.Error("Error on execute packet {0}", type);
-                            Logger.Error(e);
+                            Logger.Error(e, "Error on packet dispatch {0}", type);
                         }
                     }
                 }
@@ -148,17 +145,9 @@ public class LoginProtocolHandler(ILoginConnectionTable loginConnectionTable) : 
         }
         catch (Exception e)
         {
-            connection?.Shutdown();
+            connection.Shutdown();
             Logger.Error(e);
         }
-    }
-
-    public void RegisterPacket<TPacket>(uint type, ILoginPacketHandler<TPacket> packetHandler) where TPacket : LoginPacket
-    {
-        _packets.AddOrUpdate(type,
-            addValueFactory: static (_, arg) => arg,
-            updateValueFactory: static (_, _, arg) => arg,
-            factoryArgument: (typeof(TPacket), packetHandler));
     }
 
     private static void HandleUnknownPacket(LoginConnection connection, uint type, PacketStream stream)

--- a/AAEmu.Login/Core/PacketHandlers/ServiceCollectionExtensions.cs
+++ b/AAEmu.Login/Core/PacketHandlers/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using AAEmu.Login.Core.Network;
+﻿using AAEmu.Login.Core.Network.Internal;
 using AAEmu.Login.Core.Network.Login;
 using AAEmu.Login.Core.PacketHandlers.C2L;
 using AAEmu.Login.Core.PacketHandlers.G2L;
@@ -12,11 +12,12 @@ public static class ServiceCollectionExtensions
 {
     public static void AddInternalPacketHandlers(this IServiceCollection services)
     {
-        services.AddSingleton<IInternalPacketHandler<GLRegisterGameServerPacket>, GLRegisterGameServerPacketHandler>();
-        services.AddSingleton<IInternalPacketHandler<GLRequestInfoPacket>, GLRequestInfoPacketHandler>();
-        services.AddSingleton<IInternalPacketHandler<GLPlayerReconnectPacket>, GLPlayerReconnectPacketHandler>();
-        services.AddSingleton<IInternalPacketHandler<GLPlayerEnterPacket>, GLPlayerEnterPacketHandler>();
-        services.AddSingleton<IInternalPacketHandler<GLGameServerLoadPacket>, GLGameServerLoadPacketHandler>();
+        services
+            .AddInternalPacket<GLRegisterGameServerPacket, GLRegisterGameServerPacketHandler>()
+            .AddInternalPacket<GLRequestInfoPacket, GLRequestInfoPacketHandler>()
+            .AddInternalPacket<GLPlayerReconnectPacket, GLPlayerReconnectPacketHandler>()
+            .AddInternalPacket<GLPlayerEnterPacket, GLPlayerEnterPacketHandler>()
+            .AddInternalPacket<GLGameServerLoadPacket, GLGameServerLoadPacketHandler>();
     }
 
     public static void AddLoginPacketHandlers(this IServiceCollection services)
@@ -36,7 +37,7 @@ public static class ServiceCollectionExtensions
             .AddLoginPacket<CARequestAuthTrionPacket, CARequestAuthTrionPacketHandler>()
             .AddLoginPacket<CARequestReconnectPacket, CARequestReconnectPacketHandler>();
     }
-    
+
     private static IServiceCollection AddLoginPacket<TPacket, TPacketHandler>(
         this IServiceCollection services)
         where TPacket : LoginPacket, ILoginPacket, new()
@@ -47,6 +48,21 @@ public static class ServiceCollectionExtensions
         {
             var handler = sp.GetRequiredService<ILoginPacketHandler<TPacket>>();
             return new LoginPacketDescriptor<TPacket>(TPacket.TypeId, handler);
+        });
+
+        return services;
+    }
+
+    private static IServiceCollection AddInternalPacket<TPacket, TPacketHandler>(
+        this IServiceCollection services)
+        where TPacket : InternalPacket, IInternalPacket, new()
+        where TPacketHandler : class, IInternalPacketHandler<TPacket>
+    {
+        services.AddSingleton<IInternalPacketHandler<TPacket>, TPacketHandler>();
+        services.AddSingleton<IInternalPacketDescriptor>(sp =>
+        {
+            var handler = sp.GetRequiredService<IInternalPacketHandler<TPacket>>();
+            return new InternalPacketDescriptor<TPacket>(TPacket.TypeId, handler);
         });
 
         return services;

--- a/AAEmu.Login/Core/PacketHandlers/ServiceCollectionExtensions.cs
+++ b/AAEmu.Login/Core/PacketHandlers/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
-﻿using AAEmu.Login.Core.PacketHandlers.C2L;
+﻿using AAEmu.Login.Core.Network;
+using AAEmu.Login.Core.Network.Login;
+using AAEmu.Login.Core.PacketHandlers.C2L;
 using AAEmu.Login.Core.PacketHandlers.G2L;
 using AAEmu.Login.Core.Packets.C2L;
 using AAEmu.Login.Core.Packets.G2L;
@@ -16,21 +18,37 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IInternalPacketHandler<GLPlayerEnterPacket>, GLPlayerEnterPacketHandler>();
         services.AddSingleton<IInternalPacketHandler<GLGameServerLoadPacket>, GLGameServerLoadPacketHandler>();
     }
-    
+
     public static void AddLoginPacketHandlers(this IServiceCollection services)
     {
-        services.AddSingleton<ILoginPacketHandler<CACancelEnterWorldPacket>, CACancelEnterWorldPacketHandler>();
-        services.AddSingleton<ILoginPacketHandler<CAChallengeResponse2Packet>, CAChallengeResponse2PacketHandler>();
-        services.AddSingleton<ILoginPacketHandler<CAChallengeResponsePacket>, CAChallengeResponsePacketHandler>();
-        services.AddSingleton<ILoginPacketHandler<CAEnterWorldPacket>, CAEnterWorldPacketHandler>();
-        services.AddSingleton<ILoginPacketHandler<CAListWorldPacket>, CAListWorldPacketHandler>();
-        services.AddSingleton<ILoginPacketHandler<CAOtpNumberPacket>, CAOtpNumberPacketHandler>();
-        services.AddSingleton<ILoginPacketHandler<CAPcCertNumberPacket>, CAPcCertNumberPacketHandler>();
-        services.AddSingleton<ILoginPacketHandler<CARequestAuthGameOnPacket>, CARequestAuthGameOnPacketHandler>();
-        services.AddSingleton<ILoginPacketHandler<CARequestAuthMailRuPacket>, CARequestAuthMailRuPacketHandler>();
-        services.AddSingleton<ILoginPacketHandler<CARequestAuthPacket>, CARequestAuthPacketHandler>();
-        services.AddSingleton<ILoginPacketHandler<CARequestAuthTencentPacket>, CARequestAuthTencentPacketHandler>();
-        services.AddSingleton<ILoginPacketHandler<CARequestAuthTrionPacket>, CARequestAuthTrionPacketHandler>();
-        services.AddSingleton<ILoginPacketHandler<CARequestReconnectPacket>, CARequestReconnectPacketHandler>();
+        services
+            .AddLoginPacket<CACancelEnterWorldPacket, CACancelEnterWorldPacketHandler>()
+            .AddLoginPacket<CAChallengeResponse2Packet, CAChallengeResponse2PacketHandler>()
+            .AddLoginPacket<CAChallengeResponsePacket, CAChallengeResponsePacketHandler>()
+            .AddLoginPacket<CAEnterWorldPacket, CAEnterWorldPacketHandler>()
+            .AddLoginPacket<CAListWorldPacket, CAListWorldPacketHandler>()
+            .AddLoginPacket<CAOtpNumberPacket, CAOtpNumberPacketHandler>()
+            .AddLoginPacket<CAPcCertNumberPacket, CAPcCertNumberPacketHandler>()
+            .AddLoginPacket<CARequestAuthGameOnPacket, CARequestAuthGameOnPacketHandler>()
+            .AddLoginPacket<CARequestAuthMailRuPacket, CARequestAuthMailRuPacketHandler>()
+            .AddLoginPacket<CARequestAuthPacket, CARequestAuthPacketHandler>()
+            .AddLoginPacket<CARequestAuthTencentPacket, CARequestAuthTencentPacketHandler>()
+            .AddLoginPacket<CARequestAuthTrionPacket, CARequestAuthTrionPacketHandler>()
+            .AddLoginPacket<CARequestReconnectPacket, CARequestReconnectPacketHandler>();
+    }
+    
+    private static IServiceCollection AddLoginPacket<TPacket, TPacketHandler>(
+        this IServiceCollection services)
+        where TPacket : LoginPacket, ILoginPacket, new()
+        where TPacketHandler : class, ILoginPacketHandler<TPacket>
+    {
+        services.AddSingleton<ILoginPacketHandler<TPacket>, TPacketHandler>();
+        services.AddSingleton<ILoginPacketDescriptor>(sp =>
+        {
+            var handler = sp.GetRequiredService<ILoginPacketHandler<TPacket>>();
+            return new LoginPacketDescriptor<TPacket>(TPacket.TypeId, handler);
+        });
+
+        return services;
     }
 }

--- a/AAEmu.Login/Core/Packets/C2L/CACancelEnterWorldPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CACancelEnterWorldPacket.cs
@@ -3,8 +3,10 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CACancelEnterWorldPacket() : LoginPacket(CLOffsets.CACancelEnterWorldPacket)
+public class CACancelEnterWorldPacket() : LoginPacket(TypeId), ILoginPacket
 {
+    public new static ushort TypeId => CLOffsets.CACancelEnterWorldPacket;
+
     public byte WorldId { get; private set; }
     
     public override void Read(PacketStream stream)

--- a/AAEmu.Login/Core/Packets/C2L/CAChallengeResponse2Packet.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAChallengeResponse2Packet.cs
@@ -3,8 +3,10 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CAChallengeResponse2Packet() : LoginPacket(CLOffsets.CAChallengeResponse2Packet)
+public class CAChallengeResponse2Packet() : LoginPacket(TypeId), ILoginPacket
 {
+    public new static ushort TypeId => CLOffsets.CAChallengeResponse2Packet;
+    
     public override void Read(PacketStream stream)
     {
         for (var i = 0; i < 8; i++)

--- a/AAEmu.Login/Core/Packets/C2L/CAChallengeResponsePacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAChallengeResponsePacket.cs
@@ -3,8 +3,10 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CAChallengeResponsePacket() : LoginPacket(CLOffsets.CAChallengeResponsePacket)
+public class CAChallengeResponsePacket() : LoginPacket(TypeId), ILoginPacket
 {
+    public new static ushort TypeId => CLOffsets.CAChallengeResponsePacket;
+    
     public override void Read(PacketStream stream)
     {
         for (var i = 0; i < 4; i++)

--- a/AAEmu.Login/Core/Packets/C2L/CAEnterWorldPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAEnterWorldPacket.cs
@@ -4,8 +4,10 @@ using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CAEnterWorldPacket() : LoginPacket(CLOffsets.CAEnterWorldPacket)
+public class CAEnterWorldPacket() : LoginPacket(TypeId), ILoginPacket
 {
+    public new static ushort TypeId => CLOffsets.CAEnterWorldPacket;
+    
     public ulong Flag { get; private set; }
     public GameServerId GsId { get; private set; }
 

--- a/AAEmu.Login/Core/Packets/C2L/CAListWorldPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAListWorldPacket.cs
@@ -3,8 +3,10 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CAListWorldPacket() : LoginPacket(CLOffsets.CAListWorldPacket)
+public class CAListWorldPacket() : LoginPacket(TypeId), ILoginPacket
 {
+    public new static ushort TypeId => CLOffsets.CAListWorldPacket;
+    
     public ulong Flag { get; private set; }
     
     public override void Read(PacketStream stream)

--- a/AAEmu.Login/Core/Packets/C2L/CAOtpNumberPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAOtpNumberPacket.cs
@@ -3,8 +3,10 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CAOtpNumberPacket() : LoginPacket(CLOffsets.CAOtpNumberPacket)
+public class CAOtpNumberPacket() : LoginPacket(TypeId), ILoginPacket
 {
+    public new static ushort TypeId => CLOffsets.CAOtpNumberPacket;
+    
     public override void Read(PacketStream stream)
     {
         var num = stream.ReadString(); // TODO but on old client length const 8

--- a/AAEmu.Login/Core/Packets/C2L/CAPcCertNumberPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAPcCertNumberPacket.cs
@@ -3,8 +3,10 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CAPcCertNumberPacket() : LoginPacket(CLOffsets.CAPcCertNumberPacket)
+public class CAPcCertNumberPacket() : LoginPacket(TypeId), ILoginPacket
 {
+    public new static ushort TypeId => CLOffsets.CAPcCertNumberPacket;
+    
     public override void Read(PacketStream stream)
     {
         var num = stream.ReadString(); // TODO but on old client length const 8

--- a/AAEmu.Login/Core/Packets/C2L/CARequestAuthGameOnPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CARequestAuthGameOnPacket.cs
@@ -3,8 +3,10 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CARequestAuthGameOnPacket() : LoginPacket(CLOffsets.CARequestAuthGameOnPacket)
+public class CARequestAuthGameOnPacket() : LoginPacket(TypeId), ILoginPacket
 {
+    public new static ushort TypeId => CLOffsets.CARequestAuthGameOnPacket;
+    
     public override void Read(PacketStream stream)
     {
         var pFrom = stream.ReadUInt32();

--- a/AAEmu.Login/Core/Packets/C2L/CARequestAuthMailRuPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CARequestAuthMailRuPacket.cs
@@ -3,8 +3,10 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CARequestAuthMailRuPacket() : LoginPacket(CLOffsets.CARequestAuthMailRuPacket)
+public class CARequestAuthMailRuPacket() : LoginPacket(TypeId), ILoginPacket
 {
+    public new static ushort TypeId => CLOffsets.CARequestAuthMailRuPacket;
+    
     public string? Id { get; private set; }
     public byte[]? Token { get; private set; }
 

--- a/AAEmu.Login/Core/Packets/C2L/CARequestAuthPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CARequestAuthPacket.cs
@@ -3,8 +3,10 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CARequestAuthPacket() : LoginPacket(CLOffsets.CARequestAuthPacket)
+public class CARequestAuthPacket() : LoginPacket(TypeId), ILoginPacket
 {
+    public new static ushort TypeId => CLOffsets.CARequestAuthPacket;
+    
     public string? Account { get; private set; }
 
     public override void Read(PacketStream stream)

--- a/AAEmu.Login/Core/Packets/C2L/CARequestAuthTencentPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CARequestAuthTencentPacket.cs
@@ -3,8 +3,10 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CARequestAuthTencentPacket() : LoginPacket(CLOffsets.CARequestAuthTencentPacket)
+public class CARequestAuthTencentPacket() : LoginPacket(TypeId), ILoginPacket
 {
+    public new static ushort TypeId => CLOffsets.CARequestAuthTencentPacket;
+    
     public override void Read(PacketStream stream)
     {
         var pFrom = stream.ReadUInt32();
@@ -15,6 +17,5 @@ public class CARequestAuthTencentPacket() : LoginPacket(CLOffsets.CARequestAuthT
         var sig = stream.ReadBytes(128); // length 128 or len?
         var key = stream.ReadBytes(16); // length 16
         var mac = stream.ReadBytes(8);
-
     }
 }

--- a/AAEmu.Login/Core/Packets/C2L/CARequestAuthTrionPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CARequestAuthTrionPacket.cs
@@ -4,8 +4,10 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CARequestAuthTrionPacket() : LoginPacket(CLOffsets.CARequestAuthTrionPacket)
+public class CARequestAuthTrionPacket() : LoginPacket(TypeId), ILoginPacket
 {
+    public new static ushort TypeId => CLOffsets.CARequestAuthTrionPacket;
+    
     public string? Username { get; private set; }
     public string? Password { get; private set; }
 

--- a/AAEmu.Login/Core/Packets/C2L/CARequestReconnectPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CARequestReconnectPacket.cs
@@ -4,8 +4,10 @@ using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
-public class CARequestReconnectPacket() : LoginPacket(CLOffsets.CARequestReconnectPacket)
+public class CARequestReconnectPacket() : LoginPacket(TypeId), ILoginPacket
 {
+    public new static ushort TypeId => CLOffsets.CARequestReconnectPacket;
+    
     public GameServerId GsId { get; private set; }
     public AccountId AccountId { get; private set; }
     public uint Cookie { get; private set; }

--- a/AAEmu.Login/Core/Packets/G2L/GLGameServerLoadPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLGameServerLoadPacket.cs
@@ -4,8 +4,10 @@ using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Packets.G2L;
 
-public class GLGameServerLoadPacket() : InternalPacket(GLOffsets.GLGameServerLoadPacket)
+public class GLGameServerLoadPacket() : InternalPacket(TypeId), IInternalPacket
 {
+    public new static ushort TypeId => GLOffsets.GLGameServerLoadPacket;
+    
     public GSLoad Load { get; private set; }
 
     public override void Read(PacketStream stream)

--- a/AAEmu.Login/Core/Packets/G2L/GLPlayerEnterPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLPlayerEnterPacket.cs
@@ -4,8 +4,10 @@ using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Packets.G2L;
 
-public class GLPlayerEnterPacket() : InternalPacket(GLOffsets.GLPlayerEnterPacket)
+public class GLPlayerEnterPacket() : InternalPacket(TypeId), IInternalPacket
 {
+    public new static ushort TypeId => GLOffsets.GLPlayerEnterPacket;
+    
     public ConnectionId ConnectionId { get; private set; }
     public GameServerId GsId { get; private set; }
     public byte Result { get; private set; }

--- a/AAEmu.Login/Core/Packets/G2L/GLPlayerReconnectPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLPlayerReconnectPacket.cs
@@ -4,8 +4,10 @@ using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Packets.G2L;
 
-public class GLPlayerReconnectPacket() : InternalPacket(GLOffsets.GLPlayerReconnectPacket)
+public class GLPlayerReconnectPacket() : InternalPacket(TypeId), IInternalPacket
 {
+    public new static ushort TypeId => GLOffsets.GLPlayerReconnectPacket;
+    
     public GameServerId GsId { get; private set; }
     public AccountId AccountId { get; private set; }
     public uint Token { get; private set; }

--- a/AAEmu.Login/Core/Packets/G2L/GLRegisterGameServerPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLRegisterGameServerPacket.cs
@@ -4,8 +4,10 @@ using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Packets.G2L;
 
-public class GLRegisterGameServerPacket() : InternalPacket(GLOffsets.GLRegisterGameServerPacket)
+public class GLRegisterGameServerPacket() : InternalPacket(TypeId), IInternalPacket
 {
+    public new static ushort TypeId => GLOffsets.GLRegisterGameServerPacket;
+    
     public string? SecretKey { get; private set; }
     public GameServerId GsId { get; private set; }
     public List<GameServerId>? Mirrors { get; private set; }

--- a/AAEmu.Login/Core/Packets/G2L/GLRequestInfoPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLRequestInfoPacket.cs
@@ -5,8 +5,10 @@ using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Packets.G2L;
 
-public class GLRequestInfoPacket() : InternalPacket(GLOffsets.GLRequestInfoPacket)
+public class GLRequestInfoPacket() : InternalPacket(TypeId), IInternalPacket
 {
+    public new static ushort TypeId => GLOffsets.GLRequestInfoPacket;
+    
     public ConnectionId ConnectionId { get; private set; }
     public uint RequestId { get; private set; }
     public List<LoginCharacterInfo>? Characters { get; private set; }


### PR DESCRIPTION
Register login server packets via DI.

The `LoginPacketDescriptor` and `InternalPacketDescriptor` types remove the need for a cast from `LoginPacket`/`InternalPacket` to the specific packet type accepted by the handler, ensuring static type safety.