### PR TITLE
[Game] Fixes some buff tick related things

### DIFF
--- a/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
+++ b/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
@@ -252,42 +252,25 @@ public class BuffTemplate
             return;
         }
 
-        var mateList = caster.ParentWorld?.MateManager.GetActiveMates(owner.Id) ?? owner.ParentWorld.MateManager.GetActiveMates(owner.Id);
-        // TODO: Rider spot only?
-        foreach (var mate in mateList)
+        foreach (var tickEff in TickEffects)
         {
-            foreach (var tickEff in TickEffects)
+            if (tickEff.TargetBuffTagId > 0 &&
+                !owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId(tickEff.TargetBuffTagId)))
+                continue;
+            if (tickEff.TargetNoBuffTagId > 0 &&
+                owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId(tickEff.TargetNoBuffTagId)))
+                continue;
+
+            var eff = SkillManager.Instance.GetEffectTemplate(tickEff.EffectId);
+            if (eff == null)
             {
-                if (caster is Character character && character.IsRiding)
-                {
-                    if (tickEff.TargetBuffTagId > 0 &&
-                        !mate.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId(tickEff.TargetBuffTagId)))
-                        return;
-                    if (tickEff.TargetNoBuffTagId > 0 &&
-                        mate.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId(tickEff.TargetNoBuffTagId)))
-                        return;
-                }
-                else
-                {
-                    if (tickEff.TargetBuffTagId > 0 &&
-                        !owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId(tickEff.TargetBuffTagId)))
-                        return;
-                    if (tickEff.TargetNoBuffTagId > 0 &&
-                        owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId(tickEff.TargetNoBuffTagId)))
-                        return;
-                }
-
-                var eff = SkillManager.Instance.GetEffectTemplate(tickEff.EffectId);
-                if (eff == null)
-                {
-                    return;
-                }
-
-                var targetObj = new SkillCastUnitTarget(owner.ObjId);
-                var skillObj = new SkillObject(); // TODO ?
-                eff.Apply(caster, buff.SkillCaster, owner, targetObj, new CastBuff(buff), new EffectSource(this),
-                    skillObj, DateTime.UtcNow);
+                continue;
             }
+
+            var targetObj = new SkillCastUnitTarget(owner.ObjId);
+            var skillObj = new SkillObject(); // TODO ?
+            eff.Apply(caster, buff.SkillCaster, owner, targetObj, new CastBuff(buff), new EffectSource(this), skillObj,
+                DateTime.UtcNow);
         }
     }
 


### PR DESCRIPTION
- Removed the mount-specific checks as they don't seem to be needed anymore.
- Added regular tick effects on buff owner which seems to be working correctly. `skillObj` probably still needs to be generated correctly here for some edge-cases.
