### PR TITLE
[Game] Fix #1310 Cleanly shutting the server down incorrectly deletes placed doodads.

### DIFF
--- a/AAEmu.Game/Core/Managers/World/SpawnManager.cs
+++ b/AAEmu.Game/Core/Managers/World/SpawnManager.cs
@@ -207,6 +207,7 @@ public class SpawnManager(WorldInstance parentWorld)
                 }
                 else
                 {
+                    doodad.IsPersistent = false; // Don't force additional deletes by detaching the doodad from the save system
                     doodad.Delete();
                 }
 

--- a/AAEmu.Game/Models/Game/DoodadObj/DoodadCoffer.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/DoodadCoffer.cs
@@ -25,7 +25,8 @@ public class DoodadCoffer : Doodad
 
     public override void Delete()
     {
-        ItemContainer?.Delete();
+        if (IsPersistent)
+            ItemContainer?.Delete();
         base.Delete();
     }
 


### PR DESCRIPTION
Fixes #1310 
- Fixed code in `DeSpawnAll` to detached doodads from the save manager so they don't get deleted on a shutdown.
- Added additional code to `DoodadCoffer` to prevent items from being deleted on shutdown.
