### PR TITLE
Fixed normalizedRate calculation

### DIFF
--- a/AAEmu.Game/Models/Game/Items/Loots/LootPack.cs
+++ b/AAEmu.Game/Models/Game/Items/Loots/LootPack.cs
@@ -259,7 +259,7 @@ public class LootPack
                                     continue;
                                 }
                             }
-                            normalizedRate += loot.AlwaysDrop ? loot.DropRate : 10_000_000;
+                            normalizedRate += loot.AlwaysDrop ? 10_000_000 : loot.DropRate;
                             if (!tmpSelectedItemsByGroup.ContainsKey(groupNo))
                                 tmpSelectedItemsByGroup.Add(groupNo, []);
                             tmpSelectedItemsByGroup[groupNo].Add(loot);


### PR DESCRIPTION
Loot normalizedRate was being increased by 10_000_000 per item within the group not set to always drop, rather than by the drop_rate for that item. This caused decreased item drops from loot packs.