### PR TITLE
[Game] Fix sys-dungeon entry count check

### DIFF
--- a/AAEmu.Game/Core/Managers/IndunManager.cs
+++ b/AAEmu.Game/Core/Managers/IndunManager.cs
@@ -12,23 +12,19 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
+// ReSharper disable once ClassNeverInstantiated.Global
 public class IndunManager : Singleton<IndunManager>
 {
-    private static Logger Logger = LogManager.GetCurrentClassLogger();
+    // ReSharper disable once InconsistentNaming
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-    private Dictionary<uint, Dictionary<uint, int>> _attempts; // <ownerId, <zoneGroupId, attempts>> - использовано попыток прохождения данжона
-    private const int FreeAttempts = 3;  // свободных попыток
-    // Unused private const int ExtraAttempts = 2; // дополнительных попыток
-    private Dictionary<uint, Dictionary<uint, bool>> _waitingDungeonAccessAttemptsCleared; // <ownerId, <zoneGroupId, waiting>>, откат 4 часа, + еще 4 часа, если израсходовали дополнительные попытки
-
+    private Dictionary<uint, Dictionary<uint, List<DateTime>>> EntryHistory { get; } = []; // <ownerId, <zoneGroupId, entry time>> - dungeon attempts used
     // ReSharper disable once ChangeFieldTypeToSystemThreadingLock
     private readonly object _lock = new();
 
     public void Initialize()
     {
-        TickManager.Instance.OnTick.Subscribe(IndunInfoTick, TimeSpan.FromSeconds(10), true);
-        _attempts ??= [];
-        _waitingDungeonAccessAttemptsCleared ??= [];
+        TickManager.Instance.OnTick.Subscribe(IndunInfoTick, TimeSpan.FromSeconds(30), true);
     }
 
     private void IndunInfoTick(TimeSpan delta)
@@ -100,7 +96,6 @@ public class IndunManager : Singleton<IndunManager>
     public bool RequestSystemInstance(Character character, uint zoneId, uint channelId, out Dungeon dungeon)
     {
         dungeon = null;
-        // TODO ZoneId=183 - Arche mall
         if (character == null)
         {
             Logger.Info("[IndunManager] Player offline.");
@@ -179,7 +174,7 @@ public class IndunManager : Singleton<IndunManager>
             return false;
         }
 
-        // 1 - Check if player is already a member of a active dungeon in this zone and re-enter it if they are
+        // 1 - Check if player is already a member of an active dungeon in this zone and re-enter it if they are
         var possibleTargetInstances = GetExistingDungeonsByZoneKey(targetZone.ZoneKey);
         foreach (var possibleTargetInstance in possibleTargetInstances)
         {
@@ -309,9 +304,9 @@ public class IndunManager : Singleton<IndunManager>
     private bool VerifyDungeonEnterRequirements(IndunZone dungeonZone, Character character, Team team)
     {
         // Check access count
-        if (GetWaitingDungeonAccess(character.Id, dungeonZone.ZoneGroupId))
+        if (!CheckEntryAttemptCount(character.Id, dungeonZone.ZoneGroupId, dungeonZone, false))
         {
-            Logger.Warn($"Requesting instance too many daily entries, characterId: {character.Id}, zoneGroupId: {dungeonZone.ZoneGroupId}");
+            
             character.SendErrorMessage(ErrorMessageType.InstanceVisitLimit);
             return false;
         }
@@ -532,143 +527,39 @@ public class IndunManager : Singleton<IndunManager>
         }
     }
 
-    public void ClearAttemts(Dungeon dungeon)
+    public bool CheckEntryAttemptCount(uint characterId, uint zoneGroupId, IndunZone indunZone, bool addAsNewEnty)
     {
         lock (_lock)
         {
-            var characterId = dungeon.IsTeamOwned ? dungeon.GetOwnerTeam.OwnerId : dungeon.GetCharacterOwner?.Id ?? 0;
-            var zoneGroupId = dungeon.GetZoneGroupId;
-            if (_waitingDungeonAccessAttemptsCleared.TryGetValue(characterId, out var waitingDungeonAccess))
+            if (!EntryHistory.ContainsKey(characterId))
+                EntryHistory.Add(characterId, []);
+
+            var zoneAndEntries = EntryHistory.GetValueOrDefault(characterId);
+
+            if (!zoneAndEntries.ContainsKey(zoneGroupId))
+                zoneAndEntries.Add(zoneGroupId, []);
+
+            var entriesList = zoneAndEntries.GetValueOrDefault(zoneGroupId);
+
+            // Can customize this to your start of the day to make this daily entry count
+            var thresholdTime = DateTime.UtcNow.AddHours(-4);
+            var lastEntriesQuery = entriesList.Where(x => x >= thresholdTime).ToList();
+
+            if (lastEntriesQuery.Count >= indunZone.EnterCount)
             {
-                waitingDungeonAccess.Remove(zoneGroupId);
-            }
-        }
-    }
-
-    internal bool GetWaitingDungeonAccess(Dungeon dungeon)
-    {
-        lock (_lock)
-        {
-            var characterId = dungeon.IsTeamOwned ? dungeon.GetOwnerTeam.OwnerId : dungeon.GetCharacterOwner?.Id ?? 0;
-            var zoneGroupId = dungeon.GetZoneGroupId;
-
-            if (_waitingDungeonAccessAttemptsCleared.TryGetValue(characterId, out var waitingDungeonAccess))
-            {
-                if (waitingDungeonAccess.TryGetValue(zoneGroupId, out var wda))
-                {
-                    return wda;
-                }
-            }
-        }
-
-        return false;
-    }
-    internal bool GetWaitingDungeonAccess(uint characterId, uint zoneGroupId)
-    {
-        lock (_lock)
-        {
-            if (_waitingDungeonAccessAttemptsCleared.TryGetValue(characterId, out var waitingDungeonAccess))
-            {
-                if (waitingDungeonAccess.TryGetValue(zoneGroupId, out var wda))
-                {
-                    return wda;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    internal void SetWaitingDungeonAccess(uint characterId, uint zoneGroupId, bool value)
-    {
-        lock (_lock)
-        {
-            if (_waitingDungeonAccessAttemptsCleared.TryGetValue(characterId, out var waitingDungeonAccess))
-            {
-                if (waitingDungeonAccess.TryGetValue(zoneGroupId, out _))
-                {
-                    waitingDungeonAccess[zoneGroupId] = value;
-                }
-                else
-                {
-                    var w = new Dictionary<uint, bool>();
-                    w.TryAdd(zoneGroupId, value);
-                    _waitingDungeonAccessAttemptsCleared.TryAdd(characterId, w);
-                }
-            }
-        }
-    }
-    internal void SetWaitingDungeonAccess(Dungeon dungeon, bool value)
-    {
-        lock (_lock)
-        {
-            var characterId = dungeon.IsTeamOwned ? dungeon.GetOwnerTeam.OwnerId : dungeon.GetCharacterOwner?.Id ?? 0;
-            var zoneGroupId = dungeon.GetZoneGroupId;
-
-            if (_waitingDungeonAccessAttemptsCleared.TryGetValue(characterId, out var waitingDungeonAccess))
-            {
-                if (waitingDungeonAccess.TryGetValue(zoneGroupId, out _))
-                {
-                    waitingDungeonAccess[zoneGroupId] = value;
-                }
-                else
-                {
-                    var w = new Dictionary<uint, bool>();
-                    w.TryAdd(zoneGroupId, value);
-                    _waitingDungeonAccessAttemptsCleared.TryAdd(characterId, w);
-                }
-            }
-        }
-    }
-
-    public bool CheckingAttempt(Dungeon dungeon)
-    {
-        lock (_lock)
-        {
-            var res = false;
-            var characterId = dungeon.IsTeamOwned ? dungeon.GetOwnerTeam.OwnerId : dungeon.GetCharacterOwner?.Id ?? 0;
-            var zoneGroupId = dungeon.GetZoneGroupId;
-
-            if (GetWaitingDungeonAccess(dungeon))
-            {
+                // Max entries reached
+                Logger.Warn($"Requesting instance too many daily entries ({lastEntriesQuery.Count} / {indunZone.EnterCount}), characterId: {characterId}, zoneGroupId: {zoneGroupId}");
                 return false;
             }
 
-            if (_attempts.TryGetValue(characterId, out var cd))
+            // Add current entry attempt if requested
+            if (addAsNewEnty)
             {
-                if (cd.TryGetValue(zoneGroupId, out _))
-                {
-                    if (cd[zoneGroupId] >= FreeAttempts)
-                    {
-                        TickManager.Instance.OnTick.Subscribe(dungeon.WaitingDungeonAccessAttemptsCleared, TimeSpan.FromHours(4), true);
-                    }
-                    else
-                    {
-                        res = true;
-                        cd[zoneGroupId]++;
-                    }
-                }
-                else
-                {
-                    res = true;
-                    cd = [];
-                    cd.TryAdd(zoneGroupId, 1);
-                    _attempts.TryAdd(characterId, cd);
-
-                    SetWaitingDungeonAccess(characterId, zoneGroupId, false);
-                }
-            }
-            else
-            {
-                res = true;
-                cd = [];
-                cd.TryAdd(zoneGroupId, 1);
-                _attempts.TryAdd(characterId, cd);
-
-                SetWaitingDungeonAccess(characterId, zoneGroupId, false);
+                entriesList.Add(DateTime.UtcNow);
+                Logger.Warn($"Added entry for player {characterId} in zone {zoneGroupId}, Count is now {entriesList.Count}");
             }
 
-            return res; // true - еще можно сходить в данжон, false - израсходовали свободные попытки, израсходовали дополнительные попытки
+            return true; // true - you could also go to the dungeon, false - used up free attempts, used up extra attempts
         }
     }
 
@@ -676,17 +567,13 @@ public class IndunManager : Singleton<IndunManager>
     {
         lock (_lock)
         {
-            if (_attempts is { Count: > 0 })
+            if (EntryHistory is { Count: > 0 })
             {
-                foreach (var attempt in _attempts)
+                foreach (var (characterId, zoneAndEntries) in EntryHistory)
                 {
-                    _attempts.TryGetValue(attempt.Key, out var cds);
-                    if (cds != null)
+                    foreach (var (zoneGroupId, entriesList) in zoneAndEntries)
                     {
-                        foreach (var cd in cds)
-                        {
-                            Logger.Debug($"For player={attempt.Key}: {cd.Value} attempts in dungeon attemptId={cd.Key}");
-                        }
+                        Logger.Debug($"For player={characterId} ({WorldManager.Instance.GetCharacterById(characterId)?.Name}): {entriesList.Count} entries into dungeon zone group {zoneGroupId} ({ZoneManager.Instance.GetZoneGroupById(zoneGroupId)?.Name})");
                     }
                 }
             }

--- a/AAEmu.Game/GameData/IndunGameData.cs
+++ b/AAEmu.Game/GameData/IndunGameData.cs
@@ -1,4 +1,5 @@
 ﻿using AAEmu.Commons.Utils;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.GameData.Framework;
 using AAEmu.Game.Models.Game.Indun;
 using AAEmu.Game.Models.Game.Indun.Actions;
@@ -10,6 +11,7 @@ using Microsoft.Data.Sqlite;
 namespace AAEmu.Game.GameData;
 
 [GameData]
+// ReSharper disable once ClassNeverInstantiated.Global
 public class IndunGameData : Singleton<IndunGameData>, IGameDataLoader
 {
     private Dictionary<uint, IndunAction> _indunActions;
@@ -81,13 +83,15 @@ public class IndunGameData : Singleton<IndunGameData>, IGameDataLoader
             {
                 while (reader.Read())
                 {
-                    var action = new IndunActionChangeDoodadPhases();
-                    action.Id = reader.GetUInt32("id");
-                    action.DetailId = reader.GetUInt32("detail_id");
-                    action.ZoneGroupId = reader.GetUInt16("zone_group_id");
-                    action.NextActionId = reader.GetUInt32("next_action_id", 0);
-                    action.DoodadAlmightyId = reader.GetUInt32("doodad_almighty_id");
-                    action.DoodadFuncGroupId = reader.GetUInt32("doodad_func_group_id");
+                    var action = new IndunActionChangeDoodadPhases
+                    {
+                        Id = reader.GetUInt32("id"),
+                        DetailId = reader.GetUInt32("detail_id"),
+                        ZoneGroupId = reader.GetUInt16("zone_group_id"),
+                        NextActionId = reader.GetUInt32("next_action_id", 0),
+                        DoodadAlmightyId = reader.GetUInt32("doodad_almighty_id"),
+                        DoodadFuncGroupId = reader.GetUInt32("doodad_func_group_id")
+                    };
 
                     _indunActions.Add(action.Id, action);
                 }
@@ -105,12 +109,14 @@ public class IndunGameData : Singleton<IndunGameData>, IGameDataLoader
             {
                 while (reader.Read())
                 {
-                    var action = new IndunActionRemoveTaggedNpcs();
-                    action.Id = reader.GetUInt32("id");
-                    action.DetailId = reader.GetUInt32("detail_id");
-                    action.ZoneGroupId = reader.GetUInt16("zone_group_id");
-                    action.NextActionId = reader.GetUInt32("next_action_id", 0);
-                    action.TagId = reader.GetUInt32("tag_id");
+                    var action = new IndunActionRemoveTaggedNpcs
+                    {
+                        Id = reader.GetUInt32("id"),
+                        DetailId = reader.GetUInt32("detail_id"),
+                        ZoneGroupId = reader.GetUInt16("zone_group_id"),
+                        NextActionId = reader.GetUInt32("next_action_id", 0),
+                        TagId = reader.GetUInt32("tag_id")
+                    };
 
                     _indunActions.Add(action.Id, action);
                 }
@@ -128,12 +134,14 @@ public class IndunGameData : Singleton<IndunGameData>, IGameDataLoader
             {
                 while (reader.Read())
                 {
-                    var action = new IndunActionSetRoomCleareds();
-                    action.Id = reader.GetUInt32("id");
-                    action.DetailId = reader.GetUInt32("detail_id");
-                    action.ZoneGroupId = reader.GetUInt16("zone_group_id");
-                    action.NextActionId = reader.GetUInt32("next_action_id", 0);
-                    action.IndunRoomId = reader.GetUInt32("indun_room_id");
+                    var action = new IndunActionSetRoomCleareds
+                    {
+                        Id = reader.GetUInt32("id"),
+                        DetailId = reader.GetUInt32("detail_id"),
+                        ZoneGroupId = reader.GetUInt16("zone_group_id"),
+                        NextActionId = reader.GetUInt32("next_action_id", 0),
+                        IndunRoomId = reader.GetUInt32("indun_room_id")
+                    };
 
                     _indunActions.Add(action.Id, action);
                 }
@@ -149,11 +157,13 @@ public class IndunGameData : Singleton<IndunGameData>, IGameDataLoader
             {
                 while (reader.Read())
                 {
-                    var action = new IndunActionNpcSpawner();
-                    action.Id = reader.GetUInt32("id");
-                    action.DetailId = reader.GetUInt32("detail_id");
-                    action.ZoneGroupId = reader.GetUInt16("zone_group_id");
-                    action.NextActionId = reader.GetUInt32("next_action_id", 0);
+                    var action = new IndunActionNpcSpawner
+                    {
+                        Id = reader.GetUInt32("id"),
+                        DetailId = reader.GetUInt32("detail_id"),
+                        ZoneGroupId = reader.GetUInt16("zone_group_id"),
+                        NextActionId = reader.GetUInt32("next_action_id", 0)
+                    };
 
                     _indunActions.Add(action.Id, action);
                 }
@@ -173,13 +183,15 @@ public class IndunGameData : Singleton<IndunGameData>, IGameDataLoader
             {
                 while (reader.Read())
                 {
-                    var indunEvent = new IndunEventDoodadSpawneds();
-                    indunEvent.Id = reader.GetUInt32("id");
-                    indunEvent.ConditionId = reader.GetUInt32("condition_id");
-                    indunEvent.ZoneGroupId = reader.GetUInt16("zone_group_id");
-                    indunEvent.StartActionId = reader.GetUInt32("start_action_id");
-                    indunEvent.DoodadAlmightyId = reader.GetUInt32("doodad_almighty_id");
-                    indunEvent.DoodadFuncGroupId = reader.GetUInt32("doodad_func_group_id");
+                    var indunEvent = new IndunEventDoodadSpawneds
+                    {
+                        Id = reader.GetUInt32("id"),
+                        ConditionId = reader.GetUInt32("condition_id"),
+                        ZoneGroupId = reader.GetUInt16("zone_group_id"),
+                        StartActionId = reader.GetUInt32("start_action_id"),
+                        DoodadAlmightyId = reader.GetUInt32("doodad_almighty_id"),
+                        DoodadFuncGroupId = reader.GetUInt32("doodad_func_group_id")
+                    };
 
                     if (!_indunEvents.ContainsKey(indunEvent.ZoneGroupId))
                         _indunEvents.Add(indunEvent.ZoneGroupId, []);
@@ -200,12 +212,14 @@ public class IndunGameData : Singleton<IndunGameData>, IGameDataLoader
             {
                 while (reader.Read())
                 {
-                    var indunEvent = new IndunEventNoAliveChInRooms();
-                    indunEvent.Id = reader.GetUInt32("id");
-                    indunEvent.ConditionId = reader.GetUInt32("condition_id");
-                    indunEvent.ZoneGroupId = reader.GetUInt16("zone_group_id");
-                    indunEvent.StartActionId = reader.GetUInt32("start_action_id");
-                    indunEvent.RoomId = reader.GetUInt32("room_id");
+                    var indunEvent = new IndunEventNoAliveChInRooms
+                    {
+                        Id = reader.GetUInt32("id"),
+                        ConditionId = reader.GetUInt32("condition_id"),
+                        ZoneGroupId = reader.GetUInt16("zone_group_id"),
+                        StartActionId = reader.GetUInt32("start_action_id"),
+                        RoomId = reader.GetUInt32("room_id")
+                    };
 
                     if (!_indunEvents.ContainsKey(indunEvent.ZoneGroupId))
                         _indunEvents.Add(indunEvent.ZoneGroupId, []);
@@ -226,12 +240,14 @@ public class IndunGameData : Singleton<IndunGameData>, IGameDataLoader
             {
                 while (reader.Read())
                 {
-                    var indunEvent = new IndunEventNpcCombatEndeds();
-                    indunEvent.Id = reader.GetUInt32("id");
-                    indunEvent.ConditionId = reader.GetUInt32("condition_id");
-                    indunEvent.ZoneGroupId = reader.GetUInt16("zone_group_id");
-                    indunEvent.StartActionId = reader.GetUInt32("start_action_id");
-                    indunEvent.NpcId = reader.GetUInt32("npc_id");
+                    var indunEvent = new IndunEventNpcCombatEndeds
+                    {
+                        Id = reader.GetUInt32("id"),
+                        ConditionId = reader.GetUInt32("condition_id"),
+                        ZoneGroupId = reader.GetUInt16("zone_group_id"),
+                        StartActionId = reader.GetUInt32("start_action_id"),
+                        NpcId = reader.GetUInt32("npc_id")
+                    };
 
                     if (!_indunEvents.ContainsKey(indunEvent.ZoneGroupId))
                         _indunEvents.Add(indunEvent.ZoneGroupId, []);
@@ -252,12 +268,14 @@ public class IndunGameData : Singleton<IndunGameData>, IGameDataLoader
             {
                 while (reader.Read())
                 {
-                    var indunEvent = new IndunEventNpcCombatStarteds();
-                    indunEvent.Id = reader.GetUInt32("id");
-                    indunEvent.ConditionId = reader.GetUInt32("condition_id");
-                    indunEvent.ZoneGroupId = reader.GetUInt16("zone_group_id");
-                    indunEvent.StartActionId = reader.GetUInt32("start_action_id");
-                    indunEvent.NpcId = reader.GetUInt32("npc_id");
+                    var indunEvent = new IndunEventNpcCombatStarteds
+                    {
+                        Id = reader.GetUInt32("id"),
+                        ConditionId = reader.GetUInt32("condition_id"),
+                        ZoneGroupId = reader.GetUInt16("zone_group_id"),
+                        StartActionId = reader.GetUInt32("start_action_id"),
+                        NpcId = reader.GetUInt32("npc_id")
+                    };
 
                     if (!_indunEvents.ContainsKey(indunEvent.ZoneGroupId))
                         _indunEvents.Add(indunEvent.ZoneGroupId, []);
@@ -278,12 +296,14 @@ public class IndunGameData : Singleton<IndunGameData>, IGameDataLoader
             {
                 while (reader.Read())
                 {
-                    var indunEvent = new IndunEventNpcKilleds();
-                    indunEvent.Id = reader.GetUInt32("id");
-                    indunEvent.ConditionId = reader.GetUInt32("condition_id");
-                    indunEvent.ZoneGroupId = reader.GetUInt16("zone_group_id");
-                    indunEvent.StartActionId = reader.GetUInt32("start_action_id");
-                    indunEvent.NpcId = reader.GetUInt32("npc_id");
+                    var indunEvent = new IndunEventNpcKilleds
+                    {
+                        Id = reader.GetUInt32("id"),
+                        ConditionId = reader.GetUInt32("condition_id"),
+                        ZoneGroupId = reader.GetUInt16("zone_group_id"),
+                        StartActionId = reader.GetUInt32("start_action_id"),
+                        NpcId = reader.GetUInt32("npc_id")
+                    };
 
                     if (!_indunEvents.ContainsKey(indunEvent.ZoneGroupId))
                         _indunEvents.Add(indunEvent.ZoneGroupId, []);
@@ -304,12 +324,14 @@ public class IndunGameData : Singleton<IndunGameData>, IGameDataLoader
             {
                 while (reader.Read())
                 {
-                    var indunEvent = new IndunEventNpcSpawneds();
-                    indunEvent.Id = reader.GetUInt32("id");
-                    indunEvent.ConditionId = reader.GetUInt32("condition_id");
-                    indunEvent.ZoneGroupId = reader.GetUInt16("zone_group_id");
-                    indunEvent.StartActionId = reader.GetUInt32("start_action_id");
-                    indunEvent.NpcId = reader.GetUInt32("npc_id");
+                    var indunEvent = new IndunEventNpcSpawneds
+                    {
+                        Id = reader.GetUInt32("id"),
+                        ConditionId = reader.GetUInt32("condition_id"),
+                        ZoneGroupId = reader.GetUInt16("zone_group_id"),
+                        StartActionId = reader.GetUInt32("start_action_id"),
+                        NpcId = reader.GetUInt32("npc_id")
+                    };
 
                     if (!_indunEvents.ContainsKey(indunEvent.ZoneGroupId))
                         _indunEvents.Add(indunEvent.ZoneGroupId, []);
@@ -335,6 +357,9 @@ public class IndunGameData : Singleton<IndunGameData>, IGameDataLoader
                     var indunZone = new IndunZone
                     {
                         ZoneGroupId = reader.GetUInt32("zone_group_id"),
+                        // EnterCount = reader.GetUInt32("enter_count"),
+                        Name = reader.GetString("name"),
+                        Comment = reader.GetString("comment"),
                         LevelMin = reader.GetUInt32("level_min"),
                         LevelMax = reader.GetUInt32("level_max"),
                         MaxPlayers = reader.GetUInt32("max_players"),
@@ -346,6 +371,11 @@ public class IndunGameData : Singleton<IndunGameData>, IGameDataLoader
                         ClientDriven = reader.GetBoolean("client_driven", true),
                         SelectChannel = reader.GetBoolean("select_channel", true)
                     };
+
+                    // Hack for earlier versions
+                    // Exception for Mirage and Library
+                    indunZone.EnterCount = indunZone.ZoneGroupId == 49 || indunZone.SelectChannel ? 1000u : 3u;
+                    indunZone.LocalizedName = LocalizationManager.Instance.Get("indun_zones", "name", indunZone.ZoneGroupId, indunZone.Name);
 
                     _indunZones.Add(indunZone.ZoneGroupId, indunZone);
 
@@ -364,11 +394,13 @@ public class IndunGameData : Singleton<IndunGameData>, IGameDataLoader
             {
                 while (reader.Read())
                 {
-                    var room = new IndunRoom();
-                    room.Id = reader.GetUInt32("id");
-                    room.DoodadId = reader.GetUInt32("center_doodad_id");
-                    room.Radius = reader.GetUInt32("radius");
-                    room.ZoneGroupId = reader.GetUInt32("zone_group_id");
+                    var room = new IndunRoom
+                    {
+                        Id = reader.GetUInt32("id"),
+                        DoodadId = reader.GetUInt32("center_doodad_id"),
+                        Radius = reader.GetUInt32("radius"),
+                        ZoneGroupId = reader.GetUInt32("zone_group_id")
+                    };
                     _indunRooms.Add(room.Id, room);
                 }
             }

--- a/AAEmu.Game/Models/Game/Indun/Dungeon.cs
+++ b/AAEmu.Game/Models/Game/Indun/Dungeon.cs
@@ -52,7 +52,7 @@ public class Dungeon
     public Character GetCharacterOwner { get => _characterOwner; }
     public Team.Team GetOwnerTeam { get => _ownerTeam; }
     public uint GetZoneGroupId { get => _indunZone.ZoneGroupId; }
-    public bool IsSystem { get; set; }
+    public bool IsSystem { get; init; }
     public bool FinishedLoading { get; set; }
     private readonly DateTime _createTime = DateTime.UtcNow;
 
@@ -91,18 +91,17 @@ public class Dungeon
         }
         var worldTemplate = WorldManager.Instance.GetWorldTemplateByZoneKey(zoneKeys[0]);
 
-        Logger.Info($"[Dungeon] Create system dungeon...");
-        // для zone_key: 260=arche_mall, 296=instance_library_1, 297=instance_library_2, 298=instance_library_3
-        // или
-        // для group_id: 49=arche_mall, 70=instance_library_1, 71=instance_library_2, 72=instance_library_3
-        Logger.Info($"[Dungeon] don't make a copy of the instance ...");
+        Logger.Info($"[Dungeon] Create system dungeon {worldTemplate?.Name} - channel {channelId}...");
         World = WorldManager.Instance.CreateWorldInstance(worldTemplate, channelId, overrideInstanceId, fixedInstanceId, character);
         World.DungeonInstance = this;
+        _zoneInstanceId = new ZoneInstanceId(zoneKeys.First(), World.Id);
+
         // If started by a character, enter them into queue
         if (character != null)
         {
             PlayersWithAccess.Add(character.Id);
-            EnterRequests.Add(character);
+            QueuePlayer(character);
+            // EnterRequests.Add(character);
         }
         // Add team members to allow access
         if (team != null)
@@ -114,7 +113,6 @@ public class Dungeon
                 PlayersWithAccess.Add(teamMember.Character.Id);
             }
         }
-        _zoneInstanceId = new ZoneInstanceId(zoneKeys.First(), World.Id);
 
         TickManager.Instance.OnTick.Subscribe(AreaClearTick, TimeSpan.FromSeconds(1), true);
 
@@ -145,9 +143,9 @@ public class Dungeon
     public bool QueuePlayer(Character character)
     {
         if (EnterRequests.Contains(character))
-            return false;
+            return true;
         
-        if (!IndunManager.Instance.CheckingAttempt(this))
+        if (!IndunManager.Instance.CheckEntryAttemptCount(character.Id, GetZoneGroupId, _indunZone, true))
         {
             Logger.Info($"[{World}] Player {character.Name} did too many dungeon attempts.");
             character.SendErrorMessage(ErrorMessageType.InstanceVisitLimit);
@@ -258,7 +256,7 @@ public class Dungeon
     /// </summary>
     public bool DestroyDungeon()
     {
-        Logger.Info($"[Dungeon] instanceId={_zoneInstanceId.InstanceId}, zoneId={_zoneInstanceId.ZoneId}: Destroying dungeon...");
+        Logger.Info($"[Dungeon] instanceId={_zoneInstanceId?.InstanceId}, zoneId={_zoneInstanceId?.ZoneId}: Destroying dungeon...");
 
         TickManager.Instance.OnTick.UnSubscribe(AreaClearTick);
 
@@ -683,16 +681,5 @@ public class Dungeon
                 room.SetRoomPlayerCount(World.Id, (uint)radiusCount);
             }
         }
-    }
-
-    public void WaitingDungeonAccessAttemptsCleared(TimeSpan delta)
-    {
-        if (!IndunManager.Instance.GetWaitingDungeonAccess(this))
-        {
-            IndunManager.Instance.SetWaitingDungeonAccess(this, true);
-            return;
-        }
-        TickManager.Instance.OnTick.UnSubscribe(WaitingDungeonAccessAttemptsCleared);
-        IndunManager.Instance.ClearAttemts(this);
     }
 }

--- a/AAEmu.Game/Models/Game/Indun/IndunZone.cs
+++ b/AAEmu.Game/Models/Game/Indun/IndunZone.cs
@@ -2,19 +2,68 @@ namespace AAEmu.Game.Models.Game.Indun;
 
 public class IndunZone
 {
-    public uint ZoneGroupId { get; set; }
-    public string Name { get; set; }
-    public string Comment { get; set; }
-    public uint LevelMin { get; set; } = 1;
-    public uint LevelMax { get; set; } = 100;
-    public uint MaxPlayers { get; set; } = 9999;
-    public bool PvP { get; set; } = true;
-    public bool HasGraveyard { get; set; } = true;
-    public uint ItemId { get; set; }
-    public uint RestoreItemTime { get; set; }
-    public bool PartyOnly { get; set; }
-    public bool ClientDriven { get; set; }
-    public bool SelectChannel { get; set; }
+    /// <summary>
+    /// ZoneGroupId for this dungeon
+    /// </summary>
+    public uint ZoneGroupId { get; init; }
+    /// <summary>
+    /// Dungeon nam
+    /// </summary>
+    public string Name { get; init; }
+    /// <summary>
+    /// Dungeon comments
+    /// </summary>
+    public string Comment { get; init; }
+    /// <summary>
+    /// Minimum character level required to enter this dungeon
+    /// </summary>
+    public uint LevelMin { get; init; } = 1;
+    /// <summary>
+    /// Maximum level a character can have to enter this dungeon
+    /// </summary>
+    public uint LevelMax { get; init; } = 100;
+    /// <summary>
+    /// Maximum number of players in this dungeon
+    /// </summary>
+    public uint MaxPlayers { get; init; } = 9999;
+    /// <summary>
+    /// Set to false, then PvP is NOT allowed in this dungeon (used for Mirage and Library)
+    /// </summary>
+    public bool PvP { get; init; } = true;
+    /// <summary>
+    /// If this dungeon has its own respawn points, not sure how this is used
+    /// </summary>
+    public bool HasGraveyard { get; init; } = true;
+    /// <summary>
+    /// If set, the itemTemplateId of the item required/consumed to enter this dungeon
+    /// </summary>
+    public uint ItemId { get; init; }
+    /// <summary>
+    /// Minimum time in seconds between repeat dungeon creations by the same player
+    /// </summary>
+    public uint RestoreItemTime { get; init; }
+    /// <summary>
+    /// Does the player need to be part of a party in order to enter this dungeon
+    /// </summary>
+    public bool PartyOnly { get; init; }
+    /// <summary>
+    /// Is this dungeon only run clients-side
+    /// </summary>
+    public bool ClientDriven { get; init; }
+    /// <summary>
+    /// Does this dungeon have a channel select
+    /// </summary>
+    public bool SelectChannel { get; init; }
+
+    /// <summary>
+    /// Maximum number of times a player can entry this instance (0 = can't enter).
+    /// In later versions this field is actually stored in the compact.
+    /// </summary>
+    public uint EnterCount { get; set; } = 1000;
+
+    /// <summary>
+    /// Cached localized name of this dungeon
+    /// </summary>
     public string LocalizedName { get; set; }
 
     public override string ToString()


### PR DESCRIPTION
- Fix the issue where entering a system dungeon like Mirage Isle would also have a entry limit of 3 every 4 hours.
- Changed how the server keeps track of dungeon entries.
- Changed default Sys-Dungeon entry count to 1000 like it is on later versions.
