### PR TITLE
Expose Actability Rate in world settings

### DIFF
--- a/AAEmu.Game/Configurations/World.json
+++ b/AAEmu.Game/Configurations/World.json
@@ -15,6 +15,7 @@
         "GeoDataMode": false,
         "PreLoadTerrain": false,
         "MaxInstances": 32,
-        "TargetPhysicsTps": 25.0
+        "TargetPhysicsTps": 25.0,
+        "ActabilityRate": 1.0
     }
 }

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -1488,7 +1488,7 @@ public partial class Character : Unit, ICharacter
         {
             // Get multiplier before adding points
             expMultiplier = Actability.Actabilities[(uint)actabilityId].GetExpMultiplier();
-            actabilityChange = Math.Abs(change);
+            actabilityChange = (int)(Math.Abs(change) * AppConfiguration.Instance.World.ActabilityRate);
             actabilityStep = Actability.Actabilities[(uint)actabilityId].Step;
             actabilityChange = Actability.AddPoint((uint)actabilityId, actabilityChange);
         }

--- a/AAEmu.Game/Models/Game/Configurations.cs
+++ b/AAEmu.Game/Models/Game/Configurations.cs
@@ -59,7 +59,7 @@ public class WorldConfig
     /// <summary>
     /// Number of days 1 week worth of tax pays for, set this to 3640 would make 1 tax payment last for about 10 years.
     /// </summary>
-    public uint DaysForTaxPayment { get; set; } = 7u; 
+    public uint DaysForTaxPayment { get; set; } = 7u;
 
     /// <summary>
     /// Set a minimum access-level that a character must have to ignore falling damage (for devs)
@@ -91,6 +91,11 @@ public class WorldConfig
     /// Target Ticks per Second to use for Physics threads
     /// </summary>
     public float TargetPhysicsTps { get; set; } = 25f;
+
+    /// <summary>
+    /// Server-side Actability Points multiplier (on top of buffs)
+    /// </summary>
+    public double ActabilityRate { get; set; } = 1.0;
 }
 
 public class DungeonLoadConfig


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Introduce a setting to change the actability rate and expose it in the world settings. Courtesy of Muskrat Deville @ Discord.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This surfaces a way to adjust the rate of change for proficiency.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Do any activity that would change proficiency
2. Change the ActabilityRate setting to 1000.0 in World.json and restart the server
3. Do the same activity and notice the change in [gains](https://i.pinimg.com/736x/4e/2e/58/4e2e5816bb5647ea302b96079d939f84.jpg)

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.