### PR TITLE
Add setting for mail reward delay

### DIFF
--- a/AAEmu.Game/Configurations/Specialty.json
+++ b/AAEmu.Game/Configurations/Specialty.json
@@ -5,6 +5,7 @@
 		"RatioDecreasePerPack": 0.5,
 		"RatioDecreaseTickMinutes": 1.0,
 		"RatioIncreasePerTick": 5.0,
-		"RatioRegenTickMinutes": 60.0
+		"RatioRegenTickMinutes": 60.0,
+		"TradePackMailDelayInMinutes": 480.0
 	}
 }

--- a/AAEmu.Game/Models/Game/Configurations.cs
+++ b/AAEmu.Game/Models/Game/Configurations.cs
@@ -1,4 +1,5 @@
-﻿using AAEmu.Commons.Network;
+﻿using System.Text.Json.Serialization;
+using AAEmu.Commons.Network;
 // ReSharper disable ClassNeverInstantiated.Global
 
 namespace AAEmu.Game.Models.Game;
@@ -207,6 +208,15 @@ public class SpecialtyConfig
     /// Time in minutes before a traded pack is no longer counted towards the trade rate calculation
     /// </summary>
     public double RatioRegenTickMinutes { get; set; } = 60f;
+
+    /// <summary>
+    /// Time in minutes to delay trade pack reward mail delivery. Default is 8 hours.
+    /// </summary>
+    /// <remarks>
+    /// The default value is 8 hours. This setting controls how long after delivery 
+    /// a player must wait before receiving their trade pack reward via mail.
+    /// </remarks>
+    public double TradePackMailDelayInMinutes { get; set; } = 480f;
 }
 
 public class ScriptsConfig

--- a/AAEmu.Game/Models/Game/Mails/MailForSpeciality.cs
+++ b/AAEmu.Game/Models/Game/Mails/MailForSpeciality.cs
@@ -20,7 +20,6 @@ public class MailForSpeciality : BaseMail
     private bool _sellerIsCrafter;
     // unused private int _itemCountTotal;
 
-    private static TimeSpan TradePackMailDelay = TimeSpan.FromHours(8); // Default is 8 hours
     private static string TradeDeliveryName = ".sellBackpack";
     private static string TradeDeliveryTitle = "Speciality Payment";
     private static string TradeDeliveryTitleSeller = "Speciality Payment [Delivery]";
@@ -94,7 +93,7 @@ public class MailForSpeciality : BaseMail
 
         MailType = MailType.SysSellBackpack;
 
-        Body.RecvDate = DateTime.UtcNow + TradePackMailDelay;
+        Body.RecvDate = DateTime.UtcNow.AddMinutes(AppConfiguration.Instance.Specialty.TradePackMailDelayInMinutes);
     }
 
     /// <summary>

--- a/AAEmu.Game/Scripts/Commands/SetTradePackMailDelay.cs
+++ b/AAEmu.Game/Scripts/Commands/SetTradePackMailDelay.cs
@@ -1,0 +1,49 @@
+﻿using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.Game;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Utils.Scripts;
+using AAEmu.Game.Models;
+
+namespace AAEmu.Game.Scripts.Commands;
+
+public class SetTradePackMailDelay : ICommand
+{
+    public string[] CommandNames { get; set; } = ["settradepackmaildelay"];
+
+    public void OnLoad()
+    {
+        CommandManager.Instance.Register(CommandNames, this);
+    }
+
+    public string GetCommandLineHelp()
+    {
+        return "<delay_in_minutes>";
+    }
+
+    public string GetCommandHelpText()
+    {
+        return $"Changes the delay in receiving the trade pack reward mail to <delay> minute(s)\n" +
+               $"Example usage:\n" +
+               $"Receive the reward without delay: {CommandManager.CommandPrefix} {CommandNames[0]} 0\n" +
+               $"Receive the reward in five minutes: {CommandManager.CommandPrefix} {CommandNames[0]} 5\n" +
+               $"Receive the reward in 4 hours: {CommandManager.CommandPrefix} {CommandNames[0]} 240\n";
+    }
+
+    public void Execute(Character character, string[] args, IMessageOutput messageOutput)
+    {
+        if (args.Length == 0)
+        {
+            CommandManager.SendDefaultHelpText(this, messageOutput);
+            return;
+        }
+
+        if (double.TryParse(args.First(), out var delay))
+        {
+            AppConfiguration.Instance.Specialty.TradePackMailDelayInMinutes = delay;
+            CommandManager.SendNormalText(this, messageOutput, $"Trade Pack Mail Delay set to {delay} minute(s)");
+            return;
+        }
+
+        CommandManager.SendErrorText(this, messageOutput, $"Invalid delay: {args.First()}");
+    }
+}


### PR DESCRIPTION
## Description
Introduced a configuration setting to control the delay before trade pack rewards are delivered via mail. This replaces the previously hardcoded delay value. The default is set to 8 hours.

## Related Issue
N/A

## Motivation and Context
Making the mail reward delay configurable allows easier balancing without code changes. This also improves maintainability and prepares the system for externalized config management in the future.

## How Has This Been Tested?
- Manually tested with valid and invalid configuration values
- Confirmed the default value (8h) applies when config is absent
- Verified server behavior respects the new delay setting during trade pack hand-in

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
