### PR TITLE
fix: improve region handling and object visibility updates

### DIFF
--- a/AAEmu.Game/Core/Managers/World/WorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/WorldManager.cs
@@ -896,61 +896,77 @@ public class WorldManager : Singleton<WorldManager>, IWorldManager
     }
 
     /// <summary>
-    /// Adds or updates a GameObject of its region object list
+    /// Adds a <see cref="GameObject"/> to its region or updates its region if it has moved.
     /// </summary>
-    /// <param name="obj"></param>
+    /// <param name="obj">The game object to add or update.</param>
     public void AddVisibleObject(GameObject obj)
     {
         if (obj == null)
             return;
-        var region = GetRegion(obj); // Get region of an Object or its Root object if it has one
-        var currentRegion = obj.Region; // Current Region this object is in
 
-        // If region didn't change, ignore
+        var region = GetRegion(obj); // Target region of the object or its root
+        var currentRegion = obj.Region; // Current region of the object
+
+        // Ignore if region did not change
         if (region == null || currentRegion != null && currentRegion.Equals(region))
             return;
 
         if (currentRegion == null)
         {
-            // If no currentRegion, add it (happens on new spawns)
-            foreach (var neighbor in region.GetNeighbors())
-                neighbor.AddToCharacters(obj);
-
+            // First-time placement (e.g. new spawn)
             region.AddObject(obj);
             obj.Region = region;
+
+            // Make object visible in its region and all neighboring regions
+            region.AddToCharacters(obj);
+            foreach (var neighbor in region.GetNeighbors())
+                neighbor.AddToCharacters(obj);
         }
         else
         {
-            // No longer in the same region, update things
-            // Remove visibility from oldNeighbors
+            // Region changed: update visibility and membership
+
+            // Remove from characters in regions no longer visible
             var diffs = currentRegion.FindDifferenceBetweenRegions(region);
             if (diffs != null)
                 foreach (var diff in diffs)
                     diff?.RemoveFromCharacters(obj);
 
-            // Add visibility to newNeighbours
+            // Add to characters in newly visible regions
             diffs = region.FindDifferenceBetweenRegions(currentRegion);
             if (diffs != null)
                 foreach (var diff in diffs)
                     if (obj.IsVisible)
                         diff?.AddToCharacters(obj);
 
-            // Add this obj to the new region
+            // Move the object to the new region
             region.AddObject(obj);
-            // Update its region
             obj.Region = region;
-
-            // remove the obj from the old region
             currentRegion.RemoveObject(obj);
+
+            // --- IMPORTANT ---
+            // Recursively update regions of all children,
+            // since their world position changed with the parent.
+            if (obj.Transform?.Children?.Count > 0)
+            {
+                foreach (var child in obj.Transform.Children)
+                {
+                    if (child?.GameObject != null)
+                        AddVisibleObject(child.GameObject);
+                }
+            }
+            // --- END ---
         }
 
-        // Also show children
+        // Ensure children are added on initial spawn
         if (obj.Transform?.Children?.Count > 0)
+        {
             foreach (var child in obj.Transform.Children)
+            {
                 if (child != null)
                     AddVisibleObject(child.GameObject);
-
-        //Logger.Warn($" objects={_objects.Count}, doodads={_doodads.Count}, npcs={_npcs.Count}, characters={_characters.Count}");
+            }
+        }
     }
 
     /// <summary>

--- a/AAEmu.Game/Models/Game/World/Region.cs
+++ b/AAEmu.Game/Models/Game/World/Region.cs
@@ -134,7 +134,7 @@ public class Region
                 // Ignore doodads here, as we have a special packet for those
                 if (go is Doodad)
                     continue;
-                
+
                 if (go is Gimmick)
                     continue;
 
@@ -183,9 +183,10 @@ public class Region
         if (_objects == null)
             return;
 
-        // remove all visible objects in the region from the player
+        // Special handling for characters (players)
         if (obj is Character character1)
         {
+            // Existing logic for sending SCUnitsRemovedPacket, SCDoodadsRemovedPacket, etc. remains unchanged.
             var unitIds = GetListId<Unit>([], character1.ObjId).ToArray();
             var units = GetList(new List<Unit>(), character1.ObjId);
             foreach (var t in units)
@@ -195,7 +196,6 @@ public class Region
                     npc.Ai.ShouldTick = false;
                 }
             }
-
             for (var offset = 0; offset < unitIds.Length; offset += SCUnitsRemovedPacket.MaxCountPerPacket)
             {
                 var length = unitIds.Length - offset;
@@ -215,7 +215,7 @@ public class Region
                 Array.Copy(doodadIds, offset, temp, 0, temp.Length);
                 character1.SendPacket(new SCDoodadsRemovedPacket(last, temp));
             }
-            
+
             var gimmickIds = GetList<Gimmick>([], character1.ObjId).Select(g => g.ObjId).ToArray();
             for (var offset = 0; offset < gimmickIds.Length; offset += SCGimmicksRemovedPacket.MaxCountPerPacket)
             {
@@ -231,12 +231,44 @@ public class Region
                 character1.CurrentTarget = null;
                 character1.SendPacket(new SCTargetChangedPacket(character1.ObjId, 0));
             }
-            // TODO ... others types...
         }
+        // Special handling for non-player objects (NPCs, vehicles, doodads, etc.)
+        else
+        {
+            // Get all characters in this region that should receive a removal packet
+            var charactersInRegion = GetList(new List<Character>(), obj.ObjId);
 
-        // remove the object from all players in the region
-        foreach (var character in GetList(new List<Character>(), obj.ObjId))
-            obj.RemoveVisibleObject(character);
+            // --- IMPORTANT FIX ---
+            // Filter the list: keep only players who are NOT in the object's new region or its neighbors.
+            // This prevents sending "false" removal packets to players who should still see the object.
+            var charactersToRemoveFrom = new List<Character>();
+            foreach (var character in charactersInRegion)
+            {
+                // Check if the player is in the object's region or one of its neighboring regions.
+                // If yes, the player should still see the object, so no packet is sent.
+                var objRegion = WorldManager.Instance.GetRegion(obj); // Get the current region of the object
+                if (objRegion != null)
+                {
+                    var objNeighbors = objRegion.GetNeighbors();
+                    var characterRegion = WorldManager.Instance.GetRegion(character); // Get the region of the player
+
+                    // If the player's region matches the object's region or one of its neighbors, skip this player.
+                    if (characterRegion != null && (characterRegion.Equals(objRegion) || objNeighbors.Contains(characterRegion)))
+                    {
+                        continue; // Skip, do not send packet to this player
+                    }
+                }
+                // If the player is outside the object's visibility range, add them to the removal list
+                charactersToRemoveFrom.Add(character);
+            }
+            // --- END OF FIX ---
+
+            // Send the removal packet ONLY to the filtered list of players
+            foreach (var character in charactersToRemoveFrom)
+            {
+                obj.RemoveVisibleObject(character);
+            }
+        }
     }
 
     public Region[] GetNeighbors()


### PR DESCRIPTION
### Why
- Players could receive false removal packets when objects moved between regions, causing them to "disappear" while still in range.
- Child objects did not properly update their regions when the parent moved, leading to inconsistencies in visibility.
- Comments were inconsistent and unclear.

### How
- Filter removal packets: only send to players truly outside the object's region and its neighbors.
- Add recursive region update for child objects when the parent region changes.
- Ensure children are correctly added on first spawn.
- Cleaned up and unified inline documentation for better maintainability.

### Impact
- Prevents incorrect visibility updates and reduces client/server desync.
- Ensures more reliable world state synchronization for all players.
- No breaking API changes, only internal logic improvements.