### PR TITLE
[Game] Fixed craft time calculation

### DIFF
--- a/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
@@ -37,6 +37,7 @@ public class CharacterManager : Singleton<CharacterManager>
     private readonly Dictionary<int, List<Expand>> _expands;
     private readonly Dictionary<uint, AppellationTemplate> _appellations;
     private readonly Dictionary<uint, ActabilityTemplate> _actabilities;
+    private readonly Dictionary<uint, ActabilityCategoriesTemplate> _actabilitiesCategories;
     private readonly Dictionary<int, ExpertLimit> _expertLimits;
     private readonly Dictionary<int, ExpandExpertLimit> _expandExpertLimits;
 
@@ -47,6 +48,7 @@ public class CharacterManager : Singleton<CharacterManager>
         _expands = [];
         _appellations = [];
         _actabilities = [];
+        _actabilitiesCategories = [];
         _expertLimits = [];
         _expandExpertLimits = [];
     }
@@ -71,6 +73,15 @@ public class CharacterManager : Singleton<CharacterManager>
     public ActabilityTemplate GetActability(uint id)
     {
         return _actabilities[id];
+    }
+
+    public uint GetActabilityIdByCategoryId(uint id)
+    {
+        if (_actabilitiesCategories.TryGetValue(id, out var actabilityCategory))
+        {
+            return _actabilities.GetValueOrDefault(actabilityCategory.GroupId)?.Id ?? 0;
+        }
+        return 0;
     }
 
     public ExpertLimit GetExpertLimit(int step)
@@ -308,6 +319,25 @@ public class CharacterManager : Singleton<CharacterManager>
                         template.Name = reader.GetString("name");
                         template.UnitAttributeId = reader.GetInt32("unit_attr_id");
                         _actabilities.Add(template.Id, template);
+                    }
+                }
+            }
+
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT * FROM actability_categories";
+                command.Prepare();
+                using (var reader = new SQLiteWrapperReader(command.ExecuteReader()))
+                {
+                    while (reader.Read())
+                    {
+                        var template = new ActabilityCategoriesTemplate();
+                        template.Id = reader.GetUInt32("id");
+                        template.Name = reader.GetString("name");
+                        template.GroupId = reader.GetUInt32("group_id");
+                        template.VisibleUi = reader.GetBoolean("visible_ui", true);
+                        template.VisibleOrder = reader.GetInt32("visible_order");
+                        _actabilitiesCategories.Add(template.Id, template);
                     }
                 }
             }

--- a/AAEmu.Game/Models/Game/Char/Actability.cs
+++ b/AAEmu.Game/Models/Game/Char/Actability.cs
@@ -9,10 +9,21 @@ public class Actability(ActabilityTemplate template)
     public int Point { get; set; }
     public byte Step { get; set; }
 
+    // Values for 1.2, not sure about the XP multiplier, might not have existed back then
+    //                                                Rank    0      1      2      3      4      5      6      7
+    //                                                 Exp    0      10k    20k    30k    40k    50k    70k    90k
+    private static readonly float[] s_expMultipliers       = [1.00f, 1.00f, 1.00f, 1.00f, 1.00f, 1.00f, 1.00f, 1.00f];
+    private static readonly float[] s_laborCostMultipliers = [1.00f, 1.00f, 0.95f, 0.90f, 0.85f, 0.80f, 0.77f, 0.77f];
+    private static readonly float[] s_timeMultipliers      = [1.00f, 1.00f, 0.95f, 0.90f, 0.85f, 0.80f, 0.77f, 0.77f];
+    // TODO: Maybe apply the multipliers of the next step even when next rank isn't unlocked/upgraded yet, but you are at max xp for current rank 
+
+    /*
     // These are 3.x values, and might not be correct for 1.2
+    //                                                Rank    0      1      2      3      4      5      6      7      8      9      10     11
     private static readonly float[] s_expMultipliers       = [1.00f, 1.20f, 1.40f, 1.60f, 1.80f, 2.00f, 2.20f, 2.40f, 2.60f, 2.80f, 3.00f, 3.30f];
     private static readonly float[] s_laborCostMultipliers = [1.00f, 1.00f, 0.95f, 0.90f, 0.85f, 0.80f, 0.80f, 0.80f, 0.80f, 0.75f, 0.70f, 0.60f];
     private static readonly float[] s_timeMultipliers      = [1.00f, 0.97f, 0.94f, 0.94f, 0.94f, 0.88f, 0.88f, 0.88f, 0.84f, 0.84f, 0.80f, 0.74f];
+    */
 
     /// <summary>
     /// Gets Exp multiplier for the current skill level

--- a/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
@@ -1,4 +1,5 @@
 ﻿using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.UnitManagers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game.Crafts;
 using AAEmu.Game.Models.Game.DoodadObj;
@@ -112,10 +113,14 @@ public class CharacterCraft(Character owner)
         var speedMultiplier = 1f;
         if (craft.AcId > 0)
         {
-            var actAbility = owner.Actability.Actabilities.GetValueOrDefault(craft.AcId);
-            if (actAbility != null)
+            var actAbilityId = CharacterManager.Instance.GetActabilityIdByCategoryId(craft.AcId);
+            if (actAbilityId > 0)
             {
-                speedMultiplier *= actAbility.GetProductionTimeMultiplier();
+                var actAbility = owner.Actability.Actabilities.GetValueOrDefault(actAbilityId);
+                if (actAbility != null)
+                {
+                    speedMultiplier *= actAbility.GetProductionTimeMultiplier();
+                }
             }
         }
         skill.CastTimeMultiplier = speedMultiplier;

--- a/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
@@ -109,6 +109,16 @@ public class CharacterCraft(Character owner)
 
         var skill = new Skill(SkillManager.Instance.GetSkillTemplate(craft.SkillId));
         ConsumeLaborPower = skill.Template.ConsumeLaborPower;
+        var speedMultiplier = 1f;
+        if (craft.AcId > 0)
+        {
+            var actAbility = owner.Actability.Actabilities.GetValueOrDefault(craft.AcId);
+            if (actAbility != null)
+            {
+                speedMultiplier *= actAbility.GetProductionTimeMultiplier();
+            }
+        }
+        skill.CastTimeMultiplier = speedMultiplier;
         skill.Use(Owner, caster, target, null, false, out _);
     }
 

--- a/AAEmu.Game/Models/Game/Char/Templates/ActabilityCategoriesTemplate.cs
+++ b/AAEmu.Game/Models/Game/Char/Templates/ActabilityCategoriesTemplate.cs
@@ -1,0 +1,10 @@
+namespace AAEmu.Game.Models.Game.Char.Templates;
+
+public class ActabilityCategoriesTemplate
+{
+    public uint Id { get; set; }
+    public string Name { get; set; }
+    public uint GroupId { get; set; }
+    public bool VisibleUi { get; set; }
+    public int VisibleOrder { get; set; }
+}

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -47,6 +47,11 @@ public class Skill
     public bool Cancelled { get; set; } = false;
     public Action Callback { get; set; }
 
+    /// <summary>
+    /// Multiplier that can be added as an additional modifier to casting times
+    /// </summary>
+    public float CastTimeMultiplier { get; set; } = 1f;
+
     //public bool isAutoAttack;
     //public SkillTask autoAttackTask;
 
@@ -293,6 +298,7 @@ public class Skill
         var castTime = 0;
         if (Template.CastingTime > 0)
             castTime = (int)(unit.CastTimeMul * unit.SkillModifiersCache.ApplyModifiers(this, SkillAttribute.CastTime, Template.CastingTime));
+        castTime = (int)Math.Round((float)castTime * CastTimeMultiplier);
 
         /*
         // TODO: Replace Old code

--- a/AAEmu.sln.DotSettings
+++ b/AAEmu.sln.DotSettings
@@ -38,6 +38,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=funcs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=gass/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Gemming/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=groupid/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=growlgate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Gweonid/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=harani/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
- Added craft skill multiplier data for 1.2 version
- Added loading of `actability_categories` table that was needed to be able to directly map a craft to a `ActAbility` group