### PR TITLE
Client version/3.0 client (2017 04 20)

### DIFF
--- a/AAEmu.Commons/Utils/Helper.cs
+++ b/AAEmu.Commons/Utils/Helper.cs
@@ -50,7 +50,7 @@ namespace AAEmu.Commons.Utils;
 
 public static class Helper
 {
-    private static Dictionary<Tuple<object, int>, DateTime> intervals = new();
+    private static ConcurrentDictionary<Tuple<object, int>, DateTime> intervals = new(); //ConcurrentDictionary с корректной логикой обновления вместо DDictionary. После этого те рандомные вылеты по InvalidOperationException должны исчезнуть.
 
     /// <summary>
     /// Возвращает true если прошло не менее указанного интервала времени (после предыдущего срабатывания)

--- a/AAEmu.Game/Models/Game/Items/Containers/ItemContainer.cs
+++ b/AAEmu.Game/Models/Game/Items/Containers/ItemContainer.cs
@@ -670,6 +670,10 @@ public class ItemContainer
             {
                 itemTasks.Add(new ItemAdd(newItem));
                 newItemsList.Add(newItem);
+                if (ContainerType != SlotType.Mail)  //A line from GPT is to prevent items moved to the mail slot from triggering quests. lol
+                {
+                    Owner?.Inventory.OnAcquiredItem(newItem, addAmount);  //Solves the problem when the first item received was not included in the quest. (stack creation condition)
+                }
             }
             else
                 throw new GameException("AcquireDefaultItem(); Unable to add new items"); // Inventory should have enough space, something went wrong


### PR DESCRIPTION
Helper.cs: Dictionary has been replaced by ConcurrentDictionary with the correct update logic. After that, those random InvalidOperationException crashes should disappear.

private static ConcurrentDictionary<Tuple<object, int>, DateTime> intervals = new();



ItemContainer.cs: Checking for a new stack. (Solves the problem when the quests did not take into account the first item).

if (AddOrMoveExistingItem(ItemTaskType.Invalid, newItem, prefSlot)) // Task set to invalid as we send our own packets inside this function
            {
                itemTasks.Add(new ItemAdd(newItem));
                newItemsList.Add(newItem);
                if (ContainerType != SlotType.Mail)
                {
                    Owner?.Inventory.OnAcquiredItem(newItem, addAmount);
                }
            }
            else
            {
                throw new GameException("AcquireDefaultItem(); Unable to add new items"); // Inventory should have enough space, something went wrong
            }





Helper.cs: Dictionary заменён на ConcurrentDictionary с корректной логикой обновления. После этого те рандомные вылеты по InvalidOperationException должны исчезнуть.


ItemContainer.cs: Проверка на получение нового стака. (Решает проблему, когда квесты не учитывали первый предмет).

