### PR TITLE
[Game] Implement crafting grade inheritance

### DIFF
--- a/AAEmu.Game/Core/Managers/ItemManager.cs
+++ b/AAEmu.Game/Core/Managers/ItemManager.cs
@@ -79,6 +79,9 @@ public class ItemManager : Singleton<ItemManager>
     private bool _loadedUserItems;
     // private Dictionary<ulong, Item> _timerSubscriptionsItems;
 
+    public static int MaxGradeId;
+    public static int MaxGradeValue;
+
     public ItemTemplate GetTemplate(uint id)
     {
         return _templates.GetValueOrDefault(id);
@@ -552,6 +555,8 @@ public class ItemManager : Singleton<ItemManager>
                         _grades.Add(template.Grade, template);
                         _gradesOrdered.Add(template.GradeOrder, template);
                     }
+                    MaxGradeId = _grades.Keys.Max();
+                    MaxGradeValue = _gradesOrdered.Keys.Max();
                 }
             }
 

--- a/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
@@ -367,8 +367,9 @@ public class CharacterCraft(Character owner)
     private static int FreeRegrade(int baseGrade)
     {
         int grade = baseGrade;
-        //Check grade is not mythic
-        if (grade != (int)ItemGrade.Mythic)
+        var maxGrade = Enum.GetValues<ItemGrade>().Max();
+        //Check grade is not already max
+        if (grade != (int)maxGrade)
         {
             //5% chance
             var luckyRoll = Random.Shared.Next(0, 20);

--- a/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
@@ -166,14 +166,11 @@ public class CharacterCraft(Character owner)
         {
             // Search Bag container for the material  
             Item foundMaterial = null;
-            var container = Owner.Inventory.Bag;
+            if (Owner.Inventory.Bag.GetAllItemsByTemplate(mainGradeMaterial.ItemId, -1, out var items, out _))
             {
-                if (container.GetAllItemsByTemplate(mainGradeMaterial.ItemId, -1, out var items, out _))
+                if (items.Count > 0)
                 {
-                    if (items.Count > 0)
-                    {
-                        foundMaterial = items[0];
-                    }
+                    foundMaterial = items[0];
                 }
             }
 

--- a/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
@@ -373,11 +373,15 @@ public class CharacterCraft(Character owner)
     private static int FreeRegrade(int baseGrade)
     {
         int grade = baseGrade;
-        //5% chance
-        var luckyRoll = Random.Shared.Next(0, 20);
-        if (luckyRoll < 1)
+        //Check grade is not mythic
+        if (grade != 11)
         {
-            grade++;
+            //5% chance
+            var luckyRoll = Random.Shared.Next(0, 20);
+            if (luckyRoll < 1)
+            {
+                grade++;
+            }
         }
         return grade;
     }

--- a/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
@@ -245,16 +245,13 @@ public class CharacterCraft(Character owner)
             if (template is EquipItemTemplate) // Check if material is equipment  
             {
                 // Search bag container for this material
-                var container = Owner.Inventory.Bag;
+                if (Owner.Inventory.Bag.GetAllItemsByTemplate(material.ItemId, -1, out var items, out _))
                 {
-                    if (container.GetAllItemsByTemplate(material.ItemId, -1, out var items, out _))
+                    if (items.Count > 0)
                     {
-                        if (items.Count > 0)
-                        {
-                            gradeMaterial = items[0];
-                            inheritedGrade = gradeMaterial.Grade;
-                            break;
-                        }
+                        gradeMaterial = items[0];
+                        inheritedGrade = gradeMaterial.Grade;
+                        break;
                     }
                 }
             }
@@ -374,7 +371,7 @@ public class CharacterCraft(Character owner)
     {
         int grade = baseGrade;
         //Check grade is not mythic
-        if (grade != 11)
+        if (grade != (int)ItemGrade.Mythic)
         {
             //5% chance
             var luckyRoll = Random.Shared.Next(0, 20);

--- a/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
@@ -367,7 +367,7 @@ public class CharacterCraft(Character owner)
     private static int FreeRegrade(int baseGrade)
     {
         int grade = baseGrade;
-        var maxGrade = Enum.GetValues<ItemGrade>().Max();
+        var maxGrade = ItemManager.MaxGradeValue;
         //Check grade is not already max
         if (grade != (int)maxGrade)
         {

--- a/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
@@ -7,6 +7,7 @@ using AAEmu.Game.Models.Game.DoodadObj.Static;
 using AAEmu.Game.Models.Game.Housing;
 using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Items.Actions;
+using AAEmu.Game.Models.Game.Items.Templates;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Tasks.Skills;
 
@@ -155,16 +156,142 @@ public class CharacterCraft(Character owner)
             return;
         }
 
-        foreach (var product in CurrentCraft.CraftProducts)
+        /*
+        // "Proper" Grade inheritance referencing the compact flags, doesn't work for 1.2
+        // Find the material that determines the grade for inheritance
+        byte inheritedGrade = 0;
+        var mainGradeMaterial = CurrentCraft.CraftMaterials.FirstOrDefault(m => m.MainGrade);
+        Owner.SendDebugMessage($"Looking for main grade material. Found: {mainGradeMaterial?.ItemId ?? 0}");
+        if (mainGradeMaterial != null)
         {
-            // Check if we're crafting a trade pack, if so, try to remove currently equipped backpack slot
-            if (ItemManager.Instance.IsAutoEquipTradePack(product.ItemId) == false)
+            // Search Bag container for the material  
+            Item foundMaterial = null;
+            var container = Owner.Inventory.Bag;
             {
-                Owner.Inventory.Bag.AcquireDefaultItem(ItemTaskType.CraftActSaved, product.ItemId, product.Amount, -1, Owner.Id);
+                if (container.GetAllItemsByTemplate(mainGradeMaterial.ItemId, -1, out var items, out _))
+                {
+                    if (items.Count > 0)
+                    {
+                        foundMaterial = items[0];
+                    }
+                }
+            }
+
+            if (foundMaterial != null)
+            {
+                inheritedGrade = foundMaterial.Grade;
+                Owner.SendDebugMessage($"Found material {mainGradeMaterial.ItemId} with grade {inheritedGrade}");
             }
             else
             {
-                if (!Owner.Inventory.TryEquipNewBackPack(ItemTaskType.CraftPickupProduct, product.ItemId, product.Amount, -1, Owner.Id))
+                Owner.SendDebugMessage($"Could not find material {mainGradeMaterial.ItemId} in any container");
+            }
+        }
+
+        foreach (var product in CurrentCraft.CraftProducts)
+        {
+            // Determine the grade to use for this product  
+            int gradeToUse = -1; // Default grade
+
+            if (product.UseGrade)
+            {
+                // If UseGrade is true, inherit from main grade material and roll for free regrade  
+                gradeToUse = FreeRegrade((int)inheritedGrade);
+                Owner.SendDebugMessage($"Product {product.ItemId} will use inherited grade {gradeToUse}");
+            }
+            else if (product.ItemGradeId > 0)
+            {
+                // If ItemGradeId is specified, use that grade  
+                gradeToUse = (int)product.ItemGradeId;
+                Owner.SendDebugMessage($"Product {product.ItemId} will use fixed grade {gradeToUse}");
+            }
+            else
+            {
+                Owner.SendDebugMessage($"Product will use default grade: {gradeToUse}");
+            }
+
+            // Check if template allows grade changes  
+            var template = ItemManager.Instance.GetTemplate(product.ItemId);
+            if (template != null)
+            {
+                Owner.SendDebugMessage($"Product template {product.ItemId} - FixedGrade: {template.FixedGrade}, Gradable: {template.Gradable}");
+            }
+
+            // Check if we're crafting a trade pack, if so, try to remove currently equipped backpack slot
+            if (ItemManager.Instance.IsAutoEquipTradePack(product.ItemId) == false)
+            {
+                Owner.Inventory.Bag.AcquireDefaultItem(ItemTaskType.CraftActSaved, product.ItemId, product.Amount, gradeToUse, Owner.Id);
+            }
+            else
+            {
+                if (!Owner.Inventory.TryEquipNewBackPack(ItemTaskType.CraftPickupProduct, product.ItemId, product.Amount, gradeToUse, Owner.Id))
+                {
+                    Owner.SendErrorMessage(ErrorMessageType.CraftCantActAnyMore, ErrorMessageType.BackpackOccupied, 0, false);
+                    CancelCraft();
+                    return;
+                }
+            }
+        }
+        */
+
+        // "Improper" Heuristic Grade inheritance to be used for 1.2 only, due to unset flags in compact.
+        byte inheritedGrade = 0;
+        Item gradeMaterial = null;
+        // Find equipment materials that could provide grade  
+        // Search for the first equipment material in the craft  
+        foreach (var material in CurrentCraft.CraftMaterials)
+        {
+            var template = ItemManager.Instance.GetTemplate(material.ItemId);
+            if (template is EquipItemTemplate) // Check if material is equipment  
+            {
+                // Search bag container for this material
+                var container = Owner.Inventory.Bag;
+                {
+                    if (container.GetAllItemsByTemplate(material.ItemId, -1, out var items, out _))
+                    {
+                        if (items.Count > 0)
+                        {
+                            gradeMaterial = items[0];
+                            inheritedGrade = gradeMaterial.Grade;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        foreach (var product in CurrentCraft.CraftProducts)
+        {
+            // Determine if this product should inherit grade  
+            var productTemplate = ItemManager.Instance.GetTemplate(product.ItemId);
+            int gradeToUse = -1;
+
+            // If we found an equipment material, inherit grade and roll for free regrade
+            if (gradeMaterial != null)
+            {
+                gradeToUse = FreeRegrade((int)inheritedGrade);
+            }
+            else if (product.ItemGradeId > 0)
+            {
+                // Use specified grade if set  
+                gradeToUse = (int)product.ItemGradeId;
+            }
+
+            // Check if template allows grade changes  
+            var template = ItemManager.Instance.GetTemplate(product.ItemId);
+            if (template != null)
+            {
+                Owner.SendDebugMessage($"Product template {product.ItemId} - FixedGrade: {template.FixedGrade}, Gradable: {template.Gradable}");
+            }
+
+            // Check if we're crafting a trade pack, if so, try to remove currently equipped backpack slot
+            if (ItemManager.Instance.IsAutoEquipTradePack(product.ItemId) == false)
+            {
+                Owner.Inventory.Bag.AcquireDefaultItem(ItemTaskType.CraftActSaved, product.ItemId, product.Amount, gradeToUse, Owner.Id);
+            }
+            else
+            {
+                if (!Owner.Inventory.TryEquipNewBackPack(ItemTaskType.CraftPickupProduct, product.ItemId, product.Amount, gradeToUse, Owner.Id))
                 {
                     Owner.SendErrorMessage(ErrorMessageType.CraftCantActAnyMore, ErrorMessageType.BackpackOccupied, 0, false);
                     CancelCraft();
@@ -237,5 +364,21 @@ public class CharacterCraft(Character owner)
         }
 
         // Might want to send a packet here, I think there is a packet when crafting fails. Not sure yet.
+    }
+
+    /// <summary>
+    ///Roll for chance of free regrade, Use when inheriting grade only.
+    /// Uses a magic number for the chance based on user statistics, replace if/when actual data tables are found.
+    ///</summary>
+    private static int FreeRegrade(int baseGrade)
+    {
+        int grade = baseGrade;
+        //5% chance
+        var luckyRoll = Random.Shared.Next(0, 20);
+        if (luckyRoll < 1)
+        {
+            grade++;
+        }
+        return grade;
     }
 }

--- a/AAEmu.Game/Models/Game/Items/Loots/LootPack.cs
+++ b/AAEmu.Game/Models/Game/Items/Loots/LootPack.cs
@@ -26,6 +26,7 @@ public class LootPack
     /// </summary>
     /// <param name="player">Player whose loot multipliers need to be used</param>
     /// <param name="actabilityType">Actability that triggered the Loot generation</param>
+    /// <param name="inheritedGrade">Grade to inherit (Optional)</param>
     /// <returns></returns>
     public List<(uint itemId, int count, byte grade, uint originalGroup)> GeneratePack(Character player, ActabilityType actabilityType, byte? inheritedGrade = null)
     {
@@ -172,6 +173,7 @@ public class LootPack
     /// <param name="lootGoldRate">1.0f = 100% applies to coins item only</param>
     /// <param name="player">The player the loot is generated for, currently only used to handle exclusions</param>
     /// <param name="actabilityType">AbilityType used to initiate the loot generation (used to calculate bonus)</param>
+    /// <param name="inheritedGrade">Grade to inherit (Optional)</param>
     /// <returns></returns>
     public List<(uint itemId, int count, byte grade, uint lootGroupOrigin)> GeneratePackNewV2(float lootDropRate, float lootGoldRate, Character player, ActabilityType actabilityType, byte? inheritedGrade = null)
     {
@@ -508,6 +510,7 @@ public class LootPack
     /// <param name="actabilityType"></param>
     /// <param name="taskType"></param>
     /// <param name="generatedList"></param>
+    /// <param name="inheritedGrade">Grade to inherit (Optional)</param>
     public bool GiveLootPack(Character character, ActabilityType actabilityType, ItemTaskType taskType, List<(uint itemId, int count, byte grade, uint originalGroup)> generatedList = null, byte? inheritedGrade = null)
     {
         // If it is not generated yet, generate loot pack info now

--- a/AAEmu.Game/Models/Game/Items/Loots/LootPack.cs
+++ b/AAEmu.Game/Models/Game/Items/Loots/LootPack.cs
@@ -27,11 +27,11 @@ public class LootPack
     /// <param name="player">Player whose loot multipliers need to be used</param>
     /// <param name="actabilityType">Actability that triggered the Loot generation</param>
     /// <returns></returns>
-    public List<(uint itemId, int count, byte grade, uint originalGroup)> GeneratePack(Character player, ActabilityType actabilityType)
+    public List<(uint itemId, int count, byte grade, uint originalGroup)> GeneratePack(Character player, ActabilityType actabilityType, byte? inheritedGrade = null)
     {
         var lootDropRate = (100f + player.DropRateMul) / 100f;
         var lootGoldRate = (100f + player.LootGoldMul) / 100f;
-        return GeneratePackNewV2(lootDropRate, lootGoldRate, player, actabilityType);
+        return GeneratePackNewV2(lootDropRate, lootGoldRate, player, actabilityType, inheritedGrade);
     }
 
     /// <summary>
@@ -173,7 +173,7 @@ public class LootPack
     /// <param name="player">The player the loot is generated for, currently only used to handle exclusions</param>
     /// <param name="actabilityType">AbilityType used to initiate the loot generation (used to calculate bonus)</param>
     /// <returns></returns>
-    public List<(uint itemId, int count, byte grade, uint lootGroupOrigin)> GeneratePackNewV2(float lootDropRate, float lootGoldRate, Character player, ActabilityType actabilityType)
+    public List<(uint itemId, int count, byte grade, uint lootGroupOrigin)> GeneratePackNewV2(float lootDropRate, float lootGoldRate, Character player, ActabilityType actabilityType, byte? inheritedGrade = null)
     {
         var items = new List<(uint itemId, int count, byte grade, uint lootGroupOrigin)>();
 
@@ -308,8 +308,8 @@ public class LootPack
                     if (loot.ItemId == Item.Coins)
                         countToAddNow = (int)Math.Round(countToAddNow * lootGoldRate * AppConfiguration.Instance.World.GoldLootMultiplier);
                     // Choose grade
-                    var generatedGrade = loot.GradeId;
-                    if (group?.ItemGradeDistributionId > 0)
+                    var generatedGrade = inheritedGrade ?? loot.GradeId;
+                    if (inheritedGrade == null && group?.ItemGradeDistributionId > 0)
                         generatedGrade = GetGradeFromDistribution(group.ItemGradeDistributionId);
                     // Add selected item to final item
                     items.Add((loot.ItemId, countToAddNow, generatedGrade, loot.Group));
@@ -508,10 +508,10 @@ public class LootPack
     /// <param name="actabilityType"></param>
     /// <param name="taskType"></param>
     /// <param name="generatedList"></param>
-    public bool GiveLootPack(Character character, ActabilityType actabilityType, ItemTaskType taskType, List<(uint itemId, int count, byte grade, uint originalGroup)> generatedList = null)
+    public bool GiveLootPack(Character character, ActabilityType actabilityType, ItemTaskType taskType, List<(uint itemId, int count, byte grade, uint originalGroup)> generatedList = null, byte? inheritedGrade = null)
     {
         // If it is not generated yet, generate loot pack info now
-        generatedList ??= GeneratePack(character, actabilityType);
+        generatedList ??= GeneratePack(character, actabilityType, inheritedGrade);
 
         var canAdd = true;
         // First check for room

--- a/AAEmu.Game/Models/Game/Skills/Effects/GainLootPackItemEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/GainLootPackItemEffect.cs
@@ -66,12 +66,8 @@ public class GainLootPackItemEffect : EffectTemplate
             character.Inventory.Bag.ConsumeItem(ItemTaskType.ConsumeSkillSource, ConsumeItemId, ConsumeCount, null);
         }
 
-        // Get the source item's grade if we need to inherit it  
-        byte? inheritedGrade = null;
-        if (InheritGrade)
-        {
-            inheritedGrade = sourceItem.Grade;
-        }
+        //Get the source item's grade if we need to inherit it  
+        byte? inheritedGrade = InheritGrade ? sourceItem.Grade : null;
 
         // Give the results
         pack.GiveLootPack(character, actAbility, ItemTaskType.SkillEffectGainItem, inheritedGrade: inheritedGrade);

--- a/AAEmu.Game/Models/Game/Skills/Effects/GainLootPackItemEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/GainLootPackItemEffect.cs
@@ -66,8 +66,15 @@ public class GainLootPackItemEffect : EffectTemplate
             character.Inventory.Bag.ConsumeItem(ItemTaskType.ConsumeSkillSource, ConsumeItemId, ConsumeCount, null);
         }
 
+        // Get the source item's grade if we need to inherit it  
+        byte? inheritedGrade = null;
+        if (InheritGrade)
+        {
+            inheritedGrade = sourceItem.Grade;
+        }
+
         // Give the results
-        pack.GiveLootPack(character, actAbility, ItemTaskType.SkillEffectGainItem);
+        pack.GiveLootPack(character, actAbility, ItemTaskType.SkillEffectGainItem, inheritedGrade: inheritedGrade);
 
         Logger.Debug($"GainLootPackItemEffect {LootPackId}");
     }


### PR DESCRIPTION
This adds missing functionality to the crafting system that does the following;
- Crafts the first equipment tier at the correct grade.
- Allows subsequent tiers to inherit the grade properly.
- Adds the free bonus grade on craft RNG mechanic.
- Successfully passes grade through sealed equipment without resetting back to basic grade.

Disclaimer; With regards to the large comment block, that is the proper implementation of grade inheritance that would reference required flags in the compact however, said flags are not set in the 1.2 compact and therefore it will not function. As a result I have used a heuristic implementation instead but decided to leave the "proper" code block in place for later versions that do have the flags correctly set.