### PR TITLE
chore(docker): upgrade .NET SDK and runtime base images from 9.0 to 10.0

### DIFF
--- a/AAEmu.Game/Dockerfile
+++ b/AAEmu.Game/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS builder
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS builder
 ARG CONFIGURATION
 ARG RUNTIME
 ARG FRAMEWORK
@@ -13,7 +13,7 @@ COPY ./AAEmu.Commons ./AAEmu.Commons
 COPY ./AAEmu.Game ./AAEmu.Game
 RUN dotnet publish ./AAEmu.Game/AAEmu.Game.csproj -c $CONFIGURATION -r $RUNTIME --self-contained true -f $FRAMEWORK
 
-FROM mcr.microsoft.com/dotnet/runtime:9.0-alpine
+FROM mcr.microsoft.com/dotnet/runtime:10.0-alpine
 
 ARG CONFIGURATION
 ARG FRAMEWORK

--- a/AAEmu.Login/Dockerfile
+++ b/AAEmu.Login/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS builder
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS builder
 ARG CONFIGURATION
 ARG RUNTIME
 ARG FRAMEWORK
@@ -10,7 +10,7 @@ COPY ./AAEmu.Commons ./AAEmu.Commons
 COPY ./AAEmu.Login ./AAEmu.Login
 RUN dotnet publish ./AAEmu.Login/AAEmu.Login.csproj -c $CONFIGURATION -r $RUNTIME --self-contained true -f $FRAMEWORK
 
-FROM mcr.microsoft.com/dotnet/runtime:9.0-alpine
+FROM mcr.microsoft.com/dotnet/runtime:10.0-alpine
 
 ARG CONFIGURATION
 ARG FRAMEWORK


### PR DESCRIPTION
## Description

This PR updates the base images in both `AAEmu.Game` and `AAEmu.Login` Dockerfiles from .NET 9.0-alpine to .NET 10.0-alpine for both the SDK (build) and runtime stages.

Changes affect the following lines:
- `FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine` → `10.0-alpine`
- `FROM mcr.microsoft.com/dotnet/runtime:9.0-alpine` → `10.0-alpine`

## Related Issue

N/A (routine maintenance/upgrade)

## Motivation and Context

PR #1338 updated several scripts/project files to target .NET 10.  
This current change completes that upgrade by aligning the Docker base images with the same .NET 10 version already adopted in the rest of the build pipeline.

Additional reasons for the update include:

- Moving to the latest stable .NET version for continued security updates, bug fixes, and performance improvements
- Avoiding version skew between the build-time SDK and runtime images, which can lead to subtle compatibility issues in multi-stage builds (package resolution differences, trimming/AOT behavior variances, tooling assumptions, etc.)
- Following good container hygiene by keeping base images on actively supported versions

## How Has This Been Tested?

- Successfully built both images locally using the updated Dockerfiles
- Verified that the resulting containers start correctly in development environment
- Confirmed the published application still loads and responds to basic health checks
- No breaking changes expected as this is a patch-level upgrade within the same major .NET lineage

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Maintenance / infrastructure improvement

## Checklist:

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **CONTRIBUTING** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed