### PR TITLE
fix(game): corrects item consumption order

### DIFF
--- a/AAEmu.Game/Models/Game/Items/Containers/ItemContainer.cs
+++ b/AAEmu.Game/Models/Game/Items/Containers/ItemContainer.cs
@@ -547,7 +547,7 @@ public class ItemContainer
         // Check all remaining items
         if (amountToConsume > 0)
         {
-            foreach (var i in foundItems)
+            foreach (var i in foundItems.OrderBy(x => x.Slot))
             {
                 var toRemove = Math.Min(i.Count, amountToConsume);
                 i.Count -= toRemove;


### PR DESCRIPTION
Sorts the list used by ConsumeItem() by slot order instead of newest. 
Fixes the underlying cause of issue #1337.