### PR TITLE
feat: Support IPv6 for internal game server to login server communication

### DIFF
--- a/AAEmu.Login/Core/Network/Internal/InternalNetwork.cs
+++ b/AAEmu.Login/Core/Network/Internal/InternalNetwork.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Net.Sockets;
 using AAEmu.Commons.Network.Core;
 using AAEmu.Login.Models;
 using Microsoft.Extensions.Options;
@@ -17,9 +18,10 @@ public class InternalNetwork(IInternalProtocolHandler protocolHandler, IOptions<
     {
         var config = appConfig.Value.InternalNetwork;
         var host =
-            new IPEndPoint(config.Host.Equals("*") ? IPAddress.Any : IPAddress.Parse(config.Host), config.Port);
+            new IPEndPoint(config.Host.Equals("*") ? IPAddress.IPv6Any : IPAddress.Parse(config.Host), config.Port);
 
         _server = new Server(host.Address, host.Port, protocolHandler);
+        _server.OptionDualMode = host.AddressFamily == AddressFamily.InterNetworkV6;
         _server.Start();
 
         Logger.Info("InternalNetwork started");


### PR DESCRIPTION
Affects only internal communication between the login server and game server. The public-facing networks are still IPv4 for the client to connect to.

Operates in dual mode for IPv4 support over IPv6, if listening on an IPv6 address (e.g. listening on ::1 can accept connections to 127.0.0.1).

This fixes a connection bug if the first IP address resolved from the login server's hostname (e.g. localhost) by the game server is an IPv6 address (::1), as the login server previously wouldn't have been listening on that interface.