### PR TITLE
fix(game): order item stack list when acquiring items

### DIFF
--- a/AAEmu.Game/Models/Game/Items/Containers/ItemContainer.cs
+++ b/AAEmu.Game/Models/Game/Items/Containers/ItemContainer.cs
@@ -654,7 +654,7 @@ public class ItemContainer
         // Never update in mail or auction containers
         if (ContainerType != SlotType.Mail && ContainerType != SlotType.Auction)
         {
-            foreach (var i in currentItems)
+            foreach (var i in currentItems.OrderBy(x => x.Slot))
             {
                 var freeSpace = i.Template.MaxCount - i.Count;
                 if (freeSpace > 0)


### PR DESCRIPTION
Orders the item stack list when acquiring items to select the first available stack by slot order.
This ensures that new stackable items are placed in the correct stacks.