### PR TITLE
chore: Use the Microsoft.Extensions.Logging abstraction in login server

### DIFF
--- a/AAEmu.Login/AAEmu.Login.csproj
+++ b/AAEmu.Login/AAEmu.Login.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
     <PackageReference Include="NLog" />
+    <PackageReference Include="NLog.Extensions.Logging" />
     <PackageReference Include="OSVersionExt.NetStd" />
   </ItemGroup>
 

--- a/AAEmu.Login/AAEmu.Login.csproj
+++ b/AAEmu.Login/AAEmu.Login.csproj
@@ -21,6 +21,8 @@
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
     <PackageReference Include="NLog" />
     <PackageReference Include="NLog.Extensions.Logging" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OSVersionExt.NetStd" />
   </ItemGroup>
 

--- a/AAEmu.Login/Core/Controllers/GameController.cs
+++ b/AAEmu.Login/Core/Controllers/GameController.cs
@@ -7,15 +7,17 @@ using AAEmu.Login.Core.Network.Internal;
 using AAEmu.Login.Core.Packets.L2C;
 using AAEmu.Login.Core.Packets.L2G;
 using AAEmu.Login.Models;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using NLog;
 
 namespace AAEmu.Login.Core.Controllers;
 
-public class GameController(IRequestController requestController, IOptions<AppConfiguration> appConfig)
+public class GameController(
+    IRequestController requestController,
+    IOptions<AppConfiguration> appConfig,
+    ILogger<GameController> logger)
     : IGameController
 {
-    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private readonly ConcurrentDictionary<GameServerId, GameServer> _gameServers = [];
     private readonly Dictionary<GameServerId, GameServerId> _mirrorsId = [];
 
@@ -27,7 +29,7 @@ public class GameController(IRequestController requestController, IOptions<AppCo
         connection.SendPacket(message);
     }
 
-    private static string ResolveHostName(string host)
+    private string ResolveHostName(string host)
     {
         try
         {
@@ -36,17 +38,17 @@ public class GameController(IRequestController requestController, IOptions<AppCo
                 parsedHost.AddressList.FirstOrDefault(ip => ip.AddressFamily == AddressFamily.InterNetwork);
             if (firstIPv4Address != null)
             {
-                Logger.Debug($"Resolved {host} to {firstIPv4Address}");
+                logger.LogDebug("Resolved {Host} to {Address}", host, firstIPv4Address);
                 return firstIPv4Address.ToString();
             }
 
-            Logger.Warn($"Unable to resolved {host}");
+            logger.LogWarning("Unable to resolve {Host} to an IPv4 address", host);
             return host;
         }
-        catch (Exception e)
+        catch (Exception ex)
         {
             // in case of errors, just return it un-parsed
-            Logger.Error(e, $"Exception resolving {host}: {e.Message}");
+            logger.LogError(ex, "Exception resolving {Host}", host);
             return host;
         }
     }
@@ -67,29 +69,32 @@ public class GameController(IRequestController requestController, IOptions<AppCo
             var gameServer = new GameServer(id, name, host, port);
             if (!_gameServers.TryAdd(gameServer.Id, gameServer))
             {
-                Logger.Error("Game Server {id} ({name}) already exists in the game_servers table!", gameServer.Id.Value,
+                logger.LogError("Game Server {ID} ({Name}) already exists in the game_servers table!",
+                    gameServer.Id.Value,
                     gameServer.Name);
             }
 
             var extraInfo = host != loadedHost ? "from " + loadedHost :
                 appConfig.Value.SkipHostResolve ? " (unresolved)" : "";
-            Logger.Info($"Game Server {id.Value}: {name} -> {host}:{port} {extraInfo}");
+            logger.LogInformation("Game Server {ID}: {Name} -> {Host}:{Port} {ExtraInfo}", id.Value, name, host, port,
+                extraInfo);
         }
 
         if (_gameServers.IsEmpty)
         {
-            Logger.Fatal("No servers have been defined in the game_servers table!");
+            logger.LogCritical("No servers have been defined in the game_servers table!");
             return;
         }
 
-        Logger.Info($"Loaded {_gameServers.Count} game server(s)");
+        logger.LogInformation("Loaded {Count} game server(s)", _gameServers.Count);
     }
 
     public void Add(GameServerId gsId, List<GameServerId> mirrorsId, InternalConnection connection)
     {
         if (!_gameServers.TryGetValue(gsId, out var gameServer))
         {
-            Logger.Error($"GameServer connection from {connection.Ip} is requesting an invalid WorldId {gsId}");
+            logger.LogError("GameServer connection from {GameServerIP} is requesting an invalid WorldId {GsId}",
+                connection.Ip, gsId);
 
             Task.Run(() =>
                 SendPacketWithDelay(connection, 5000, new LGRegisterGameServerPacket(GSRegisterResult.Error)));
@@ -109,7 +114,8 @@ public class GameController(IRequestController requestController, IOptions<AppCo
             _mirrorsId.Add(mirrorId, gsId);
         }
 
-        Logger.Info($"Registered GameServer {gameServer.Id} ({gameServer.Name}) from {connection.Ip}");
+        logger.LogInformation("Registered GameServer {GameServerId} ({GameServerName}) from {ConnectionIP}",
+            gameServer.Id, gameServer.Name, connection.Ip);
     }
 
     public void Remove(GameServerId gsId)

--- a/AAEmu.Login/Core/Controllers/LoginController.cs
+++ b/AAEmu.Login/Core/Controllers/LoginController.cs
@@ -4,16 +4,17 @@ using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.Packets.L2C;
 using AAEmu.Login.Core.Packets.L2G;
 using AAEmu.Login.Models;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MySql.Data.MySqlClient;
-using NLog;
 
 namespace AAEmu.Login.Core.Controllers;
 
-public class LoginController(IGameController gameController, IOptions<AppConfiguration> appConfig) : ILoginController
+public class LoginController(
+    IGameController gameController,
+    IOptions<AppConfiguration> appConfig,
+    ILogger<LoginController> logger) : ILoginController
 {
-    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
-
     private readonly bool _autoAccount = appConfig.Value.AutoAccount;
 
     private readonly ConcurrentDictionary<GameServerId, ConcurrentDictionary<uint, AccountId>>
@@ -61,7 +62,7 @@ public class LoginController(IGameController gameController, IOptions<AppConfigu
 
         if (command.ExecuteNonQuery() != 1)
         {
-            Logger.Warn("Database update failed, error occurred while updating account login IP and time");
+            logger.LogWarning("Database update failed, error occurred while updating account login IP and time");
         }
 
         # endregion
@@ -115,7 +116,7 @@ public class LoginController(IGameController gameController, IOptions<AppConfigu
         connection.LastLogin = DateTime.UtcNow;
         connection.LastIp = connection.Ip;
 
-        Logger.Info("{0} connected.", connection.AccountName);
+        logger.LogInformation("{AccountName} connected.", connection.AccountName);
         connection.SendPacket(new ACJoinResponsePacket(0, 6));
         connection.SendPacket(new ACAuthResponsePacket(connection.AccountId, 6));
 
@@ -133,7 +134,7 @@ public class LoginController(IGameController gameController, IOptions<AppConfigu
 
         if (command.ExecuteNonQuery() != 1)
         {
-            Logger.Warn("Database update failed, error occurred while updating account login IP and time");
+            logger.LogWarning("Database update failed, error occurred while updating account login IP and time");
         }
 
         # endregion
@@ -161,7 +162,7 @@ public class LoginController(IGameController gameController, IOptions<AppConfigu
             return;
         }
 
-        Logger.Debug("Created account from invalid username login with value:" + username);
+        logger.LogDebug("Created account from invalid username login with value: {Username}", username);
         Login(connection, username, password);
     }
 

--- a/AAEmu.Login/Core/Controllers/RequestController.cs
+++ b/AAEmu.Login/Core/Controllers/RequestController.cs
@@ -1,9 +1,11 @@
 ﻿using System.Collections.Concurrent;
 using AAEmu.Login.Utils;
+using Microsoft.Extensions.Logging;
 
 namespace AAEmu.Login.Core.Controllers;
 
-public class RequestController() : IdManager("RequestController", firstId, lastId, objTables, exclude), IRequestController
+public class RequestController(ILogger<RequestController> logger)
+    : IdManager("RequestController", firstId, lastId, objTables, exclude, logger), IRequestController
 {
     private const uint firstId = 0x00000001;
     private const uint lastId = 0x00FFFFFF;

--- a/AAEmu.Login/Core/Network/Internal/InternalNetwork.cs
+++ b/AAEmu.Login/Core/Network/Internal/InternalNetwork.cs
@@ -2,16 +2,17 @@
 using System.Net.Sockets;
 using AAEmu.Commons.Network.Core;
 using AAEmu.Login.Models;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using NLog;
 
 namespace AAEmu.Login.Core.Network.Internal;
 
-public class InternalNetwork(IInternalProtocolHandler protocolHandler, IOptions<AppConfiguration> appConfig)
+public class InternalNetwork(
+    IInternalProtocolHandler protocolHandler,
+    IOptions<AppConfiguration> appConfig,
+    ILogger<InternalNetwork> logger)
     : IInternalNetwork
 {
-    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
-
     private Server? _server;
 
     public void Start()
@@ -24,7 +25,7 @@ public class InternalNetwork(IInternalProtocolHandler protocolHandler, IOptions<
         _server.OptionDualMode = host.AddressFamily == AddressFamily.InterNetworkV6;
         _server.Start();
 
-        Logger.Info("InternalNetwork started");
+        logger.LogInformation("InternalNetwork started");
     }
 
     public void Stop()
@@ -32,6 +33,6 @@ public class InternalNetwork(IInternalProtocolHandler protocolHandler, IOptions<
         if (_server?.IsStarted == true)
             _server.Stop();
 
-        Logger.Info("InternalNetwork stoped");
+        logger.LogInformation("InternalNetwork stopped");
     }
 }

--- a/AAEmu.Login/Core/Network/Internal/InternalProtocolHandler.cs
+++ b/AAEmu.Login/Core/Network/Internal/InternalProtocolHandler.cs
@@ -7,24 +7,23 @@ using AAEmu.Commons.Network.Core;
 using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Models;
-using NLog;
+using Microsoft.Extensions.Logging;
 
 namespace AAEmu.Login.Core.Network.Internal;
 
 public class InternalProtocolHandler(
     IEnumerable<IInternalPacketDescriptor> packetDescriptors,
     IGameController gameController,
-    IInternalConnectionTable internalConnectionTable)
+    IInternalConnectionTable internalConnectionTable,
+    ILogger<InternalProtocolHandler> logger)
     : BaseProtocolHandler, IInternalProtocolHandler
 {
-    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
-
     private readonly ConcurrentDictionary<ushort, IInternalPacketDescriptor> _packets =
         new(packetDescriptors.ToDictionary(d => d.TypeId));
 
     public override void OnConnect(ISession session)
     {
-        Logger.Info("GameServer from {0} connected, session id: {1}", session.Ip.ToString(),
+        logger.LogInformation("GameServer from {IP} connected, session id: {SessionID}", session.Ip.ToString(),
             session.SessionId.ToString(CultureInfo.InvariantCulture));
         var con = new InternalConnection(session);
         InternalConnection.OnConnect();
@@ -33,7 +32,7 @@ public class InternalProtocolHandler(
 
     public override void OnDisconnect(ISession session)
     {
-        Logger.Info("GameServer from {0} disconnected", session.Ip.ToString());
+        logger.LogInformation("GameServer from {IP} disconnected", session.Ip.ToString());
         if (session.GetAttribute("gsId") is { } gsId)
             gameController.Remove((GameServerId)gsId);
         internalConnectionTable.RemoveConnection(session.SessionId);
@@ -44,7 +43,7 @@ public class InternalProtocolHandler(
         var connection = internalConnectionTable.GetConnection(session.SessionId);
         if (connection == null)
         {
-            Logger.Error("Connection not found for session {0}", session.SessionId);
+            logger.LogError("Connection not found for session {SessionID}", session.SessionId);
             return;
         }
 
@@ -99,9 +98,9 @@ public class InternalProtocolHandler(
                     {
                         packetDescriptor.Dispatch(stream2, connection);
                     }
-                    catch (Exception e)
+                    catch (Exception ex)
                     {
-                        Logger.Error(e, "Error on packet dispatch {0}", type);
+                        logger.LogError(ex, "Error on packet dispatch {Type}", type);
                     }
                 }
             }
@@ -114,11 +113,16 @@ public class InternalProtocolHandler(
         }
     }
 
-    private static void HandleUnknownPacket(ISession session, uint type, PacketStream stream)
+    private void HandleUnknownPacket(ISession session, uint type, PacketStream stream)
     {
+        if (!logger.IsEnabled(LogLevel.Error))
+        {
+            return;
+        }
+
         var dump = new StringBuilder();
         for (var i = stream.Pos; i < stream.Count; i++)
             dump.Append($"{stream.Buffer[i]:x2} ");
-        Logger.Error("Unknown packet 0x{0:x2} from {1}:\n{2}", type, session.Ip, dump);
+        logger.LogError("Unknown packet 0x{Type:x2} from {SessionIP}:\n{Dump}", type, session.Ip, dump);
     }
 }

--- a/AAEmu.Login/Core/Network/Login/LoginNetwork.cs
+++ b/AAEmu.Login/Core/Network/Login/LoginNetwork.cs
@@ -1,15 +1,16 @@
 ﻿using System.Net;
 using AAEmu.Commons.Network.Core;
 using AAEmu.Login.Models;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using NLog;
 
 namespace AAEmu.Login.Core.Network.Login;
 
-public class LoginNetwork(ILoginProtocolHandler protocolHandler, IOptions<AppConfiguration> appConfig) : ILoginNetwork
+public class LoginNetwork(
+    ILoginProtocolHandler protocolHandler,
+    IOptions<AppConfiguration> appConfig,
+    ILogger<LoginNetwork> logger) : ILoginNetwork
 {
-    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
-
     private Server? _server;
 
     public void Start()
@@ -19,7 +20,7 @@ public class LoginNetwork(ILoginProtocolHandler protocolHandler, IOptions<AppCon
             config.Host.Equals("*") ? IPAddress.Any : IPAddress.Parse(config.Host), config.Port, protocolHandler);
         _server.Start();
 
-        Logger.Info("Network started with Number of Connections: " + config.NumConnections);
+        logger.LogInformation("Network started with number of connections: {Connections}", config.NumConnections);
     }
 
     public void Stop()
@@ -27,6 +28,6 @@ public class LoginNetwork(ILoginProtocolHandler protocolHandler, IOptions<AppCon
         if (_server is { IsStarted: true })
             _server.Stop();
 
-        Logger.Info("Network stopped");
+        logger.LogInformation("Network stopped");
     }
 }

--- a/AAEmu.Login/Core/Network/Login/LoginProtocolHandler.cs
+++ b/AAEmu.Login/Core/Network/Login/LoginProtocolHandler.cs
@@ -6,32 +6,32 @@ using AAEmu.Commons.Network;
 using AAEmu.Commons.Network.Core;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Models;
-using NLog;
+using Microsoft.Extensions.Logging;
 
 namespace AAEmu.Login.Core.Network.Login;
 
 public class LoginProtocolHandler(
     IEnumerable<ILoginPacketDescriptor> packetDescriptors,
-    ILoginConnectionTable loginConnectionTable) : BaseProtocolHandler, ILoginProtocolHandler
+    ILoginConnectionTable loginConnectionTable,
+    ILogger<LoginProtocolHandler> logger) : BaseProtocolHandler, ILoginProtocolHandler
 {
-    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
-
     private readonly ConcurrentDictionary<ushort, ILoginPacketDescriptor> _packets =
         new(packetDescriptors.ToDictionary(d => d.TypeId));
 
     public override void OnConnect(ISession session)
     {
-        Logger.Debug($"Connection from {session.Ip} established, session id: {session.SessionId}");
+        logger.LogDebug("Connection from {SessionIP} established, session id: {SessionID}", session.Ip,
+            session.SessionId);
         try
         {
             var con = new LoginConnection(session);
             LoginConnection.OnConnect();
             loginConnectionTable.AddConnection(con);
         }
-        catch (Exception e)
+        catch (Exception ex)
         {
             session.Close();
-            Logger.Error(e);
+            logger.LogError(ex, "Error on connection from {SessionIP}", session.Ip);
         }
     }
 
@@ -39,7 +39,7 @@ public class LoginProtocolHandler(
     {
         if (session is null)
         {
-            Logger.Error("Unexpected null Session");
+            logger.LogError("Unexpected null Session");
             return;
         }
 
@@ -49,13 +49,13 @@ public class LoginProtocolHandler(
             if (con != null)
                 loginConnectionTable.RemoveConnection(new ConnectionId(session.SessionId));
         }
-        catch (Exception e)
+        catch (Exception ex)
         {
             session.Close();
-            Logger.Error(e);
+            logger.LogError(ex, "Error on disconnection from {SessionIP}", session.Ip);
         }
 
-        Logger.Debug($"Client from {session.Ip} disconnected");
+        logger.LogDebug("Client from {SessionIP} disconnected", session.Ip);
     }
 
     public override void OnReceive(ISession session, byte[] buf, int offset, int bytes)
@@ -67,10 +67,10 @@ public class LoginProtocolHandler(
                 return;
             OnReceive(connection, buf, offset, bytes);
         }
-        catch (Exception e)
+        catch (Exception ex)
         {
             session.Close();
-            Logger.Error(e);
+            logger.LogError(ex, "Error on receiving data from {SessionIP}", session.Ip);
         }
     }
 
@@ -129,9 +129,9 @@ public class LoginProtocolHandler(
                         {
                             packetDescriptor.Dispatch(stream2, connection);
                         }
-                        catch (Exception e)
+                        catch (Exception ex)
                         {
-                            Logger.Error(e, "Error on packet dispatch {0}", type);
+                            logger.LogError(ex, "Error on packet dispatch {Type}", type);
                         }
                     }
                 }
@@ -143,18 +143,23 @@ public class LoginProtocolHandler(
                 }
             }
         }
-        catch (Exception e)
+        catch (Exception ex)
         {
             connection.Shutdown();
-            Logger.Error(e);
+            logger.LogError(ex, "Error on receiving data from {ConnectionIP}", connection.Ip);
         }
     }
 
-    private static void HandleUnknownPacket(LoginConnection connection, uint type, PacketStream stream)
+    private void HandleUnknownPacket(LoginConnection connection, uint type, PacketStream stream)
     {
+        if (!logger.IsEnabled(LogLevel.Error))
+        {
+            return;
+        }
+
         var dump = new StringBuilder();
         for (var i = stream.Pos; i < stream.Count; i++)
             dump.Append($"{stream.Buffer[i]:x2} ");
-        Logger.Error("Unknown packet 0x{0:x2} from {1}:\n{2}", (object)type, (object)connection.Ip, (object)dump);
+        logger.LogError("Unknown packet 0x{Type:x2} from {ConnectionIP}:\n{Dump}", type, connection.Ip, dump);
     }
 }

--- a/AAEmu.Login/LoginService.cs
+++ b/AAEmu.Login/LoginService.cs
@@ -5,8 +5,8 @@ using AAEmu.Login.Core.Network.Internal;
 using AAEmu.Login.Core.Network.Login;
 using AAEmu.Login.Models;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using NLog;
 
 namespace AAEmu.Login;
 
@@ -15,21 +15,20 @@ public sealed class LoginService(
     IRequestController requestController,
     IInternalNetwork internalNetwork,
     ILoginNetwork loginNetwork,
-    IOptions<AppConfiguration> appConfig) : IHostedService, IDisposable
+    IOptions<AppConfiguration> appConfig,
+    ILogger<LoginService> logger) : IHostedService, IDisposable
 {
-    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
-
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        Logger.Info("Starting daemon: AAEmu.Login");
+        logger.LogInformation("Starting daemon: AAEmu.Login");
         // Check for updates
         using (var connection = MySQL.CreateConnection())
         {
             if (!MySqlDatabaseUpdater.Run(connection, "aaemu_login",
                     appConfig.Value.Connections.MySQLProvider.Database))
             {
-                Logger.Fatal("Failed up update database !");
-                Logger.Fatal("Press Ctrl+C to quit");
+                logger.LogCritical("Failed to update database!");
+                logger.LogCritical("Press Ctrl+C to quit");
                 return Task.CompletedTask;
             }
         }
@@ -43,7 +42,7 @@ public sealed class LoginService(
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
-        Logger.Info("Stopping daemon.");
+        logger.LogInformation("Stopping daemon.");
         loginNetwork.Stop();
         internalNetwork.Stop();
         return Task.CompletedTask;
@@ -51,7 +50,6 @@ public sealed class LoginService(
 
     public void Dispose()
     {
-        Logger.Info("Disposing....");
-        LogManager.Flush();
+        logger.LogInformation("Disposing...");
     }
 }

--- a/AAEmu.Login/LoginService.cs
+++ b/AAEmu.Login/LoginService.cs
@@ -18,18 +18,19 @@ public sealed class LoginService(
     IOptions<AppConfiguration> appConfig,
     ILogger<LoginService> logger) : IHostedService, IDisposable
 {
-    public Task StartAsync(CancellationToken cancellationToken)
+    public async Task StartAsync(CancellationToken cancellationToken)
     {
         logger.LogInformation("Starting daemon: AAEmu.Login");
+
         // Check for updates
-        using (var connection = MySQL.CreateConnection())
+        await using (var connection = MySQL.CreateConnection())
         {
             if (!MySqlDatabaseUpdater.Run(connection, "aaemu_login",
                     appConfig.Value.Connections.MySQLProvider.Database))
             {
                 logger.LogCritical("Failed to update database!");
                 logger.LogCritical("Press Ctrl+C to quit");
-                return Task.CompletedTask;
+                return;
             }
         }
 
@@ -37,7 +38,6 @@ public sealed class LoginService(
         gameController.Load();
         loginNetwork.Start();
         internalNetwork.Start();
-        return Task.CompletedTask;
     }
 
     public Task StopAsync(CancellationToken cancellationToken)

--- a/AAEmu.Login/Program.cs
+++ b/AAEmu.Login/Program.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Logging;
 using NLog;
 using NLog.Config;
 using NLog.Extensions.Logging;
+using OpenTelemetry;
 using OSVersionExtension;
 
 namespace AAEmu.Login;
@@ -45,7 +46,14 @@ public static class Program
 
         // Configure services
         builder.Logging.ClearProviders()
-            .AddNLog();
+            .AddNLog()
+            .AddOpenTelemetry(logging =>
+            {
+                logging.IncludeFormattedMessage = true;
+                logging.IncludeScopes = true;
+            });;
+        builder.Services.AddOpenTelemetry()
+            .UseOtlpExporter();
         builder.Services.AddOptions();
         builder.Services.AddOptionsWithValidateOnStart<AppConfiguration>()
             .BindConfiguration("")

--- a/AAEmu.Login/Program.cs
+++ b/AAEmu.Login/Program.cs
@@ -10,8 +10,10 @@ using AAEmu.Login.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using NLog;
 using NLog.Config;
+using NLog.Extensions.Logging;
 using OSVersionExtension;
 
 namespace AAEmu.Login;
@@ -42,6 +44,8 @@ public static class Program
             .AddCommandLine(args);
 
         // Configure services
+        builder.Logging.ClearProviders()
+            .AddNLog();
         builder.Services.AddOptions();
         builder.Services.AddOptionsWithValidateOnStart<AppConfiguration>()
             .BindConfiguration("")

--- a/AAEmu.Login/Utils/IdManager.cs
+++ b/AAEmu.Login/Utils/IdManager.cs
@@ -2,13 +2,13 @@
 using AAEmu.Commons.Exceptions;
 using AAEmu.Commons.Utils;
 using AAEmu.Commons.Utils.DB;
-using NLog;
+using Microsoft.Extensions.Logging;
 
 namespace AAEmu.Login.Utils;
 
 public class IdManager
 {
-    protected static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
+    protected ILogger Logger { get; }
 
     private BitSet? _freeIds;
     private int _freeIdCount;
@@ -23,8 +23,10 @@ public class IdManager
     private readonly bool _distinct;
     private readonly Lock _lock = new();
 
-    public IdManager(string name, uint firstId, uint lastId, string[,] objTables, uint[] exclude, bool distinct = false)
+    public IdManager(string name, uint firstId, uint lastId, string[,] objTables, uint[] exclude, ILogger logger,
+        bool distinct = false)
     {
+        Logger = logger;
         _name = name;
         _firstId = firstId;
         _lastId = lastId;
@@ -50,7 +52,8 @@ public class IdManager
                 var objectId = (int)(usedObjectId - _firstId);
                 if (usedObjectId < _firstId)
                 {
-                    Logger.Warn("{0}: Object ID {1} in DB is less than {2}", _name, usedObjectId, _firstId);
+                    Logger.LogWarning("{Name}: Object ID {ObjectID} in DB is less than {FirstID}", _name, usedObjectId,
+                        _firstId);
                     continue;
                 }
 
@@ -61,12 +64,11 @@ public class IdManager
             }
 
             _nextFreeId = _freeIds.NextClear(0);
-            Logger.Info("{0} successfully initialized", _name);
+            Logger.LogInformation("{Name} successfully initialized", _name);
         }
-        catch (Exception e)
+        catch (Exception ex)
         {
-            Logger.Error("{0} could not be initialized correctly", _name);
-            Logger.Error(e);
+            Logger.LogError(ex, "{Name} could not be initialized correctly", _name);
             return false;
         }
 
@@ -101,7 +103,7 @@ public class IdManager
             return [];
 
         var result = new uint[count];
-        Logger.Info("{0}: Extracting {1} used id's from data tables...", _name, count);
+        Logger.LogInformation("{Name}: Extracting {Count} used id's from data tables...", _name, count);
 
         command.CommandText = query;
         using (var reader = command.ExecuteReader())
@@ -113,7 +115,7 @@ public class IdManager
                 idx++;
             }
 
-            Logger.Info("{0}: Successfully extracted {1} used id's from data tables.", _name, idx);
+            Logger.LogInformation("{Name}: Successfully extracted {Count} used id's from data tables.", _name, idx);
         }
 
         return result;
@@ -135,7 +137,7 @@ public class IdManager
             Interlocked.Increment(ref _freeIdCount);
         }
         else
-            Logger.Warn("{0}: release objectId {1} failed", _name, usedObjectId);
+            Logger.LogWarning("{Name}: release objectId {ObjectID} failed", _name, usedObjectId);
     }
 
     public virtual void ReleaseId(IEnumerable<uint> usedObjectIds)

--- a/AAEmu.Login/Utils/MySQLInitializer.cs
+++ b/AAEmu.Login/Utils/MySQLInitializer.cs
@@ -6,10 +6,13 @@ using Microsoft.Extensions.Options;
 
 namespace AAEmu.Login.Utils;
 
-public class MySqlInitializer(IOptions<AppConfiguration> appConfig, ILogger<MySqlInitializer> logger)
-    : BackgroundService
+public class MySqlInitializer(IOptions<AppConfiguration> appConfig, ILogger<MySqlInitializer> logger) : IHostedService
 {
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    // Not using BackgroundService here due to it not preventing other hosted services from starting:
+    // https://learn.microsoft.com/en-us/dotnet/core/compatibility/extensions/10.0/backgroundservice-executeasync-task
+    // This service needs to run before any other service that relies on the database.
+
+    public async Task StartAsync(CancellationToken cancellationToken)
     {
         MySQL.SetConfiguration(appConfig.Value.Connections.MySQLProvider);
 
@@ -27,4 +30,6 @@ public class MySqlInitializer(IOptions<AppConfiguration> appConfig, ILogger<MySq
             throw;
         }
     }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/AAEmu.Login/Utils/MySQLInitializer.cs
+++ b/AAEmu.Login/Utils/MySQLInitializer.cs
@@ -1,15 +1,14 @@
 ﻿using AAEmu.Commons.Utils.DB;
 using AAEmu.Login.Models;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using NLog;
 
 namespace AAEmu.Login.Utils;
 
-public class MySqlInitializer(IOptions<AppConfiguration> appConfig) : BackgroundService
+public class MySqlInitializer(IOptions<AppConfiguration> appConfig, ILogger<MySqlInitializer> logger)
+    : BackgroundService
 {
-    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
-    
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         MySQL.SetConfiguration(appConfig.Value.Connections.MySQLProvider);
@@ -18,13 +17,13 @@ public class MySqlInitializer(IOptions<AppConfiguration> appConfig) : Background
         {
             // Test the DB connection
             await using var connection = MySQL.CreateConnection();
-            Logger.Info("MySQL connection established successfully to {0}. Server version {1}", connection.DataSource,
+            logger.LogInformation("MySQL connection established successfully to {DataSource}. Server version {Version}",
+                connection.DataSource,
                 connection.ServerVersion);
         }
         catch (Exception ex)
         {
-            Logger.Fatal(ex, "MySQL connection failed, check your configuration!");
-            LogManager.Flush();
+            logger.LogCritical(ex, "MySQL connection failed, check your configuration!");
             throw;
         }
     }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,20 +9,20 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.11.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.6" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="MySql.Data" Version="9.1.0" />
     <PackageVersion Include="NCrontab" Version="3.3.3" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="NLog" Version="5.3.4" />
+    <PackageVersion Include="NLog" Version="6.0.7" />
     <PackageVersion Include="NLua" Version="1.7.3" />
     <PackageVersion Include="NetCoreServer" Version="8.0.7" />
     <PackageVersion Include="OSVersionExt.NetStd" Version="3.0.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,6 +23,7 @@
     <PackageVersion Include="NCrontab" Version="3.3.3" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NLog" Version="6.0.7" />
+    <PackageVersion Include="NLog.Extensions.Logging" Version="6.1.0" />
     <PackageVersion Include="NLua" Version="1.7.3" />
     <PackageVersion Include="NetCoreServer" Version="8.0.7" />
     <PackageVersion Include="OSVersionExt.NetStd" Version="3.0.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,6 +26,8 @@
     <PackageVersion Include="NLog.Extensions.Logging" Version="6.1.0" />
     <PackageVersion Include="NLua" Version="1.7.3" />
     <PackageVersion Include="NetCoreServer" Version="8.0.7" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
     <PackageVersion Include="OSVersionExt.NetStd" Version="3.0.1" />
     <PackageVersion Include="System.Drawing.Primitives" Version="4.3.0" />
     <PackageVersion Include="System.Numerics.Vectors" Version="4.6.0" />


### PR DESCRIPTION
This PR sets up NLog as the logging provider for Microsoft.Extensions.Logging, allowing the use of the `ILogger` abstraction.

Use of the abstraction allows easier migration to other logging providers in the future, as well as easier integration of OpenTelemetry for exporting the logs to observability platforms (including the Aspire dashboard).

This PR also sets up an initial OpenTelemetry exporter via OTLP (this should be made configurable in future, e.g. setting the endpoint and protocol, or disabling entirely).