### PR TITLE
refactor(login): Separate the app configuration into smaller parts

### DIFF
--- a/AAEmu.Login/Core/Network/Internal/InternalNetwork.cs
+++ b/AAEmu.Login/Core/Network/Internal/InternalNetwork.cs
@@ -9,7 +9,7 @@ namespace AAEmu.Login.Core.Network.Internal;
 
 public class InternalNetwork(
     IInternalProtocolHandler protocolHandler,
-    IOptions<AppConfiguration> appConfig,
+    IOptions<InternalNetworkConfig> internalNetworkConfig,
     ILogger<InternalNetwork> logger)
     : IInternalNetwork
 {
@@ -17,7 +17,7 @@ public class InternalNetwork(
 
     public void Start()
     {
-        var config = appConfig.Value.InternalNetwork;
+        var config = internalNetworkConfig.Value;
         var host =
             new IPEndPoint(config.Host.Equals("*") ? IPAddress.IPv6Any : IPAddress.Parse(config.Host), config.Port);
 

--- a/AAEmu.Login/Core/Network/Login/LoginNetwork.cs
+++ b/AAEmu.Login/Core/Network/Login/LoginNetwork.cs
@@ -8,14 +8,14 @@ namespace AAEmu.Login.Core.Network.Login;
 
 public class LoginNetwork(
     ILoginProtocolHandler protocolHandler,
-    IOptions<AppConfiguration> appConfig,
+    IOptions<PublicNetworkConfig> publicNetworkConfig,
     ILogger<LoginNetwork> logger) : ILoginNetwork
 {
     private Server? _server;
 
     public void Start()
     {
-        var config = appConfig.Value.Network;
+        var config = publicNetworkConfig.Value;
         _server = new Server(
             config.Host.Equals("*") ? IPAddress.Any : IPAddress.Parse(config.Host), config.Port, protocolHandler);
         _server.Start();

--- a/AAEmu.Login/LoginService.cs
+++ b/AAEmu.Login/LoginService.cs
@@ -15,7 +15,7 @@ public sealed class LoginService(
     IRequestController requestController,
     IInternalNetwork internalNetwork,
     ILoginNetwork loginNetwork,
-    IOptions<AppConfiguration> appConfig,
+    IOptions<DBConnectionsConfig> dbConnectionsConfig,
     ILogger<LoginService> logger) : IHostedService, IDisposable
 {
     public async Task StartAsync(CancellationToken cancellationToken)
@@ -26,7 +26,7 @@ public sealed class LoginService(
         await using (var connection = MySQL.CreateConnection())
         {
             if (!MySqlDatabaseUpdater.Run(connection, "aaemu_login",
-                    appConfig.Value.Connections.MySQLProvider.Database))
+                    dbConnectionsConfig.Value.MySQLProvider.Database))
             {
                 logger.LogCritical("Failed to update database!");
                 logger.LogCritical("Press Ctrl+C to quit");

--- a/AAEmu.Login/Models/AppConfiguration.cs
+++ b/AAEmu.Login/Models/AppConfiguration.cs
@@ -1,33 +1,25 @@
 ﻿using System.ComponentModel.DataAnnotations;
-using AAEmu.Commons.Models;
 
 namespace AAEmu.Login.Models;
 
+/// <summary>
+/// Contains general application configuration.
+/// </summary>
 public class AppConfiguration
 {
+    /// <summary>
+    /// Gets or sets the secret key used to verify game servers when registering themselves with the login server.
+    /// </summary>
     [Required]
     public required string SecretKey { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether accounts should be created automatically if they do not exist.
+    /// </summary>
     public bool AutoAccount { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to skip host resolution of game server hostnames.
+    /// </summary>
     public bool SkipHostResolve { get; set; }
-    [Required]
-    public required DBConnections Connections { get; set; }
-    [Required]
-    public required NetworkConfig InternalNetwork { get; set; }
-    [Required]
-    public required NetworkConfig Network { get; set; }
-
-    public class NetworkConfig
-    {
-        [Required]
-        public required string Host { get; set; }
-        [Required]
-        public required ushort Port { get; set; }
-        public required int NumConnections { get; set; }
-    }
-
-    public class DBConnections
-    {
-        [Required]
-        public required MySqlConnectionSettings MySQLProvider { get; set; }
-    }
 }

--- a/AAEmu.Login/Models/DBConnectionsConfig.cs
+++ b/AAEmu.Login/Models/DBConnectionsConfig.cs
@@ -1,0 +1,18 @@
+﻿using System.ComponentModel.DataAnnotations;
+using AAEmu.Commons.Models;
+
+namespace AAEmu.Login.Models;
+
+/// <summary>
+/// Contains database connection configuration settings.
+/// </summary>
+public class DBConnectionsConfig
+{
+    public const string ConfigurationSectionName = "Connections";
+
+    /// <summary>
+    /// Gets or sets the MySQL database connection settings.
+    /// </summary>
+    [Required]
+    public required MySqlConnectionSettings MySQLProvider { get; set; }
+}

--- a/AAEmu.Login/Models/InternalNetworkConfig.cs
+++ b/AAEmu.Login/Models/InternalNetworkConfig.cs
@@ -1,0 +1,9 @@
+﻿namespace AAEmu.Login.Models;
+
+/// <summary>
+/// Contains internal network configuration for game server connections.
+/// </summary>
+public class InternalNetworkConfig : NetworkConfig
+{
+    public const string ConfigurationSectionName = "InternalNetwork";
+}

--- a/AAEmu.Login/Models/NetworkConfig.cs
+++ b/AAEmu.Login/Models/NetworkConfig.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace AAEmu.Login.Models;
+
+/// <summary>
+/// A base class for network configuration settings.
+/// </summary>
+public abstract class NetworkConfig
+{
+    /// <summary>
+    /// Gets or sets the host address to listen on.
+    /// </summary>
+    [Required]
+    public required string Host { get; set; }
+
+    /// <summary>
+    /// Gets or sets the port number to listen on.
+    /// </summary>
+    [Required]
+    public required ushort Port { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of simultaneous connections allowed.
+    /// </summary>
+    public required int NumConnections { get; set; }
+}

--- a/AAEmu.Login/Models/PublicNetworkConfig.cs
+++ b/AAEmu.Login/Models/PublicNetworkConfig.cs
@@ -1,0 +1,9 @@
+﻿namespace AAEmu.Login.Models;
+
+/// <summary>
+/// Contains public network configuration for client connections.
+/// </summary>
+public class PublicNetworkConfig : NetworkConfig
+{
+    public const string ConfigurationSectionName = "Network";
+}

--- a/AAEmu.Login/Program.cs
+++ b/AAEmu.Login/Program.cs
@@ -58,6 +58,15 @@ public static class Program
         builder.Services.AddOptionsWithValidateOnStart<AppConfiguration>()
             .BindConfiguration("")
             .ValidateDataAnnotations();
+        builder.Services.AddOptionsWithValidateOnStart<DBConnectionsConfig>()
+            .BindConfiguration(DBConnectionsConfig.ConfigurationSectionName)
+            .ValidateDataAnnotations();
+        builder.Services.AddOptionsWithValidateOnStart<InternalNetworkConfig>()
+            .BindConfiguration(InternalNetworkConfig.ConfigurationSectionName)
+            .ValidateDataAnnotations();
+        builder.Services.AddOptionsWithValidateOnStart<PublicNetworkConfig>()
+            .BindConfiguration(PublicNetworkConfig.ConfigurationSectionName)
+            .ValidateDataAnnotations();
 
         builder.Services.AddHostedService<MySqlInitializer>();
         builder.Services.AddHostedService<LoginService>();

--- a/AAEmu.Login/Utils/MySQLInitializer.cs
+++ b/AAEmu.Login/Utils/MySQLInitializer.cs
@@ -6,7 +6,8 @@ using Microsoft.Extensions.Options;
 
 namespace AAEmu.Login.Utils;
 
-public class MySqlInitializer(IOptions<AppConfiguration> appConfig, ILogger<MySqlInitializer> logger) : IHostedService
+public class MySqlInitializer(IOptions<DBConnectionsConfig> dbConnectionsConfig, ILogger<MySqlInitializer> logger)
+    : IHostedService
 {
     // Not using BackgroundService here due to it not preventing other hosted services from starting:
     // https://learn.microsoft.com/en-us/dotnet/core/compatibility/extensions/10.0/backgroundservice-executeasync-task
@@ -14,7 +15,7 @@ public class MySqlInitializer(IOptions<AppConfiguration> appConfig, ILogger<MySq
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        MySQL.SetConfiguration(appConfig.Value.Connections.MySQLProvider);
+        MySQL.SetConfiguration(dbConnectionsConfig.Value.MySQLProvider);
 
         try
         {


### PR DESCRIPTION
Separating into independent parts keeps to the design objectives of the [Options pattern](https://learn.microsoft.com/en-us/dotnet/core/extensions/options):

> * The [Interface Segregation Principle (ISP) or Encapsulation](https://learn.microsoft.com/en-us/dotnet/architecture/modern-web-apps-azure/architectural-principles#encapsulation): Scenarios (classes) that depend on configuration settings depend only on the configuration settings that they use.
> * [Separation of Concerns](https://learn.microsoft.com/en-us/dotnet/architecture/modern-web-apps-azure/architectural-principles#separation-of-concerns): Settings for different parts of the app aren't dependent or coupled with one another.

Each part is still bound to the same section of the configuration, so functionally there's no change.

Also added some more XML documentation.