### PR TITLE
chore: Shrink container images by doing framework-dependent publish

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -34,4 +34,4 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./AAEmu.UnitTests/TestResults/coverage.net10.0.info
+          path-to-lcov: ./AAEmu.UnitTests/TestResults/coverage.info

--- a/AAEmu.Game/Dockerfile
+++ b/AAEmu.Game/Dockerfile
@@ -1,7 +1,5 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS builder
 ARG CONFIGURATION
-ARG RUNTIME
-ARG FRAMEWORK
 ARG GAME_DB_URL
 
 RUN apk add --no-cache xz
@@ -11,13 +9,11 @@ COPY ./Directory.Build.props .
 COPY ./Directory.Packages.props .
 COPY ./AAEmu.Commons ./AAEmu.Commons
 COPY ./AAEmu.Game ./AAEmu.Game
-RUN dotnet publish ./AAEmu.Game/AAEmu.Game.csproj -c $CONFIGURATION -r $RUNTIME --self-contained true -f $FRAMEWORK
+RUN dotnet publish ./AAEmu.Game/AAEmu.Game.csproj -c $CONFIGURATION -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/runtime:10.0-alpine
 
 ARG CONFIGURATION
-ARG FRAMEWORK
-ARG RUNTIME
 ARG LOGIN_HOST
 ARG LOGIN_PORT
 ARG DB_HOST
@@ -28,7 +24,7 @@ ARG DB_PASSWORD
 RUN apk add --no-cache openssl mysql-client
 
 WORKDIR app
-COPY --from=builder app/AAEmu.Game/bin/$CONFIGURATION/$FRAMEWORK/$RUNTIME/publish ./
+COPY --from=builder /app/publish ./
 
 EXPOSE 1239 1250
-ENTRYPOINT ["./AAEmu.Game"]
+ENTRYPOINT ["dotnet", "AAEmu.Game.dll"]

--- a/AAEmu.Login/Dockerfile
+++ b/AAEmu.Login/Dockerfile
@@ -1,20 +1,16 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS builder
 ARG CONFIGURATION
-ARG RUNTIME
-ARG FRAMEWORK
 
 WORKDIR app
 COPY ./Directory.Build.props .
 COPY ./Directory.Packages.props .
 COPY ./AAEmu.Commons ./AAEmu.Commons
 COPY ./AAEmu.Login ./AAEmu.Login
-RUN dotnet publish ./AAEmu.Login/AAEmu.Login.csproj -c $CONFIGURATION -r $RUNTIME --self-contained true -f $FRAMEWORK
+RUN dotnet publish ./AAEmu.Login/AAEmu.Login.csproj -c $CONFIGURATION -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/runtime:10.0-alpine
 
 ARG CONFIGURATION
-ARG FRAMEWORK
-ARG RUNTIME
 ARG DB_HOST
 ARG DB_PORT
 ARG DB_USER
@@ -24,7 +20,7 @@ RUN apk add --no-cache openssl mysql-client
 
 WORKDIR app
 
-COPY --from=builder app/AAEmu.Login/bin/$CONFIGURATION/$FRAMEWORK/$RUNTIME/publish ./
+COPY --from=builder /app/publish ./
 
 EXPOSE 1234 1237
-ENTRYPOINT ["./AAEmu.Login"]
+ENTRYPOINT ["dotnet", "AAEmu.Login.dll"]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,8 +2,7 @@
   <PropertyGroup>
     <Company>AAEmu</Company>
     <Copyright>Copyright (c) 2019 - 2025 the AAEmu contributors</Copyright>
-    <TargetFrameworks>net10.0</TargetFrameworks>
-    <RuntimeIdentifiers>win-x64;win-x86;win-arm64;linux-x64;linux-arm64;linux-arm;linux-musl-x64;linux-musl-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
+    <TargetFramework>net10.0</TargetFramework>
     <VersionPrefix>0.3.0.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Instead of doing self-contained publishes that include the .NET runtime libraries built into the executable, this PR does framework-dependent publishes that rely on the .NET runtime being provided externally. The container image `mcr.microsoft.com/dotnet/runtime:10.0-alpine` already provides the .NET runtime components, so self-contained was an unnecessary duplication.

Reduces login server image from 337 MB down to 222 MB (saving 115 MB).
Reduces game server image from 395 MB down to 331 MB (saving 64 MB).

Speeds up `dotnet restore` by removing runtime identifiers. When publishing for a specific runtime, the `-r` argument can be used: `dotnet publish -r win-x64 --self-contained`.