### PR TITLE
feat(login): Login state machine via LoginSession class

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -26,6 +26,8 @@ jobs:
         run: dotnet run --configuration Release --no-build --project AAEmu.Game/AAEmu.Game.csproj compiler-check
       - name: Test
         run: dotnet test --project AAEmu.UnitTests --configuration Release --no-build --coverage --coverage-output coverage.cobertura.xml --coverage-output-format cobertura --results-directory ./TestResults
+      - name: Login Integration Tests
+        run: dotnet test --project AAEmu.Login.IntegrationTests --configuration Release --no-build
       - name: Coveralls GitHub Action
         uses: coverallsapp/github-action@v2
         with:

--- a/AAEmu.Game/GameService.cs
+++ b/AAEmu.Game/GameService.cs
@@ -26,15 +26,18 @@ namespace AAEmu.Game;
 public sealed class GameService : IHostedService, IDisposable
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
+    private static TimeProvider s_timeProvider = TimeProvider.System;
     public static DateTime StartTime { get; private set; } = DateTime.UtcNow;
-    public static TimeSpan TimeSinceStart => DateTime.UtcNow.Subtract(StartTime);
+    public static TimeSpan TimeSinceStart => s_timeProvider.GetUtcNow().UtcDateTime.Subtract(StartTime);
 
     private readonly ManagerOrchestrator _orchestrator;
 
-    public GameService(IServiceProvider serviceProvider, ManagerOrchestrator orchestrator)
+    public GameService(IServiceProvider serviceProvider, ManagerOrchestrator orchestrator, TimeProvider timeProvider)
     {
         SingletonContainer.ServiceProvider = serviceProvider;
         _orchestrator = orchestrator;
+        s_timeProvider = timeProvider;
+        StartTime = timeProvider.GetUtcNow().UtcDateTime;
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)

--- a/AAEmu.Game/Program.cs
+++ b/AAEmu.Game/Program.cs
@@ -104,6 +104,7 @@ public static class Program
             .ConfigureServices((hostContext, services) =>
             {
                 services.AddOptions();
+                services.AddSingleton(TimeProvider.System);
 
                 // -- Hosted services --
                 services.AddSingleton<IHostedService, GameService>();

--- a/AAEmu.Login.IntegrationTests/AAEmu.Login.IntegrationTests.csproj
+++ b/AAEmu.Login.IntegrationTests/AAEmu.Login.IntegrationTests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <!-- Enable Testing Platform support for dotnet test -->
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AAEmu.Commons\AAEmu.Commons.csproj" />
+    <ProjectReference Include="..\AAEmu.Login\AAEmu.Login.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="Microsoft.Testing.Extensions.Telemetry" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport.Abstractions" />
+    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Testcontainers" />
+    <PackageReference Include="Testcontainers.MySql" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\SQL\aaemu_login.sql" Link="SQL\aaemu_login.sql" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/AAEmu.Login.IntegrationTests/Fixtures/MySqlFixture.cs
+++ b/AAEmu.Login.IntegrationTests/Fixtures/MySqlFixture.cs
@@ -1,0 +1,62 @@
+using AAEmu.Commons.Models;
+using AAEmu.Commons.Utils.DB;
+using MySql.Data.MySqlClient;
+using Testcontainers.MySql;
+using Xunit;
+
+namespace AAEmu.Login.IntegrationTests.Fixtures;
+
+public class MySqlFixture : IAsyncLifetime
+{
+    private readonly MySqlContainer _container = new MySqlBuilder()
+        .WithImage("mysql:8.0")
+        .WithDatabase("aaemu_login")
+        .WithUsername("test")
+        .WithPassword("test")
+        .Build();
+
+    public async ValueTask InitializeAsync()
+    {
+        await _container.StartAsync();
+
+        var schemaPath = Path.Combine(AppContext.BaseDirectory, "SQL", "aaemu_login.sql");
+        var schemaSql = await File.ReadAllTextAsync(schemaPath);
+
+        // Strip CREATE DATABASE / USE lines — Testcontainers already created the DB
+        var filteredLines = schemaSql
+            .Split('\n')
+            .Where(line =>
+            {
+                var trimmed = line.TrimStart().ToUpperInvariant();
+                return !trimmed.StartsWith("CREATE DATABASE") && !trimmed.StartsWith("USE ");
+            });
+        var cleanedSql = string.Join('\n', filteredLines);
+
+        await using var connection = new MySqlConnection(_container.GetConnectionString());
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = cleanedSql;
+        await command.ExecuteNonQueryAsync();
+
+        // Point the static MySQL connection factory at the container
+        var connectionString = _container.GetConnectionString();
+        var builder = new MySqlConnectionStringBuilder(connectionString);
+        MySQL.SetConfiguration(new MySqlConnectionSettings
+        {
+            Host = builder.Server,
+            Port = (ushort)builder.Port,
+            User = builder.UserID,
+            Password = builder.Password,
+            Database = builder.Database
+        });
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _container.DisposeAsync();
+    }
+}
+
+[CollectionDefinition("MySql")]
+public class MySqlCollection : ICollectionFixture<MySqlFixture>;

--- a/AAEmu.Login.IntegrationTests/LoginControllerIntegrationTests.cs
+++ b/AAEmu.Login.IntegrationTests/LoginControllerIntegrationTests.cs
@@ -1,0 +1,140 @@
+using System.Net;
+using AAEmu.Commons.Utils.DB;
+using AAEmu.Login.Core.Controllers;
+using AAEmu.Login.Core.PacketHandlers.C2L;
+using AAEmu.Login.Models;
+using AAEmu.Login.Utils;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace AAEmu.Login.IntegrationTests;
+
+[Collection("MySql")]
+public class LoginControllerIntegrationTests : IAsyncLifetime
+{
+    private readonly IPAddress _ipAddress = IPAddress.Parse("127.0.0.1");
+
+    public async ValueTask InitializeAsync()
+    {
+        await using var connection = MySQL.CreateConnection();
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = "TRUNCATE TABLE users;";
+        await cmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private static LoginController CreateController(bool autoAccount = false)
+    {
+        var gameController = new Mock<IGameController>();
+        var appConfig =
+            Options.Create(new AppConfiguration
+            {
+                SecretKey = "test-key", AutoAccount = autoAccount, GameServers = []
+            });
+        var connectionFactory = new Mock<IMySqlConnectionFactory>();
+        connectionFactory.Setup(f => f.CreateConnection()).Returns(MySQL.CreateConnection);
+        var logger = new Mock<ILogger<LoginController>>();
+        return new LoginController(gameController.Object, appConfig, connectionFactory.Object, logger.Object);
+    }
+
+    private static async Task InsertUser(string username, string password, bool banned = false, int banReason = 0)
+    {
+        await using var connection = MySQL.CreateConnection();
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText =
+            "INSERT INTO users (username, password, email, last_ip, last_login, created_at, updated_at, banned, ban_reason) " +
+            "VALUES (@username, @password, '', '', 0, 0, 0, @banned, @ban_reason)";
+        cmd.Parameters.AddWithValue("@username", username);
+        cmd.Parameters.AddWithValue("@password", password);
+        cmd.Parameters.AddWithValue("@banned", banned ? 1 : 0);
+        cmd.Parameters.AddWithValue("@ban_reason", banReason);
+        await cmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Login_NonExistentUser_AutoAccountOff_ReturnsFailed()
+    {
+        var controller = CreateController(autoAccount: false);
+
+        var result = await controller.Login("no_such_user", "pass", _ipAddress, TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.Equal(LoginDeniedReason.BadResponse, result.DenialReason);
+    }
+
+    [Fact]
+    public async Task Login_NonExistentUser_AutoAccountOn_CreatesAndSucceeds()
+    {
+        var controller = CreateController(autoAccount: true);
+
+        var result = await controller.Login("autouser", "newpass", _ipAddress, TestContext.Current.CancellationToken);
+
+        Assert.True(result.Success);
+        Assert.NotEqual(default, result.AccountId);
+    }
+
+    [Fact]
+    public async Task Login_CorrectPassword_ReturnsSuccess()
+    {
+        await InsertUser("alice", "mypassword");
+        var controller = CreateController();
+
+        var result =
+            await controller.Login("alice", "mypassword", _ipAddress, TestContext.Current.CancellationToken);
+
+        Assert.True(result.Success);
+    }
+
+    [Fact]
+    public async Task Login_WrongPassword_ReturnsFailed()
+    {
+        await InsertUser("bob", "correctpass");
+        var controller = CreateController();
+
+        var result = await controller.Login("bob", "wrongpass", _ipAddress, TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.Equal(LoginDeniedReason.BadResponse, result.DenialReason);
+    }
+
+    [Fact]
+    public async Task Login_BannedUser_ReturnsBanReason()
+    {
+        await InsertUser("banned_user", "pass", banned: true, banReason: 5);
+        var controller = CreateController();
+
+        var result = await controller.Login("banned_user", "pass", _ipAddress, TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.Equal(LoginDeniedReason.TryTradeCashTemporal, result.DenialReason);
+    }
+
+    [Fact]
+    public async Task Login_UpdatesLastLoginAndIp()
+    {
+        await InsertUser("tracker", "pass");
+        var controller = CreateController();
+ 
+        var result = await controller.Login("tracker", "pass", _ipAddress, TestContext.Current.CancellationToken);
+        Assert.True(result.Success);
+
+        // Verify the DB was updated
+        await using var connection = MySQL.CreateConnection();
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT last_ip, last_login, updated_at FROM users WHERE username=@username";
+        cmd.Parameters.AddWithValue("@username", "tracker");
+        await using var reader = await cmd.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        Assert.True(await reader.ReadAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal(_ipAddress, IPAddress.Parse(reader["last_ip"].ToString()!));
+
+        var lastLogin = Convert.ToInt64(reader["last_login"]);
+        Assert.True(lastLogin > 0, "last_login should be updated to a non-zero timestamp");
+
+        var updatedAt = Convert.ToInt64(reader["updated_at"]);
+        Assert.True(updatedAt > 0, "updated_at should be updated to a non-zero timestamp");
+    }
+}

--- a/AAEmu.Login.IntegrationTests/LoginControllerIntegrationTests.cs
+++ b/AAEmu.Login.IntegrationTests/LoginControllerIntegrationTests.cs
@@ -29,11 +29,10 @@ public class LoginControllerIntegrationTests : IAsyncLifetime
     private static LoginController CreateController(bool autoAccount = false)
     {
         var gameController = new Mock<IGameController>();
-        var appConfig =
-            Options.Create(new AppConfiguration
-            {
-                SecretKey = "test-key", AutoAccount = autoAccount, GameServers = []
-            });
+        var appConfig = Options.Create(new AppConfiguration
+        {
+            SecretKey = "test-key", AutoAccount = autoAccount, GameServers = []
+        });
         var connectionFactory = new Mock<IMySqlConnectionFactory>();
         connectionFactory.Setup(f => f.CreateConnection()).Returns(MySQL.CreateConnection);
         var logger = new Mock<ILogger<LoginController>>();

--- a/AAEmu.Login/Core/Authentication/AuthFlowResult.cs
+++ b/AAEmu.Login/Core/Authentication/AuthFlowResult.cs
@@ -1,0 +1,30 @@
+using AAEmu.Login.Core.PacketHandlers.C2L;
+using AAEmu.Login.Models;
+
+namespace AAEmu.Login.Core.Authentication;
+
+/// <summary>
+/// The result of an authentication flow step.
+/// </summary>
+public abstract record AuthFlowResult
+{
+    private AuthFlowResult() { }
+
+    /// <summary>
+    /// Authentication completed successfully.
+    /// </summary>
+    /// <param name="AccountId">The authenticated account ID.</param>
+    /// <param name="Username">The authenticated username, if available.</param>
+    public sealed record Success(AccountId AccountId, string? Username = null) : AuthFlowResult;
+
+    /// <summary>
+    /// Authentication was denied.
+    /// </summary>
+    /// <param name="Reason">The denial reason code to send to the client.</param>
+    public sealed record Denied(LoginDeniedReason Reason) : AuthFlowResult;
+
+    /// <summary>
+    /// The flow is in progress and managing itself.
+    /// </summary>
+    public sealed record Pending : AuthFlowResult;
+}

--- a/AAEmu.Login/Core/Authentication/IAuthenticationFlow.cs
+++ b/AAEmu.Login/Core/Authentication/IAuthenticationFlow.cs
@@ -1,0 +1,31 @@
+using AAEmu.Login.Core.Network.Connections;
+
+namespace AAEmu.Login.Core.Authentication;
+
+/// <summary>
+/// Represents an authentication flow that can be started and may require
+/// additional steps before completing.
+/// </summary>
+/// <remarks>
+/// Flows are pure decision-makers that return <see cref="AuthFlowResult"/> values.
+/// <see cref="ILoginSession"/> manages the lifecycle: setting the current flow on
+/// <see cref="AuthFlowResult.Pending"/>, and clearing it on
+/// <see cref="AuthFlowResult.Success"/> or <see cref="AuthFlowResult.Denied"/>.
+/// </remarks>
+public interface IAuthenticationFlow
+{
+    /// <summary>
+    /// Starts the authentication flow.
+    /// </summary>
+    /// <param name="client">The login client for sending responses.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The result of starting the flow:
+    /// <list type="bullet">
+    ///   <item><see cref="AuthFlowResult.Success"/> - authentication completed successfully</item>
+    ///   <item><see cref="AuthFlowResult.Denied"/> - authentication failed</item>
+    ///   <item><see cref="AuthFlowResult.Pending"/> - flow needs additional input</item>
+    /// </list>
+    /// </returns>
+    Task<AuthFlowResult> StartAsync(ILoginClient client, CancellationToken cancellationToken);
+}

--- a/AAEmu.Login/Core/Authentication/PasswordAuthFlow.cs
+++ b/AAEmu.Login/Core/Authentication/PasswordAuthFlow.cs
@@ -1,0 +1,25 @@
+using System.Net;
+using AAEmu.Login.Core.Controllers;
+using AAEmu.Login.Core.Network.Connections;
+
+namespace AAEmu.Login.Core.Authentication;
+
+/// <summary>
+/// Authentication flow using username and password (EU method).
+/// This is a single-step flow that completes immediately.
+/// </summary>
+public class PasswordAuthFlow(
+    ILoginController loginController,
+    string username,
+    string password,
+    IPAddress clientIp) : IAuthenticationFlow
+{
+    public async Task<AuthFlowResult> StartAsync(ILoginClient client, CancellationToken cancellationToken)
+    {
+        var result = await loginController.Login(username, password, clientIp, cancellationToken);
+
+        return result.Success
+            ? new AuthFlowResult.Success(result.AccountId, username)
+            : new AuthFlowResult.Denied(result.DenialReason);
+    }
+}

--- a/AAEmu.Login/Core/Authentication/ReconnectAuthFlow.cs
+++ b/AAEmu.Login/Core/Authentication/ReconnectAuthFlow.cs
@@ -1,0 +1,22 @@
+using AAEmu.Login.Core.Controllers;
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.PacketHandlers.C2L;
+using AAEmu.Login.Models;
+
+namespace AAEmu.Login.Core.Authentication;
+
+/// <summary>
+/// Wraps reconnection validation as an authentication flow so it goes through
+/// <see cref="ILoginSession.AuthenticateAsync"/> like all other auth paths.
+/// </summary>
+public class ReconnectAuthFlow(ILoginController loginController, GameServerId gsId, AccountId accountId, uint token)
+    : IAuthenticationFlow
+{
+    public async Task<AuthFlowResult> StartAsync(ILoginClient client, CancellationToken cancellationToken)
+    {
+        var result = await loginController.Reconnect(gsId, accountId, token);
+        return result.Success
+            ? new AuthFlowResult.Success(result.AccountId)
+            : new AuthFlowResult.Denied(LoginDeniedReason.BadResponse);
+    }
+}

--- a/AAEmu.Login/Core/Controllers/GameController.cs
+++ b/AAEmu.Login/Core/Controllers/GameController.cs
@@ -126,7 +126,7 @@ public class GameController(
         gameServer.MirrorsId.Clear();
     }
 
-    public async Task RequestWorldListAsync(LoginConnection connection)
+    public async Task RequestWorldListAsync(ILoginConnection connection)
     {
         var gameServers = _gameServers.Values.ToList();
         if (_gameServers.Values.Any(x => x.Active))

--- a/AAEmu.Login/Core/Controllers/GameController.cs
+++ b/AAEmu.Login/Core/Controllers/GameController.cs
@@ -3,7 +3,6 @@ using System.Net;
 using System.Net.Sockets;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.Network.Internal;
-using AAEmu.Login.Core.Packets.L2C;
 using AAEmu.Login.Core.Packets.L2G;
 using AAEmu.Login.Models;
 using Microsoft.Extensions.Options;
@@ -12,6 +11,7 @@ namespace AAEmu.Login.Core.Controllers;
 
 public class GameController(
     IRequestController requestController,
+    ILoginConnectionTable connectionTable,
     IOptions<AppConfiguration> appConfig,
     ILogger<GameController> logger)
     : IGameController
@@ -126,7 +126,7 @@ public class GameController(
         gameServer.MirrorsId.Clear();
     }
 
-    public async Task RequestWorldListAsync(ILoginConnection connection)
+    public async Task<WorldListResult> GetWorldListAsync(ILoginConnection connection)
     {
         var gameServers = _gameServers.Values.ToList();
         if (_gameServers.Values.Any(x => x.Active))
@@ -157,8 +157,7 @@ public class GameController(
             await creationTask;
         }
 
-        await connection.SendPacketAsync(new ACWorldListPacket(gameServers, connection.GetCharacters()),
-            CancellationToken.None);
+        return new WorldListResult(gameServers, connection.GetCharacters());
     }
 
     public void SetLoad(GameServerId gsId, byte load)
@@ -166,31 +165,34 @@ public class GameController(
         _gameServers[gsId].Load = (GSLoad)load;
     }
 
-    public void RequestEnterWorld(ILoginConnection connection, GameServerId gsId)
+    public GameServer? GetGameServer(GameServerId gsId) => _gameServers.GetValueOrDefault(gsId);
+
+    public void RequestEnterWorld(AccountId accountId, ConnectionId connectionId, GameServerId gsId)
     {
         if (!_gameServers.TryGetValue(gsId, out var gs))
+        {
+            logger.LogWarning("RequestEnterWorld: game server {GsId} not found", gsId);
             return;
+        }
+
         if (!gs.Active)
+        {
+            logger.LogWarning("RequestEnterWorld: game server {GsId} not active", gsId);
             return;
-        gs.SendPacket(new LGPlayerEnterPacket(connection.AccountId, connection.Id));
+        }
+
+        gs.SendPacket(new LGPlayerEnterPacket(accountId, connectionId));
     }
 
-    public async Task EnterWorldAsync(ILoginConnection connection, GameServerId gsId, byte result)
+    public void RouteEnterWorldResponse(ConnectionId connectionId, GameServerId gsId, byte result)
     {
-        switch (result)
+        var connection = connectionTable.GetConnection(connectionId);
+        if (connection is null)
         {
-            case 0 when _gameServers.TryGetValue(gsId, out var server):
-                await connection.SendPacketAsync(new ACWorldCookiePacket(connection, server), CancellationToken.None);
-                break;
-            case 0:
-                // TODO ...
-                break;
-            case 1:
-                await connection.SendPacketAsync(new ACEnterWorldDeniedPacket(0), CancellationToken.None); // TODO change reason
-                break;
-            default:
-                // TODO ...
-                break;
+            logger.LogWarning("RouteEnterWorldResponse: connection {ConnectionId} not found", connectionId);
+            return;
         }
+
+        connection.Session.CompleteEnterWorldRequest(gsId, result);
     }
 }

--- a/AAEmu.Login/Core/Controllers/IGameController.cs
+++ b/AAEmu.Login/Core/Controllers/IGameController.cs
@@ -14,8 +14,7 @@ public interface IGameController
     /// Requests the list of available game worlds from the specified login connection.
     /// </summary>
     /// <param name="connection">The client connection making the request.</param>
-    Task RequestWorldListAsync(LoginConnection connection);
-
+    Task RequestWorldListAsync(ILoginConnection connection);
     void SetLoad(GameServerId gsId, byte load);
     void RequestEnterWorld(ILoginConnection connection, GameServerId gsId);
     Task EnterWorldAsync(ILoginConnection connection, GameServerId gsId, byte result);

--- a/AAEmu.Login/Core/Controllers/IGameController.cs
+++ b/AAEmu.Login/Core/Controllers/IGameController.cs
@@ -14,8 +14,22 @@ public interface IGameController
     /// Requests the list of available game worlds from the specified login connection.
     /// </summary>
     /// <param name="connection">The client connection making the request.</param>
-    Task RequestWorldListAsync(ILoginConnection connection);
+    Task<WorldListResult> GetWorldListAsync(ILoginConnection connection);
     void SetLoad(GameServerId gsId, byte load);
-    void RequestEnterWorld(ILoginConnection connection, GameServerId gsId);
-    Task EnterWorldAsync(ILoginConnection connection, GameServerId gsId, byte result);
+
+    /// <summary>
+    /// Gets a game server by its ID, or null if not found.
+    /// </summary>
+    GameServer? GetGameServer(GameServerId gsId);
+
+    /// <summary>
+    /// Sends an enter world request to the game server (fire-and-forget).
+    /// The response will be routed via <see cref="RouteEnterWorldResponse"/>.
+    /// </summary>
+    void RequestEnterWorld(AccountId accountId, ConnectionId connectionId, GameServerId gsId);
+
+    /// <summary>
+    /// Routes an enter world response from a game server to the appropriate connection's session.
+    /// </summary>
+    void RouteEnterWorldResponse(ConnectionId connectionId, GameServerId gsId, byte result);
 }

--- a/AAEmu.Login/Core/Controllers/ILoginController.cs
+++ b/AAEmu.Login/Core/Controllers/ILoginController.cs
@@ -1,4 +1,5 @@
-﻿using AAEmu.Login.Core.Network.Connections;
+﻿using System.Net;
+using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Controllers;
@@ -6,20 +7,19 @@ namespace AAEmu.Login.Core.Controllers;
 public interface ILoginController
 {
     void AddReconnectionToken(InternalConnection connection, GameServerId gsId, AccountId accountId, uint token);
-    Task Reconnect(ILoginConnection connection, GameServerId gsId, AccountId accountId, uint token);
+    Task<ReconnectResult> Reconnect(GameServerId gsId, AccountId accountId, uint token);
 
     /// <summary>
     /// Kr Method Auth
     /// </summary>
-    /// <param name="connection"></param>
-    /// <param name="username"></param>
-    Task Login(ILoginConnection connection, string username);
+    Task<LoginResult> Login(string username);
 
     /// <summary>
     /// Eu Method Auth
     /// </summary>
-    /// <param name="connection"></param>
-    /// <param name="username"></param>
-    /// <param name="password"></param>
-    Task Login(ILoginConnection connection, string username, ReadOnlyMemory<byte> password);
+    /// <param name="username">The username.</param>
+    /// <param name="password">The password sent by the client.</param>
+    /// <param name="ip">The client IP address for recording.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<LoginResult> Login(string username, string password, IPAddress ip, CancellationToken cancellationToken);
 }

--- a/AAEmu.Login/Core/Controllers/ILoginController.cs
+++ b/AAEmu.Login/Core/Controllers/ILoginController.cs
@@ -6,14 +6,14 @@ namespace AAEmu.Login.Core.Controllers;
 public interface ILoginController
 {
     void AddReconnectionToken(InternalConnection connection, GameServerId gsId, AccountId accountId, uint token);
-    Task Reconnect(LoginConnection connection, GameServerId gsId, AccountId accountId, uint token);
+    Task Reconnect(ILoginConnection connection, GameServerId gsId, AccountId accountId, uint token);
 
     /// <summary>
     /// Kr Method Auth
     /// </summary>
     /// <param name="connection"></param>
     /// <param name="username"></param>
-    Task Login(LoginConnection connection, string username);
+    Task Login(ILoginConnection connection, string username);
 
     /// <summary>
     /// Eu Method Auth
@@ -21,5 +21,5 @@ public interface ILoginController
     /// <param name="connection"></param>
     /// <param name="username"></param>
     /// <param name="password"></param>
-    Task Login(LoginConnection connection, string username, ReadOnlyMemory<byte> password);
+    Task Login(ILoginConnection connection, string username, ReadOnlyMemory<byte> password);
 }

--- a/AAEmu.Login/Core/Controllers/LoginController.cs
+++ b/AAEmu.Login/Core/Controllers/LoginController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Concurrent;
+using System.Net;
 using AAEmu.Login.Core.Network.Connections;
-using AAEmu.Login.Core.Packets.L2C;
+using AAEmu.Login.Core.PacketHandlers.C2L;
 using AAEmu.Login.Core.Packets.L2G;
 using AAEmu.Login.Models;
 using AAEmu.Login.Utils;
@@ -23,9 +24,7 @@ public class LoginController(
     /// <summary>
     /// Kr Method Auth
     /// </summary>
-    /// <param name="connection"></param>
-    /// <param name="username"></param>
-    public async Task Login(ILoginConnection connection, string username)
+    public async Task<LoginResult> Login(string username)
     {
         await using var connect = connectionFactory.CreateConnection();
         await using var command = connect.CreateCommand();
@@ -34,19 +33,13 @@ public class LoginController(
         await using var reader = command.ExecuteReader();
         if (!await reader.ReadAsync())
         {
-            await connection.SendPacketAsync(new ACLoginDeniedPacket(2), CancellationToken.None);
-            return;
+            return new LoginResult(false, default, LoginDeniedReason.BadAccount);
         }
 
         // TODO ... validation password
 
-        connection.AccountId = new AccountId(reader.GetUInt32("id"));
-        connection.AccountName = username;
-        connection.LastLogin = DateTime.UtcNow;
-        connection.LastIp = connection.Ip;
-
-        await connection.SendPacketAsync(new ACJoinResponsePacket(0, 6), CancellationToken.None);
-        await connection.SendPacketAsync(new ACAuthResponsePacket(connection.AccountId, 6), CancellationToken.None);
+        var accountId = new AccountId(reader.GetUInt32("id"));
+        var lastLogin = DateTime.UtcNow;
 
         await reader.CloseAsync();
 
@@ -55,10 +48,10 @@ public class LoginController(
         command.Parameters.Clear();
         command.CommandText =
             "UPDATE `users` SET last_ip = @last_ip, last_login = @last_login, updated_at = @updated_at WHERE id = @id";
-        command.Parameters.AddWithValue("@id", connection.AccountId.Value);
-        command.Parameters.AddWithValue("@last_ip", connection.LastIp.ToString());
-        command.Parameters.AddWithValue("@last_login", ((DateTimeOffset)connection.LastLogin).ToUnixTimeSeconds());
-        command.Parameters.AddWithValue("@updated_at", ((DateTimeOffset)connection.LastLogin).ToUnixTimeSeconds());
+        command.Parameters.AddWithValue("@id", accountId.Value);
+        command.Parameters.AddWithValue("@last_ip", "");
+        command.Parameters.AddWithValue("@last_login", ((DateTimeOffset)lastLogin).ToUnixTimeSeconds());
+        command.Parameters.AddWithValue("@updated_at", ((DateTimeOffset)lastLogin).ToUnixTimeSeconds());
 
         if (await command.ExecuteNonQueryAsync() != 1)
         {
@@ -66,15 +59,15 @@ public class LoginController(
         }
 
         # endregion
+
+        return new LoginResult(true, accountId, default);
     }
 
     /// <summary>
     /// Eu Method Auth
     /// </summary>
-    /// <param name="connection"></param>
-    /// <param name="username"></param>
-    /// <param name="password"></param>
-    public async Task Login(ILoginConnection connection, string username, ReadOnlyMemory<byte> password)
+    public async Task<LoginResult> Login(string username, string password, IPAddress ip,
+        CancellationToken cancellationToken)
     {
         await using var connect = connectionFactory.CreateConnection();
         await using var command = connect.CreateCommand();
@@ -86,39 +79,29 @@ public class LoginController(
             if (_autoAccount)
             {
                 await reader.CloseAsync();
-                await CreateAndLoginInvalid(connection, username, password, connect);
-            }
-            else
-            {
-                await connection.SendPacketAsync(new ACLoginDeniedPacket(2), CancellationToken.None);
+                return await CreateAndLoginInvalid(username, password, ip, connect);
             }
 
-            return;
+            return new LoginResult(false, default, LoginDeniedReason.BadResponse);
         }
 
-        var expectedPassword = Convert.FromBase64String(reader.GetString("password"));
-        if (!password.Span.SequenceEqual(expectedPassword))
+        var storedPassword = reader.GetString("password");
+        if (password != storedPassword)
         {
-            await connection.SendPacketAsync(new ACLoginDeniedPacket(2), CancellationToken.None);
-            return;
+            return new LoginResult(false, default, LoginDeniedReason.BadResponse);
         }
 
         var banned = reader.GetBoolean("banned");
         if (banned)
         {
-            var banReason = (byte)reader.GetUInt32("ban_reason");
-            await connection.SendPacketAsync(new ACLoginDeniedPacket(banReason), CancellationToken.None);
-            return;
+            var banReason = (LoginDeniedReason)(byte)reader.GetUInt32("ban_reason");
+            return new LoginResult(false, default, banReason);
         }
 
-        connection.AccountId = new AccountId(reader.GetUInt32("id"));
-        connection.AccountName = username;
-        connection.LastLogin = DateTime.UtcNow;
-        connection.LastIp = connection.Ip;
+        var accountId = new AccountId(reader.GetUInt32("id"));
+        var lastLogin = DateTime.UtcNow;
 
-        logger.LogInformation("{AccountName} connected.", connection.AccountName);
-        await connection.SendPacketAsync(new ACJoinResponsePacket(0, 6), CancellationToken.None);
-        await connection.SendPacketAsync(new ACAuthResponsePacket(connection.AccountId, 6), CancellationToken.None);
+        logger.LogInformation("{Username} connected.", username);
 
         await reader.CloseAsync();
 
@@ -127,10 +110,10 @@ public class LoginController(
         command.Parameters.Clear();
         command.CommandText =
             "UPDATE `users` SET last_ip = @last_ip, last_login = @last_login, updated_at = @updated_at WHERE id = @id";
-        command.Parameters.AddWithValue("@id", connection.AccountId.Value);
-        command.Parameters.AddWithValue("@last_ip", connection.LastIp.ToString());
-        command.Parameters.AddWithValue("@last_login", ((DateTimeOffset)connection.LastLogin).ToUnixTimeSeconds());
-        command.Parameters.AddWithValue("@updated_at", ((DateTimeOffset)connection.LastLogin).ToUnixTimeSeconds());
+        command.Parameters.AddWithValue("@id", accountId.Value);
+        command.Parameters.AddWithValue("@last_ip", ip);
+        command.Parameters.AddWithValue("@last_login", ((DateTimeOffset)lastLogin).ToUnixTimeSeconds());
+        command.Parameters.AddWithValue("@updated_at", ((DateTimeOffset)lastLogin).ToUnixTimeSeconds());
 
         if (await command.ExecuteNonQueryAsync() != 1)
         {
@@ -138,32 +121,31 @@ public class LoginController(
         }
 
         # endregion
+
+        return new LoginResult(true, accountId, default);
     }
 
-    public async Task CreateAndLoginInvalid(ILoginConnection connection, string username, ReadOnlyMemory<byte> password,
-        MySqlConnection connect)
+    private async Task<LoginResult> CreateAndLoginInvalid(string username, string password, IPAddress clientIp,
+        MySqlConnection connection)
     {
-        var pass = Convert.ToBase64String(password.Span);
-
-        await using var command = connect.CreateCommand();
+        await using var command = connection.CreateCommand();
         command.CommandText =
             "INSERT into users (username, password, email, last_ip, last_login, created_at, updated_at) VALUES (@username, @password, @email, @last_ip, @last_login, @created_at, @updated_at)";
         command.Parameters.AddWithValue("@username", username);
-        command.Parameters.AddWithValue("@password", pass);
+        command.Parameters.AddWithValue("@password", password);
         command.Parameters.AddWithValue("@email", "");
-        command.Parameters.AddWithValue("@last_ip", connection.Ip.ToString());
+        command.Parameters.AddWithValue("@last_ip", clientIp);
         command.Parameters.AddWithValue("@last_login", ((DateTimeOffset)DateTime.UtcNow).ToUnixTimeSeconds());
         command.Parameters.AddWithValue("@created_at", ((DateTimeOffset)DateTime.UtcNow).ToUnixTimeSeconds());
         command.Parameters.AddWithValue("@updated_at", ((DateTimeOffset)DateTime.UtcNow).ToUnixTimeSeconds());
 
         if (await command.ExecuteNonQueryAsync() != 1)
         {
-            await connection.SendPacketAsync(new ACLoginDeniedPacket(2), CancellationToken.None);
-            return;
+            return new LoginResult(false, default, LoginDeniedReason.BadResponse);
         }
 
         logger.LogDebug("Created account from invalid username login with value {Username}", username);
-        await Login(connection, username, password);
+        return await Login(username, password, clientIp, CancellationToken.None);
     }
 
     public void AddReconnectionToken(InternalConnection connection, GameServerId gsId, AccountId accountId, uint token)
@@ -173,7 +155,7 @@ public class LoginController(
         connection.SendPacket(new LGPlayerReconnectPacket(token));
     }
 
-    public async Task Reconnect(ILoginConnection connection, GameServerId gsId, AccountId accountId, uint token)
+    public Task<ReconnectResult> Reconnect(GameServerId gsId, AccountId accountId, uint token)
     {
         if (!_tokens.ContainsKey(gsId))
         {
@@ -182,25 +164,22 @@ public class LoginController(
             else
             {
                 // TODO ...
-                return;
+                return Task.FromResult(new ReconnectResult(false, default));
             }
         }
 
         if (!_tokens[gsId].TryGetValue(token, out var value))
         {
             // TODO ...
-            return;
+            return Task.FromResult(new ReconnectResult(false, default));
         }
 
         if (value == accountId)
         {
-            connection.AccountId = accountId;
-            await connection.SendPacketAsync(new ACJoinResponsePacket(0, 6), CancellationToken.None);
-            await connection.SendPacketAsync(new ACAuthResponsePacket(connection.AccountId, 6), CancellationToken.None);
+            return Task.FromResult(new ReconnectResult(true, accountId));
         }
-        else
-        {
-            // TODO ...
-        }
+
+        // TODO ...
+        return Task.FromResult(new ReconnectResult(false, default));
     }
 }

--- a/AAEmu.Login/Core/Controllers/LoginController.cs
+++ b/AAEmu.Login/Core/Controllers/LoginController.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Net;
+using System.Text.RegularExpressions;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.PacketHandlers.C2L;
 using AAEmu.Login.Core.Packets.L2G;
@@ -10,7 +11,7 @@ using MySql.Data.MySqlClient;
 
 namespace AAEmu.Login.Core.Controllers;
 
-public class LoginController(
+public partial class LoginController(
     IGameController gameController,
     IOptions<AppConfiguration> appConfig,
     IMySqlConnectionFactory connectionFactory,
@@ -20,6 +21,10 @@ public class LoginController(
 
     private readonly ConcurrentDictionary<GameServerId, ConcurrentDictionary<uint, AccountId>>
         _tokens = []; // gsId, [token, accountId]
+
+    // Allows Unicode letters and digits (any script), plus _ . - @. No control characters or newlines.
+    [GeneratedRegex(@"^[\p{L}\p{Nd}_.\-@]{1,32}$")]
+    private static partial Regex UsernameRegex();
 
     /// <summary>
     /// Kr Method Auth
@@ -101,7 +106,7 @@ public class LoginController(
         var accountId = new AccountId(reader.GetUInt32("id"));
         var lastLogin = DateTime.UtcNow;
 
-        logger.LogInformation("{Username} connected.", username);
+        logger.LogInformation("{Username} connected.", username.ReplaceLineEndings(" "));
 
         await reader.CloseAsync();
 
@@ -128,6 +133,9 @@ public class LoginController(
     private async Task<LoginResult> CreateAndLoginInvalid(string username, string password, IPAddress clientIp,
         MySqlConnection connection)
     {
+        if (!UsernameRegex().IsMatch(username))
+            return new LoginResult(false, default, LoginDeniedReason.BadAccount);
+
         await using var command = connection.CreateCommand();
         command.CommandText =
             "INSERT into users (username, password, email, last_ip, last_login, created_at, updated_at) VALUES (@username, @password, @email, @last_ip, @last_login, @created_at, @updated_at)";

--- a/AAEmu.Login/Core/Controllers/LoginController.cs
+++ b/AAEmu.Login/Core/Controllers/LoginController.cs
@@ -25,7 +25,7 @@ public class LoginController(
     /// </summary>
     /// <param name="connection"></param>
     /// <param name="username"></param>
-    public async Task Login(LoginConnection connection, string username)
+    public async Task Login(ILoginConnection connection, string username)
     {
         await using var connect = connectionFactory.CreateConnection();
         await using var command = connect.CreateCommand();
@@ -74,7 +74,7 @@ public class LoginController(
     /// <param name="connection"></param>
     /// <param name="username"></param>
     /// <param name="password"></param>
-    public async Task Login(LoginConnection connection, string username, ReadOnlyMemory<byte> password)
+    public async Task Login(ILoginConnection connection, string username, ReadOnlyMemory<byte> password)
     {
         await using var connect = connectionFactory.CreateConnection();
         await using var command = connect.CreateCommand();
@@ -140,7 +140,7 @@ public class LoginController(
         # endregion
     }
 
-    public async Task CreateAndLoginInvalid(LoginConnection connection, string username, ReadOnlyMemory<byte> password,
+    public async Task CreateAndLoginInvalid(ILoginConnection connection, string username, ReadOnlyMemory<byte> password,
         MySqlConnection connect)
     {
         var pass = Convert.ToBase64String(password.Span);
@@ -173,7 +173,7 @@ public class LoginController(
         connection.SendPacket(new LGPlayerReconnectPacket(token));
     }
 
-    public async Task Reconnect(LoginConnection connection, GameServerId gsId, AccountId accountId, uint token)
+    public async Task Reconnect(ILoginConnection connection, GameServerId gsId, AccountId accountId, uint token)
     {
         if (!_tokens.ContainsKey(gsId))
         {

--- a/AAEmu.Login/Core/Network/Connections/ILoginClient.cs
+++ b/AAEmu.Login/Core/Network/Connections/ILoginClient.cs
@@ -1,0 +1,17 @@
+using AAEmu.Login.Core.PacketHandlers.C2L;
+using AAEmu.Login.Models;
+
+namespace AAEmu.Login.Core.Network.Connections;
+
+/// <summary>
+/// Abstraction for sending response packets to the client.
+/// Decouples business logic from protocol-level packet construction.
+/// </summary>
+public interface ILoginClient
+{
+    ValueTask SendAuthSuccessAsync(AccountId accountId, CancellationToken cancellationToken);
+    ValueTask SendAuthDeniedAsync(LoginDeniedReason reason, CancellationToken cancellationToken);
+    ValueTask SendWorldListAsync(WorldListResult worldList, CancellationToken cancellationToken);
+    ValueTask SendWorldCookieAsync(GameServer server, CancellationToken cancellationToken);
+    ValueTask SendEnterWorldDeniedAsync(byte reason, CancellationToken cancellationToken);
+}

--- a/AAEmu.Login/Core/Network/Connections/ILoginConnection.cs
+++ b/AAEmu.Login/Core/Network/Connections/ILoginConnection.cs
@@ -23,6 +23,12 @@ public interface ILoginConnection
     IPAddress Ip { get; }
 
     /// <summary>
+    /// The session managing the login flow state machine.
+    /// Used by infrastructure code for routing. Most code should receive ILoginSession directly.
+    /// </summary>
+    ILoginSession Session { get; }
+
+    /// <summary>
     /// Triggered when the client connection is closed.
     /// </summary>
     CancellationToken ConnectionClosed { get; }

--- a/AAEmu.Login/Core/Network/Connections/ILoginConnection.cs
+++ b/AAEmu.Login/Core/Network/Connections/ILoginConnection.cs
@@ -29,6 +29,10 @@ public interface ILoginConnection
 
     bool IsLocallyConnected { get; }
     AccountId AccountId { get; set; }
+    Dictionary<GameServerId, List<LoginCharacterInfo>> Characters { get; }
+    string? AccountName { get; set; }
+    DateTime LastLogin { get; set; }
+    IPAddress? LastIp { get; set; }
 
     ValueTask SendPacketAsync(LoginPacket packet, CancellationToken cancellationToken);
     ValueTask SendPacketAsync(ReadOnlyMemory<byte> packet, CancellationToken cancellationToken);

--- a/AAEmu.Login/Core/Network/Connections/ILoginSession.cs
+++ b/AAEmu.Login/Core/Network/Connections/ILoginSession.cs
@@ -1,0 +1,81 @@
+using AAEmu.Login.Core.Authentication;
+using AAEmu.Login.Core.Network.Login;
+using AAEmu.Login.Models;
+
+namespace AAEmu.Login.Core.Network.Connections;
+
+/// <summary>
+/// Manages the login flow state machine for a client connection.
+/// </summary>
+public interface ILoginSession
+{
+    /// <summary>
+    /// Gets the underlying connection for this session.
+    /// </summary>
+    ILoginConnection Connection { get; }
+
+    /// <summary>
+    /// Gets the client abstraction for sending response packets.
+    /// </summary>
+    ILoginClient Client { get; }
+
+    /// <summary>
+    /// Gets the current state of the login session.
+    /// </summary>
+    LoginState State { get; }
+
+    /// <summary>
+    /// Gets the current authentication flow, if any (read-only, for diagnostics).
+    /// </summary>
+    IAuthenticationFlow? CurrentAuthFlow { get; }
+
+    /// <summary>
+    /// Sends a packet to the client.
+    /// </summary>
+    ValueTask SendPacketAsync(LoginPacket packet, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Starts a new authentication flow. Validates that the session is in the Connected state,
+    /// transitions to Authenticating, and processes the flow result.
+    /// Sends auth success/denied packets internally.
+    /// </summary>
+    /// <param name="flow">The authentication flow to start.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task AuthenticateAsync(IAuthenticationFlow flow, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Continues an in-progress authentication flow. Validates that the session is in the Authenticating state
+    /// and that the current flow matches the expected type.
+    /// Sends auth success/denied packets internally.
+    /// </summary>
+    /// <typeparam name="TFlow">The expected flow type.</typeparam>
+    /// <param name="step">The step to execute on the flow.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task ContinueAuthAsync<TFlow>(Func<TFlow, Task<AuthFlowResult>> step, CancellationToken cancellationToken)
+        where TFlow : class, IAuthenticationFlow;
+
+    /// <summary>
+    /// Initiates entering the world on the specified game server.
+    /// Sends world cookie or denied packets internally via a background task.
+    /// </summary>
+    /// <param name="gsId">The game server to enter.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task InitiateEnterWorldAsync(GameServerId gsId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Cancels an in-progress enter world request.
+    /// </summary>
+    void CancelEnterWorld();
+
+    /// <summary>
+    /// Completes a pending enter world request with the result from the game server.
+    /// </summary>
+    /// <param name="gsId">The game server that responded.</param>
+    /// <param name="result">The result code (0 = success).</param>
+    void CompleteEnterWorldRequest(GameServerId gsId, byte result);
+
+    /// <summary>
+    /// Marks the session as disconnected and cancels any pending operations.
+    /// </summary>
+    Task DisconnectAsync();
+}

--- a/AAEmu.Login/Core/Network/Connections/ILoginSessionFactory.cs
+++ b/AAEmu.Login/Core/Network/Connections/ILoginSessionFactory.cs
@@ -1,0 +1,6 @@
+namespace AAEmu.Login.Core.Network.Connections;
+
+public interface ILoginSessionFactory
+{
+    ILoginSession Create(ILoginConnection connection);
+}

--- a/AAEmu.Login/Core/Network/Connections/LoginClient.cs
+++ b/AAEmu.Login/Core/Network/Connections/LoginClient.cs
@@ -1,0 +1,30 @@
+using AAEmu.Login.Core.PacketHandlers.C2L;
+using AAEmu.Login.Core.Packets.L2C;
+using AAEmu.Login.Models;
+
+namespace AAEmu.Login.Core.Network.Connections;
+
+/// <summary>
+/// Implementation of <see cref="ILoginClient"/> that wraps an <see cref="ILoginConnection"/>
+/// and constructs the appropriate packets.
+/// </summary>
+public sealed class LoginClient(ILoginConnection connection) : ILoginClient
+{
+    public async ValueTask SendAuthSuccessAsync(AccountId accountId, CancellationToken cancellationToken)
+    {
+        await connection.SendPacketAsync(new ACJoinResponsePacket(0, 6), cancellationToken);
+        await connection.SendPacketAsync(new ACAuthResponsePacket(accountId, 6), cancellationToken);
+    }
+
+    public ValueTask SendAuthDeniedAsync(LoginDeniedReason reason, CancellationToken cancellationToken) =>
+        connection.SendPacketAsync(new ACLoginDeniedPacket(reason), cancellationToken);
+
+    public ValueTask SendWorldListAsync(WorldListResult worldList, CancellationToken cancellationToken) =>
+        connection.SendPacketAsync(new ACWorldListPacket(worldList.GameServers, worldList.Characters), cancellationToken);
+
+    public ValueTask SendWorldCookieAsync(GameServer server, CancellationToken cancellationToken) =>
+        connection.SendPacketAsync(new ACWorldCookiePacket(connection, server), cancellationToken);
+
+    public ValueTask SendEnterWorldDeniedAsync(byte reason, CancellationToken cancellationToken) =>
+        connection.SendPacketAsync(new ACEnterWorldDeniedPacket(reason), cancellationToken);
+}

--- a/AAEmu.Login/Core/Network/Connections/LoginConnection.cs
+++ b/AAEmu.Login/Core/Network/Connections/LoginConnection.cs
@@ -126,7 +126,7 @@ public sealed class LoginConnection : ILoginConnectionOwner
                         try
                         {
                             // Dispatch the packet for further processing.
-                            await packetDescriptor.Dispatch(packet, this);
+                            await packetDescriptor.Dispatch(packet, this, ConnectionClosed);
                         }
                         catch (Exception ex)
                         {

--- a/AAEmu.Login/Core/Network/Connections/LoginConnection.cs
+++ b/AAEmu.Login/Core/Network/Connections/LoginConnection.cs
@@ -11,15 +11,19 @@ namespace AAEmu.Login.Core.Network.Connections;
 
 public sealed class LoginConnection : ILoginConnectionOwner
 {
-    private readonly ConnectionContext _session;
+    private readonly ConnectionContext _connectionContext;
     private readonly ConnectionIdLease _connectionIdLease;
     private readonly ConcurrentDictionary<ushort, ILoginPacketDescriptor> _packets;
     private readonly ILoginProtocolHandler _protocolHandler;
     private readonly SemaphoreSlim _writeLock = new(1);
     private readonly ILogger _logger;
+    private ILoginSession? _session;
 
     public ConnectionId Id => _connectionIdLease.Id;
-    public IPAddress Ip => _session.RemoteEndPoint is IPEndPoint ipEndPoint ? ipEndPoint.Address : IPAddress.None;
+
+    public IPAddress Ip =>
+        _connectionContext.RemoteEndPoint is IPEndPoint ipEndPoint ? ipEndPoint.Address : IPAddress.None;
+    public ILoginSession Session => _session ?? throw new InvalidOperationException("Session not set");
     public InternalConnection? InternalConnection { get; set; }
 
     public AccountId AccountId { get; set; }
@@ -33,24 +37,29 @@ public sealed class LoginConnection : ILoginConnectionOwner
     /// <summary>
     /// Triggered when the client connection is closed.
     /// </summary>
-    public CancellationToken ConnectionClosed => _session.ConnectionClosed;
+    public CancellationToken ConnectionClosed => _connectionContext.ConnectionClosed;
 
-    public LoginConnection(ConnectionContext session, ConnectionIdLease connectionIdLease,
+    public LoginConnection(ConnectionContext connectionContext, ConnectionIdLease connectionIdLease,
         ConcurrentDictionary<ushort, ILoginPacketDescriptor> packets, ILoginProtocolHandler protocolHandler,
         ILogger logger)
     {
-        _session = session;
+        _connectionContext = connectionContext;
         _connectionIdLease = connectionIdLease;
         _packets = packets;
         _protocolHandler = protocolHandler;
         _logger = logger;
 
         // checks if a connection is from the same machine
-        var localIp = ((IPEndPoint?)session.LocalEndPoint)?.Address.ToString() ?? "local";
-        var remoteIp = ((IPEndPoint?)session.RemoteEndPoint)?.Address.ToString() ?? "remote";
+        var localIp = ((IPEndPoint?)connectionContext.LocalEndPoint)?.Address.ToString() ?? "local";
+        var remoteIp = ((IPEndPoint?)connectionContext.RemoteEndPoint)?.Address.ToString() ?? "remote";
         IsLocallyConnected = localIp == remoteIp;
 
         Characters = [];
+    }
+
+    public void SetSession(ILoginSession session)
+    {
+        _session = session;
     }
 
     public async ValueTask SendPacketAsync(LoginPacket packet, CancellationToken cancellationToken)
@@ -58,8 +67,8 @@ public sealed class LoginConnection : ILoginConnectionOwner
         await _writeLock.WaitAsync(cancellationToken);
         try
         {
-            packet.EncodeTo(_session.Transport.Output);
-            await _session.Transport.Output.FlushAsync(cancellationToken);
+            packet.EncodeTo(_connectionContext.Transport.Output);
+            await _connectionContext.Transport.Output.FlushAsync(cancellationToken);
         }
         finally
         {
@@ -72,7 +81,7 @@ public sealed class LoginConnection : ILoginConnectionOwner
         await _writeLock.WaitAsync(cancellationToken);
         try
         {
-            await _session.Transport.Output.WriteAsync(packet, cancellationToken);
+            await _connectionContext.Transport.Output.WriteAsync(packet, cancellationToken);
         }
         finally
         {
@@ -84,7 +93,7 @@ public sealed class LoginConnection : ILoginConnectionOwner
     {
         try
         {
-            await RunConnectionAsync();
+            await DispatchMessagesAsync();
         }
         catch (Exception ex) when (!IsExpectedDisconnectException(ex))
         {
@@ -97,14 +106,9 @@ public sealed class LoginConnection : ILoginConnectionOwner
         }
     }
 
-    private async Task RunConnectionAsync()
-    {
-        await DispatchMessagesAsync();
-    }
-
     private async Task DispatchMessagesAsync()
     {
-        var input = _session.Transport.Input;
+        var input = _connectionContext.Transport.Input;
 
         try
         {
@@ -123,10 +127,10 @@ public sealed class LoginConnection : ILoginConnectionOwner
                     }
                     else
                     {
+                        // Dispatch the packet sequentially
                         try
                         {
-                            // Dispatch the packet for further processing.
-                            await packetDescriptor.Dispatch(packet, this, ConnectionClosed);
+                            await packetDescriptor.Dispatch(packet, Session, ConnectionClosed);
                         }
                         catch (Exception ex)
                         {
@@ -156,9 +160,9 @@ public sealed class LoginConnection : ILoginConnectionOwner
 
     public void Shutdown()
     {
-        if (!_session.ConnectionClosed.IsCancellationRequested)
+        if (!_connectionContext.ConnectionClosed.IsCancellationRequested)
         {
-            _session.Abort();
+            _connectionContext.Abort();
         }
     }
 
@@ -204,11 +208,14 @@ public sealed class LoginConnection : ILoginConnectionOwner
             or OperationCanceledException;
     }
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
-        // _session ConnectionContext is owned by LoginConnectionHandler, so is not disposed here
+        // Notify the session that the connection is being disposed
+        if (_session is not null)
+            await _session.DisconnectAsync();
+
+        // ConnectionContext is owned by LoginConnectionHandler, so is not disposed here
         _writeLock.Dispose();
         _connectionIdLease.Dispose();
-        return ValueTask.CompletedTask;
     }
 }

--- a/AAEmu.Login/Core/Network/Connections/LoginSession.cs
+++ b/AAEmu.Login/Core/Network/Connections/LoginSession.cs
@@ -1,0 +1,355 @@
+using AAEmu.Login.Core.Authentication;
+using AAEmu.Login.Core.Controllers;
+using AAEmu.Login.Core.Network.Login;
+using AAEmu.Login.Core.PacketHandlers.C2L;
+using AAEmu.Login.Models;
+using Microsoft.Extensions.Options;
+
+namespace AAEmu.Login.Core.Network.Connections;
+
+/// <summary>
+/// Manages the login flow state machine for a client connection.
+/// The instance members of this class are thread-safe.
+/// </summary>
+public sealed class LoginSession(
+    ILoginConnection connection,
+    IGameController gameController,
+    TimeProvider timeProvider,
+    IOptions<AppConfiguration> appConfig,
+    ILogger<LoginSession> logger)
+    : ILoginSession
+{
+    private readonly TimeSpan _enterWorldTimeout = appConfig.Value.EnterWorldTimeout;
+    private readonly Lock _lock = new();
+
+    private LoginState _state = LoginState.Connected;
+    private IAuthenticationFlow? _currentAuthFlow;
+    private CancellationTokenSource? _enterWorldCts;
+    private TaskCompletionSource<EnterWorldResult>? _enterWorldTcs;
+    private GameServerId? _pendingGsId;
+    private Task? _enterWorldBackgroundTask;
+
+    internal Task? EnterWorldBackgroundTask => _enterWorldBackgroundTask;
+
+    public ILoginConnection Connection { get; } = connection;
+
+    public ILoginClient Client { get; } = new LoginClient(connection);
+
+    public LoginState State
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _state;
+            }
+        }
+    }
+
+    public IAuthenticationFlow? CurrentAuthFlow
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _currentAuthFlow;
+            }
+        }
+    }
+
+    public ValueTask SendPacketAsync(LoginPacket packet, CancellationToken cancellationToken) =>
+        Connection.SendPacketAsync(packet, cancellationToken);
+
+    public async Task AuthenticateAsync(IAuthenticationFlow flow, CancellationToken cancellationToken)
+    {
+        bool canProceed;
+
+        lock (_lock)
+        {
+            if (_state != LoginState.Connected)
+            {
+                logger.LogWarning(
+                    "Cannot authenticate: invalid state {State} for connection {ConnectionId}",
+                    _state, Connection.Id);
+                canProceed = false;
+            }
+            else
+            {
+                _state = LoginState.Authenticating;
+                canProceed = true;
+            }
+        }
+
+        if (!canProceed)
+        {
+            await SendAuthResultAsync(new AuthFlowResult.Denied(LoginDeniedReason.BadResponse), cancellationToken);
+            return;
+        }
+
+        var result = await flow.StartAsync(Client, cancellationToken);
+        ProcessAuthResult(result, flow);
+        await SendAuthResultAsync(result, cancellationToken);
+    }
+
+    public async Task ContinueAuthAsync<TFlow>(Func<TFlow, Task<AuthFlowResult>> step,
+        CancellationToken cancellationToken)
+        where TFlow : class, IAuthenticationFlow
+    {
+        TFlow? flow;
+        LoginDeniedReason? earlyDenial = null;
+
+        lock (_lock)
+        {
+            if (_state != LoginState.Authenticating)
+            {
+                logger.LogWarning(
+                    "Cannot continue auth: invalid state {State} for connection {ConnectionId}",
+                    _state, Connection.Id);
+                flow = null;
+                earlyDenial = LoginDeniedReason.BadResponse;
+            }
+            else if (_currentAuthFlow is not TFlow typedFlow)
+            {
+                logger.LogWarning(
+                    "Auth flow type mismatch: expected {Expected}, got {Actual} for connection {ConnectionId}",
+                    typeof(TFlow).Name, _currentAuthFlow?.GetType().Name ?? "null", Connection.Id);
+                _currentAuthFlow = null;
+                _state = LoginState.Disconnected;
+                flow = null;
+                earlyDenial = LoginDeniedReason.BadResponse;
+                Connection.Shutdown();
+            }
+            else
+            {
+                flow = typedFlow;
+            }
+        }
+
+        if (earlyDenial is not null)
+        {
+            await SendAuthResultAsync(new AuthFlowResult.Denied(earlyDenial.Value), cancellationToken);
+            return;
+        }
+
+        var result = await step(flow!);
+        ProcessAuthResult(result, flow!);
+        await SendAuthResultAsync(result, cancellationToken);
+    }
+
+    private async Task SendAuthResultAsync(AuthFlowResult result, CancellationToken cancellationToken)
+    {
+        switch (result)
+        {
+            case AuthFlowResult.Success success:
+                await Client.SendAuthSuccessAsync(success.AccountId, cancellationToken);
+                break;
+
+            case AuthFlowResult.Denied denied:
+                await Client.SendAuthDeniedAsync(denied.Reason, cancellationToken);
+                break;
+
+            // Pending: flow is managing itself, nothing to send
+        }
+    }
+
+    private void ProcessAuthResult(AuthFlowResult result, IAuthenticationFlow flow)
+    {
+        lock (_lock)
+        {
+            switch (result)
+            {
+                case AuthFlowResult.Success success:
+                    Connection.AccountId = success.AccountId;
+                    if (success.Username is not null)
+                        Connection.AccountName = success.Username;
+                    Connection.LastLogin = timeProvider.GetUtcNow().DateTime;
+                    Connection.LastIp = Connection.Ip;
+                    _currentAuthFlow = null;
+                    _state = LoginState.Authenticated;
+                    break;
+
+                case AuthFlowResult.Denied:
+                    _currentAuthFlow = null;
+                    _state = LoginState.Connected;
+                    break;
+
+                case AuthFlowResult.Pending:
+                    _currentAuthFlow = flow;
+                    // Stay in Authenticating
+                    break;
+            }
+        }
+    }
+
+    public async Task InitiateEnterWorldAsync(GameServerId gsId, CancellationToken cancellationToken)
+    {
+        CancellationTokenSource linkedCts;
+        TaskCompletionSource<EnterWorldResult> tcs;
+
+        lock (_lock)
+        {
+            if (_state != LoginState.Authenticated)
+            {
+                logger.LogWarning(
+                    "Cannot enter world: invalid state {State} for connection {ConnectionId}",
+                    _state, Connection.Id);
+                return;
+            }
+
+            if (gameController.GetGameServer(gsId) is not { Active: true })
+            {
+                logger.LogWarning(
+                    "Cannot enter world: game server {GsId} not available for connection {ConnectionId}",
+                    gsId, Connection.Id);
+                return;
+            }
+
+            _state = LoginState.EnteringWorld;
+            _pendingGsId = gsId;
+
+            _enterWorldCts = CancellationTokenSource.CreateLinkedTokenSource(
+                Connection.ConnectionClosed, cancellationToken);
+            _enterWorldTcs = new TaskCompletionSource<EnterWorldResult>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            linkedCts = _enterWorldCts;
+            tcs = _enterWorldTcs;
+        }
+
+        // Send request to game server (outside the lock)
+        gameController.RequestEnterWorld(Connection.AccountId, Connection.Id, gsId);
+
+        // Spawn background task to await response and send result
+        _enterWorldBackgroundTask = RunEnterWorldBackgroundAsync(tcs, linkedCts);
+    }
+
+    private async Task RunEnterWorldBackgroundAsync(TaskCompletionSource<EnterWorldResult> tcs,
+        CancellationTokenSource linkedCts)
+    {
+        try
+        {
+            var result = await tcs.Task.WaitAsync(_enterWorldTimeout, timeProvider, linkedCts.Token);
+
+            if (result is { Success: true, Server: not null })
+            {
+                await Client.SendWorldCookieAsync(result.Server, CancellationToken.None);
+            }
+            else
+            {
+                await Client.SendEnterWorldDeniedAsync(result.DenialReason, CancellationToken.None);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            logger.LogDebug("EnterWorld cancelled for connection {ConnectionId}", Connection.Id);
+        }
+        catch (TimeoutException)
+        {
+            logger.LogWarning("EnterWorld timed out for connection {ConnectionId}", Connection.Id);
+            try
+            {
+                await Client.SendEnterWorldDeniedAsync(0, CancellationToken.None);
+            }
+            catch
+            {
+                // Connection may be closed
+            }
+        }
+        finally
+        {
+            lock (_lock)
+            {
+                CleanupEnterWorldState();
+                if (_state == LoginState.EnteringWorld)
+                {
+                    _state = LoginState.Authenticated;
+                }
+            }
+        }
+    }
+
+    public void CancelEnterWorld()
+    {
+        lock (_lock)
+        {
+            if (_state != LoginState.EnteringWorld)
+            {
+                logger.LogDebug("CancelEnterWorld ignored: not in EnteringWorld state for connection {ConnectionId}",
+                    Connection.Id);
+                return;
+            }
+
+            logger.LogDebug("Cancelling EnterWorld for connection {ConnectionId}", Connection.Id);
+
+            // Cancel the CTS to trigger the awaiting task
+            _enterWorldCts?.Cancel();
+        }
+    }
+
+    public void CompleteEnterWorldRequest(GameServerId gsId, byte result)
+    {
+        lock (_lock)
+        {
+            if (_state != LoginState.EnteringWorld)
+            {
+                logger.LogWarning(
+                    "CompleteEnterWorldRequest ignored: not in EnteringWorld state for connection {ConnectionId}",
+                    Connection.Id);
+                return;
+            }
+
+            if (_pendingGsId != gsId)
+            {
+                logger.LogWarning(
+                    "CompleteEnterWorldRequest ignored: gsId mismatch (expected {Expected}, got {Actual}) for connection {ConnectionId}",
+                    _pendingGsId, gsId, Connection.Id);
+                return;
+            }
+
+            var success = result == 0;
+            GameServer? server = null;
+
+            if (success)
+            {
+                server = gameController.GetGameServer(gsId);
+            }
+
+            _enterWorldTcs?.TrySetResult(new EnterWorldResult(success, server, result));
+        }
+    }
+
+    public async Task DisconnectAsync()
+    {
+        Task? backgroundTask;
+
+        lock (_lock)
+        {
+            if (_state == LoginState.Disconnected)
+                return;
+
+            logger.LogDebug("Session disconnected for connection {ConnectionId}", Connection.Id);
+
+            // Cancel any pending enter world operation
+            _enterWorldCts?.Cancel();
+            CleanupEnterWorldState();
+
+            _state = LoginState.Disconnected;
+            backgroundTask = _enterWorldBackgroundTask;
+        }
+
+        if (backgroundTask is not null)
+        {
+            // Ignore errors during cleanup
+            await backgroundTask.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+        }
+    }
+
+    private void CleanupEnterWorldState()
+    {
+        // Must be called while holding _lock
+        _enterWorldCts?.Dispose();
+        _enterWorldCts = null;
+        _enterWorldTcs = null;
+        _pendingGsId = null;
+    }
+}

--- a/AAEmu.Login/Core/Network/Connections/LoginSessionFactory.cs
+++ b/AAEmu.Login/Core/Network/Connections/LoginSessionFactory.cs
@@ -1,0 +1,22 @@
+using AAEmu.Login.Core.Controllers;
+using AAEmu.Login.Models;
+using Microsoft.Extensions.Options;
+
+namespace AAEmu.Login.Core.Network.Connections;
+
+public class LoginSessionFactory(
+    IGameController gameController,
+    TimeProvider timeProvider,
+    IOptions<AppConfiguration> appConfig,
+    ILoggerFactory loggerFactory) : ILoginSessionFactory
+{
+    public ILoginSession Create(ILoginConnection connection)
+    {
+        return new LoginSession(
+            connection,
+            gameController,
+            timeProvider,
+            appConfig,
+            loggerFactory.CreateLogger<LoginSession>());
+    }
+}

--- a/AAEmu.Login/Core/Network/Connections/LoginState.cs
+++ b/AAEmu.Login/Core/Network/Connections/LoginState.cs
@@ -1,0 +1,10 @@
+namespace AAEmu.Login.Core.Network.Connections;
+
+public enum LoginState
+{
+    Connected,
+    Authenticating,
+    Authenticated,
+    EnteringWorld,
+    Disconnected
+}

--- a/AAEmu.Login/Core/Network/Login/ILoginPacketDescriptor.cs
+++ b/AAEmu.Login/Core/Network/Login/ILoginPacketDescriptor.cs
@@ -6,12 +6,12 @@ namespace AAEmu.Login.Core.Network.Login;
 public interface ILoginPacketDescriptor
 {
     ushort TypeId { get; }
-    
+
     /// <summary>
     /// Reads the packet from the stream and dispatches it to the appropriate handler.
     /// </summary>
     /// <param name="stream">The stream containing the packet data.</param>
-    /// <param name="connection">The connection where the packet was received.</param>
+    /// <param name="session">The session where the packet was received.</param>
     /// <param name="cancellationToken">A token that can be used to observe cancellation requests.</param>
-    Task Dispatch(PacketStream stream, LoginConnection connection, CancellationToken cancellationToken);
+    Task Dispatch(PacketStream stream, ILoginSession session, CancellationToken cancellationToken);
 }

--- a/AAEmu.Login/Core/Network/Login/ILoginPacketDescriptor.cs
+++ b/AAEmu.Login/Core/Network/Login/ILoginPacketDescriptor.cs
@@ -12,5 +12,6 @@ public interface ILoginPacketDescriptor
     /// </summary>
     /// <param name="stream">The stream containing the packet data.</param>
     /// <param name="connection">The connection where the packet was received.</param>
-    Task Dispatch(PacketStream stream, LoginConnection connection);
+    /// <param name="cancellationToken">A token that can be used to observe cancellation requests.</param>
+    Task Dispatch(PacketStream stream, LoginConnection connection, CancellationToken cancellationToken);
 }

--- a/AAEmu.Login/Core/Network/Login/LoginConnectionFactory.cs
+++ b/AAEmu.Login/Core/Network/Login/LoginConnectionFactory.cs
@@ -8,6 +8,7 @@ public class LoginConnectionFactory(
     IEnumerable<ILoginPacketDescriptor> packetDescriptors,
     ILoginProtocolHandler protocolHandler,
     IConnectionIdLeaseFactory connectionIdLeaseFactory,
+    ILoginSessionFactory sessionFactory,
     ILoggerFactory loggerFactory) : ILoginConnectionFactory
 {
     private readonly ConcurrentDictionary<ushort, ILoginPacketDescriptor> _packets =
@@ -18,8 +19,14 @@ public class LoginConnectionFactory(
         var connectionIdLease = connectionIdLeaseFactory.Rent();
         try
         {
-            return new LoginConnection(connectionContext, connectionIdLease, _packets, protocolHandler,
+            var connection = new LoginConnection(connectionContext, connectionIdLease, _packets, protocolHandler,
                 loggerFactory.CreateLogger<LoginConnection>());
+
+            // Create and attach the session to manage the login state machine
+            var session = sessionFactory.Create(connection);
+            connection.SetSession(session);
+
+            return connection;
         }
         catch
         {

--- a/AAEmu.Login/Core/Network/Login/LoginPacket.cs
+++ b/AAEmu.Login/Core/Network/Login/LoginPacket.cs
@@ -4,7 +4,7 @@ using AAEmu.Login.Core.Network.Connections;
 
 namespace AAEmu.Login.Core.Network.Login;
 
-public abstract class LoginPacket(ushort typeId) : PacketBase<LoginConnection>(typeId)
+public abstract class LoginPacket(ushort typeId) : PacketBase<ILoginConnection>(typeId)
 {
     public void EncodeTo(IBufferWriter<byte> bufferWriter)
     {
@@ -29,7 +29,7 @@ public abstract class LoginPacket(ushort typeId) : PacketBase<LoginConnection>(t
         return ps;
     }
 
-    public override PacketBase<LoginConnection> Decode(PacketStream ps)
+    public override PacketBase<ILoginConnection> Decode(PacketStream ps)
     {
         try
         {

--- a/AAEmu.Login/Core/Network/Login/LoginPacketDescriptor.cs
+++ b/AAEmu.Login/Core/Network/Login/LoginPacketDescriptor.cs
@@ -10,10 +10,10 @@ public class LoginPacketDescriptor<TPacket>(ushort packetId, ILoginPacketHandler
 {
     public ushort TypeId { get; } = packetId;
 
-    public async Task Dispatch(PacketStream stream, LoginConnection connection)
+    public async Task Dispatch(PacketStream stream, LoginConnection connection, CancellationToken cancellationToken)
     {
         var packet = new TPacket { Connection = connection };
         packet.Decode(stream);
-        await handler.Execute(packet, connection);
+        await handler.Execute(packet, connection, cancellationToken);
     }
 }

--- a/AAEmu.Login/Core/Network/Login/LoginPacketDescriptor.cs
+++ b/AAEmu.Login/Core/Network/Login/LoginPacketDescriptor.cs
@@ -10,10 +10,10 @@ public class LoginPacketDescriptor<TPacket>(ushort packetId, ILoginPacketHandler
 {
     public ushort TypeId { get; } = packetId;
 
-    public async Task Dispatch(PacketStream stream, LoginConnection connection, CancellationToken cancellationToken)
+    public async Task Dispatch(PacketStream stream, ILoginSession session, CancellationToken cancellationToken)
     {
-        var packet = new TPacket { Connection = connection };
+        var packet = new TPacket { Connection = session.Connection };
         packet.Decode(stream);
-        await handler.Execute(packet, connection, cancellationToken);
+        await handler.Execute(packet, session, cancellationToken);
     }
 }

--- a/AAEmu.Login/Core/Network/Login/ServiceCollectionExtensions.cs
+++ b/AAEmu.Login/Core/Network/Login/ServiceCollectionExtensions.cs
@@ -9,8 +9,10 @@ public static class ServiceCollectionExtensions
     public static void AddLoginNetwork(this IServiceCollection services)
     {
         services
+            .AddSingleton(TimeProvider.System)
             .AddSingleton<ILoginProtocolHandler, LoginProtocolHandler>()
             .AddSingleton<ILoginConnectionTable, LoginConnectionTable>()
+            .AddSingleton<ILoginSessionFactory, LoginSessionFactory>()
             .AddSingleton<ILoginConnectionFactory, LoginConnectionFactory>()
             .AddSingleton<IConnectionIdLeaseFactory, ConnectionIdLeaseFactory>()
             .AddSingleton<IIdManager<ConnectionId>, SimpleIdManager<ConnectionId>>(_ =>

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CACancelEnterWorldPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CACancelEnterWorldPacketHandler.cs
@@ -9,5 +9,6 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CACancelEnterWorldPacketHandler : ILoginPacketHandler<CACancelEnterWorldPacket>
 {
-    public Task Execute(CACancelEnterWorldPacket packet, ILoginConnection connection) => Task.CompletedTask;
+    public Task Execute(CACancelEnterWorldPacket packet, ILoginConnection connection,
+        CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CACancelEnterWorldPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CACancelEnterWorldPacketHandler.cs
@@ -9,5 +9,5 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CACancelEnterWorldPacketHandler : ILoginPacketHandler<CACancelEnterWorldPacket>
 {
-    public Task Execute(CACancelEnterWorldPacket packet, LoginConnection connection) => Task.CompletedTask;
+    public Task Execute(CACancelEnterWorldPacket packet, ILoginConnection connection) => Task.CompletedTask;
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CACancelEnterWorldPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CACancelEnterWorldPacketHandler.cs
@@ -9,6 +9,10 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CACancelEnterWorldPacketHandler : ILoginPacketHandler<CACancelEnterWorldPacket>
 {
-    public Task Execute(CACancelEnterWorldPacket packet, ILoginConnection connection,
-        CancellationToken cancellationToken) => Task.CompletedTask;
+    public Task Execute(CACancelEnterWorldPacket packet, ILoginSession session,
+        CancellationToken cancellationToken)
+    {
+        session.CancelEnterWorld();
+        return Task.CompletedTask;
+    }
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponse2PacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponse2PacketHandler.cs
@@ -11,9 +11,10 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// <seealso cref="ACChallenge2Packet"/>
 public class CAChallengeResponse2PacketHandler : ILoginPacketHandler<CAChallengeResponse2Packet>
 {
-    public async Task Execute(CAChallengeResponse2Packet packet, ILoginConnection connection)
+    public async Task Execute(CAChallengeResponse2Packet packet, ILoginConnection connection,
+        CancellationToken cancellationToken)
     {
         // Deny as this auth method is not supported
-        await connection.SendPacketAsync(new ACLoginDeniedPacket(2), CancellationToken.None);
+        await connection.SendPacketAsync(new ACLoginDeniedPacket(2), cancellationToken);
     }
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponse2PacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponse2PacketHandler.cs
@@ -11,10 +11,10 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// <seealso cref="ACChallenge2Packet"/>
 public class CAChallengeResponse2PacketHandler : ILoginPacketHandler<CAChallengeResponse2Packet>
 {
-    public async Task Execute(CAChallengeResponse2Packet packet, ILoginConnection connection,
+    public async Task Execute(CAChallengeResponse2Packet packet, ILoginSession session,
         CancellationToken cancellationToken)
     {
         // Deny as this auth method is not supported
-        await connection.SendPacketAsync(new ACLoginDeniedPacket(2), cancellationToken);
+        await session.SendPacketAsync(new ACLoginDeniedPacket(LoginDeniedReason.BadResponse), cancellationToken);
     }
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponse2PacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponse2PacketHandler.cs
@@ -11,7 +11,7 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// <seealso cref="ACChallenge2Packet"/>
 public class CAChallengeResponse2PacketHandler : ILoginPacketHandler<CAChallengeResponse2Packet>
 {
-    public async Task Execute(CAChallengeResponse2Packet packet, LoginConnection connection)
+    public async Task Execute(CAChallengeResponse2Packet packet, ILoginConnection connection)
     {
         // Deny as this auth method is not supported
         await connection.SendPacketAsync(new ACLoginDeniedPacket(2), CancellationToken.None);

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponsePacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponsePacketHandler.cs
@@ -11,10 +11,10 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// <seealso cref="ACChallengePacket"/>
 public class CAChallengeResponsePacketHandler : ILoginPacketHandler<CAChallengeResponsePacket>
 {
-    public async Task Execute(CAChallengeResponsePacket packet, ILoginConnection connection,
+    public async Task Execute(CAChallengeResponsePacket packet, ILoginSession session,
         CancellationToken cancellationToken)
     {
         // Deny as this auth method is not supported
-        await connection.SendPacketAsync(new ACLoginDeniedPacket(3), cancellationToken);
+        await session.SendPacketAsync(new ACLoginDeniedPacket(LoginDeniedReason.DuplicateLogin), cancellationToken);
     }
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponsePacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponsePacketHandler.cs
@@ -11,7 +11,7 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// <seealso cref="ACChallengePacket"/>
 public class CAChallengeResponsePacketHandler : ILoginPacketHandler<CAChallengeResponsePacket>
 {
-    public async Task Execute(CAChallengeResponsePacket packet, LoginConnection connection)
+    public async Task Execute(CAChallengeResponsePacket packet, ILoginConnection connection)
     {
         // Deny as this auth method is not supported
         await connection.SendPacketAsync(new ACLoginDeniedPacket(3), CancellationToken.None);

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponsePacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponsePacketHandler.cs
@@ -11,9 +11,10 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// <seealso cref="ACChallengePacket"/>
 public class CAChallengeResponsePacketHandler : ILoginPacketHandler<CAChallengeResponsePacket>
 {
-    public async Task Execute(CAChallengeResponsePacket packet, ILoginConnection connection)
+    public async Task Execute(CAChallengeResponsePacket packet, ILoginConnection connection,
+        CancellationToken cancellationToken)
     {
         // Deny as this auth method is not supported
-        await connection.SendPacketAsync(new ACLoginDeniedPacket(3), CancellationToken.None);
+        await connection.SendPacketAsync(new ACLoginDeniedPacket(3), cancellationToken);
     }
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAEnterWorldPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAEnterWorldPacketHandler.cs
@@ -9,7 +9,7 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CAEnterWorldPacketHandler(IGameController gameController) : ILoginPacketHandler<CAEnterWorldPacket>
 {
-    public Task Execute(CAEnterWorldPacket packet, ILoginConnection connection)
+    public Task Execute(CAEnterWorldPacket packet, ILoginConnection connection, CancellationToken cancellationToken)
     {
         gameController.RequestEnterWorld(connection, packet.GsId);
         return Task.CompletedTask;

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAEnterWorldPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAEnterWorldPacketHandler.cs
@@ -1,5 +1,4 @@
-﻿using AAEmu.Login.Core.Controllers;
-using AAEmu.Login.Core.Network.Connections;
+﻿using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.Packets.C2L;
 
 namespace AAEmu.Login.Core.PacketHandlers.C2L;
@@ -7,11 +6,11 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// <summary>
 /// Handles the <see cref="CAEnterWorldPacket"/> which is sent by the client to request entering the game world.
 /// </summary>
-public class CAEnterWorldPacketHandler(IGameController gameController) : ILoginPacketHandler<CAEnterWorldPacket>
+public class CAEnterWorldPacketHandler
+    : ILoginPacketHandler<CAEnterWorldPacket>
 {
-    public Task Execute(CAEnterWorldPacket packet, ILoginConnection connection, CancellationToken cancellationToken)
+    public async Task Execute(CAEnterWorldPacket packet, ILoginSession session, CancellationToken cancellationToken)
     {
-        gameController.RequestEnterWorld(connection, packet.GsId);
-        return Task.CompletedTask;
+        await session.InitiateEnterWorldAsync(packet.GsId, cancellationToken);
     }
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAEnterWorldPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAEnterWorldPacketHandler.cs
@@ -9,7 +9,7 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CAEnterWorldPacketHandler(IGameController gameController) : ILoginPacketHandler<CAEnterWorldPacket>
 {
-    public Task Execute(CAEnterWorldPacket packet, LoginConnection connection)
+    public Task Execute(CAEnterWorldPacket packet, ILoginConnection connection)
     {
         gameController.RequestEnterWorld(connection, packet.GsId);
         return Task.CompletedTask;

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAListWorldPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAListWorldPacketHandler.cs
@@ -10,7 +10,8 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CAListWorldPacketHandler(IGameController gameController) : ILoginPacketHandler<CAListWorldPacket>
 {
-    public async Task Execute(CAListWorldPacket packet, ILoginConnection connection)
+    public async Task Execute(CAListWorldPacket packet, ILoginConnection connection,
+        CancellationToken cancellationToken)
     {
         await gameController.RequestWorldListAsync(connection);
     }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAListWorldPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAListWorldPacketHandler.cs
@@ -10,9 +10,11 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CAListWorldPacketHandler(IGameController gameController) : ILoginPacketHandler<CAListWorldPacket>
 {
-    public async Task Execute(CAListWorldPacket packet, ILoginConnection connection,
+    public async Task Execute(CAListWorldPacket packet, ILoginSession session,
         CancellationToken cancellationToken)
     {
-        await gameController.RequestWorldListAsync(connection);
+        var worldList = await gameController.GetWorldListAsync(session.Connection);
+
+        await session.Client.SendWorldListAsync(worldList, cancellationToken);
     }
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAListWorldPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAListWorldPacketHandler.cs
@@ -10,7 +10,7 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CAListWorldPacketHandler(IGameController gameController) : ILoginPacketHandler<CAListWorldPacket>
 {
-    public async Task Execute(CAListWorldPacket packet, LoginConnection connection)
+    public async Task Execute(CAListWorldPacket packet, ILoginConnection connection)
     {
         await gameController.RequestWorldListAsync(connection);
     }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAOtpNumberPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAOtpNumberPacketHandler.cs
@@ -9,5 +9,5 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CAOtpNumberPacketHandler : ILoginPacketHandler<CAOtpNumberPacket>
 {
-    public Task Execute(CAOtpNumberPacket packet, LoginConnection connection) => Task.CompletedTask;
+    public Task Execute(CAOtpNumberPacket packet, ILoginConnection connection) => Task.CompletedTask;
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAOtpNumberPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAOtpNumberPacketHandler.cs
@@ -9,6 +9,6 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CAOtpNumberPacketHandler : ILoginPacketHandler<CAOtpNumberPacket>
 {
-    public Task Execute(CAOtpNumberPacket packet, ILoginConnection connection, CancellationToken cancellationToken) =>
+    public Task Execute(CAOtpNumberPacket packet, ILoginSession session, CancellationToken cancellationToken) =>
         Task.CompletedTask;
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAOtpNumberPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAOtpNumberPacketHandler.cs
@@ -9,5 +9,6 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CAOtpNumberPacketHandler : ILoginPacketHandler<CAOtpNumberPacket>
 {
-    public Task Execute(CAOtpNumberPacket packet, ILoginConnection connection) => Task.CompletedTask;
+    public Task Execute(CAOtpNumberPacket packet, ILoginConnection connection, CancellationToken cancellationToken) =>
+        Task.CompletedTask;
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAPcCertNumberPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAPcCertNumberPacketHandler.cs
@@ -8,5 +8,6 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CAPcCertNumberPacketHandler : ILoginPacketHandler<CAPcCertNumberPacket>
 {
-    public Task Execute(CAPcCertNumberPacket packet, ILoginConnection connection) => Task.CompletedTask;
+    public Task Execute(CAPcCertNumberPacket packet, ILoginConnection connection,
+        CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAPcCertNumberPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAPcCertNumberPacketHandler.cs
@@ -8,5 +8,5 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CAPcCertNumberPacketHandler : ILoginPacketHandler<CAPcCertNumberPacket>
 {
-    public Task Execute(CAPcCertNumberPacket packet, LoginConnection connection) => Task.CompletedTask;
+    public Task Execute(CAPcCertNumberPacket packet, ILoginConnection connection) => Task.CompletedTask;
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAPcCertNumberPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAPcCertNumberPacketHandler.cs
@@ -8,6 +8,6 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CAPcCertNumberPacketHandler : ILoginPacketHandler<CAPcCertNumberPacket>
 {
-    public Task Execute(CAPcCertNumberPacket packet, ILoginConnection connection,
+    public Task Execute(CAPcCertNumberPacket packet, ILoginSession session,
         CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthGameOnPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthGameOnPacketHandler.cs
@@ -9,5 +9,6 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CARequestAuthGameOnPacketHandler : ILoginPacketHandler<CARequestAuthGameOnPacket>
 {
-    public Task Execute(CARequestAuthGameOnPacket packet, ILoginConnection connection) => Task.CompletedTask;
+    public Task Execute(CARequestAuthGameOnPacket packet, ILoginConnection connection,
+        CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthGameOnPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthGameOnPacketHandler.cs
@@ -9,6 +9,6 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CARequestAuthGameOnPacketHandler : ILoginPacketHandler<CARequestAuthGameOnPacket>
 {
-    public Task Execute(CARequestAuthGameOnPacket packet, ILoginConnection connection,
+    public Task Execute(CARequestAuthGameOnPacket packet, ILoginSession session,
         CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthGameOnPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthGameOnPacketHandler.cs
@@ -9,5 +9,5 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CARequestAuthGameOnPacketHandler : ILoginPacketHandler<CARequestAuthGameOnPacket>
 {
-    public Task Execute(CARequestAuthGameOnPacket packet, LoginConnection connection) => Task.CompletedTask;
+    public Task Execute(CARequestAuthGameOnPacket packet, ILoginConnection connection) => Task.CompletedTask;
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthMailRuPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthMailRuPacketHandler.cs
@@ -11,7 +11,7 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 public class CARequestAuthMailRuPacketHandler(ILoginController loginController)
     : ILoginPacketHandler<CARequestAuthMailRuPacket>
 {
-    public async Task Execute(CARequestAuthMailRuPacket packet, LoginConnection connection)
+    public async Task Execute(CARequestAuthMailRuPacket packet, ILoginConnection connection)
     {
         await loginController.Login(connection, packet.Id!, packet.Token);
     }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthMailRuPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthMailRuPacketHandler.cs
@@ -11,7 +11,8 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 public class CARequestAuthMailRuPacketHandler(ILoginController loginController)
     : ILoginPacketHandler<CARequestAuthMailRuPacket>
 {
-    public async Task Execute(CARequestAuthMailRuPacket packet, ILoginConnection connection)
+    public async Task Execute(CARequestAuthMailRuPacket packet, ILoginConnection connection,
+        CancellationToken cancellationToken)
     {
         await loginController.Login(connection, packet.Id!, packet.Token);
     }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthMailRuPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthMailRuPacketHandler.cs
@@ -1,3 +1,4 @@
+using AAEmu.Login.Core.Authentication;
 using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.Packets.C2L;
@@ -11,9 +12,11 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 public class CARequestAuthMailRuPacketHandler(ILoginController loginController)
     : ILoginPacketHandler<CARequestAuthMailRuPacket>
 {
-    public async Task Execute(CARequestAuthMailRuPacket packet, ILoginConnection connection,
+    public async Task Execute(CARequestAuthMailRuPacket packet, ILoginSession session,
         CancellationToken cancellationToken)
     {
-        await loginController.Login(connection, packet.Id!, packet.Token);
+        var tokenBase64 = Convert.ToBase64String(packet.Token!);
+        var flow = new PasswordAuthFlow(loginController, packet.Id!, tokenBase64, session.Connection.Ip);
+        await session.AuthenticateAsync(flow, cancellationToken);
     }
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthPacketHandler.cs
@@ -9,7 +9,7 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CARequestAuthPacketHandler(ILoginController loginController) : ILoginPacketHandler<CARequestAuthPacket>
 {
-    public async Task Execute(CARequestAuthPacket packet, LoginConnection connection)
+    public async Task Execute(CARequestAuthPacket packet, ILoginConnection connection)
     {
         await loginController.Login(connection, packet.Account!);
 

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthPacketHandler.cs
@@ -1,3 +1,4 @@
+using AAEmu.Login.Core.Authentication;
 using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.Packets.C2L;
@@ -9,11 +10,25 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CARequestAuthPacketHandler(ILoginController loginController) : ILoginPacketHandler<CARequestAuthPacket>
 {
-    public async Task Execute(CARequestAuthPacket packet, ILoginConnection connection,
+    public async Task Execute(CARequestAuthPacket packet, ILoginSession session,
         CancellationToken cancellationToken)
     {
-        await loginController.Login(connection, packet.Account!);
+        var flow = new KrLoginFlow(loginController, packet.Account!);
+        await session.AuthenticateAsync(flow, cancellationToken);
+    }
 
-        // Connection.SendPacket(new ACChallengePacket()); // TODO ...
+    /// <summary>
+    /// Simple auth flow wrapping the Kr method (username-only login).
+    /// Will be replaced by KoreaAuthFlow with multi-step auth support.
+    /// </summary>
+    private class KrLoginFlow(ILoginController loginController, string username) : IAuthenticationFlow
+    {
+        public async Task<AuthFlowResult> StartAsync(ILoginClient client, CancellationToken cancellationToken)
+        {
+            var result = await loginController.Login(username);
+            return result.Success
+                ? new AuthFlowResult.Success(result.AccountId, username)
+                : new AuthFlowResult.Denied(result.DenialReason);
+        }
     }
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthPacketHandler.cs
@@ -9,7 +9,8 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CARequestAuthPacketHandler(ILoginController loginController) : ILoginPacketHandler<CARequestAuthPacket>
 {
-    public async Task Execute(CARequestAuthPacket packet, ILoginConnection connection)
+    public async Task Execute(CARequestAuthPacket packet, ILoginConnection connection,
+        CancellationToken cancellationToken)
     {
         await loginController.Login(connection, packet.Account!);
 

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthTencentPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthTencentPacketHandler.cs
@@ -9,5 +9,5 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CARequestAuthTencentPacketHandler : ILoginPacketHandler<CARequestAuthTencentPacket>
 {
-    public Task Execute(CARequestAuthTencentPacket packet, LoginConnection connection) => Task.CompletedTask;
+    public Task Execute(CARequestAuthTencentPacket packet, ILoginConnection connection) => Task.CompletedTask;
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthTencentPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthTencentPacketHandler.cs
@@ -9,5 +9,6 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CARequestAuthTencentPacketHandler : ILoginPacketHandler<CARequestAuthTencentPacket>
 {
-    public Task Execute(CARequestAuthTencentPacket packet, ILoginConnection connection) => Task.CompletedTask;
+    public Task Execute(CARequestAuthTencentPacket packet, ILoginConnection connection,
+        CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthTencentPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthTencentPacketHandler.cs
@@ -9,6 +9,6 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CARequestAuthTencentPacketHandler : ILoginPacketHandler<CARequestAuthTencentPacket>
 {
-    public Task Execute(CARequestAuthTencentPacket packet, ILoginConnection connection,
+    public Task Execute(CARequestAuthTencentPacket packet, ILoginSession session,
         CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthTrionPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthTrionPacketHandler.cs
@@ -12,7 +12,8 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 public class CARequestAuthTrionPacketHandler(ILoginController loginController)
     : ILoginPacketHandler<CARequestAuthTrionPacket>
 {
-    public async Task Execute(CARequestAuthTrionPacket packet, ILoginConnection connection)
+    public async Task Execute(CARequestAuthTrionPacket packet, ILoginConnection connection,
+        CancellationToken cancellationToken)
     {
         var token = Helpers.StringToByteArray(packet.Password!);
         await loginController.Login(connection, packet.Username!, token);

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthTrionPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthTrionPacketHandler.cs
@@ -1,4 +1,5 @@
 using AAEmu.Commons.Utils;
+using AAEmu.Login.Core.Authentication;
 using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.Packets.C2L;
@@ -12,10 +13,12 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 public class CARequestAuthTrionPacketHandler(ILoginController loginController)
     : ILoginPacketHandler<CARequestAuthTrionPacket>
 {
-    public async Task Execute(CARequestAuthTrionPacket packet, ILoginConnection connection,
+    public async Task Execute(CARequestAuthTrionPacket packet, ILoginSession session,
         CancellationToken cancellationToken)
     {
-        var token = Helpers.StringToByteArray(packet.Password!);
-        await loginController.Login(connection, packet.Username!, token);
+        var passwordBytes = Helpers.StringToByteArray(packet.Password!);
+        var passwordBase64 = Convert.ToBase64String(passwordBytes);
+        var flow = new PasswordAuthFlow(loginController, packet.Username!, passwordBase64, session.Connection.Ip);
+        await session.AuthenticateAsync(flow, cancellationToken);
     }
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthTrionPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthTrionPacketHandler.cs
@@ -12,7 +12,7 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 public class CARequestAuthTrionPacketHandler(ILoginController loginController)
     : ILoginPacketHandler<CARequestAuthTrionPacket>
 {
-    public async Task Execute(CARequestAuthTrionPacket packet, LoginConnection connection)
+    public async Task Execute(CARequestAuthTrionPacket packet, ILoginConnection connection)
     {
         var token = Helpers.StringToByteArray(packet.Password!);
         await loginController.Login(connection, packet.Username!, token);

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestReconnectPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestReconnectPacketHandler.cs
@@ -1,3 +1,4 @@
+using AAEmu.Login.Core.Authentication;
 using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.Packets.C2L;
@@ -11,9 +12,10 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 public class CARequestReconnectPacketHandler(ILoginController loginController)
     : ILoginPacketHandler<CARequestReconnectPacket>
 {
-    public async Task Execute(CARequestReconnectPacket packet, ILoginConnection connection,
+    public async Task Execute(CARequestReconnectPacket packet, ILoginSession session,
         CancellationToken cancellationToken)
     {
-        await loginController.Reconnect(connection, packet.GsId, packet.AccountId, packet.Cookie);
+        var flow = new ReconnectAuthFlow(loginController, packet.GsId, packet.AccountId, packet.Cookie);
+        await session.AuthenticateAsync(flow, cancellationToken);
     }
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestReconnectPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestReconnectPacketHandler.cs
@@ -11,7 +11,7 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 public class CARequestReconnectPacketHandler(ILoginController loginController)
     : ILoginPacketHandler<CARequestReconnectPacket>
 {
-    public async Task Execute(CARequestReconnectPacket packet, LoginConnection connection)
+    public async Task Execute(CARequestReconnectPacket packet, ILoginConnection connection)
     {
         await loginController.Reconnect(connection, packet.GsId, packet.AccountId, packet.Cookie);
     }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestReconnectPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestReconnectPacketHandler.cs
@@ -11,7 +11,8 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 public class CARequestReconnectPacketHandler(ILoginController loginController)
     : ILoginPacketHandler<CARequestReconnectPacket>
 {
-    public async Task Execute(CARequestReconnectPacket packet, ILoginConnection connection)
+    public async Task Execute(CARequestReconnectPacket packet, ILoginConnection connection,
+        CancellationToken cancellationToken)
     {
         await loginController.Reconnect(connection, packet.GsId, packet.AccountId, packet.Cookie);
     }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/LoginDeniedReason.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/LoginDeniedReason.cs
@@ -1,0 +1,79 @@
+﻿namespace AAEmu.Login.Core.PacketHandlers.C2L;
+
+public enum LoginDeniedReason : byte
+{
+    /// <summary>
+    /// "Authentication Failed". Generic auth failure.
+    /// </summary>
+    LoginUnknown = 0,
+
+    /// <summary>
+    /// Username or password wrong.
+    /// </summary>
+    BadAccount = 1,
+
+    /// <summary>
+    /// Username or password wrong.
+    /// </summary>
+    BadResponse = 2,
+
+    /// <summary>
+    /// Account already logged in
+    /// </summary>
+    DuplicateLogin = 3,
+
+    /// <summary>
+    /// The game is unavailable right now (e.g. under service/maintenance).
+    /// </summary>
+    ServiceTime = 4,
+
+    /// <summary>
+    /// Account is suspended for $$ days due to suspicious transactions.
+    /// </summary>
+    TryTradeCashTemporal = 5,
+
+
+    // 6 = "try_trade_cash_forever";
+    // 7 = "traded_cash_temporal";
+    // 8 = "traded_cash_forever";
+    // 9 = "try_trade_item_servers";
+    // 10 = "traded_item_servers";
+    // 11 = "traded_account";
+    // 12 = "try_cheat_temporal";
+    // 13 = "try_cheat_forever";
+    // 14 = "cheated";
+    // 15 = "gamble_temporal";
+    // 16 = "gamble_forever";
+    // 17 = "abuse_bug_forever";
+    // 18 = "abuse_bug_temporal";
+    // 19 = "use_bot_forever";
+    // 20 = "use_bot_temporal";
+    // 21 = "use_bad_sw_temporal";
+    // 22 = "use_bad_sw_forever";
+    // 23 = "bad_user_workplace";
+    // 24 = "bad_user_proxy_ip";
+    // 25 = "steal_info";
+    // 26 = "foul_lang_temporal";
+    // 27 = "foul_lang_forever";
+    // 28 = "bad_game_name";
+    // 29 = "disturb_play";
+    // 30 = "abnormal_play";
+    // 31 = "disturb_gm";
+    // 32 = "fraudful_report";
+    // 33 = "fake_gm";
+    // 34 = "wait_cert";
+    // 35 = "steal_account_temporal";
+    // 36 = "steal_account_forever";
+    // 37 = "fraudful_steal_report";
+    // 38 = "steal_person";
+    // 39 = "request_by_self";
+    // 40 = "request_by_parent";
+    // 41 = "ads";
+    // 42 = "request_by_authority";
+    // 43 = "defraud_pay";
+    // 44 = "unpaid_account";
+    // 45 = "bulk_blocked_account";
+    // 46 = "unpaid_pcbang";
+    // 47 = "congested_server";
+    // 48 = "invalid_mac";
+}

--- a/AAEmu.Login/Core/PacketHandlers/G2L/GLGameServerLoadPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/G2L/GLGameServerLoadPacketHandler.cs
@@ -8,7 +8,8 @@ namespace AAEmu.Login.Core.PacketHandlers.G2L;
 /// </summary>
 public class GLGameServerLoadPacketHandler : IInternalPacketHandler<GLGameServerLoadPacket>
 {
-    public Task Execute(GLGameServerLoadPacket packet, InternalConnection connection)
+    public Task Execute(GLGameServerLoadPacket packet, InternalConnection connection,
+        CancellationToken cancellationToken)
     {
         connection.GameServer!.Load = packet.Load;
         return Task.CompletedTask;

--- a/AAEmu.Login/Core/PacketHandlers/G2L/GLPlayerEnterPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/G2L/GLPlayerEnterPacketHandler.cs
@@ -10,7 +10,8 @@ namespace AAEmu.Login.Core.PacketHandlers.G2L;
 public class GLPlayerEnterPacketHandler(IGameController gameController, ILoginConnectionTable loginConnectionTable)
     : IInternalPacketHandler<GLPlayerEnterPacket>
 {
-    public async Task Execute(GLPlayerEnterPacket packet, InternalConnection connection)
+    public async Task Execute(GLPlayerEnterPacket packet, InternalConnection connection,
+        CancellationToken cancellationToken)
     {
         var loginConnection = loginConnectionTable.GetConnection(packet.ConnectionId);
         await gameController.EnterWorldAsync(loginConnection!, packet.GsId, packet.Result);

--- a/AAEmu.Login/Core/PacketHandlers/G2L/GLPlayerEnterPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/G2L/GLPlayerEnterPacketHandler.cs
@@ -7,13 +7,13 @@ namespace AAEmu.Login.Core.PacketHandlers.G2L;
 /// <summary>
 /// Handles the <see cref="GLPlayerEnterPacket"/> which is sent by the game server when a player enters the game world.
 /// </summary>
-public class GLPlayerEnterPacketHandler(IGameController gameController, ILoginConnectionTable loginConnectionTable)
+public class GLPlayerEnterPacketHandler(IGameController gameController)
     : IInternalPacketHandler<GLPlayerEnterPacket>
 {
-    public async Task Execute(GLPlayerEnterPacket packet, InternalConnection connection,
+    public Task Execute(GLPlayerEnterPacket packet, InternalConnection connection,
         CancellationToken cancellationToken)
     {
-        var loginConnection = loginConnectionTable.GetConnection(packet.ConnectionId);
-        await gameController.EnterWorldAsync(loginConnection!, packet.GsId, packet.Result);
+        gameController.RouteEnterWorldResponse(packet.ConnectionId, packet.GsId, packet.Result);
+        return Task.CompletedTask;
     }
 }

--- a/AAEmu.Login/Core/PacketHandlers/G2L/GLPlayerReconnectPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/G2L/GLPlayerReconnectPacketHandler.cs
@@ -11,7 +11,8 @@ namespace AAEmu.Login.Core.PacketHandlers.G2L;
 public class GLPlayerReconnectPacketHandler(ILoginController loginController)
     : IInternalPacketHandler<GLPlayerReconnectPacket>
 {
-    public Task Execute(GLPlayerReconnectPacket packet, InternalConnection connection)
+    public Task Execute(GLPlayerReconnectPacket packet, InternalConnection connection,
+        CancellationToken cancellationToken)
     {
         loginController.AddReconnectionToken(connection, packet.GsId, packet.AccountId, packet.Token);
         return Task.CompletedTask;

--- a/AAEmu.Login/Core/PacketHandlers/G2L/GLRegisterGameServerPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/G2L/GLRegisterGameServerPacketHandler.cs
@@ -18,12 +18,14 @@ public class GLRegisterGameServerPacketHandler(IGameController gameController, I
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
-    public Task Execute(GLRegisterGameServerPacket packet, InternalConnection connection)
+    public Task Execute(GLRegisterGameServerPacket packet, InternalConnection connection,
+        CancellationToken cancellationToken)
     {
         if (packet.SecretKey != appConfig.Value.SecretKey)
         {
             Logger.Error($"Connection {connection.Ip}, bad secret key");
-            Task.Run(() => SendPacketWithDelay(5000, new LGRegisterGameServerPacket(GSRegisterResult.Error)));
+            Task.Run(() => SendPacketWithDelay(5000, new LGRegisterGameServerPacket(GSRegisterResult.Error)),
+                cancellationToken);
             // Connection.SendPacket(new LGRegisterGameServerPacket(GSRegisterResult.Error));
             return Task.CompletedTask;
         }
@@ -33,7 +35,7 @@ public class GLRegisterGameServerPacketHandler(IGameController gameController, I
 
         async Task SendPacketWithDelay(int delay, InternalPacket message)
         {
-            await Task.Delay(delay);
+            await Task.Delay(delay, cancellationToken);
             connection.SendPacket(message);
         }
     }

--- a/AAEmu.Login/Core/PacketHandlers/G2L/GLRequestInfoPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/G2L/GLRequestInfoPacketHandler.cs
@@ -13,7 +13,7 @@ public class GLRequestInfoPacketHandler(
     ILoginConnectionTable loginConnectionTable)
     : IInternalPacketHandler<GLRequestInfoPacket>
 {
-    public Task Execute(GLRequestInfoPacket packet, InternalConnection connection)
+    public Task Execute(GLRequestInfoPacket packet, InternalConnection connection, CancellationToken cancellationToken)
     {
         var loginConnection = loginConnectionTable.GetConnection(packet.ConnectionId);
         if (packet.Characters!.Count > 0)

--- a/AAEmu.Login/Core/PacketHandlers/IInternalPacketHandler`T.cs
+++ b/AAEmu.Login/Core/PacketHandlers/IInternalPacketHandler`T.cs
@@ -7,5 +7,5 @@ public interface IInternalPacketHandler<in TPacket> : IPacketHandler<TPacket, In
     IInternalPacketHandler where TPacket : InternalPacket
 {
     Task IInternalPacketHandler.Execute(InternalPacket packet, InternalConnection connection) =>
-        Execute((TPacket)packet, connection);
+        Execute((TPacket)packet, connection, CancellationToken.None);
 }

--- a/AAEmu.Login/Core/PacketHandlers/ILoginPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/ILoginPacketHandler.cs
@@ -5,5 +5,5 @@ namespace AAEmu.Login.Core.PacketHandlers;
 
 public interface ILoginPacketHandler
 {
-    Task Execute(LoginPacket packet, ILoginConnection connection, CancellationToken cancellationToken);
+    Task Execute(LoginPacket packet, ILoginSession session, CancellationToken cancellationToken);
 }

--- a/AAEmu.Login/Core/PacketHandlers/ILoginPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/ILoginPacketHandler.cs
@@ -5,5 +5,5 @@ namespace AAEmu.Login.Core.PacketHandlers;
 
 public interface ILoginPacketHandler
 {
-    Task Execute(LoginPacket packet, ILoginConnection connection);
+    Task Execute(LoginPacket packet, ILoginConnection connection, CancellationToken cancellationToken);
 }

--- a/AAEmu.Login/Core/PacketHandlers/ILoginPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/ILoginPacketHandler.cs
@@ -5,5 +5,5 @@ namespace AAEmu.Login.Core.PacketHandlers;
 
 public interface ILoginPacketHandler
 {
-    Task Execute(LoginPacket packet, LoginConnection connection);
+    Task Execute(LoginPacket packet, ILoginConnection connection);
 }

--- a/AAEmu.Login/Core/PacketHandlers/ILoginPacketHandler`T.cs
+++ b/AAEmu.Login/Core/PacketHandlers/ILoginPacketHandler`T.cs
@@ -3,9 +3,9 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.PacketHandlers;
 
-public interface ILoginPacketHandler<in TPacket> : IPacketHandler<TPacket, LoginConnection>,
+public interface ILoginPacketHandler<in TPacket> : IPacketHandler<TPacket, ILoginConnection>,
     ILoginPacketHandler where TPacket : LoginPacket
 {
-    Task ILoginPacketHandler.Execute(LoginPacket packet, LoginConnection connection) =>
+    Task ILoginPacketHandler.Execute(LoginPacket packet, ILoginConnection connection) =>
         Execute((TPacket)packet, connection);
 }

--- a/AAEmu.Login/Core/PacketHandlers/ILoginPacketHandler`T.cs
+++ b/AAEmu.Login/Core/PacketHandlers/ILoginPacketHandler`T.cs
@@ -6,6 +6,6 @@ namespace AAEmu.Login.Core.PacketHandlers;
 public interface ILoginPacketHandler<in TPacket> : IPacketHandler<TPacket, ILoginConnection>,
     ILoginPacketHandler where TPacket : LoginPacket
 {
-    Task ILoginPacketHandler.Execute(LoginPacket packet, ILoginConnection connection) =>
-        Execute((TPacket)packet, connection);
+    Task ILoginPacketHandler.Execute(LoginPacket packet, ILoginConnection connection,
+        CancellationToken cancellationToken) => Execute((TPacket)packet, connection, cancellationToken);
 }

--- a/AAEmu.Login/Core/PacketHandlers/ILoginPacketHandler`T.cs
+++ b/AAEmu.Login/Core/PacketHandlers/ILoginPacketHandler`T.cs
@@ -3,9 +3,9 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.PacketHandlers;
 
-public interface ILoginPacketHandler<in TPacket> : IPacketHandler<TPacket, ILoginConnection>,
+public interface ILoginPacketHandler<in TPacket> : IPacketHandler<TPacket, ILoginSession>,
     ILoginPacketHandler where TPacket : LoginPacket
 {
-    Task ILoginPacketHandler.Execute(LoginPacket packet, ILoginConnection connection,
-        CancellationToken cancellationToken) => Execute((TPacket)packet, connection, cancellationToken);
+    Task ILoginPacketHandler.Execute(LoginPacket packet, ILoginSession session,
+        CancellationToken cancellationToken) => Execute((TPacket)packet, session, cancellationToken);
 }

--- a/AAEmu.Login/Core/PacketHandlers/IPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/IPacketHandler.cs
@@ -2,5 +2,5 @@ namespace AAEmu.Login.Core.PacketHandlers;
 
 public interface IPacketHandler<in TPacket, in TConnection>
 {
-    Task Execute(TPacket packet, TConnection connection);
+    Task Execute(TPacket packet, TConnection connection, CancellationToken cancellationToken);
 }

--- a/AAEmu.Login/Core/Packets/L2C/ACLoginDeniedPacket.cs
+++ b/AAEmu.Login/Core/Packets/L2C/ACLoginDeniedPacket.cs
@@ -1,6 +1,7 @@
 ﻿using System.Buffers.Binary;
 using AAEmu.Commons.Network;
 using AAEmu.Login.Core.Network.Login;
+using AAEmu.Login.Core.PacketHandlers.C2L;
 
 namespace AAEmu.Login.Core.Packets.L2C;
 
@@ -14,13 +15,13 @@ namespace AAEmu.Login.Core.Packets.L2C;
 /// For example, reason <c>try_trade_cash_temporal</c> uses <c>$1</c> for the
 /// number of suspension days, so pass the day count as the first element.
 /// </param>
-public class ACLoginDeniedPacket(byte reason, params int[] vp) : LoginPacket(LCOffsets.ACLoginDeniedPacket)
+public class ACLoginDeniedPacket(LoginDeniedReason reason, params int[] vp) : LoginPacket(LCOffsets.ACLoginDeniedPacket)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(reason);
+        stream.Write((byte)reason);
         stream.Write(BuildVpData(), appendSize: true); // vp - binary: [0x00 + int32_le] per entry
-        stream.Write(""); // msg
+        stream.Write(""); // msg - completely overrides the displayed message
 
         return stream;
     }

--- a/AAEmu.Login/Models/AppConfiguration.cs
+++ b/AAEmu.Login/Models/AppConfiguration.cs
@@ -23,6 +23,11 @@ public class AppConfiguration
     /// </summary>
     public bool SkipHostResolve { get; set; }
 
+    /// <summary>
+    /// Timeout for the game server to respond to an EnterWorld request.
+    /// </summary>
+    public TimeSpan EnterWorldTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
     [Required]
     public required List<GameServerConfig> GameServers { get; set; }
 

--- a/AAEmu.Login/Models/EnterWorldResult.cs
+++ b/AAEmu.Login/Models/EnterWorldResult.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Login.Models;
+
+public readonly record struct EnterWorldResult(bool Success, GameServer? Server, byte DenialReason);

--- a/AAEmu.Login/Models/LoginResult.cs
+++ b/AAEmu.Login/Models/LoginResult.cs
@@ -1,0 +1,5 @@
+using AAEmu.Login.Core.PacketHandlers.C2L;
+
+namespace AAEmu.Login.Models;
+
+public readonly record struct LoginResult(bool Success, AccountId AccountId, LoginDeniedReason DenialReason);

--- a/AAEmu.Login/Models/ReconnectResult.cs
+++ b/AAEmu.Login/Models/ReconnectResult.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Login.Models;
+
+public readonly record struct ReconnectResult(bool Success, AccountId AccountId);

--- a/AAEmu.Login/Models/WorldListResult.cs
+++ b/AAEmu.Login/Models/WorldListResult.cs
@@ -1,0 +1,7 @@
+using AAEmu.Commons.Models;
+
+namespace AAEmu.Login.Models;
+
+public readonly record struct WorldListResult(
+    List<GameServer> GameServers,
+    List<LoginCharacterInfo> Characters);

--- a/AAEmu.UnitTests/AAEmu.UnitTests.csproj
+++ b/AAEmu.UnitTests/AAEmu.UnitTests.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
   
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.Testing.Extensions.Telemetry" />

--- a/AAEmu.UnitTests/Login/Core/Controllers/GameControllerTests.cs
+++ b/AAEmu.UnitTests/Login/Core/Controllers/GameControllerTests.cs
@@ -1,0 +1,302 @@
+#nullable enable
+using AAEmu.Commons.Models;
+using AAEmu.Commons.Network.Core;
+using AAEmu.Login.Core.Controllers;
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Login.Core.Controllers;
+
+public class GameControllerTests
+{
+    private readonly Mock<IRequestController> _requestController = new();
+    private readonly Mock<ILoginConnectionTable> _connectionTable = new();
+
+    private static readonly GameServerId s_gsId1 = new(1);
+    private static readonly GameServerId s_gsId2 = new(2);
+    private static readonly GameServerId s_gsId3 = new(3);
+    private static readonly AccountId s_accountId = new(100);
+    private static readonly ConnectionId s_connectionId = new(50);
+
+    private GameController CreateSut(AppConfiguration config) =>
+        new(_requestController.Object, _connectionTable.Object,
+            Options.Create(config), NullLogger<GameController>.Instance);
+
+    private static AppConfiguration MakeConfig(
+        params (byte id, string name, string host, ushort port, bool hidden)[] servers) =>
+        new()
+        {
+            SecretKey = "test",
+            SkipHostResolve = true,
+            GameServers = servers.Select(s => new AppConfiguration.GameServerConfig
+            {
+                Id = s.id,
+                Name = s.name,
+                Host = s.host,
+                Port = s.port,
+                Hidden = s.hidden
+            }).ToList()
+        };
+
+    /// <summary>Creates an InternalConnection backed by a loose mock session (SendPacket is a no-op).</summary>
+    private static InternalConnection CreateConnection() => new(Mock.Of<ISession>());
+
+    /// <summary>Creates an InternalConnection with a verifiable mock session.</summary>
+    private static (InternalConnection connection, Mock<ISession> sessionMock) CreateTrackedConnection()
+    {
+        var mock = new Mock<ISession>();
+        mock.Setup(s => s.Ip).Returns(System.Net.IPAddress.Loopback);
+        return (new InternalConnection(mock.Object), mock);
+    }
+
+    [Fact]
+    public void Load_VisibleServer_IsAvailableViaGetGameServer()
+    {
+        var sut = CreateSut(MakeConfig((s_gsId1.Value, "World1", "127.0.0.1", 1234, false)));
+
+        sut.Load();
+
+        var server = sut.GetGameServer(s_gsId1);
+        Assert.NotNull(server);
+        Assert.Equal("World1", server.Name);
+        Assert.Equal("127.0.0.1", server.Host);
+        Assert.Equal(1234, server.Port);
+    }
+
+    [Fact]
+    public void Load_HiddenServer_IsNotAvailableViaGetGameServer()
+    {
+        var sut = CreateSut(MakeConfig((s_gsId1.Value, "HiddenWorld", "127.0.0.1", 1234, true)));
+
+        sut.Load();
+
+        Assert.Null(sut.GetGameServer(s_gsId1));
+    }
+
+    [Fact]
+    public void Load_MixedServers_OnlyLoadsVisibleOnes()
+    {
+        var sut = CreateSut(MakeConfig(
+            (s_gsId1.Value, "Visible", "127.0.0.1", 1234, false),
+            (s_gsId2.Value, "Hidden", "127.0.0.2", 5678, true)));
+
+        sut.Load();
+
+        Assert.NotNull(sut.GetGameServer(s_gsId1));
+        Assert.Null(sut.GetGameServer(s_gsId2));
+    }
+
+    [Fact]
+    public void GetGameServer_UnknownId_ReturnsNull()
+    {
+        var sut = CreateSut(MakeConfig());
+
+        Assert.Null(sut.GetGameServer(s_gsId1));
+    }
+
+    [Fact]
+    public void TryGetParentId_NoMirrorRegistered_ReturnsFalse()
+    {
+        var sut = CreateSut(MakeConfig((s_gsId1.Value, "World1", "127.0.0.1", 1234, false)));
+        sut.Load();
+
+        var found = sut.TryGetParentId(s_gsId1, out _);
+
+        Assert.False(found);
+    }
+
+    [Fact]
+    public void TryGetParentId_AfterAddWithMirror_ReturnsTrueWithParentId()
+    {
+        var sut = CreateSut(MakeConfig(
+            (s_gsId1.Value, "World1", "127.0.0.1", 1234, false),
+            (s_gsId2.Value, "Mirror", "127.0.0.2", 1234, false)));
+        sut.Load();
+        sut.Add(s_gsId1, [s_gsId2], CreateConnection());
+
+        var found = sut.TryGetParentId(s_gsId2, out var parentId);
+
+        Assert.True(found);
+        Assert.Equal(s_gsId1, parentId);
+    }
+
+    [Fact]
+    public void Add_KnownServerId_MakesServerActive()
+    {
+        var sut = CreateSut(MakeConfig((s_gsId1.Value, "World1", "127.0.0.1", 1234, false)));
+        sut.Load();
+
+        sut.Add(s_gsId1, [], CreateConnection());
+
+        Assert.True(sut.GetGameServer(s_gsId1)!.Active);
+    }
+
+    [Fact]
+    public void Add_WithMirrors_MakesMirrorServersActive()
+    {
+        var sut = CreateSut(MakeConfig(
+            (s_gsId1.Value, "World1", "127.0.0.1", 1234, false),
+            (s_gsId2.Value, "Mirror1", "127.0.0.2", 1234, false),
+            (s_gsId3.Value, "Mirror2", "127.0.0.3", 1234, false)));
+        sut.Load();
+
+        sut.Add(s_gsId1, [s_gsId2, s_gsId3], CreateConnection());
+
+        Assert.True(sut.GetGameServer(s_gsId2)!.Active);
+        Assert.True(sut.GetGameServer(s_gsId3)!.Active);
+    }
+
+    [Fact]
+    public void Remove_AfterAdd_ClearsServerConnection()
+    {
+        var sut = CreateSut(MakeConfig((s_gsId1.Value, "World1", "127.0.0.1", 1234, false)));
+        sut.Load();
+        sut.Add(s_gsId1, [], CreateConnection());
+
+        sut.Remove(s_gsId1);
+
+        Assert.False(sut.GetGameServer(s_gsId1)!.Active);
+    }
+
+    [Fact]
+    public void Remove_WithMirrors_ClearsMirrorConnections()
+    {
+        var sut = CreateSut(MakeConfig(
+            (s_gsId1.Value, "World1", "127.0.0.1", 1234, false),
+            (s_gsId2.Value, "Mirror", "127.0.0.2", 1234, false)));
+        sut.Load();
+        sut.Add(s_gsId1, [s_gsId2], CreateConnection());
+
+        sut.Remove(s_gsId1);
+
+        Assert.False(sut.GetGameServer(s_gsId2)!.Active);
+        Assert.False(sut.TryGetParentId(s_gsId2, out _));
+    }
+
+    [Fact]
+    public void Remove_UnknownServerId_DoesNotThrow()
+    {
+        var sut = CreateSut(MakeConfig());
+
+        sut.Remove(s_gsId1);
+    }
+
+    [Fact]
+    public void SetLoad_SetsLoadOnServer()
+    {
+        var sut = CreateSut(MakeConfig((s_gsId1.Value, "World1", "127.0.0.1", 1234, false)));
+        sut.Load();
+
+        sut.SetLoad(s_gsId1, (byte)GSLoad.High);
+
+        Assert.Equal(GSLoad.High, sut.GetGameServer(s_gsId1)!.Load);
+    }
+
+    [Fact]
+    public void RequestEnterWorld_UnknownGsId_DoesNotThrow()
+    {
+        var sut = CreateSut(MakeConfig());
+
+        sut.RequestEnterWorld(s_accountId, s_connectionId, s_gsId1);
+    }
+
+    [Fact]
+    public void RequestEnterWorld_KnownButInactiveServer_DoesNotThrow()
+    {
+        var sut = CreateSut(MakeConfig((s_gsId1.Value, "World1", "127.0.0.1", 1234, false)));
+        sut.Load(); // loaded but never Add()ed, so inactive
+
+        sut.RequestEnterWorld(s_accountId, s_connectionId, s_gsId1);
+    }
+
+    [Fact]
+    public void RequestEnterWorld_ActiveServer_SendsPacketToSession()
+    {
+        var sut = CreateSut(MakeConfig((s_gsId1.Value, "World1", "127.0.0.1", 1234, false)));
+        sut.Load();
+        var (connection, sessionMock) = CreateTrackedConnection();
+        sut.Add(s_gsId1, [], connection);
+        sessionMock.Invocations.Clear(); // discard the packet sent during Add()
+
+        sut.RequestEnterWorld(s_accountId, s_connectionId, s_gsId1);
+
+        sessionMock.Verify(s => s.SendPacket(It.IsAny<byte[]>()), Times.Once);
+    }
+
+    [Fact]
+    public void RouteEnterWorldResponse_ConnectionNotFound_DoesNotThrow()
+    {
+        var sut = CreateSut(MakeConfig());
+        _connectionTable.Setup(t => t.GetConnection(s_connectionId)).Returns(default(ILoginConnection?));
+
+        sut.RouteEnterWorldResponse(s_connectionId, s_gsId1, 0);
+    }
+
+    [Fact]
+    public void RouteEnterWorldResponse_ConnectionFound_DelegatesToSession()
+    {
+        var sut = CreateSut(MakeConfig());
+        var sessionMock = new Mock<ILoginSession>();
+        var connectionMock = new Mock<ILoginConnection>();
+        connectionMock.Setup(c => c.Session).Returns(sessionMock.Object);
+        _connectionTable.Setup(t => t.GetConnection(s_connectionId)).Returns(connectionMock.Object);
+
+        sut.RouteEnterWorldResponse(s_connectionId, s_gsId1, 42);
+
+        sessionMock.Verify(s => s.CompleteEnterWorldRequest(s_gsId1, 42), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetWorldListAsync_NoServersLoaded_ReturnsEmptyResult()
+    {
+        var sut = CreateSut(MakeConfig());
+        var connectionMock = new Mock<ILoginConnection>();
+        connectionMock.Setup(c => c.GetCharacters()).Returns([]);
+
+        var result = await sut.GetWorldListAsync(connectionMock.Object);
+
+        Assert.Empty(result.GameServers);
+        Assert.Empty(result.Characters);
+    }
+
+    [Fact]
+    public async Task GetWorldListAsync_LoadedButInactiveServers_ReturnsServersWithoutRequesting()
+    {
+        var sut = CreateSut(MakeConfig((s_gsId1.Value, "World1", "127.0.0.1", 1234, false)));
+        sut.Load();
+        var connectionMock = new Mock<ILoginConnection>();
+        connectionMock.Setup(c => c.GetCharacters()).Returns([]);
+
+        var result = await sut.GetWorldListAsync(connectionMock.Object);
+
+        Assert.Single(result.GameServers);
+        Assert.Empty(result.Characters);
+        _requestController.Verify(r => r.Create(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetWorldListAsync_ActiveServer_RequestsCharacterInfoPerServer()
+    {
+        var sut = CreateSut(MakeConfig((s_gsId1.Value, "World1", "127.0.0.1", 1234, false)));
+        sut.Load();
+        sut.Add(s_gsId1, [], CreateConnection());
+
+        var connectionMock = new Mock<ILoginConnection>();
+        connectionMock.Setup(c => c.Id).Returns(s_connectionId);
+        connectionMock.Setup(c => c.AccountId).Returns(s_accountId);
+        connectionMock.Setup(c => c.Characters)
+            .Returns(new Dictionary<GameServerId, List<LoginCharacterInfo>>());
+        connectionMock.Setup(c => c.GetCharacters()).Returns([]);
+        _requestController.Setup(r => r.Create(1, It.IsAny<int>()))
+            .Returns(([1u], Task.CompletedTask));
+
+        var result = await sut.GetWorldListAsync(connectionMock.Object);
+
+        Assert.Single(result.GameServers);
+        _requestController.Verify(r => r.Create(1, It.IsAny<int>()), Times.Once);
+    }
+}

--- a/AAEmu.UnitTests/Login/Core/Network/Connections/LoginSessionTests.cs
+++ b/AAEmu.UnitTests/Login/Core/Network/Connections/LoginSessionTests.cs
@@ -1,0 +1,398 @@
+#nullable enable
+
+using System.Net;
+using AAEmu.Login.Core.Authentication;
+using AAEmu.Login.Core.Controllers;
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Network.Login;
+using AAEmu.Login.Core.PacketHandlers.C2L;
+using AAEmu.Login.Core.Packets.L2C;
+using AAEmu.Login.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+using ISession = AAEmu.Commons.Network.Core.ISession;
+
+namespace AAEmu.UnitTests.Login.Core.Network.Connections;
+
+public class LoginSessionTests
+{
+    private static readonly AccountId s_testAccountId = new(100);
+    private static readonly ConnectionId s_testConnectionId = new(42);
+    private static readonly GameServerId s_testGsId = new(1);
+    private static readonly IPAddress s_testIp = IPAddress.Parse("10.0.0.1");
+
+    private readonly Mock<ILoginConnection> _mockConnection;
+    private readonly Mock<IGameController> _mockGameController;
+    private readonly List<LoginPacket> _sentPackets = [];
+    private readonly CancellationTokenSource _connectionClosedCts = new();
+    private readonly LoginSession _session;
+
+    public LoginSessionTests()
+    {
+        _mockConnection = new Mock<ILoginConnection>();
+        _mockConnection.SetupGet(c => c.Id).Returns(s_testConnectionId);
+        _mockConnection.SetupGet(c => c.Ip).Returns(s_testIp);
+        _mockConnection.SetupGet(c => c.ConnectionClosed).Returns(_connectionClosedCts.Token);
+        _mockConnection.SetupProperty(c => c.AccountId);
+        _mockConnection.SetupProperty(c => c.AccountName);
+        _mockConnection.SetupProperty(c => c.LastLogin);
+        _mockConnection.SetupProperty(c => c.LastIp);
+        _mockConnection
+            .Setup(c => c.SendPacketAsync(It.IsAny<LoginPacket>(), It.IsAny<CancellationToken>()))
+            .Callback<LoginPacket, CancellationToken>((p, _) => _sentPackets.Add(p))
+            .Returns(ValueTask.CompletedTask);
+
+        _mockGameController = new Mock<IGameController>();
+
+        var appConfig = Options.Create(new AppConfiguration
+        {
+            SecretKey = "test", EnterWorldTimeout = TimeSpan.FromMilliseconds(200), GameServers = []
+        });
+
+        _session = new LoginSession(
+            _mockConnection.Object,
+            _mockGameController.Object,
+            TimeProvider.System,
+            appConfig,
+            Mock.Of<ILogger<LoginSession>>());
+    }
+
+    private LoginSession CreateSessionWithTimeProvider(TimeProvider timeProvider)
+    {
+        var appConfig = Options.Create(new AppConfiguration
+        {
+            SecretKey = "test", EnterWorldTimeout = TimeSpan.FromMilliseconds(200), GameServers = []
+        });
+
+        return new LoginSession(
+            _mockConnection.Object,
+            _mockGameController.Object,
+            timeProvider,
+            appConfig,
+            Mock.Of<ILogger<LoginSession>>());
+    }
+
+    private static Mock<IAuthenticationFlow> CreateMockFlow(AuthFlowResult result)
+    {
+        var mock = new Mock<IAuthenticationFlow>();
+        mock.Setup(f => f.StartAsync(It.IsAny<ILoginClient>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+        return mock;
+    }
+
+    private async Task AuthenticateSuccessfullyAsync(LoginSession? session = null)
+    {
+        session ??= _session;
+        var flow = CreateMockFlow(new AuthFlowResult.Success(s_testAccountId, "testuser"));
+        await session.AuthenticateAsync(flow.Object, CancellationToken.None);
+        _sentPackets.Clear();
+    }
+
+    private GameServer CreateActiveGameServer(GameServerId gsId)
+    {
+        var server = new GameServer(gsId, "TestServer", "127.0.0.1", 1234)
+        {
+            Connection = new InternalConnection(Mock.Of<ISession>())
+        };
+        _mockGameController.Setup(g => g.GetGameServer(gsId)).Returns(server);
+        return server;
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_Success_SendsJoinThenAuthResponse()
+    {
+        var flow = CreateMockFlow(new AuthFlowResult.Success(s_testAccountId, "testuser"));
+
+        await _session.AuthenticateAsync(flow.Object, CancellationToken.None);
+
+        Assert.Equal(2, _sentPackets.Count);
+        Assert.IsType<ACJoinResponsePacket>(_sentPackets[0]);
+        Assert.IsType<ACAuthResponsePacket>(_sentPackets[1]);
+        Assert.Equal(LoginState.Authenticated, _session.State);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_Denied_SendsLoginDeniedPacket()
+    {
+        var flow = CreateMockFlow(new AuthFlowResult.Denied(LoginDeniedReason.BadAccount));
+
+        await _session.AuthenticateAsync(flow.Object, CancellationToken.None);
+
+        Assert.Single(_sentPackets);
+        Assert.IsType<ACLoginDeniedPacket>(_sentPackets[0]);
+        Assert.Equal(LoginState.Connected, _session.State);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_FromWrongState_SendsDeniedBadResponse()
+    {
+        await AuthenticateSuccessfullyAsync();
+
+        var flow = CreateMockFlow(new AuthFlowResult.Success(s_testAccountId));
+        await _session.AuthenticateAsync(flow.Object, CancellationToken.None);
+
+        Assert.Single(_sentPackets);
+        Assert.IsType<ACLoginDeniedPacket>(_sentPackets[0]);
+        Assert.Equal(LoginState.Authenticated, _session.State);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_Pending_NoPacketSent()
+    {
+        var flow = CreateMockFlow(new AuthFlowResult.Pending());
+
+        await _session.AuthenticateAsync(flow.Object, CancellationToken.None);
+
+        Assert.Empty(_sentPackets);
+        Assert.Equal(LoginState.Authenticating, _session.State);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_Success_SetsConnectionProperties()
+    {
+        var flow = CreateMockFlow(new AuthFlowResult.Success(s_testAccountId, "testuser"));
+
+        await _session.AuthenticateAsync(flow.Object, CancellationToken.None);
+
+        Assert.Equal(s_testAccountId, _mockConnection.Object.AccountId);
+        Assert.Equal("testuser", _mockConnection.Object.AccountName);
+        Assert.Equal(s_testIp, _mockConnection.Object.LastIp);
+        // LastLogin should be set to approximately now
+        Assert.True(
+            DateTime.UtcNow - _mockConnection.Object.LastLogin < TimeSpan.FromSeconds(5),
+            "LastLogin should be recent");
+    }
+
+    [Fact]
+    public async Task ContinueAuthAsync_MatchingFlow_Success_SendsAuthPackets()
+    {
+        // Start with pending flow
+        var flow = new Mock<IAuthenticationFlow>();
+        flow.Setup(f => f.StartAsync(It.IsAny<ILoginClient>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthFlowResult.Pending());
+        await _session.AuthenticateAsync(flow.Object, CancellationToken.None);
+        _sentPackets.Clear();
+
+        // Continue with success
+        await _session.ContinueAuthAsync<IAuthenticationFlow>(
+            _ => Task.FromResult<AuthFlowResult>(new AuthFlowResult.Success(s_testAccountId, "user")),
+            CancellationToken.None);
+
+        Assert.Equal(2, _sentPackets.Count);
+        Assert.IsType<ACJoinResponsePacket>(_sentPackets[0]);
+        Assert.IsType<ACAuthResponsePacket>(_sentPackets[1]);
+        Assert.Equal(LoginState.Authenticated, _session.State);
+    }
+
+    [Fact]
+    public async Task ContinueAuthAsync_MatchingFlow_Denied_SendsDeniedPacket()
+    {
+        var flow = new Mock<IAuthenticationFlow>();
+        flow.Setup(f => f.StartAsync(It.IsAny<ILoginClient>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthFlowResult.Pending());
+        await _session.AuthenticateAsync(flow.Object, CancellationToken.None);
+        _sentPackets.Clear();
+
+        await _session.ContinueAuthAsync<IAuthenticationFlow>(
+            _ => Task.FromResult<AuthFlowResult>(new AuthFlowResult.Denied(LoginDeniedReason.BadAccount)),
+            CancellationToken.None);
+
+        Assert.Single(_sentPackets);
+        Assert.IsType<ACLoginDeniedPacket>(_sentPackets[0]);
+        Assert.Equal(LoginState.Connected, _session.State);
+    }
+
+    /// <summary>
+    /// A distinct flow interface for type-mismatch testing.
+    /// </summary>
+    private interface IOtherFlow : IAuthenticationFlow;
+
+    [Fact]
+    public async Task ContinueAuthAsync_WrongFlowType_SendsDeniedAndShutdown()
+    {
+        // Start with a mocked IAuthenticationFlow
+        var flow = new Mock<IAuthenticationFlow>();
+        flow.Setup(f => f.StartAsync(It.IsAny<ILoginClient>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthFlowResult.Pending());
+        await _session.AuthenticateAsync(flow.Object, CancellationToken.None);
+        _sentPackets.Clear();
+
+        // Continue expecting IOtherFlow = type mismatch
+        await _session.ContinueAuthAsync<IOtherFlow>(
+            _ => Task.FromResult<AuthFlowResult>(new AuthFlowResult.Success(s_testAccountId)),
+            CancellationToken.None);
+
+        Assert.Single(_sentPackets);
+        Assert.IsType<ACLoginDeniedPacket>(_sentPackets[0]);
+        _mockConnection.Verify(c => c.Shutdown(), Times.Once);
+        Assert.Equal(LoginState.Disconnected, _session.State);
+    }
+
+    [Fact]
+    public async Task ContinueAuthAsync_FromWrongState_SendsDenied()
+    {
+        // Session is in Connected state (no pending auth)
+        await _session.ContinueAuthAsync<IAuthenticationFlow>(
+            _ => Task.FromResult<AuthFlowResult>(new AuthFlowResult.Success(s_testAccountId)),
+            CancellationToken.None);
+
+        Assert.Single(_sentPackets);
+        Assert.IsType<ACLoginDeniedPacket>(_sentPackets[0]);
+        Assert.Equal(LoginState.Connected, _session.State);
+    }
+
+    [Fact]
+    public async Task InitiateEnterWorld_Success_SendsWorldCookiePacket()
+    {
+        await AuthenticateSuccessfullyAsync();
+        CreateActiveGameServer(s_testGsId);
+
+        await _session.InitiateEnterWorldAsync(s_testGsId, CancellationToken.None);
+        _session.CompleteEnterWorldRequest(s_testGsId, 0);
+        await _session.EnterWorldBackgroundTask!;
+
+        Assert.Single(_sentPackets);
+        Assert.IsType<ACWorldCookiePacket>(_sentPackets[0]);
+        Assert.Equal(LoginState.Authenticated, _session.State);
+    }
+
+    [Fact]
+    public async Task InitiateEnterWorld_Failure_SendsEnterWorldDeniedPacket()
+    {
+        await AuthenticateSuccessfullyAsync();
+        CreateActiveGameServer(s_testGsId);
+
+        await _session.InitiateEnterWorldAsync(s_testGsId, CancellationToken.None);
+        _session.CompleteEnterWorldRequest(s_testGsId, 1);
+        await _session.EnterWorldBackgroundTask!;
+
+        Assert.Single(_sentPackets);
+        Assert.IsType<ACEnterWorldDeniedPacket>(_sentPackets[0]);
+        Assert.Equal(LoginState.Authenticated, _session.State);
+    }
+
+    [Fact]
+    public async Task InitiateEnterWorld_Timeout_SendsEnterWorldDenied()
+    {
+        var fakeTime = new FakeTimeProvider();
+        var session = CreateSessionWithTimeProvider(fakeTime);
+        await AuthenticateSuccessfullyAsync(session);
+        CreateActiveGameServer(s_testGsId);
+
+        await session.InitiateEnterWorldAsync(s_testGsId, CancellationToken.None);
+
+        // Advance past the 200ms timeout
+        fakeTime.Advance(TimeSpan.FromMilliseconds(300));
+        await session.EnterWorldBackgroundTask!;
+
+        Assert.Single(_sentPackets);
+        Assert.IsType<ACEnterWorldDeniedPacket>(_sentPackets[0]);
+        Assert.Equal(LoginState.Authenticated, session.State);
+    }
+
+    [Fact]
+    public async Task InitiateEnterWorld_FromWrongState_NoAction()
+    {
+        // Session is in Connected state
+        await _session.InitiateEnterWorldAsync(s_testGsId, CancellationToken.None);
+
+        Assert.Empty(_sentPackets);
+        Assert.Equal(LoginState.Connected, _session.State);
+    }
+
+    [Fact]
+    public async Task InitiateEnterWorld_ServerNotActive_NoAction()
+    {
+        await AuthenticateSuccessfullyAsync();
+
+        // Server with no connection (not active)
+        var server = new GameServer(s_testGsId, "TestServer", "127.0.0.1", 1234);
+        _mockGameController.Setup(g => g.GetGameServer(s_testGsId)).Returns(server);
+
+        await _session.InitiateEnterWorldAsync(s_testGsId, CancellationToken.None);
+
+        Assert.Empty(_sentPackets);
+        Assert.Equal(LoginState.Authenticated, _session.State);
+    }
+
+    [Fact]
+    public async Task CompleteEnterWorld_GsIdMismatch_Ignored()
+    {
+        await AuthenticateSuccessfullyAsync();
+        CreateActiveGameServer(s_testGsId);
+
+        await _session.InitiateEnterWorldAsync(s_testGsId, CancellationToken.None);
+
+        // Complete with a different gsId
+        var wrongGsId = new GameServerId(99);
+        _session.CompleteEnterWorldRequest(wrongGsId, 0);
+        Assert.Empty(_sentPackets);
+
+        // Clean up: cancel to avoid timeout firing later
+        _session.CancelEnterWorld();
+        await _session.EnterWorldBackgroundTask!;
+    }
+
+    [Fact]
+    public async Task CancelEnterWorld_WhileEntering_CancelsOperation()
+    {
+        await AuthenticateSuccessfullyAsync();
+        CreateActiveGameServer(s_testGsId);
+
+        await _session.InitiateEnterWorldAsync(s_testGsId, CancellationToken.None);
+        _session.CancelEnterWorld();
+        await _session.EnterWorldBackgroundTask!;
+
+        Assert.Empty(_sentPackets);
+        Assert.Equal(LoginState.Authenticated, _session.State);
+    }
+
+    [Fact]
+    public async Task CancelEnterWorld_NotEntering_Ignored()
+    {
+        await AuthenticateSuccessfullyAsync();
+
+        _session.CancelEnterWorld();
+
+        Assert.Empty(_sentPackets);
+        Assert.Equal(LoginState.Authenticated, _session.State);
+    }
+
+    [Fact]
+    public async Task DisconnectAsync_CancelsPendingEnterWorld()
+    {
+        await AuthenticateSuccessfullyAsync();
+        CreateActiveGameServer(s_testGsId);
+
+        await _session.InitiateEnterWorldAsync(s_testGsId, CancellationToken.None);
+        await _session.DisconnectAsync();
+
+        // Should not send any packets since disconnect cancels before result
+        Assert.Empty(_sentPackets);
+        Assert.Equal(LoginState.Disconnected, _session.State);
+    }
+
+    [Fact]
+    public async Task DisconnectAsync_FromAuthenticated_SetsDisconnected()
+    {
+        await AuthenticateSuccessfullyAsync();
+
+        await _session.DisconnectAsync();
+
+        Assert.Empty(_sentPackets);
+        Assert.Equal(LoginState.Disconnected, _session.State);
+    }
+
+    [Fact]
+    public async Task DisconnectAsync_AlreadyDisconnected_Idempotent()
+    {
+        await _session.DisconnectAsync();
+        await _session.DisconnectAsync();
+
+        Assert.Empty(_sentPackets);
+        Assert.Equal(LoginState.Disconnected, _session.State);
+    }
+}

--- a/AAEmu.UnitTests/Login/Core/Network/Login/LoginConnectionFactoryTests.cs
+++ b/AAEmu.UnitTests/Login/Core/Network/Login/LoginConnectionFactoryTests.cs
@@ -18,6 +18,7 @@ public class LoginConnectionFactoryTests
 {
     private readonly Mock<ILoginProtocolHandler> _mockProtocolHandler = new();
     private readonly Mock<IConnectionIdLeaseFactory> _mockLeaseFactory = new();
+    private readonly Mock<ILoginSessionFactory> _mockSessionFactory = new();
     private readonly ILoggerFactory _loggerFactory = NullLoggerFactory.Instance;
 
     [Fact]
@@ -33,6 +34,7 @@ public class LoginConnectionFactoryTests
             [],
             _mockProtocolHandler.Object,
             _mockLeaseFactory.Object,
+            _mockSessionFactory.Object,
             _loggerFactory);
 
         var mockContext = CreateMockConnectionContext();
@@ -58,6 +60,7 @@ public class LoginConnectionFactoryTests
             [],
             _mockProtocolHandler.Object,
             _mockLeaseFactory.Object,
+            _mockSessionFactory.Object,
             _loggerFactory);
 
         var mockContext = CreateMockConnectionContext();
@@ -86,6 +89,7 @@ public class LoginConnectionFactoryTests
             [],
             _mockProtocolHandler.Object,
             _mockLeaseFactory.Object,
+            _mockSessionFactory.Object,
             _loggerFactory);
 
         var mockContext1 = CreateMockConnectionContext();
@@ -122,6 +126,7 @@ public class LoginConnectionFactoryTests
             packetDescriptors,
             _mockProtocolHandler.Object,
             _mockLeaseFactory.Object,
+            _mockSessionFactory.Object,
             _loggerFactory);
 
         var mockContext = CreateMockConnectionContext();
@@ -150,6 +155,7 @@ public class LoginConnectionFactoryTests
             packetDescriptors,
             _mockProtocolHandler.Object,
             _mockLeaseFactory.Object,
+            _mockSessionFactory.Object,
             _loggerFactory));
     }
 
@@ -166,6 +172,7 @@ public class LoginConnectionFactoryTests
             [],
             _mockProtocolHandler.Object,
             _mockLeaseFactory.Object,
+            _mockSessionFactory.Object,
             _loggerFactory);
 
         // Create context where local and remote are the same IP
@@ -195,6 +202,7 @@ public class LoginConnectionFactoryTests
             [],
             _mockProtocolHandler.Object,
             _mockLeaseFactory.Object,
+            _mockSessionFactory.Object,
             _loggerFactory);
 
         // Create context where local and remote are different IPs

--- a/AAEmu.UnitTests/Services/GameServiceTests.cs
+++ b/AAEmu.UnitTests/Services/GameServiceTests.cs
@@ -2,6 +2,8 @@
 using AAEmu.Game.Core.Managers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
 using Xunit;
 
 namespace AAEmu.UnitTests.Services;
@@ -14,68 +16,54 @@ public class GameServiceTests
     [Fact]
     public void StartTime_IsInitializedToUtcNow()
     {
-        // Arrange & Act
-        var startTime = GameService.StartTime;
+        var fakeTime = new FakeTimeProvider();
+        var sp = Mock.Of<IServiceProvider>();
+        var orchestrator = new ManagerOrchestrator(sp, new ServiceCollection());
+        using var service = new GameService(sp, orchestrator, fakeTime);
 
-        // Assert
-        Assert.True(startTime <= DateTime.UtcNow);
-        Assert.True((DateTime.UtcNow - startTime).TotalSeconds < 1);
+        Assert.Equal(fakeTime.GetUtcNow().UtcDateTime, GameService.StartTime);
     }
 
     [Fact]
     public void TimeSinceStart_ReturnsTimeSpanSinceStart()
     {
-        // Arrange
-        var startTime = GameService.StartTime;
+        var fakeTime = new FakeTimeProvider();
+        var sp = Mock.Of<IServiceProvider>();
+        var orchestrator = new ManagerOrchestrator(sp, new ServiceCollection());
+        using var service = new GameService(sp, orchestrator, fakeTime);
 
-        // Act
-        var timeSinceStart = GameService.TimeSinceStart;
+        fakeTime.Advance(TimeSpan.FromSeconds(5));
 
-        // Assert
-        // Verify TimeSinceStart is non-negative
-        Assert.True(timeSinceStart >= TimeSpan.Zero);
-
-        // Verify TimeSinceStart is consistent with the formula: DateTime.UtcNow - StartTime
-        // Allow 100ms tolerance for execution time variation
-        var expectedTimeSinceStart = DateTime.UtcNow - startTime;
-        var tolerance = TimeSpan.FromMilliseconds(100);
-        Assert.True(timeSinceStart <= expectedTimeSinceStart + tolerance);
-        Assert.True(timeSinceStart >= expectedTimeSinceStart - tolerance);
+        Assert.Equal(TimeSpan.FromSeconds(5), GameService.TimeSinceStart);
     }
 
     [Fact]
     public void GameService_ImplementsIHostedService()
     {
-        // Arrange
-        var sp = Moq.Mock.Of<IServiceProvider>();
+        var sp = Mock.Of<IServiceProvider>();
         var orchestrator = new ManagerOrchestrator(sp, new ServiceCollection());
-        using var service = new GameService(sp, orchestrator);
+        using var service = new GameService(sp, orchestrator, TimeProvider.System);
 
-        // Assert
         Assert.IsAssignableFrom<IHostedService>(service);
     }
 
     [Fact]
     public void GameService_ImplementsIDisposable()
     {
-        // Arrange
-        var sp = Moq.Mock.Of<IServiceProvider>();
+        var sp = Mock.Of<IServiceProvider>();
         var orchestrator = new ManagerOrchestrator(sp, new ServiceCollection());
-        using var service = new GameService(sp, orchestrator);
+        using var service = new GameService(sp, orchestrator, TimeProvider.System);
 
-        // Assert
         Assert.IsAssignableFrom<IDisposable>(service);
     }
 
     [Fact]
     public async Task Dispose_DoesNotThrow()
     {
-        // Arrange
-        var sp = Moq.Mock.Of<IServiceProvider>();
+        var sp = Mock.Of<IServiceProvider>();
         var orchestrator = new ManagerOrchestrator(sp, new ServiceCollection());
-        using var service = new GameService(sp, orchestrator);
+        using var service = new GameService(sp, orchestrator, TimeProvider.System);
 
-        // Act & Assert
         service.Dispose();
         await Task.CompletedTask; // Suppress warning
     }

--- a/AAEmu.slnx
+++ b/AAEmu.slnx
@@ -118,6 +118,7 @@
   </Folder>
   <Folder Name="/Tests/">
     <Project Path="AAEmu.IntegrationTests/AAEmu.IntegrationTests.csproj" />
+    <Project Path="AAEmu.Login.IntegrationTests/AAEmu.Login.IntegrationTests.csproj" />
     <Project Path="AAEmu.UnitTests/AAEmu.UnitTests.csproj" />
   </Folder>
 </Solution>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.3.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
     <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="2.1.0" />
@@ -41,6 +42,8 @@
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+    <PackageVersion Include="Testcontainers" Version="4.4.0" />
+    <PackageVersion Include="Testcontainers.MySql" Version="4.4.0" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageVersion Include="Jitter2" Version="2.7.0" />
   </ItemGroup>


### PR DESCRIPTION
Various refactorings on the login server, mainly focused around modelling the login state machine flow explicitly via a new `LoginSession` class.

This makes it clear what the expected flow is, and allows rejection of requests that make no sense in the current state.

Adds integration tests with Testcontainers for `LoginController`, running against a real MySQL database.
Adds unit tests for the packets sent by `LoginSession`.