### PR TITLE
chore(ci): Improve build pipeline and update actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5.0.1
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '10.0.x'
 

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -24,10 +24,12 @@ jobs:
         run: dotnet build --configuration Release --no-restore
       - name: Scripts Compile
         run: dotnet run --configuration Release --no-build --project AAEmu.Game/AAEmu.Game.csproj compiler-check
+      - name: Install dotnet-coverage
+        run: dotnet tool install --global dotnet-coverage
       - name: Test
-        run: dotnet test AAEmu.UnitTests --configuration Release --no-build /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov
+        run: dotnet-coverage collect "dotnet test AAEmu.UnitTests --configuration Release --no-build" -f cobertura -o AAEmu.UnitTests/TestResults/coverage.cobertura.xml
       - name: Coveralls GitHub Action
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./AAEmu.UnitTests/TestResults/coverage.info
+          file: ./AAEmu.UnitTests/TestResults/coverage.cobertura.xml

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -13,23 +13,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
       - name: Install dependencies
         run: dotnet restore
       - name: Build
         run: dotnet build --configuration Release --no-restore
-      # - name: Scripts Compile Net 8
-      #    run: dotnet run --project AAEmu.Game/AAEmu.Game.csproj --framework net8.0 compiler-check
-      # - name: Scripts Compile Net 9
-      #    run: dotnet run --project AAEmu.Game/AAEmu.Game.csproj --framework net9.0 compiler-check      
-      - name: Scripts Compile Net 10
-        run: dotnet run --project AAEmu.Game/AAEmu.Game.csproj --framework net10.0 compiler-check
+      - name: Scripts Compile
+        run: dotnet run --configuration Release --no-build --project AAEmu.Game/AAEmu.Game.csproj compiler-check
       - name: Test
-        run: dotnet test --filter FullyQualifiedName!~AAEmu.IntegrationTests /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov
+        run: dotnet test AAEmu.UnitTests --configuration Release --no-build /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov
       - name: Coveralls GitHub Action
         uses: coverallsapp/github-action@v2
         with:

--- a/AAEmu.IntegrationTests/AAEmu.IntegrationTests.csproj
+++ b/AAEmu.IntegrationTests/AAEmu.IntegrationTests.csproj
@@ -10,14 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.msbuild">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />

--- a/AAEmu.UnitTests/AAEmu.UnitTests.csproj
+++ b/AAEmu.UnitTests/AAEmu.UnitTests.csproj
@@ -11,14 +11,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.msbuild">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,8 +34,6 @@
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageVersion Include="System.Text.Json" Version="9.0.0" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="Jitter2" Version="2.7.0" />


### PR DESCRIPTION
Re-use Release build artifacts in test/run steps with --no-build, and bump checkout to v6 and setup-dotnet to v5.

Replace Coverlet with dotnet-coverage for faster test coverage.