### PR TITLE
fix(login): Fix Dockerfile for login server using ASP.NET Core

### DIFF
--- a/AAEmu.Login/Dockerfile
+++ b/AAEmu.Login/Dockerfile
@@ -8,7 +8,7 @@ COPY ./AAEmu.Commons ./AAEmu.Commons
 COPY ./AAEmu.Login ./AAEmu.Login
 RUN dotnet publish ./AAEmu.Login/AAEmu.Login.csproj -c $CONFIGURATION -o /app/publish
 
-FROM mcr.microsoft.com/dotnet/runtime:10.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine
 
 ARG CONFIGURATION
 ARG DB_HOST


### PR DESCRIPTION
The login server now uses ASP.NET Core Kestrel (#1354), which requires the aspnet base image that includes ASP.NET Core libraries missing from the plain dotnet/runtime image