### PR TITLE
feat: Migrate manager singletons to DI for testing and parallel loading

### DIFF
--- a/AAEmu.Commons/AAEmu.Commons.csproj
+++ b/AAEmu.Commons/AAEmu.Commons.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="MySql.Data" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NLog" />

--- a/AAEmu.Commons/Utils/Singleton.cs
+++ b/AAEmu.Commons/Utils/Singleton.cs
@@ -49,6 +49,12 @@ public abstract class Singleton<T> where T : class
         {
             if (_instance != null)
                 return;
+            if (typeof(T).GetConstructor(
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                    null, Type.EmptyTypes, null) == null)
+                throw new InvalidOperationException(
+                    $"{typeof(T).Name} has no parameterless constructor. " +
+                    "Resolve it from DI, or instantiate it with explicit dependencies.");
             _instance = typeof(T).InvokeMember(typeof(T).Name,
                 BindingFlags.CreateInstance |
                 BindingFlags.Instance |

--- a/AAEmu.Commons/Utils/Singleton.cs
+++ b/AAEmu.Commons/Utils/Singleton.cs
@@ -1,5 +1,7 @@
 ﻿using System.Reflection;
 
+using Microsoft.Extensions.DependencyInjection;
+
 namespace AAEmu.Commons.Utils;
 
 #pragma warning disable IDE0079 // Remove unnecessary suppression
@@ -14,12 +16,26 @@ public abstract class Singleton<T> where T : class
     private static T _instance;
 
     /// <summary>
-    /// Gets the instance of the singleton
+    /// Gets the instance of the singleton. Resolves from the DI container when available,
+    /// caching the result so subsequent calls are free. Falls back to reflection when DI
+    /// is not configured (e.g. unit tests).
     /// </summary>
     public static T Instance
     {
         get
         {
+            if (_instance != null)
+                return _instance;
+
+            if (SingletonContainer.ServiceProvider?.GetService<T>() is { } fromDi)
+            {
+                lock (typeof(T))
+                {
+                    _instance ??= fromDi;
+                }
+                return _instance;
+            }
+
             OnInit();
             return _instance;
         }
@@ -31,6 +47,8 @@ public abstract class Singleton<T> where T : class
             return;
         lock (typeof(T))
         {
+            if (_instance != null)
+                return;
             _instance = typeof(T).InvokeMember(typeof(T).Name,
                 BindingFlags.CreateInstance |
                 BindingFlags.Instance |

--- a/AAEmu.Commons/Utils/SingletonContainer.cs
+++ b/AAEmu.Commons/Utils/SingletonContainer.cs
@@ -1,0 +1,6 @@
+namespace AAEmu.Commons.Utils;
+
+public static class SingletonContainer
+{
+    public static IServiceProvider? ServiceProvider { get; set; }
+}

--- a/AAEmu.Game/Core/Managers/AIManager.cs
+++ b/AAEmu.Game/Core/Managers/AIManager.cs
@@ -5,7 +5,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class AIManager : Singleton<AIManager>
+public class AIManager : Singleton<AIManager>, IAIManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private bool _initialized = false;

--- a/AAEmu.Game/Core/Managers/AccessLevelManager.cs
+++ b/AAEmu.Game/Core/Managers/AccessLevelManager.cs
@@ -4,7 +4,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class AccessLevelManager : Singleton<AccessLevelManager>
+public class AccessLevelManager : Singleton<AccessLevelManager>, IAccessLevelManager
 {
     private readonly List<Command> CMD = [];
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();

--- a/AAEmu.Game/Core/Managers/AccountManager.cs
+++ b/AAEmu.Game/Core/Managers/AccountManager.cs
@@ -12,7 +12,7 @@ namespace AAEmu.Game.Core.Managers;
 /// <summary>
 /// Manages Connections and Game Account settings
 /// </summary>
-public class AccountManager : Singleton<AccountManager>
+public class AccountManager : Singleton<AccountManager>, IAccountManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 

--- a/AAEmu.Game/Core/Managers/AccountManager.cs
+++ b/AAEmu.Game/Core/Managers/AccountManager.cs
@@ -12,17 +12,16 @@ namespace AAEmu.Game.Core.Managers;
 /// <summary>
 /// Manages Connections and Game Account settings
 /// </summary>
-public class AccountManager : Singleton<AccountManager>, IAccountManager
+public class AccountManager(ITickManager tickManager, ITimedRewardsManager timedRewardsManager) : Singleton<AccountManager>, IAccountManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
-    private readonly ConcurrentDictionary<uint, GameConnection> _accounts;
+    private readonly ConcurrentDictionary<uint, GameConnection> _accounts = new();
     private readonly Dictionary<uint, object> _locks = [];
 
-    public AccountManager()
+    public void Initialize()
     {
-        _accounts = new ConcurrentDictionary<uint, GameConnection>();
-        TickManager.Instance.OnTick.Subscribe(RemoveDeadConnections, TimeSpan.FromSeconds(30));
+        tickManager.OnTick.Subscribe(RemoveDeadConnections, TimeSpan.FromSeconds(30));
     }
 
     public void Add(GameConnection connection)
@@ -35,10 +34,10 @@ public class AccountManager : Singleton<AccountManager>, IAccountManager
         if (lastLogin < DateTime.UtcNow.Date)
         {
             // Logged in for a new day
-            TimedRewardsManager.Instance.DoDailyAccountLogin(connection.AccountId);
+            timedRewardsManager.DoDailyAccountLogin(connection.AccountId);
         }
         // Add offline labor
-        TimedRewardsManager.Instance.AddOfflineLabor(connection, lastLogin, accountDetails.Labor);
+        timedRewardsManager.AddOfflineLabor(connection, lastLogin, accountDetails.Labor);
     }
 
     private void RemoveDeadConnections(TimeSpan delta)

--- a/AAEmu.Game/Core/Managers/AiPathsManager.cs
+++ b/AAEmu.Game/Core/Managers/AiPathsManager.cs
@@ -6,7 +6,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class AiPathsManager : Singleton<AiPathsManager>
+public class AiPathsManager : Singleton<AiPathsManager>, IAiPathsManager
 {
     private readonly string PathFileFolder = Path.Combine("Data", "Path");
     private const string PathFileExt = ".path";

--- a/AAEmu.Game/Core/Managers/AnimationManager.cs
+++ b/AAEmu.Game/Core/Managers/AnimationManager.cs
@@ -7,7 +7,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class AnimationManager : Singleton<AnimationManager>
+public class AnimationManager : Singleton<AnimationManager>, IAnimationManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 

--- a/AAEmu.Game/Core/Managers/AuctionManager.cs
+++ b/AAEmu.Game/Core/Managers/AuctionManager.cs
@@ -19,7 +19,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class AuctionManager : Singleton<AuctionManager>
+public class AuctionManager : Singleton<AuctionManager>, IAuctionManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 

--- a/AAEmu.Game/Core/Managers/AuctionManager.cs
+++ b/AAEmu.Game/Core/Managers/AuctionManager.cs
@@ -19,7 +19,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class AuctionManager : Singleton<AuctionManager>, IAuctionManager
+public class AuctionManager(IItemManager itemManager, INameManager nameManager, IAuctionIdManager auctionIdManager, ILocalizationManager localizationManager, ITaskManager taskManager) : Singleton<AuctionManager>, IAuctionManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
@@ -32,7 +32,7 @@ public class AuctionManager : Singleton<AuctionManager>, IAuctionManager
     {
         if (AuctionLots.ContainsKey(itemToRemove.Id))
         {
-            var newItem = ItemManager.Instance.GetItemByItemId(itemToRemove.Item.Id);
+            var newItem = itemManager.GetItemByItemId(itemToRemove.Item.Id);
             if (newItem != null)
             {
                 /*
@@ -57,7 +57,7 @@ public class AuctionManager : Singleton<AuctionManager>, IAuctionManager
                 }
 
                 var buyMail = new MailForAuction(newItem, itemToRemove.ClientId, soldAmount, (int)recalculatedFee);
-                var buyerId = NameManager.Instance.GetCharacterId(buyer);
+                var buyerId = nameManager.GetCharacterId(buyer);
                 buyMail.FinalizeForSaleBuyer(buyerId);
                 buyMail.Send();
             }
@@ -78,7 +78,7 @@ public class AuctionManager : Singleton<AuctionManager>, IAuctionManager
         }
 
         // Item did not sell by end of the timer.
-        var newItem = ItemManager.Instance.GetItemByItemId(itemToRemove.Item.Id);
+        var newItem = itemManager.GetItemByItemId(itemToRemove.Item.Id);
         if (newItem != null)
         {
             // var itemList = new Item[10].ToList();
@@ -117,7 +117,7 @@ public class AuctionManager : Singleton<AuctionManager>, IAuctionManager
 
         var moneyToSubtract = auctionLot.DirectMoney * .1f;
         // var itemList = new Item[10].ToList();
-        var newItem = ItemManager.Instance.Create(auctionLot.Item.TemplateId, auctionLot.Item.Count, auctionLot.Item.Grade);
+        var newItem = itemManager.Create(auctionLot.Item.TemplateId, auctionLot.Item.Count, auctionLot.Item.Grade);
         if (newItem != null)
         {
             // itemList[0] = newItem;
@@ -270,9 +270,9 @@ public class AuctionManager : Singleton<AuctionManager>, IAuctionManager
         player.SendPacket(new SCAuctionLowestPricePacket(templateId, itemGrade, DirectMoney));
     }
 
-    private static string GetLocalizedItemNameById(uint id)
+    private string GetLocalizedItemNameById(uint id)
     {
-        return LocalizationManager.Instance.Get("items", "name", id, ItemManager.Instance.GetTemplate(id).Name ?? "");
+        return localizationManager.Get("items", "name", id, itemManager.GetTemplate(id).Name ?? "");
     }
 
     /* Unused
@@ -298,7 +298,7 @@ public class AuctionManager : Singleton<AuctionManager>, IAuctionManager
             return;
         }
 
-        AuctionIdManager.Instance.ReleaseId((uint)itemToRemove.Id);
+        auctionIdManager.ReleaseId((uint)itemToRemove.Id);
         _deletedAuctionItemIds.Add((long)itemToRemove.Id);
         if (!AuctionLots.TryRemove(itemToRemove.Id, out _))
         {
@@ -352,7 +352,7 @@ public class AuctionManager : Singleton<AuctionManager>, IAuctionManager
 
         var newAuctionLot = new AuctionLot
         {
-            Id = AuctionIdManager.Instance.GetNextId(), Duration = duration, Item = itemToList, EndTime = DateTime.UtcNow.AddHours(timeLeft),
+            Id = auctionIdManager.GetNextId(), Duration = duration, Item = itemToList, EndTime = DateTime.UtcNow.AddHours(timeLeft),
             WorldId = 1,
             ClientId = playerId,
             ClientName = playerName,
@@ -394,7 +394,7 @@ public class AuctionManager : Singleton<AuctionManager>, IAuctionManager
                             {
                                 Id = reader.GetUInt64("id"),
                                 Duration = (AuctionDuration)reader.GetByte("duration"), // 8 is 6 hours, 9 is 12 hours, 10 is 24 hours, 11 is 48 hours
-                                Item = ItemManager.Instance.GetItemByItemId(reader.GetUInt32("item_id")),
+                                Item = itemManager.GetItemByItemId(reader.GetUInt32("item_id")),
                                 PostDate = reader.GetDateTime("post_date"),
                                 EndTime = reader.GetDateTime("end_time"),
                                 WorldId = reader.GetByte("world_id"),
@@ -418,7 +418,7 @@ public class AuctionManager : Singleton<AuctionManager>, IAuctionManager
                 }
             }
             var auctionTask = new AuctionHouseTask();
-            TaskManager.Instance.Schedule(auctionTask, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
+            taskManager.Schedule(auctionTask, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
         }
         catch (Exception ex)
         {
@@ -457,7 +457,7 @@ public class AuctionManager : Singleton<AuctionManager>, IAuctionManager
 
                 if (lot.Item._holdingContainer != null)
                 {
-                    lot.Item.SlotType = ItemManager.Instance.GetContainerSlotTypeByContainerId(lot.Item._holdingContainer.ContainerId);
+                    lot.Item.SlotType = itemManager.GetContainerSlotTypeByContainerId(lot.Item._holdingContainer.ContainerId);
                 }
 
                 if (lot.Item.SlotType != SlotType.None)
@@ -654,7 +654,7 @@ public class AuctionManager : Singleton<AuctionManager>, IAuctionManager
 
     public void PostLotOnAuction(Character player, uint npcId, uint npcId2, ulong itemId, int startPrice, int buyoutPrice, AuctionDuration duration)
     {
-        var item = ItemManager.Instance.GetItemByItemId(itemId);
+        var item = itemManager.GetItemByItemId(itemId);
         if (item == null)
         {
             return;

--- a/AAEmu.Game/Core/Managers/CashShopManager.cs
+++ b/AAEmu.Game/Core/Managers/CashShopManager.cs
@@ -10,7 +10,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class CashShopManager : Singleton<CashShopManager>
+public class CashShopManager : Singleton<CashShopManager>, ICashShopManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 

--- a/AAEmu.Game/Core/Managers/CashShopManager.cs
+++ b/AAEmu.Game/Core/Managers/CashShopManager.cs
@@ -10,7 +10,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class CashShopManager : Singleton<CashShopManager>, ICashShopManager
+public class CashShopManager(IWorldManager worldManager, IAccountManager accountManager, ILocalizationManager localizationManager) : Singleton<CashShopManager>, ICashShopManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
@@ -22,11 +22,11 @@ public class CashShopManager : Singleton<CashShopManager>, ICashShopManager
 
     public void CreditDisperseTick(TimeSpan delta)
     {
-        var characters = WorldManager.Instance.GetAllCharacters();
+        var characters = worldManager.GetAllCharacters();
 
         foreach (var character in characters)
         {
-            AccountManager.Instance.AddCredits(character.AccountId, 100);
+            accountManager.AddCredits(character.AccountId, 100);
             character.SendMessage("You have received 100 credits.");
         }
     }
@@ -108,7 +108,7 @@ public class CashShopManager : Singleton<CashShopManager>, ICashShopManager
                 if (shopItem.Skus.Count <= 0 && string.IsNullOrWhiteSpace(shopItem.Name))
                 {
                     // First Item, grab it's name when needed
-                    shopItem.Name = LocalizationManager.Instance.Get("items", "name", sku.ItemId) ?? "???";
+                    shopItem.Name = localizationManager.Get("items", "name", sku.ItemId) ?? "???";
                 }
                 shopItem.Skus.Add(sku.Sku, sku);
             }
@@ -169,7 +169,7 @@ public class CashShopManager : Singleton<CashShopManager>, ICashShopManager
     public void DisableShop()
     {
         Enabled = false;
-        foreach (var character in WorldManager.Instance.GetAllCharacters())
+        foreach (var character in worldManager.GetAllCharacters())
             character?.SendPacket(new SCICSCheckTimePacket());
     }
 

--- a/AAEmu.Game/Core/Managers/ChatManager.cs
+++ b/AAEmu.Game/Core/Managers/ChatManager.cs
@@ -11,7 +11,7 @@ using NLog;
 namespace AAEmu.Game.Core.Managers;
 
 // ReSharper disable once ClassNeverInstantiated.Global
-public class ChatManager : Singleton<ChatManager>
+public class ChatManager : Singleton<ChatManager>, IChatManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 

--- a/AAEmu.Game/Core/Managers/CommandManager.cs
+++ b/AAEmu.Game/Core/Managers/CommandManager.cs
@@ -15,14 +15,8 @@ public partial class CommandManager : Singleton<CommandManager>, ICommandManager
 {
     public const string CommandPrefix = "/";
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
-    private readonly Dictionary<string, ICommand> _commands;
-    private readonly Dictionary<string, string> _commandAliases;
-
-    private CommandManager()
-    {
-        _commands = [];
-        _commandAliases = [];
-    }
+    private readonly Dictionary<string, ICommand> _commands = [];
+    private readonly Dictionary<string, string> _commandAliases = [];
 
     public List<string> GetCommandKeys()
     {

--- a/AAEmu.Game/Core/Managers/CommandManager.cs
+++ b/AAEmu.Game/Core/Managers/CommandManager.cs
@@ -11,7 +11,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public partial class CommandManager : Singleton<CommandManager>
+public partial class CommandManager : Singleton<CommandManager>, ICommandManager
 {
     public const string CommandPrefix = "/";
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();

--- a/AAEmu.Game/Core/Managers/CraftManager.cs
+++ b/AAEmu.Game/Core/Managers/CraftManager.cs
@@ -5,7 +5,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class CraftManager : Singleton<CraftManager>
+public class CraftManager : Singleton<CraftManager>, ICraftManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 

--- a/AAEmu.Game/Core/Managers/DuelManager.cs
+++ b/AAEmu.Game/Core/Managers/DuelManager.cs
@@ -28,11 +28,6 @@ public class DuelManager : Singleton<DuelManager>, IDuelManager
     private readonly ConcurrentDictionary<uint, Duel> _duels = new();
     public Dictionary<uint, FactionsEnum> SaveFactions { get; set; } = [];
 
-    protected DuelManager()
-    {
-        //
-    }
-
     public static bool Initialize()
     {
         Logger.Info("Initialising Duel Manager...");

--- a/AAEmu.Game/Core/Managers/DuelManager.cs
+++ b/AAEmu.Game/Core/Managers/DuelManager.cs
@@ -15,7 +15,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class DuelManager : Singleton<DuelManager>
+public class DuelManager : Singleton<DuelManager>, IDuelManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
@@ -26,7 +26,7 @@ public class DuelManager : Singleton<DuelManager>
 
     // there can be several duels at the same time
     private readonly ConcurrentDictionary<uint, Duel> _duels = new();
-    public Dictionary<uint, FactionsEnum> _saveFactions { get; set; } = [];
+    public Dictionary<uint, FactionsEnum> SaveFactions { get; set; } = [];
 
     protected DuelManager()
     {
@@ -110,13 +110,13 @@ public class DuelManager : Singleton<DuelManager>
     private void SetFaction(Unit ower, FactionsEnum factionId)
     {
         // change the faction temporarily
-        if (_saveFactions.ContainsKey(ower.Id))
+        if (SaveFactions.ContainsKey(ower.Id))
         {
-            _saveFactions[ower.Id] = ower.Faction.Id;
+            SaveFactions[ower.Id] = ower.Faction.Id;
         }
         else
         {
-            _saveFactions.Add(ower.Id, ower.Faction.Id);
+            SaveFactions.Add(ower.Id, ower.Faction.Id);
         }
 
         ower.SetFaction(factionId);
@@ -125,8 +125,8 @@ public class DuelManager : Singleton<DuelManager>
     private void RestoreFaction(Unit owner)
     {
         // restore the fraction
-        owner.SetFaction(_saveFactions[owner.Id]);
-        _saveFactions.Remove(owner.Id);
+        owner.SetFaction(SaveFactions[owner.Id]);
+        SaveFactions.Remove(owner.Id);
     }
 
     public void DuelStart(uint id)

--- a/AAEmu.Game/Core/Managers/EffectTaskManager.cs
+++ b/AAEmu.Game/Core/Managers/EffectTaskManager.cs
@@ -4,16 +4,16 @@ using AAEmu.Game.Models.Tasks.Skills;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class EffectTaskManager : Singleton<EffectTaskManager>, IEffectTaskManager
+public class EffectTaskManager(ITaskManager taskManager) : Singleton<EffectTaskManager>, IEffectTaskManager
 {
     /// <summary>
     /// Pre-Variant of dispel effects...
     /// </summary>
     /// <param name="buff"></param>
     /// <param name="interval">milliseconds</param>
-    public static void AddDispelTask(Buff buff, double interval)
+    public void AddDispelTask(Buff buff, double interval)
     {
         var task = new DispelTask(buff);
-        TaskManager.Instance.Schedule(task, TimeSpan.FromMilliseconds(interval)); // TODO create normal effect schedule
+        taskManager.Schedule(task, TimeSpan.FromMilliseconds(interval)); // TODO create normal effect schedule
     }
 }

--- a/AAEmu.Game/Core/Managers/EffectTaskManager.cs
+++ b/AAEmu.Game/Core/Managers/EffectTaskManager.cs
@@ -4,7 +4,7 @@ using AAEmu.Game.Models.Tasks.Skills;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class EffectTaskManager : Singleton<EffectTaskManager>
+public class EffectTaskManager : Singleton<EffectTaskManager>, IEffectTaskManager
 {
     /// <summary>
     /// Pre-Variant of dispel effects...

--- a/AAEmu.Game/Core/Managers/ExpeditionManager.cs
+++ b/AAEmu.Game/Core/Managers/ExpeditionManager.cs
@@ -18,7 +18,7 @@ using AAEmu.Game.Models.StaticValues;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class ExpeditionManager : Singleton<ExpeditionManager>
+public class ExpeditionManager : Singleton<ExpeditionManager>, IExpeditionManager
 {
     //private ExpeditionConfig _config;
     private Regex _nameRegex;

--- a/AAEmu.Game/Core/Managers/ExpeditionManager.cs
+++ b/AAEmu.Game/Core/Managers/ExpeditionManager.cs
@@ -18,7 +18,7 @@ using AAEmu.Game.Models.StaticValues;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class ExpeditionManager : Singleton<ExpeditionManager>, IExpeditionManager
+public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamManager teamManager, IWorldManager worldManager, IChatManager chatManager) : Singleton<ExpeditionManager>, IExpeditionManager
 {
     //private ExpeditionConfig _config;
     private Regex _nameRegex;
@@ -27,11 +27,11 @@ public class ExpeditionManager : Singleton<ExpeditionManager>, IExpeditionManage
 
     public IEnumerable<Expedition> Expeditions { get => _expeditions.Values; }
 
-    public static Expedition Create(string name, Character owner)
+    private Expedition Create(string name, Character owner)
     {
         var expedition = new Expedition
         {
-            Id = (FactionsEnum)ExpeditionIdManager.Instance.GetNextId(),
+            Id = (FactionsEnum)expeditionIdManager.GetNextId(),
             MotherId = owner.Faction.Id,
             Name = name,
             OwnerId = owner.Id,
@@ -200,7 +200,7 @@ public class ExpeditionManager : Singleton<ExpeditionManager>, IExpeditionManage
             }
 
         // ----------------- Conditions, can change this...
-        var team = TeamManager.Instance.GetActiveTeamByUnit(owner.Id);
+        var team = teamManager.GetActiveTeamByUnit(owner.Id);
         if (team == null)// || !team.IsParty)
         {
             // We send the same error on number of party members when we don't have a party
@@ -267,13 +267,13 @@ public class ExpeditionManager : Singleton<ExpeditionManager>, IExpeditionManage
             new SCFactionCreatedPacket(expedition, owner.ObjId, [(owner.ObjId, owner.Id, owner.Name)])
         );
 
-        WorldManager.Instance.BroadcastPacketToServer(new SCFactionListPacket(expedition));
+        worldManager.BroadcastPacketToServer(new SCFactionListPacket(expedition));
         owner.BroadcastPacket(
             new SCUnitExpeditionChangedPacket(owner.ObjId, owner.Id, "", owner.Name, 0, (uint)expedition.Id, false),
             true
         );
 
-        ChatManager.Instance.GetGuildChat(expedition).JoinChannel(owner);
+        chatManager.GetGuildChat(expedition).JoinChannel(owner);
         SendExpeditionInfo(owner);
         // owner.Save(); // Moved to SaveMananger
 
@@ -298,7 +298,7 @@ public class ExpeditionManager : Singleton<ExpeditionManager>, IExpeditionManage
         Save(expedition);
     }
 
-    public static void Invite(GameConnection connection, string invitedName)
+    public void Invite(GameConnection connection, string invitedName)
     {
         var inviter = connection.ActiveChar;
 
@@ -306,7 +306,7 @@ public class ExpeditionManager : Singleton<ExpeditionManager>, IExpeditionManage
         if (inviterMember == null || !inviter.Expedition.GetPolicyByRole(inviterMember.Role).Invite)
             return;
 
-        var invited = WorldManager.Instance.GetCharacter(invitedName);
+        var invited = worldManager.GetCharacter(invitedName);
         if (invited == null) return;
         if (invited.Expedition != null) return;
 
@@ -382,7 +382,7 @@ public class ExpeditionManager : Singleton<ExpeditionManager>, IExpeditionManage
         Save(expedition);
     }
 
-    public static void Kick(GameConnection connection, uint kickedId)
+    public void Kick(GameConnection connection, uint kickedId)
     {
         var character = connection.ActiveChar;
         var expedition = character.Expedition;
@@ -397,7 +397,7 @@ public class ExpeditionManager : Singleton<ExpeditionManager>, IExpeditionManage
 
         expedition.RemoveMember(kicked);
 
-        var kickedChar = WorldManager.Instance.GetCharacterById(kickedId);
+        var kickedChar = worldManager.GetCharacterById(kickedId);
 
         var changedPacket = new SCUnitExpeditionChangedPacket(kickedChar?.ObjId ?? 0,
             kicked.CharacterId, character.Name, kicked.Name, (uint)expedition.Id, 0, true);
@@ -467,7 +467,7 @@ public class ExpeditionManager : Singleton<ExpeditionManager>, IExpeditionManage
         Save(expedition);
     }
 
-    public static bool Disband(Character owner)
+    public bool Disband(Character owner)
     {
         var guild = owner.Expedition;
         if (guild == null)
@@ -484,7 +484,7 @@ public class ExpeditionManager : Singleton<ExpeditionManager>, IExpeditionManage
         }
         for (var i = guild.Members.Count - 1; i >= 0; i--)
         {
-            var c = WorldManager.Instance.GetCharacterById(guild.Members[i].CharacterId);
+            var c = worldManager.GetCharacterById(guild.Members[i].CharacterId);
             if (c != null)
             {
                 if (c.IsOnline)

--- a/AAEmu.Game/Core/Managers/ExperienceManager.cs
+++ b/AAEmu.Game/Core/Managers/ExperienceManager.cs
@@ -7,7 +7,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class ExperienceManager : Singleton<ExperienceManager>
+public class ExperienceManager : Singleton<ExperienceManager>, IExperienceManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 

--- a/AAEmu.Game/Core/Managers/FamilyManager.cs
+++ b/AAEmu.Game/Core/Managers/FamilyManager.cs
@@ -10,7 +10,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class FamilyManager : Singleton<FamilyManager>
+public class FamilyManager : Singleton<FamilyManager>, IFamilyManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 

--- a/AAEmu.Game/Core/Managers/FamilyManager.cs
+++ b/AAEmu.Game/Core/Managers/FamilyManager.cs
@@ -10,7 +10,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class FamilyManager : Singleton<FamilyManager>, IFamilyManager
+public class FamilyManager(IWorldManager worldManager, IChatManager chatManager, IFamilyIdManager familyIdManager) : Singleton<FamilyManager>, IFamilyManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
@@ -92,9 +92,9 @@ public class FamilyManager : Singleton<FamilyManager>, IFamilyManager
     /// <param name="inviter"></param>
     /// <param name="invitedCharacterName"></param>
     /// <param name="title"></param>
-    public static void InviteToFamily(Character inviter, string invitedCharacterName, string title)
+    public void InviteToFamily(Character inviter, string invitedCharacterName, string title)
     {
-        var invited = WorldManager.Instance.GetCharacter(invitedCharacterName);
+        var invited = worldManager.GetCharacter(invitedCharacterName);
         if (invited is { Family: 0 })
             invited.SendPacket(new SCFamilyInvitationPacket(inviter.Id, inviter.Name, 1, title));
     }
@@ -111,7 +111,7 @@ public class FamilyManager : Singleton<FamilyManager>, IFamilyManager
         if (!join)
             return;
 
-        var invitor = WorldManager.Instance.GetCharacterById(invitorId);
+        var invitor = worldManager.GetCharacterById(invitorId);
         if (invitor == null) return;
 
         if (invitor.Family == 0)
@@ -132,7 +132,7 @@ public class FamilyManager : Singleton<FamilyManager>, IFamilyManager
     {
         var family = new Family
         {
-            Id = FamilyIdManager.Instance.GetNextId()
+            Id = familyIdManager.GetNextId()
         };
 
         AddFamilyMember(family, invitor);
@@ -169,7 +169,7 @@ public class FamilyManager : Singleton<FamilyManager>, IFamilyManager
         _familyMembers.Add(member.Id, member);
         character.Family = family.Id;
 
-        ChatManager.Instance.GetFamilyChat(family.Id)?.JoinChannel(character);
+        chatManager.GetFamilyChat(family.Id)?.JoinChannel(character);
     }
 
     /// <summary>
@@ -190,7 +190,7 @@ public class FamilyManager : Singleton<FamilyManager>, IFamilyManager
             // Update Member field and send family packets
             member.Character = character;
 
-            ChatManager.Instance.GetFamilyChat(family.Id)?.JoinChannel(character);
+            chatManager.GetFamilyChat(family.Id)?.JoinChannel(character);
             character.SendPacket(new SCFamilyDescPacket(family));
             family.SendPacket(new SCFamilyMemberOnlinePacket(family.Id, member.Id, true));
         }
@@ -206,7 +206,7 @@ public class FamilyManager : Singleton<FamilyManager>, IFamilyManager
         var member = family.GetMember(character);
         member.Character = null;
 
-        ChatManager.Instance.GetFamilyChat(family.Id)?.LeaveChannel(character);
+        chatManager.GetFamilyChat(family.Id)?.LeaveChannel(character);
         family.SendPacket(new SCFamilyMemberOnlinePacket(family.Id, character.Id, false), character.Id);
     }
 
@@ -223,7 +223,7 @@ public class FamilyManager : Singleton<FamilyManager>, IFamilyManager
 
         character.SendPacket(new SCFamilyRemovedPacket(family.Id));
         family.SendPacket(new SCFamilyMemberRemovedPacket(family.Id, false, character.Id));
-        ChatManager.Instance.GetFamilyChat(family.Id)?.LeaveChannel(character);
+        chatManager.GetFamilyChat(family.Id)?.LeaveChannel(character);
 
         if (family.Members.Count < 2)
             DisbandFamily(family);
@@ -244,7 +244,7 @@ public class FamilyManager : Singleton<FamilyManager>, IFamilyManager
             var member = family.Members[i];
             if (member.Character != null)
             {
-                ChatManager.Instance.GetFamilyChat(family.Id)?.LeaveChannel(member.Character);
+                chatManager.GetFamilyChat(family.Id)?.LeaveChannel(member.Character);
                 member.Character.SendPacket(removed);
                 member.Character.Family = 0;
             }
@@ -271,7 +271,7 @@ public class FamilyManager : Singleton<FamilyManager>, IFamilyManager
         if (kickerMember.Role != 1) return; // Only the steward can kick
 
         // Load kicked character
-        var kickedCharacter = WorldManager.Instance.GetCharacterById(kickedId);
+        var kickedCharacter = worldManager.GetCharacterById(kickedId);
         var isOnline = false;
         if (kickedCharacter != null)
         {
@@ -291,7 +291,7 @@ public class FamilyManager : Singleton<FamilyManager>, IFamilyManager
 
         if (isOnline)
         {
-            ChatManager.Instance.GetFamilyChat(family.Id)?.LeaveChannel(kickedCharacter);
+            chatManager.GetFamilyChat(family.Id)?.LeaveChannel(kickedCharacter);
             kickedCharacter.SendPacket(new SCFamilyRemovedPacket(family.Id));
         }
 

--- a/AAEmu.Game/Core/Managers/FeaturesManager.cs
+++ b/AAEmu.Game/Core/Managers/FeaturesManager.cs
@@ -4,7 +4,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class FeaturesManager : Singleton<FeaturesManager>
+public class FeaturesManager : Singleton<FeaturesManager>, IFeaturesManager
 {
     public static FeatureSet Fsets { get; private set; }
 

--- a/AAEmu.Game/Core/Managers/FishSchoolManager.cs
+++ b/AAEmu.Game/Core/Managers/FishSchoolManager.cs
@@ -7,7 +7,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class FishSchoolManager : Singleton<FishSchoolManager>
+public class FishSchoolManager : Singleton<FishSchoolManager>, IFishSchoolManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     /// <summary>

--- a/AAEmu.Game/Core/Managers/FormulaManager.cs
+++ b/AAEmu.Game/Core/Managers/FormulaManager.cs
@@ -8,7 +8,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class FormulaManager : Singleton<FormulaManager>
+public class FormulaManager : Singleton<FormulaManager>, IFormulaManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private static bool _loaded = false;

--- a/AAEmu.Game/Core/Managers/FriendMananger.cs
+++ b/AAEmu.Game/Core/Managers/FriendMananger.cs
@@ -11,7 +11,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class FriendMananger : Singleton<FriendMananger>
+public class FriendMananger : Singleton<FriendMananger>, IFriendManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private Dictionary<uint, FriendTemplate> _allFriends; // temp id, template

--- a/AAEmu.Game/Core/Managers/GameScheduleManager.cs
+++ b/AAEmu.Game/Core/Managers/GameScheduleManager.cs
@@ -12,7 +12,7 @@ using DayOfWeek = AAEmu.Game.Models.Game.Schedules.DayOfWeek;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class GameScheduleManager : Singleton<GameScheduleManager>
+public class GameScheduleManager : Singleton<GameScheduleManager>, IGameScheduleManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private bool _loaded = false;

--- a/AAEmu.Game/Core/Managers/GameScheduleManager.cs
+++ b/AAEmu.Game/Core/Managers/GameScheduleManager.cs
@@ -1,5 +1,6 @@
 ﻿using AAEmu.Commons.Utils;
 using AAEmu.Game.GameData;
+using AAEmu.Game.GameData.Framework;
 using AAEmu.Game.Models.Game.Schedules;
 
 using NCrontab;
@@ -12,9 +13,12 @@ using DayOfWeek = AAEmu.Game.Models.Game.Schedules.DayOfWeek;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class GameScheduleManager : Singleton<GameScheduleManager>, IGameScheduleManager
+public class GameScheduleManager(
+    IGameDataManager gameDataManager  // ensures GameDataManager.Load() runs before this Load()
+) : Singleton<GameScheduleManager>, IGameScheduleManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
+    private readonly IGameDataManager _gameDataManager = gameDataManager;
     private bool _loaded = false;
     private Dictionary<int, GameSchedules> _gameSchedules; // GameScheduleId, GameSchedules
     private Dictionary<int, GameScheduleSpawners> _gameScheduleSpawners;

--- a/AAEmu.Game/Core/Managers/GimmickManager.cs
+++ b/AAEmu.Game/Core/Managers/GimmickManager.cs
@@ -86,12 +86,14 @@ public class GimmickManager(WorldInstance parentWorld)
         }
 
         gimmick.Time = (uint)(DateTime.UtcNow - DateTime.UtcNow.Date).TotalMilliseconds;
-        _activeGimmicks.TryAdd(gimmick.ObjId, gimmick);
+        lock (_activeGimmicks)
+            _activeGimmicks.TryAdd(gimmick.ObjId, gimmick);
     }
 
     public void RemoveActiveGimmick(Gimmick gimmick)
     {
-        _activeGimmicks.Remove(gimmick.ObjId);
+        lock (_activeGimmicks)
+            _activeGimmicks.Remove(gimmick.ObjId);
     }
 
     /// <summary>

--- a/AAEmu.Game/Core/Managers/HousingManager.cs
+++ b/AAEmu.Game/Core/Managers/HousingManager.cs
@@ -32,7 +32,21 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class HousingManager : Singleton<HousingManager>, IHousingManager
+public class HousingManager(
+    IObjectIdManager objectIdManager,
+    IFactionManager factionManager,
+    ILocalizationManager localizationManager,
+    IWorldManager worldManager,
+    ITaskManager taskManager,
+    ISkillManager skillManager,
+    IHousingIdManager housingIdManager,
+    IHousingTldManager housingTldManager,
+    IItemManager itemManager,
+    IMailManager mailManager,
+    INameManager nameManager,
+    IZoneManager zoneManager,
+    IDoodadManager doodadManager,
+    IUccManager uccManager) : Singleton<HousingManager>, IHousingManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
@@ -90,13 +104,13 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
 
         var house = new House
         {
-            TlId = tlId > 0 ? tlId : (ushort)HousingTldManager.Instance.GetNextId(),
-            ObjId = objectId > 0 ? objectId : ObjectIdManager.Instance.GetNextId(),
+            TlId = tlId > 0 ? tlId : (ushort)housingTldManager.GetNextId(),
+            ObjId = objectId > 0 ? objectId : objectIdManager.GetNextId(),
             Template = template,
             TemplateId = template.Id, // duplicate Id
             Id = template.Id,
-            Faction = FactionManager.Instance.GetFaction(factionId),
-            Name = LocalizationManager.Instance.Get("housings", "name", template.Id),
+            Faction = factionManager.GetFaction(factionId),
+            Name = localizationManager.Get("housings", "name", template.Id),
             Transform = { InstanceId = worldInstance.Id }
         };
         house.Hp = house.MaxHp;
@@ -119,7 +133,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
         _housesTl = [];
         _removedHousings = [];
 
-        worldInstance ??= WorldManager.Instance.GetWorld(WorldManager.DefaultInstanceId);
+        worldInstance ??= worldManager.GetWorld(WorldManager.DefaultInstanceId);
 
         // var housingAreas = new Dictionary<uint, HousingAreas>();
         // var houseTaxes = new Dictionary<uint, HouseTax>();
@@ -149,7 +163,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
                             new Vector3(reader.GetFloat("roll"), reader.GetFloat("pitch"), reader.GetFloat("yaw"))
                         );
                         house.Transform.InstanceId = house.ParentWorld.Id; // Just to be sure
-                        house.Transform.ZoneId = WorldManager.Instance.GetZoneId(house.ParentWorld.Template, house.Transform.World.Position.X, house.Transform.World.Position.Y);
+                        house.Transform.ZoneId = worldManager.GetZoneId(house.ParentWorld.Template, house.Transform.World.Position.X, house.Transform.World.Position.Y);
                         house.CurrentStep = reader.GetInt32("current_step");
                         house.NumAction = reader.GetInt32("current_action");
                         house.Permission = (HousingPermission)reader.GetByte("permission");
@@ -175,7 +189,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
         Logger.Info($"Loaded {_houses.Count} Player Buildings");
 
         var houseCheckTask = new HousingTaxTask();
-        TaskManager.Instance.Schedule(houseCheckTask, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(10));
+        taskManager.Schedule(houseCheckTask, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(10));
 
         Logger.Info("Started Housing Tax Timer");
     }
@@ -232,7 +246,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
     /// </summary>
     /// <param name="house"></param>
     /// <param name="isUntouchable"></param>
-    private static void SetUntouchable(House house, bool isUntouchable)
+    private void SetUntouchable(House house, bool isUntouchable)
     {
         if (isUntouchable)
         {
@@ -240,7 +254,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
                 return;
 
             // Permanent Untouchable buff, should only be removed when failed tax payment, or demolishing by hand
-            var protectionBuffTemplate = SkillManager.Instance.GetBuffTemplate((uint)BuffConstants.Untouchable);
+            var protectionBuffTemplate = skillManager.GetBuffTemplate((uint)BuffConstants.Untouchable);
             if (protectionBuffTemplate != null)
             {
                 var casterObj = new SkillCasterUnit(house.ObjId);
@@ -265,14 +279,14 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
     /// </summary>
     /// <param name="house"></param>
     /// <param name="isDeteriorating"></param>
-    private static void SetRemovalDebuff(House house, bool isDeteriorating)
+    private void SetRemovalDebuff(House house, bool isDeteriorating)
     {
         if (isDeteriorating)
         {
             if (!house.Buffs.CheckBuff((uint)BuffConstants.RemovalDebuff))
             {
                 // Permanent Untouchable buff, should only be removed when failed tax payment, or demolishing by hand
-                var protectionBuffTemplate = SkillManager.Instance.GetBuffTemplate((uint)BuffConstants.RemovalDebuff);
+                var protectionBuffTemplate = skillManager.GetBuffTemplate((uint)BuffConstants.RemovalDebuff);
                 if (protectionBuffTemplate != null)
                 {
                     var casterObj = new SkillCasterUnit(house.ObjId);
@@ -397,7 +411,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
             return;
         }
 
-        // var zoneId = WorldManager.Instance.GetZoneId(connection.ActiveChar.Transform.WorldId, posX, posY);
+        // var zoneId = worldManager.GetZoneId(connection.ActiveChar.Transform.WorldId, posX, posY);
 
         var houseTemplate = HousingGameData.Instance.GetTemplate(designId);
         CalculateBuildingTaxInfo(connection.ActiveChar.AccountId, houseTemplate, true, out var totalTaxAmountDue, out _, out _, out _, out _);
@@ -466,13 +480,13 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
         // Fallback for un-translated buildings (en_us)
         if (house.Name == string.Empty)
         {
-            var fakeLocalizedName = LocalizationManager.Instance.Get("items", "name", sourceDesignItem.Template.Id, houseTemplate.Name);
+            var fakeLocalizedName = localizationManager.Get("items", "name", sourceDesignItem.Template.Id, houseTemplate.Name);
             if (fakeLocalizedName.EndsWith(" Design"))
                 fakeLocalizedName = fakeLocalizedName.Replace(" Design", "");
             house.Name = fakeLocalizedName;
         }
 
-        house.Id = HousingIdManager.Instance.GetNextId();
+        house.Id = housingIdManager.GetNextId();
         house.Transform.Local.SetPosition(posX, posY, posZ);
         // In 1.2 the rotation in SCUnitStatePacket is sent as X, Y, Z using 1 byte each.
         // This limits us to 256 unique rotations around Z (up) that can be represented.
@@ -567,7 +581,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
                 return;
             }
             */
-            var ownerChar = WorldManager.Instance.GetCharacterById(house.OwnerId);
+            var ownerChar = worldManager.GetCharacterById(house.OwnerId);
 
             // Mark it as expired protection
             house.ProtectionEndDate = DateTime.UtcNow.AddSeconds(-1);
@@ -613,8 +627,8 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
         _removedHousings.Add(house.Id);
         _houses.Remove(house.Id);
         _housesTl.Remove(house.TlId);
-        HousingTldManager.Instance.ReleaseId(house.TlId);
-        HousingIdManager.Instance.ReleaseId(house.Id);
+        housingTldManager.ReleaseId(house.TlId);
+        housingIdManager.ReleaseId(house.Id);
         // TODO: not sure how to handle this, just instant delete it for now
         house.Delete();
         // TODO: Add to despawn handler
@@ -683,7 +697,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
     /// This function updates related tax mails of a house (if needed)
     /// </summary>
     /// <param name="house"></param>
-    public static void UpdateTaxInfo(House house)
+    public void UpdateTaxInfo(House house)
     {
         var isDemolished = house.ProtectionEndDate <= DateTime.UtcNow;
         var isTaxDue = house.TaxDueDate <= DateTime.UtcNow;
@@ -698,13 +712,13 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
         // If expired, start demolition debuffs
         if (isDemolished)
         {
-            MailManager.Instance.DeleteHouseMails(house.Id);
+            mailManager.DeleteHouseMails(house.Id);
         }
         else
         if (isTaxDue)
         {
             // TODO: update corresponding mails if needed (like update weeks unpaid etc)
-            var allMails = MailManager.Instance.GetMyHouseMails(house.Id);
+            var allMails = mailManager.GetMyHouseMails(house.Id);
 
             if (allMails.Count <= 0)
             {
@@ -730,7 +744,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
     /// </summary>
     /// <param name="house"></param>
     /// <returns></returns>
-    public static bool PayWeeklyTax(House house)
+    public bool PayWeeklyTax(House house)
     {
         house.ProtectionEndDate = house.ProtectionEndDate.AddDays(AppConfiguration.Instance.World.DaysForTaxPayment);
         return true;
@@ -761,10 +775,10 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
     /// </summary>
     /// <param name="house"></param>
     /// <param name="factionId"></param>
-    private static void UpdateHouseFaction(House house, FactionsEnum factionId)
+    private void UpdateHouseFaction(House house, FactionsEnum factionId)
     {
         house.BroadcastPacket(new SCUnitFactionChangedPacket(house.ObjId, house.Name, house.Faction?.Id ?? 0, factionId, false), true);
-        house.Faction = FactionManager.Instance.GetFaction(factionId);
+        house.Faction = factionManager.GetFaction(factionId);
     }
 
     /// <summary>
@@ -803,8 +817,8 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
             // TODO: proper grades for design
             // TODO: for future versions: Support Full-Kit demolition
             var designItemId = HousingGameData.Instance.GetItemIdByDesign(house.Template.Id);
-            var designItem = ItemManager.Instance.Create(designItemId, 1, 0);
-            var designTemplate = ItemManager.Instance.GetTemplate(designItemId);
+            var designItem = itemManager.Create(designItemId, 1, 0);
+            var designTemplate = itemManager.GetTemplate(designItemId);
             if (designTemplate != null && designItem != null)
             {
                 designItem.Grade = designTemplate.FixedGrade >= 0 ? (byte)designTemplate.FixedGrade : (byte)0;
@@ -822,7 +836,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
             {
                 if (FeaturesManager.Fsets.Check(Models.Game.Features.Feature.taxItem))
                 {
-                    var taxItem = ItemManager.Instance.Create(Item.BoundTaxCertificate, (int)(house.Template.Taxation.Tax / 5000), 0);
+                    var taxItem = itemManager.Create(Item.BoundTaxCertificate, (int)(house.Template.Taxation.Tax / 5000), 0);
                     taxItem.OwnerId = house.OwnerId;
                     taxItem.SlotType = SlotType.Mail;
                     returnedItems.Add(taxItem);
@@ -869,7 +883,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
                 continue;
             }
 
-            var thisDoodadsItem = ItemManager.Instance.GetItemByItemId(f.ItemId);
+            var thisDoodadsItem = itemManager.GetItemByItemId(f.ItemId);
             var returnedThisItem = false;
 
             var wantReturned = (newOwner == null && decoInfo.Restore) || forceRestoreAllDecor;
@@ -877,7 +891,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
             // If item is bound, always return it owner
             if (f.ItemId > 0)
             {
-                var item = ItemManager.Instance.GetItemByItemId(f.ItemId);
+                var item = itemManager.GetItemByItemId(f.ItemId);
                 if (item.ItemFlags.HasFlag(ItemFlag.SoulBound))
                     wantReturned = true;
             }
@@ -887,7 +901,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
             {
                 // TODO: Check if items should stay in the coffer when house is sold.
                 // Move it to new owner's SystemContainer first so they don't get destroyed
-                var ownerSystemContainer = ItemManager.Instance.GetItemContainerForCharacter(house.OwnerId, SlotType.System, null, 0);
+                var ownerSystemContainer = itemManager.GetItemContainerForCharacter(house.OwnerId, SlotType.System, null, 0);
                 for (var i = coffer.ItemContainer.Items.Count - 1; i >= 0; i--)
                 {
                     var cofferItem = coffer.ItemContainer.Items[i];
@@ -922,7 +936,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
                     if (f.ItemId != 0)
                     {
                         // If a single item is attached, change it's owner and location
-                        var item = ItemManager.Instance.GetItemByItemId(f.ItemId);
+                        var item = itemManager.GetItemByItemId(f.ItemId);
                         newOwner.Inventory.SystemContainer.AddOrMoveExistingItem(ItemTaskType.Invalid, item);
                     }
                     // Change doodad owner
@@ -956,8 +970,8 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
                 else
                 {
                     // It's a new one, add an item slot
-                    var furnitureItem = ItemManager.Instance.Create(f.ItemTemplateId, 1, 0);
-                    var furnitureTemplate = ItemManager.Instance.GetTemplate(f.ItemTemplateId);
+                    var furnitureItem = itemManager.Create(f.ItemTemplateId, 1, 0);
+                    var furnitureTemplate = itemManager.GetTemplate(f.ItemTemplateId);
                     furnitureItem.Grade = furnitureTemplate.FixedGrade >= 0 ? (byte)furnitureTemplate.FixedGrade : (byte)0;
                     furnitureItem.OwnerId = house.OwnerId;
                     furnitureItem.SlotType = SlotType.Mail;
@@ -995,7 +1009,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
                 newMail = new BaseMail
                 {
                     MailType = MailType.Demolish,
-                    ReceiverName = NameManager.Instance.GetCharacterName(house.OwnerId), // Doesn't seem like this needs to be set
+                    ReceiverName = nameManager.GetCharacterName(house.OwnerId), // Doesn't seem like this needs to be set
                     Header =
                     {
                         ReceiverId = house.OwnerId,
@@ -1017,7 +1031,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
 
             // If player is loaded in at the moment (which he/she should be anyway), directly manipulate the inventory
             // If not, only change the container
-            var onlineOwner = WorldManager.Instance.GetCharacterById((uint)returnedItems[i].OwnerId);
+            var onlineOwner = worldManager.GetCharacterById((uint)returnedItems[i].OwnerId);
             if (onlineOwner != null)
                 onlineOwner.Inventory.MailAttachments.AddOrMoveExistingItem(ItemTaskType.Invalid, returnedItems[i]);
             else
@@ -1071,7 +1085,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
     /// </summary>
     /// <param name="house"></param>
     /// <param name="isForSale"></param>
-    private static void SetForSaleMarkers(House house, bool isForSale)
+    private void SetForSaleMarkers(House house, bool isForSale)
     {
         var world = house.ParentWorld;
         if (world == null)
@@ -1087,14 +1101,14 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
                 var yMultiplier = postId / 2 == 0 ? -1 : 1f;
                 var zRot = (135f + 90f * postId % 360).DegToRad();
 
-                var doodad = DoodadManager.Instance.Create(house.ParentWorld,  0, ForSaleMarkerDoodadId, null, true);
+                var doodad = doodadManager.Create(house.ParentWorld,  0, ForSaleMarkerDoodadId, null, true);
                 // location
                 doodad.Transform.Local.SetPosition(
                     house.Template.GardenRadius * xMultiplier + house.Transform.World.Position.X,
                     house.Template.GardenRadius * yMultiplier + house.Transform.World.Position.Y,
                     +house.Transform.World.Position.Z);
                 // adjust height to the floor
-                doodad.Transform.Local.SetHeight(doodad.ParentWorld.Template.GeoData.GetHeight(doodad.Transform.World.Position));// WorldManager.Instance.GetHeight(doodad.Transform)));
+                doodad.Transform.Local.SetHeight(doodad.ParentWorld.Template.GeoData.GetHeight(doodad.Transform.World.Position));// worldManager.GetHeight(doodad.Transform)));
                 doodad.Transform.Local.SetZRotation(zRot);
                 //doodad.Transform.WorldId = world.Template.Id;
                 doodad.Transform.InstanceId = world.Id;
@@ -1137,7 +1151,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
     /// <param name="buyerId">Use CharacterId for selling to a specific person</param>
     /// <param name="seller">Current owner of the property (needed to manipulate inventory)</param>
     /// <returns></returns>
-    public static bool SetForSale(House house, uint price, uint buyerId, Character seller)
+    public bool SetForSale(House house, uint price, uint buyerId, Character seller)
     {
         if (house == null)
             return false;
@@ -1146,7 +1160,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
             return false;
 
         // Check if buyer exists (we just check if the name exists)
-        var buyerName = NameManager.Instance.GetCharacterName(buyerId);
+        var buyerName = nameManager.GetCharacterName(buyerId);
         if (buyerId != 0 && buyerName == null)
             return false;
 
@@ -1180,12 +1194,12 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
     /// <param name="house"></param>
     /// <param name="returnCertificates"></param>
     /// <returns></returns>
-    public static bool CancelForSale(House house, bool returnCertificates = true)
+    public bool CancelForSale(House house, bool returnCertificates = true)
     {
         if (house.SellPrice <= 0)
             return true;
         var certAmount = CalculateSaleCertifcates(house, house.SellPrice);
-        var owner = WorldManager.Instance.GetCharacterById(house.OwnerId);
+        var owner = worldManager.GetCharacterById(house.OwnerId);
 
         house.SellPrice = 0;
         house.SellToPlayerId = 0;
@@ -1204,8 +1218,8 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
                         ReceiverId = house.OwnerId,
                         SenderName = ".houseSellCancel"
                     },
-                    ReceiverName = NameManager.Instance.GetCharacterName(house.OwnerId),
-                    Title = "title(" + ZoneManager.Instance.GetZoneByKey(house.Transform.ZoneId)?.GroupId.ToString() + ",'" + house.Name + "')",
+                    ReceiverName = nameManager.GetCharacterName(house.OwnerId),
+                    Title = "title(" + zoneManager.GetZoneByKey(house.Transform.ZoneId)?.GroupId.ToString() + ",'" + house.Name + "')",
                     Body =
                     {
                         Text = "body('" + house.Name + "', " + Item.AppraisalCertificate.ToString() + ", " + certAmount.ToString() + ")"
@@ -1309,7 +1323,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
         }
 
         var previousOwner = house.OwnerId;
-        var previousOwnerName = NameManager.Instance.GetCharacterName(previousOwner);
+        var previousOwnerName = nameManager.GetCharacterName(previousOwner);
 
         // Mail confirmation mail to new owner
         var newOwnerMail = new BaseMail
@@ -1321,7 +1335,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
                 SenderName = ".houseBought"
             },
             ReceiverName = character.Name,
-            Title = "title(" + ZoneManager.Instance.GetZoneByKey(house.Transform.ZoneId)?.GroupId.ToString() + ",'" + house.Name + "')",
+            Title = "title(" + zoneManager.GetZoneByKey(house.Transform.ZoneId)?.GroupId.ToString() + ",'" + house.Name + "')",
             Body =
             {
                 Text = "body('" + previousOwnerName + "', '" + house.Name + "', " + house.SellPrice.ToString() + ")",
@@ -1372,7 +1386,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
         SetForSaleMarkers(house, false);
 
         character.SendPacket(new SCMyHousePacket(house));
-        var oldOwner = WorldManager.Instance.GetCharacterById(previousOwner);
+        var oldOwner = worldManager.GetCharacterById(previousOwner);
         if (oldOwner is { IsOnline: true })
             oldOwner.SendPacket(new SCMyHouseRemovedPacket(house.TlId));
 
@@ -1432,7 +1446,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
             return false;
 
         // Check Item
-        var item = ItemManager.Instance.GetItemByItemId(itemId);
+        var item = itemManager.GetItemByItemId(itemId);
         if (item == null || item.OwnerId != player.Id)
         {
             // Invalid Item
@@ -1448,7 +1462,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
             return false;
         }
 
-        var itemUcc = UccManager.Instance.GetUccFromItem(item);
+        var itemUcc = uccManager.GetUccFromItem(item);
 
         // Create decoration doodad
         var decorationDesign = HousingGameData.Instance.GetDecorationDesignFromId(designId);
@@ -1462,7 +1476,7 @@ public class HousingManager : Singleton<HousingManager>, IHousingManager
         }
         */
 
-        var doodad = DoodadManager.Instance.Create(house.ParentWorld, 0, decorationDesign.DoodadId, house, true);
+        var doodad = doodadManager.Create(house.ParentWorld, 0, decorationDesign.DoodadId, house, true);
         doodad.Transform.Parent = house.Transform;
         doodad.Transform.Local.SetPosition(pos.X, pos.Y, pos.Z);
         doodad.Transform.Local.ApplyFromQuaternion(quat);

--- a/AAEmu.Game/Core/Managers/HousingManager.cs
+++ b/AAEmu.Game/Core/Managers/HousingManager.cs
@@ -32,7 +32,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class HousingManager : Singleton<HousingManager>
+public class HousingManager : Singleton<HousingManager>, IHousingManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 

--- a/AAEmu.Game/Core/Managers/IAIManager.cs
+++ b/AAEmu.Game/Core/Managers/IAIManager.cs
@@ -1,0 +1,11 @@
+using AAEmu.Game.Models.Game.AI.v2.Framework;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IAIManager
+{
+    void Initialize();
+    void AddAi(NpcAi ai);
+    void Tick(TimeSpan delta);
+    void Stop();
+}

--- a/AAEmu.Game/Core/Managers/IAIManager.cs
+++ b/AAEmu.Game/Core/Managers/IAIManager.cs
@@ -2,9 +2,8 @@ using AAEmu.Game.Models.Game.AI.v2.Framework;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface IAIManager
+public interface IAIManager : IInitializable
 {
-    void Initialize();
     void AddAi(NpcAi ai);
     void Tick(TimeSpan delta);
     void Stop();

--- a/AAEmu.Game/Core/Managers/IAccessLevelManager.cs
+++ b/AAEmu.Game/Core/Managers/IAccessLevelManager.cs
@@ -1,7 +1,6 @@
 namespace AAEmu.Game.Core.Managers;
 
-public interface IAccessLevelManager
+public interface IAccessLevelManager : ILoadable
 {
-    void Load();
     int GetLevel(string commandStr);
 }

--- a/AAEmu.Game/Core/Managers/IAccessLevelManager.cs
+++ b/AAEmu.Game/Core/Managers/IAccessLevelManager.cs
@@ -1,0 +1,7 @@
+namespace AAEmu.Game.Core.Managers;
+
+public interface IAccessLevelManager
+{
+    void Load();
+    int GetLevel(string commandStr);
+}

--- a/AAEmu.Game/Core/Managers/IAccountManager.cs
+++ b/AAEmu.Game/Core/Managers/IAccountManager.cs
@@ -1,0 +1,21 @@
+using AAEmu.Game.Core.Network.Connections;
+using AAEmu.Game.Models.Account;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IAccountManager
+{
+    void Add(GameConnection connection);
+    void Remove(uint id);
+    bool Contains(uint id);
+    int Count();
+    AccountDetails GetAccountDetails(uint accountId);
+    bool AddCredits(uint accountId, int creditsAmount);
+    bool RemoveCredits(uint accountId, int credits);
+    bool AddLoyalty(uint accountId, int loyaltyAmount);
+    void UpdateLabor(uint accountId, short laborPower);
+    DateTime UpdateLoginTime(uint accountId, DateTime newTime);
+    void UpdateTickTimes(uint accountId, DateTime newTime, bool updateLabor, bool updateCredits, bool updateLoyalty);
+    void UpdateDivineClock(uint accountId, uint timeElapsed, uint timesTaken);
+    (uint, uint) GetDivineClock(uint accountId);
+}

--- a/AAEmu.Game/Core/Managers/IAccountManager.cs
+++ b/AAEmu.Game/Core/Managers/IAccountManager.cs
@@ -18,4 +18,5 @@ public interface IAccountManager
     void UpdateTickTimes(uint accountId, DateTime newTime, bool updateLabor, bool updateCredits, bool updateLoyalty);
     void UpdateDivineClock(uint accountId, uint timeElapsed, uint timesTaken);
     (uint, uint) GetDivineClock(uint accountId);
+    void Initialize();
 }

--- a/AAEmu.Game/Core/Managers/IAccountManager.cs
+++ b/AAEmu.Game/Core/Managers/IAccountManager.cs
@@ -3,7 +3,7 @@ using AAEmu.Game.Models.Account;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface IAccountManager
+public interface IAccountManager : IInitializable
 {
     void Add(GameConnection connection);
     void Remove(uint id);
@@ -18,5 +18,4 @@ public interface IAccountManager
     void UpdateTickTimes(uint accountId, DateTime newTime, bool updateLabor, bool updateCredits, bool updateLoyalty);
     void UpdateDivineClock(uint accountId, uint timeElapsed, uint timesTaken);
     (uint, uint) GetDivineClock(uint accountId);
-    void Initialize();
 }

--- a/AAEmu.Game/Core/Managers/IAiPathsManager.cs
+++ b/AAEmu.Game/Core/Managers/IAiPathsManager.cs
@@ -1,0 +1,8 @@
+using AAEmu.Game.Models.Game.AI.v2.Controls;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IAiPathsManager
+{
+    List<AiPathPoint> LoadAiPathPoints(string aiPathFileName);
+}

--- a/AAEmu.Game/Core/Managers/IAiPathsManager.cs
+++ b/AAEmu.Game/Core/Managers/IAiPathsManager.cs
@@ -2,7 +2,7 @@ using AAEmu.Game.Models.Game.AI.v2.Controls;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface IAiPathsManager
+public interface IAiPathsManager : ILoadable
 {
     List<AiPathPoint> LoadAiPathPoints(string aiPathFileName);
 }

--- a/AAEmu.Game/Core/Managers/IAnimationManager.cs
+++ b/AAEmu.Game/Core/Managers/IAnimationManager.cs
@@ -1,0 +1,10 @@
+using AAEmu.Game.Models.Game.Animation;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IAnimationManager
+{
+    void Load();
+    Anim GetAnimation(uint id);
+    Anim GetAnimation(string name);
+}

--- a/AAEmu.Game/Core/Managers/IAuctionManager.cs
+++ b/AAEmu.Game/Core/Managers/IAuctionManager.cs
@@ -9,10 +9,9 @@ using MySql.Data.MySqlClient;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface IAuctionManager
+public interface IAuctionManager : ILoadable
 {
     ConcurrentDictionary<ulong, AuctionLot> AuctionLots { get; }
-    void Load();
     void CancelAuctionLot(Character player, ulong auctionId);
     void BidOnAuctionLot(Character player, uint auctioneerId, uint auctioneerId2, AuctionLot lot, AuctionBid bid);
     void GetBidAuctionLots(Character player, int page);

--- a/AAEmu.Game/Core/Managers/IAuctionManager.cs
+++ b/AAEmu.Game/Core/Managers/IAuctionManager.cs
@@ -5,6 +5,8 @@ using AAEmu.Game.Models.Game.Auction.Templates;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Items;
 
+using MySql.Data.MySqlClient;
+
 namespace AAEmu.Game.Core.Managers;
 
 public interface IAuctionManager
@@ -20,4 +22,5 @@ public interface IAuctionManager
     AuctionLot CreateAuctionLot(uint playerId, string playerName, Item itemToList, int startPrice, int buyoutPrice, AuctionDuration duration, int minStack = 1, int maxStack = 1);
     void SearchAuctionLots(Character player, AuctionSearch search);
     void PostLotOnAuction(Character player, uint npcId, uint npcId2, ulong itemId, int startPrice, int buyoutPrice, AuctionDuration duration);
+    (int, int) Save(MySqlConnection connection, MySqlTransaction transaction);
 }

--- a/AAEmu.Game/Core/Managers/IAuctionManager.cs
+++ b/AAEmu.Game/Core/Managers/IAuctionManager.cs
@@ -1,0 +1,23 @@
+using System.Collections.Concurrent;
+
+using AAEmu.Game.Models.Game.Auction;
+using AAEmu.Game.Models.Game.Auction.Templates;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Items;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IAuctionManager
+{
+    ConcurrentDictionary<ulong, AuctionLot> AuctionLots { get; }
+    void Load();
+    void CancelAuctionLot(Character player, ulong auctionId);
+    void BidOnAuctionLot(Character player, uint auctioneerId, uint auctioneerId2, AuctionLot lot, AuctionBid bid);
+    void GetBidAuctionLots(Character player, int page);
+    void CheapestAuctionLot(Character player, uint templateId, byte itemGrade = 0);
+    void AddAuctionLot(AuctionLot lot);
+    void UpdateAuctionHouse();
+    AuctionLot CreateAuctionLot(uint playerId, string playerName, Item itemToList, int startPrice, int buyoutPrice, AuctionDuration duration, int minStack = 1, int maxStack = 1);
+    void SearchAuctionLots(Character player, AuctionSearch search);
+    void PostLotOnAuction(Character player, uint npcId, uint npcId2, ulong itemId, int startPrice, int buyoutPrice, AuctionDuration duration);
+}

--- a/AAEmu.Game/Core/Managers/ICashShopManager.cs
+++ b/AAEmu.Game/Core/Managers/ICashShopManager.cs
@@ -3,14 +3,12 @@ using AAEmu.Game.Models.Game.CashShop;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface ICashShopManager
+public interface ICashShopManager : ILoadable, IInitializable
 {
     bool Enabled { get; }
     Dictionary<uint, IcsSku> SKUs { get; set; }
     Dictionary<uint, IcsItem> ShopItems { get; set; }
     List<IcsMenu> MenuItems { get; set; }
-    void Load();
-    void Initialize();
     void EnabledShop();
     void DisableShop();
     void CreditDisperseTick(TimeSpan delta);

--- a/AAEmu.Game/Core/Managers/ICashShopManager.cs
+++ b/AAEmu.Game/Core/Managers/ICashShopManager.cs
@@ -1,0 +1,18 @@
+using AAEmu.Game.Core.Network.Connections;
+using AAEmu.Game.Models.Game.CashShop;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface ICashShopManager
+{
+    bool Enabled { get; }
+    Dictionary<uint, IcsSku> SKUs { get; set; }
+    Dictionary<uint, IcsItem> ShopItems { get; set; }
+    List<IcsMenu> MenuItems { get; set; }
+    void Load();
+    void Initialize();
+    void EnabledShop();
+    void DisableShop();
+    void CreditDisperseTick(TimeSpan delta);
+    void SendICSPage(GameConnection connection, byte mainTabId, byte subTabId, ushort page);
+}

--- a/AAEmu.Game/Core/Managers/IChatManager.cs
+++ b/AAEmu.Game/Core/Managers/IChatManager.cs
@@ -1,0 +1,24 @@
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Chat;
+using AAEmu.Game.Models.Game.Expeditions;
+using AAEmu.Game.Models.Game.Team;
+using AAEmu.Game.Models.StaticValues;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IChatManager
+{
+    void Initialize();
+    List<ChatChannel> ListAllChannels();
+    void LeaveAllChannels(Character character);
+    int CleanUpChannels();
+    ChatChannel GetFactionChat(FactionsEnum factionMotherId);
+    ChatChannel GetFactionChat(Character character);
+    ChatChannel GetNationChat(Race race);
+    ChatChannel GetNationChat(Character character);
+    ChatChannel GetZoneChat(uint zoneKey);
+    ChatChannel GetGuildChat(Expedition guild);
+    ChatChannel GetFamilyChat(uint familyId);
+    ChatChannel GetPartyChat(Team party, Character myChar);
+    ChatChannel GetRaidChat(Team party);
+}

--- a/AAEmu.Game/Core/Managers/ICommandManager.cs
+++ b/AAEmu.Game/Core/Managers/ICommandManager.cs
@@ -1,0 +1,17 @@
+using AAEmu.Game.Models.Game;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Utils.Scripts;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface ICommandManager
+{
+    List<string> GetCommandKeys();
+    ICommand GetCommandInterfaceByName(string commandName);
+    string GetCommandNameBase(string aliasName);
+    void Register(string name, ICommand command);
+    void Register(string[] names, ICommand command);
+    string UnAliasCommandName(string cmd);
+    bool Handle(Character character, string text, out IMessageOutput messageOutput);
+    void Clear();
+}

--- a/AAEmu.Game/Core/Managers/ICraftManager.cs
+++ b/AAEmu.Game/Core/Managers/ICraftManager.cs
@@ -1,6 +1,3 @@
 namespace AAEmu.Game.Core.Managers;
 
-public interface ICraftManager
-{
-    void Load();
-}
+public interface ICraftManager : ILoadable;

--- a/AAEmu.Game/Core/Managers/ICraftManager.cs
+++ b/AAEmu.Game/Core/Managers/ICraftManager.cs
@@ -1,0 +1,6 @@
+namespace AAEmu.Game.Core.Managers;
+
+public interface ICraftManager
+{
+    void Load();
+}

--- a/AAEmu.Game/Core/Managers/IDuelManager.cs
+++ b/AAEmu.Game/Core/Managers/IDuelManager.cs
@@ -1,0 +1,18 @@
+using AAEmu.Game.Models.Game;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Duels;
+using AAEmu.Game.Models.StaticValues;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IDuelManager
+{
+    Dictionary<uint, FactionsEnum> SaveFactions { get; set; }
+    void DuelRequest(Character challenger, uint challengedId);
+    void DuelAccepted(Character challenged, uint challengerId);
+    void DuelStart(uint id);
+    void DuelCancel(uint challengerId, ErrorMessageType errorMessage);
+    void DuelStop(uint id, DuelDetType det, uint loseId = 0);
+    bool DuelResultСheck(uint id);
+    DuelDistance DuelDistanceСheck(uint id);
+}

--- a/AAEmu.Game/Core/Managers/IEffectTaskManager.cs
+++ b/AAEmu.Game/Core/Managers/IEffectTaskManager.cs
@@ -1,0 +1,7 @@
+namespace AAEmu.Game.Core.Managers;
+
+/// <summary>
+/// Marker interface for EffectTaskManager. All public methods are static.
+/// This interface enables DI registration.
+/// </summary>
+public interface IEffectTaskManager;

--- a/AAEmu.Game/Core/Managers/IEffectTaskManager.cs
+++ b/AAEmu.Game/Core/Managers/IEffectTaskManager.cs
@@ -1,7 +1,8 @@
+using AAEmu.Game.Models.Game.Skills;
+
 namespace AAEmu.Game.Core.Managers;
 
-/// <summary>
-/// Marker interface for EffectTaskManager. All public methods are static.
-/// This interface enables DI registration.
-/// </summary>
-public interface IEffectTaskManager;
+public interface IEffectTaskManager
+{
+    void AddDispelTask(Buff buff, double interval);
+}

--- a/AAEmu.Game/Core/Managers/IExpeditionManager.cs
+++ b/AAEmu.Game/Core/Managers/IExpeditionManager.cs
@@ -2,8 +2,7 @@ using AAEmu.Game.Models.Game.Expeditions;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface IExpeditionManager
+public interface IExpeditionManager : ILoadable
 {
     IEnumerable<Expedition> Expeditions { get; }
-    void Load();
 }

--- a/AAEmu.Game/Core/Managers/IExpeditionManager.cs
+++ b/AAEmu.Game/Core/Managers/IExpeditionManager.cs
@@ -1,0 +1,9 @@
+using AAEmu.Game.Models.Game.Expeditions;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IExpeditionManager
+{
+    IEnumerable<Expedition> Expeditions { get; }
+    void Load();
+}

--- a/AAEmu.Game/Core/Managers/IExperienceManager.cs
+++ b/AAEmu.Game/Core/Managers/IExperienceManager.cs
@@ -1,10 +1,9 @@
 namespace AAEmu.Game.Core.Managers;
 
-public interface IExperienceManager
+public interface IExperienceManager : ILoadable
 {
     byte MaxPlayerLevel { get; }
     byte MaxMateLevel { get; }
-    void Load();
     void Load(IExperienceLevelTemplateLoader loader, byte playerLevelCap, byte mateLevelCap);
     int GetExpForLevel(byte level, bool mate = false);
     byte GetLevelFromExp(int exp, out int overflow, bool mate = false);

--- a/AAEmu.Game/Core/Managers/IExperienceManager.cs
+++ b/AAEmu.Game/Core/Managers/IExperienceManager.cs
@@ -1,0 +1,14 @@
+namespace AAEmu.Game.Core.Managers;
+
+public interface IExperienceManager
+{
+    byte MaxPlayerLevel { get; }
+    byte MaxMateLevel { get; }
+    void Load();
+    void Load(IExperienceLevelTemplateLoader loader, byte playerLevelCap, byte mateLevelCap);
+    int GetExpForLevel(byte level, bool mate = false);
+    byte GetLevelFromExp(int exp, out int overflow, bool mate = false);
+    byte GetLevelFromExp(int exp, byte currentLevel, out int overflow, bool mate = false);
+    int GetExpNeededToGivenLevel(int currentExp, byte targetLevel, bool mate = false);
+    int GetSkillPointsForLevel(byte level);
+}

--- a/AAEmu.Game/Core/Managers/IExpressTextManager.cs
+++ b/AAEmu.Game/Core/Managers/IExpressTextManager.cs
@@ -1,7 +1,6 @@
 ﻿namespace AAEmu.Game.Core.Managers;
 
-public interface IExpressTextManager
+public interface IExpressTextManager : ILoadable
 {
     uint GetExpressAnimId(uint emotionId);
-    void Load();
 }

--- a/AAEmu.Game/Core/Managers/IFamilyManager.cs
+++ b/AAEmu.Game/Core/Managers/IFamilyManager.cs
@@ -1,7 +1,12 @@
+using AAEmu.Game.Models.Game.Char;
+
 namespace AAEmu.Game.Core.Managers;
 
 public interface IFamilyManager
 {
     void Load();
     void SaveAllFamilies();
+    void OnCharacterLogin(Character character);
+    void OnCharacterLogout(Character character);
+    void LeaveFamily(Character character);
 }

--- a/AAEmu.Game/Core/Managers/IFamilyManager.cs
+++ b/AAEmu.Game/Core/Managers/IFamilyManager.cs
@@ -1,0 +1,7 @@
+namespace AAEmu.Game.Core.Managers;
+
+public interface IFamilyManager
+{
+    void Load();
+    void SaveAllFamilies();
+}

--- a/AAEmu.Game/Core/Managers/IFamilyManager.cs
+++ b/AAEmu.Game/Core/Managers/IFamilyManager.cs
@@ -2,9 +2,8 @@ using AAEmu.Game.Models.Game.Char;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface IFamilyManager
+public interface IFamilyManager : ILoadable
 {
-    void Load();
     void SaveAllFamilies();
     void OnCharacterLogin(Character character);
     void OnCharacterLogout(Character character);

--- a/AAEmu.Game/Core/Managers/IFeaturesManager.cs
+++ b/AAEmu.Game/Core/Managers/IFeaturesManager.cs
@@ -1,0 +1,7 @@
+namespace AAEmu.Game.Core.Managers;
+
+/// <summary>
+/// Marker interface for FeaturesManager. All public members of FeaturesManager are static;
+/// this interface enables DI registration and future injectable access.
+/// </summary>
+public interface IFeaturesManager;

--- a/AAEmu.Game/Core/Managers/IFishSchoolManager.cs
+++ b/AAEmu.Game/Core/Managers/IFishSchoolManager.cs
@@ -3,9 +3,8 @@ using AAEmu.Game.Models.Game.World;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface IFishSchoolManager
+public interface IFishSchoolManager : IInitializable
 {
-    void Initialize();
     void Load(WorldInstance world);
     List<Doodad> GetAllFishSchools();
 }

--- a/AAEmu.Game/Core/Managers/IFishSchoolManager.cs
+++ b/AAEmu.Game/Core/Managers/IFishSchoolManager.cs
@@ -1,0 +1,11 @@
+using AAEmu.Game.Models.Game.DoodadObj;
+using AAEmu.Game.Models.Game.World;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IFishSchoolManager
+{
+    void Initialize();
+    void Load(WorldInstance world);
+    List<Doodad> GetAllFishSchools();
+}

--- a/AAEmu.Game/Core/Managers/IFormulaManager.cs
+++ b/AAEmu.Game/Core/Managers/IFormulaManager.cs
@@ -1,0 +1,15 @@
+using AAEmu.Game.Models.Game.Formulas;
+
+using Jace;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IFormulaManager
+{
+    CalculationEngine CalculationEngine { get; }
+    void Load();
+    UnitFormula GetUnitFormula(FormulaOwnerType owner, UnitFormulaKind kind);
+    float GetUnitVariable(uint formulaId, UnitFormulaVariableType type, uint key);
+    WearableFormula GetWearableFormula(WearableFormulaType type);
+    Formula GetFormula(uint id);
+}

--- a/AAEmu.Game/Core/Managers/IFormulaManager.cs
+++ b/AAEmu.Game/Core/Managers/IFormulaManager.cs
@@ -4,10 +4,9 @@ using Jace;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface IFormulaManager
+public interface IFormulaManager : ILoadable
 {
     CalculationEngine CalculationEngine { get; }
-    void Load();
     UnitFormula GetUnitFormula(FormulaOwnerType owner, UnitFormulaKind kind);
     float GetUnitVariable(uint formulaId, UnitFormulaVariableType type, uint key);
     WearableFormula GetWearableFormula(WearableFormulaType type);

--- a/AAEmu.Game/Core/Managers/IFriendManager.cs
+++ b/AAEmu.Game/Core/Managers/IFriendManager.cs
@@ -2,9 +2,8 @@ using AAEmu.Game.Models.Game.Char;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface IFriendManager
+public interface IFriendManager : ILoadable
 {
-    void Load();
     void AddToAllFriends(FriendTemplate template);
     void RemoveFromAllFriends(uint id);
     void SendStatusChange(Character unit, bool forOnline, bool boolean);

--- a/AAEmu.Game/Core/Managers/IFriendManager.cs
+++ b/AAEmu.Game/Core/Managers/IFriendManager.cs
@@ -1,0 +1,11 @@
+using AAEmu.Game.Models.Game.Char;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IFriendManager
+{
+    void Load();
+    void AddToAllFriends(FriendTemplate template);
+    void RemoveFromAllFriends(uint id);
+    void SendStatusChange(Character unit, bool forOnline, bool boolean);
+}

--- a/AAEmu.Game/Core/Managers/IGameScheduleManager.cs
+++ b/AAEmu.Game/Core/Managers/IGameScheduleManager.cs
@@ -2,9 +2,8 @@ using AAEmu.Game.Models.Game.Schedules;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface IGameScheduleManager
+public interface IGameScheduleManager : ILoadable
 {
-    void Load();
     void LoadGameSchedules(Dictionary<int, GameSchedules> gameSchedules);
     void LoadGameScheduleSpawners(Dictionary<int, GameScheduleSpawners> gameScheduleSpawners);
     void LoadGameScheduleDoodads(Dictionary<int, GameScheduleDoodads> gameScheduleDoodads);

--- a/AAEmu.Game/Core/Managers/IGameScheduleManager.cs
+++ b/AAEmu.Game/Core/Managers/IGameScheduleManager.cs
@@ -1,0 +1,11 @@
+using AAEmu.Game.Models.Game.Schedules;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IGameScheduleManager
+{
+    void Load();
+    void LoadGameSchedules(Dictionary<int, GameSchedules> gameSchedules);
+    void LoadGameScheduleSpawners(Dictionary<int, GameScheduleSpawners> gameScheduleSpawners);
+    void LoadGameScheduleDoodads(Dictionary<int, GameScheduleDoodads> gameScheduleDoodads);
+}

--- a/AAEmu.Game/Core/Managers/IHousingManager.cs
+++ b/AAEmu.Game/Core/Managers/IHousingManager.cs
@@ -6,6 +6,8 @@ using AAEmu.Game.Models.Game.Housing;
 using AAEmu.Game.Models.Game.World;
 using AAEmu.Game.Models.StaticValues;
 
+using MySql.Data.MySqlClient;
+
 namespace AAEmu.Game.Core.Managers;
 
 public interface IHousingManager
@@ -28,7 +30,9 @@ public interface IHousingManager
     bool CancelForSale(ushort houseTlId, bool returnCertificates = true);
     bool BuyHouse(ushort houseTlId, uint money, Character character);
     void CheckHousingTaxes();
+    void UpdateTaxInfo(House house);
     bool DecorateHouse(Character player, ushort houseTlId, uint designId, Vector3 pos, Quaternion quat, uint parentObjId, ulong itemId);
     void HousingToggleAllowRecover(Character character, ushort houseTl);
     House GetHouseAtLocation(float x, float y);
+    (int, int) Save(MySqlConnection connection, MySqlTransaction transaction);
 }

--- a/AAEmu.Game/Core/Managers/IHousingManager.cs
+++ b/AAEmu.Game/Core/Managers/IHousingManager.cs
@@ -34,5 +34,6 @@ public interface IHousingManager
     bool DecorateHouse(Character player, ushort houseTlId, uint designId, Vector3 pos, Quaternion quat, uint parentObjId, ulong itemId);
     void HousingToggleAllowRecover(Character character, ushort houseTl);
     House GetHouseAtLocation(float x, float y);
+    bool PayWeeklyTax(House house);
     (int, int) Save(MySqlConnection connection, MySqlTransaction transaction);
 }

--- a/AAEmu.Game/Core/Managers/IHousingManager.cs
+++ b/AAEmu.Game/Core/Managers/IHousingManager.cs
@@ -1,0 +1,34 @@
+using System.Numerics;
+
+using AAEmu.Game.Core.Network.Connections;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Housing;
+using AAEmu.Game.Models.Game.World;
+using AAEmu.Game.Models.StaticValues;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IHousingManager
+{
+    int GetByAccountId(Dictionary<uint, House> values, uint accountId);
+    int GetByCharacterId(Dictionary<uint, House> values, uint characterId);
+    void LoadPlayerHousing(WorldInstance worldInstance);
+    void SpawnAll();
+    void ConstructHouseTax(GameConnection connection, uint designId, float x, float y, float z);
+    void HouseTaxInfo(GameConnection connection, ushort tlId);
+    void Build(GameConnection connection, uint designId, float posX, float posY, float posZ, float zRot, ulong itemId, int moneyAmount, int ht, bool autoUseAaPoint);
+    void ChangeHousePermission(GameConnection connection, ushort tlId, HousingPermission permission);
+    void ChangeHouseName(GameConnection connection, ushort tlId, string name);
+    void Demolish(GameConnection connection, House house, bool failedToPayTax, bool forceRestoreAllDecor);
+    void RemoveDeadHouse(House house);
+    bool CalculateBuildingTaxInfo(uint accountId, HousingTemplate newHouseTemplate, bool buildingNewHouse, out int totalTaxToPay, out int heavyHouseCount, out int normalHouseCount, out int hostileTaxRate, out int oneWeekTaxCount);
+    House GetHouseById(uint houseId);
+    void UpdateOwnedHousingFaction(uint characterId, FactionsEnum factionId);
+    bool SetForSale(ushort houseTlId, uint price, uint buyerId, Character seller);
+    bool CancelForSale(ushort houseTlId, bool returnCertificates = true);
+    bool BuyHouse(ushort houseTlId, uint money, Character character);
+    void CheckHousingTaxes();
+    bool DecorateHouse(Character player, ushort houseTlId, uint designId, Vector3 pos, Quaternion quat, uint parentObjId, ulong itemId);
+    void HousingToggleAllowRecover(Character character, ushort houseTl);
+    House GetHouseAtLocation(float x, float y);
+}

--- a/AAEmu.Game/Core/Managers/IIndunManager.cs
+++ b/AAEmu.Game/Core/Managers/IIndunManager.cs
@@ -1,0 +1,11 @@
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Indun;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IIndunManager
+{
+    void Initialize();
+    bool InstanceHasChannels(uint zoneId);
+    bool RequestSystemInstance(Character character, uint zoneId, uint channelId, out Dungeon dungeon);
+}

--- a/AAEmu.Game/Core/Managers/IIndunManager.cs
+++ b/AAEmu.Game/Core/Managers/IIndunManager.cs
@@ -10,4 +10,5 @@ public interface IIndunManager
     bool InstanceHasChannels(uint zoneId);
     bool RequestSystemInstance(Character character, uint zoneId, uint channelId, out Dungeon dungeon);
     void DoIndunActions(uint startActionId, WorldInstance worldInstance);
+    Dungeon CreateSystemInstance(Character character, uint zoneKey, uint channelId, bool overrideInstanceId = false, uint fixedInstanceId = 0);
 }

--- a/AAEmu.Game/Core/Managers/IIndunManager.cs
+++ b/AAEmu.Game/Core/Managers/IIndunManager.cs
@@ -4,9 +4,8 @@ using AAEmu.Game.Models.Game.World;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface IIndunManager
+public interface IIndunManager : IInitializable
 {
-    void Initialize();
     bool InstanceHasChannels(uint zoneId);
     bool RequestSystemInstance(Character character, uint zoneId, uint channelId, out Dungeon dungeon);
     void DoIndunActions(uint startActionId, WorldInstance worldInstance);

--- a/AAEmu.Game/Core/Managers/IIndunManager.cs
+++ b/AAEmu.Game/Core/Managers/IIndunManager.cs
@@ -1,5 +1,6 @@
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Indun;
+using AAEmu.Game.Models.Game.World;
 
 namespace AAEmu.Game.Core.Managers;
 
@@ -8,4 +9,5 @@ public interface IIndunManager
     void Initialize();
     bool InstanceHasChannels(uint zoneId);
     bool RequestSystemInstance(Character character, uint zoneId, uint channelId, out Dungeon dungeon);
+    void DoIndunActions(uint startActionId, WorldInstance worldInstance);
 }

--- a/AAEmu.Game/Core/Managers/IInstantGameManager.cs
+++ b/AAEmu.Game/Core/Managers/IInstantGameManager.cs
@@ -3,9 +3,8 @@ using AAEmu.Game.Models.Game.InstantGame.Static;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface IInstantGameManager
+public interface IInstantGameManager : IInitializable
 {
-    void Initialize();
     void ApplyToBattlefield(uint battlefieldId, InstantCorps corps, Character character);
     void WithdrawFromBattlefield(Character character);
 }

--- a/AAEmu.Game/Core/Managers/IInstantGameManager.cs
+++ b/AAEmu.Game/Core/Managers/IInstantGameManager.cs
@@ -1,0 +1,11 @@
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.InstantGame.Static;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IInstantGameManager
+{
+    void Initialize();
+    void ApplyToBattlefield(uint battlefieldId, InstantCorps corps, Character character);
+    void WithdrawFromBattlefield(Character character);
+}

--- a/AAEmu.Game/Core/Managers/IItemManager.cs
+++ b/AAEmu.Game/Core/Managers/IItemManager.cs
@@ -10,7 +10,7 @@ using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface IItemManager
+public interface IItemManager : ILoadable
 {
     event EventHandler OnItemsLoaded;
     ItemTemplate GetTemplate(uint id);
@@ -43,7 +43,6 @@ public interface IItemManager
     ArmorGradeBuff GetArmorGradeBuff(ArmorType type, ItemGrade grade);
     Item Create(uint templateId, int count, byte grade, bool generateId = true);
     bool AddItem(Item item);
-    void Load();
     Item GetItemByItemId(ulong itemId);
     ItemContainer GetItemContainerForCharacter(uint characterId, SlotType slotType, Unit parentUnit, uint mateId);
     CofferContainer NewCofferContainer(uint characterId);

--- a/AAEmu.Game/Core/Managers/IItemManager.cs
+++ b/AAEmu.Game/Core/Managers/IItemManager.cs
@@ -56,4 +56,5 @@ public interface IItemManager
     void UpdateItemTimers();
     bool UnwrapItem(Character character, SlotType slotType, byte slot, ulong itemId);
     ItemSet GetItemSet(uint itemSetId);
+    SlotType GetContainerSlotTypeByContainerId(ulong dbId);
 }

--- a/AAEmu.Game/Core/Managers/IItemManager.cs
+++ b/AAEmu.Game/Core/Managers/IItemManager.cs
@@ -57,4 +57,5 @@ public interface IItemManager
     bool UnwrapItem(Character character, SlotType slotType, byte slot, ulong itemId);
     ItemSet GetItemSet(uint itemSetId);
     SlotType GetContainerSlotTypeByContainerId(ulong dbId);
+    (int, int, int) Save(MySql.Data.MySqlClient.MySqlConnection connection, MySql.Data.MySqlClient.MySqlTransaction transaction);
 }

--- a/AAEmu.Game/Core/Managers/IItemManager.cs
+++ b/AAEmu.Game/Core/Managers/IItemManager.cs
@@ -1,0 +1,59 @@
+using AAEmu.Game.Models.Game.Auction.Templates;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Items;
+using AAEmu.Game.Models.Game.Items.Containers;
+using AAEmu.Game.Models.Game.Items.Loots;
+using AAEmu.Game.Models.Game.Items.Procs;
+using AAEmu.Game.Models.Game.Items.Templates;
+using AAEmu.Game.Models.Game.Skills.Templates;
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IItemManager
+{
+    event EventHandler OnItemsLoaded;
+    ItemTemplate GetTemplate(uint id);
+    EquipItemSet GetEquippedItemSet(uint id);
+    GradeTemplate GetGradeTemplate(int grade);
+    Holdable GetHoldable(uint id);
+    EquipSlotEnchantingCost GetEquipSlotEnchantingCost(uint slotTypeId);
+    GradeTemplate GetGradeTemplateByOrder(int gradeOrder);
+    ItemGradeEnchantingSupport GetItemGradEnchantingSupportByItemId(uint itemId);
+    List<LootPackDroppingNpc> GetLootPackIdByNpcId(uint npcId);
+    List<ItemTemplate> GetAllItems();
+    List<Item> GetLootConvertFish(uint templateId);
+    GradeDistributions GetGradeDistributions(byte id);
+    uint GetSocketChance(uint numSockets);
+    ItemCapScale GetItemCapScale(uint skillId);
+    float GetDurabilityRepairCostFactor();
+    float GetDurabilityConst();
+    float GetHoldableDurabilityConst();
+    float GetWearableDurabilityConst();
+    float GetItemStatConst();
+    float GetHoldableStatConst();
+    float GetWearableStatConst();
+    float GetStatValueConst();
+    AttributeModifiers GetAttributeModifiers(uint id);
+    List<uint> GetItemIdsFromDoodad(uint doodadId);
+    ItemTemplate GetItemTemplateFromItemId(uint itemId);
+    List<ItemTemplate> GetItemTemplatesForAuctionSearch(AuctionSearch searchTemplate);
+    ItemProcTemplate GetItemProcTemplate(uint templateId);
+    List<BonusTemplate> GetUnitModifiers(uint itemId);
+    ArmorGradeBuff GetArmorGradeBuff(ArmorType type, ItemGrade grade);
+    Item Create(uint templateId, int count, byte grade, bool generateId = true);
+    bool AddItem(Item item);
+    void Load();
+    Item GetItemByItemId(ulong itemId);
+    ItemContainer GetItemContainerForCharacter(uint characterId, SlotType slotType, Unit parentUnit, uint mateId);
+    CofferContainer NewCofferContainer(uint characterId);
+    ItemContainer GetItemContainerByDbId(ulong dbId);
+    bool DeleteItemContainer(ItemContainer container);
+    void LoadUserItems();
+    void ReleaseId(ulong itemId);
+    List<Item> LoadPlayerInventory(ICharacter character);
+    bool IsAutoEquipTradePack(uint itemTemplateId);
+    void UpdateItemTimers();
+    bool UnwrapItem(Character character, SlotType slotType, byte slot, ulong itemId);
+    ItemSet GetItemSet(uint itemSetId);
+}

--- a/AAEmu.Game/Core/Managers/ILoadable.cs
+++ b/AAEmu.Game/Core/Managers/ILoadable.cs
@@ -1,0 +1,4 @@
+namespace AAEmu.Game.Core.Managers;
+
+public interface ILoadable { void Load(); }
+public interface IInitializable { void Initialize(); }

--- a/AAEmu.Game/Core/Managers/ILocalizationManager.cs
+++ b/AAEmu.Game/Core/Managers/ILocalizationManager.cs
@@ -1,0 +1,8 @@
+namespace AAEmu.Game.Core.Managers;
+
+public interface ILocalizationManager
+{
+    void Load();
+    void AddTranslation(string tblName, string tblColumn, long index, string translationValue);
+    string Get(string tblName, string tblColumn, long index, string fallbackValue = "");
+}

--- a/AAEmu.Game/Core/Managers/ILocalizationManager.cs
+++ b/AAEmu.Game/Core/Managers/ILocalizationManager.cs
@@ -1,8 +1,7 @@
 namespace AAEmu.Game.Core.Managers;
 
-public interface ILocalizationManager
+public interface ILocalizationManager : ILoadable
 {
-    void Load();
     void AddTranslation(string tblName, string tblColumn, long index, string translationValue);
     string Get(string tblName, string tblColumn, long index, string fallbackValue = "");
 }

--- a/AAEmu.Game/Core/Managers/IMailManager.cs
+++ b/AAEmu.Game/Core/Managers/IMailManager.cs
@@ -2,6 +2,8 @@ using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Mails;
 
+using MySql.Data.MySqlClient;
+
 namespace AAEmu.Game.Core.Managers;
 
 public interface IMailManager
@@ -19,4 +21,6 @@ public interface IMailManager
     bool PayChargeMoney(Character character, long mailId, bool autoUseAAPoint);
     void DeleteHouseMails(uint houseId);
     List<BaseMail> GetMyHouseMails(uint houseId);
+    (int, int) Save(MySqlConnection connection, MySqlTransaction transaction);
+    Dictionary<long, BaseMail> AllPlayerMails { get; }
 }

--- a/AAEmu.Game/Core/Managers/IMailManager.cs
+++ b/AAEmu.Game/Core/Managers/IMailManager.cs
@@ -1,0 +1,22 @@
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Items;
+using AAEmu.Game.Models.Game.Mails;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IMailManager
+{
+    BaseMail GetMailById(long id);
+    uint GetNewMailId();
+    bool Send(BaseMail mail);
+    [Obsolete]
+    void SendMail(MailType type, string receiverName, string senderName, string title, string text, byte attachments, int[] moneyAmounts, long extra, List<Item> items);
+    bool DeleteMail(long id);
+    bool DeleteMail(BaseMail mail, bool trashItems = false);
+    void Load();
+    Dictionary<long, BaseMail> GetCurrentMailList(uint characterId);
+    void CheckAllMailTimings();
+    bool PayChargeMoney(Character character, long mailId, bool autoUseAAPoint);
+    void DeleteHouseMails(uint houseId);
+    List<BaseMail> GetMyHouseMails(uint houseId);
+}

--- a/AAEmu.Game/Core/Managers/IMailManager.cs
+++ b/AAEmu.Game/Core/Managers/IMailManager.cs
@@ -6,7 +6,7 @@ using MySql.Data.MySqlClient;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface IMailManager
+public interface IMailManager : ILoadable
 {
     BaseMail GetMailById(long id);
     uint GetNewMailId();
@@ -15,7 +15,6 @@ public interface IMailManager
     void SendMail(MailType type, string receiverName, string senderName, string title, string text, byte attachments, int[] moneyAmounts, long extra, List<Item> items);
     bool DeleteMail(long id);
     bool DeleteMail(BaseMail mail, bool trashItems = false);
-    void Load();
     Dictionary<long, BaseMail> GetCurrentMailList(uint characterId);
     void CheckAllMailTimings();
     bool PayChargeMoney(Character character, long mailId, bool autoUseAAPoint);

--- a/AAEmu.Game/Core/Managers/IManaRegenManager.cs
+++ b/AAEmu.Game/Core/Managers/IManaRegenManager.cs
@@ -1,0 +1,6 @@
+namespace AAEmu.Game.Core.Managers;
+
+public interface IManaRegenManager
+{
+    void Initialize();
+}

--- a/AAEmu.Game/Core/Managers/IManaRegenManager.cs
+++ b/AAEmu.Game/Core/Managers/IManaRegenManager.cs
@@ -1,6 +1,3 @@
 namespace AAEmu.Game.Core.Managers;
 
-public interface IManaRegenManager
-{
-    void Initialize();
-}
+public interface IManaRegenManager : IInitializable;

--- a/AAEmu.Game/Core/Managers/IModelManager.cs
+++ b/AAEmu.Game/Core/Managers/IModelManager.cs
@@ -2,9 +2,8 @@ using AAEmu.Game.Models.Game.Models;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface IModelManager
+public interface IModelManager : ILoadable
 {
-    void Load();
     ModelType GetModelType(uint modelId);
     ActorModel GetActorModel(uint modelId);
     ShipModelV1 GetShipModel(uint modelId);

--- a/AAEmu.Game/Core/Managers/IModelManager.cs
+++ b/AAEmu.Game/Core/Managers/IModelManager.cs
@@ -1,0 +1,13 @@
+using AAEmu.Game.Models.Game.Models;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IModelManager
+{
+    void Load();
+    ModelType GetModelType(uint modelId);
+    ActorModel GetActorModel(uint modelId);
+    ShipModelV1 GetShipModel(uint modelId);
+    VehicleModel GetVehicleModels(uint modelId);
+    bool IsFlyOrSwim(uint modelId);
+}

--- a/AAEmu.Game/Core/Managers/IMusicManager.cs
+++ b/AAEmu.Game/Core/Managers/IMusicManager.cs
@@ -1,0 +1,13 @@
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Items;
+using AAEmu.Game.Models.Game.Music;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IMusicManager
+{
+    void Load();
+    bool Save(SongData songData);
+    void UploadSong(uint charId, string title, string song, ulong itemId);
+    bool CreateSheetMusic(Character player, Item sourceItem);
+}

--- a/AAEmu.Game/Core/Managers/IMusicManager.cs
+++ b/AAEmu.Game/Core/Managers/IMusicManager.cs
@@ -4,9 +4,8 @@ using AAEmu.Game.Models.Game.Music;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface IMusicManager
+public interface IMusicManager : ILoadable
 {
-    void Load();
     bool Save(SongData songData);
     void UploadSong(uint charId, string title, string song, ulong itemId);
     bool CreateSheetMusic(Character player, Item sourceItem);

--- a/AAEmu.Game/Core/Managers/INameManager.cs
+++ b/AAEmu.Game/Core/Managers/INameManager.cs
@@ -1,0 +1,15 @@
+using AAEmu.Game.Models.StaticValues;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface INameManager
+{
+    void Load();
+    string GetCharacterName(uint characterId);
+    uint GetCharacterId(string normalizedCharacterName);
+    uint GetCharacterAccount(uint characterId);
+    CharacterCreateError ValidateCharacterName(string name);
+    void AddCharacter(uint characterId, string name, uint accountId);
+    void RemoveCharacterId(uint characterId);
+    bool NoNamesRegistered();
+}

--- a/AAEmu.Game/Core/Managers/INameManager.cs
+++ b/AAEmu.Game/Core/Managers/INameManager.cs
@@ -2,9 +2,8 @@ using AAEmu.Game.Models.StaticValues;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface INameManager
+public interface INameManager : ILoadable
 {
-    void Load();
     string GetCharacterName(uint characterId);
     uint GetCharacterId(string normalizedCharacterName);
     uint GetCharacterAccount(uint characterId);

--- a/AAEmu.Game/Core/Managers/IPlotManager.cs
+++ b/AAEmu.Game/Core/Managers/IPlotManager.cs
@@ -1,0 +1,10 @@
+using AAEmu.Game.Models.Game.Skills.Plots;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IPlotManager
+{
+    Plot GetPlot(uint id);
+    PlotEventTemplate GetEventByPlotId(uint plotId);
+    void Load();
+}

--- a/AAEmu.Game/Core/Managers/IPlotManager.cs
+++ b/AAEmu.Game/Core/Managers/IPlotManager.cs
@@ -2,9 +2,8 @@ using AAEmu.Game.Models.Game.Skills.Plots;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface IPlotManager
+public interface IPlotManager : ILoadable
 {
     Plot GetPlot(uint id);
     PlotEventTemplate GetEventByPlotId(uint plotId);
-    void Load();
 }

--- a/AAEmu.Game/Core/Managers/IPortalManager.cs
+++ b/AAEmu.Game/Core/Managers/IPortalManager.cs
@@ -1,0 +1,22 @@
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models.StaticValues;
+
+using Portal = AAEmu.Game.Models.Game.Portal;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IPortalManager
+{
+    void Load();
+    List<Portal> GetRecallBySubZoneId(uint subZoneId);
+    Portal GetRecallById(uint returnPointId);
+    Portal GetRespawnBySubZoneId(uint subZoneId);
+    Portal GetRespawnById(uint id);
+    Portal GetWorldGatesBySubZoneId(uint subZoneId);
+    Portal GetWorldGatesById(uint id);
+    uint GetDistrictReturnPoint(uint districtId);
+    uint GetDistrictReturnPoint(uint districtId, FactionsEnum factionId);
+    void OpenPortal(Character owner, SkillObjectUnk1 portalEffectObj);
+    Portal GetClosestReturnPortal(Character character);
+}

--- a/AAEmu.Game/Core/Managers/IPortalManager.cs
+++ b/AAEmu.Game/Core/Managers/IPortalManager.cs
@@ -6,9 +6,8 @@ using Portal = AAEmu.Game.Models.Game.Portal;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface IPortalManager
+public interface IPortalManager : ILoadable
 {
-    void Load();
     List<Portal> GetRecallBySubZoneId(uint subZoneId);
     Portal GetRecallById(uint returnPointId);
     Portal GetRespawnBySubZoneId(uint subZoneId);

--- a/AAEmu.Game/Core/Managers/IPublicFarmManager.cs
+++ b/AAEmu.Game/Core/Managers/IPublicFarmManager.cs
@@ -5,9 +5,8 @@ using AAEmu.Game.Models.Game.World;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface IPublicFarmManager
+public interface IPublicFarmManager : ILoadable, IInitializable
 {
-    void Initialize();
     void PublicFarmTick();
     bool InPublicFarm(WorldTemplate worldTemplate, Vector3 pos);
     FarmType GetFarmType(WorldInstance world, Vector3 pos);

--- a/AAEmu.Game/Core/Managers/IPublicFarmManager.cs
+++ b/AAEmu.Game/Core/Managers/IPublicFarmManager.cs
@@ -1,0 +1,14 @@
+using System.Numerics;
+
+using AAEmu.Game.Models.Game.CommonFarm.Static;
+using AAEmu.Game.Models.Game.World;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IPublicFarmManager
+{
+    void Initialize();
+    void PublicFarmTick();
+    bool InPublicFarm(WorldTemplate worldTemplate, Vector3 pos);
+    FarmType GetFarmType(WorldInstance world, Vector3 pos);
+}

--- a/AAEmu.Game/Core/Managers/IQuestManager.cs
+++ b/AAEmu.Game/Core/Managers/IQuestManager.cs
@@ -17,4 +17,5 @@ public interface IQuestManager
     QuestTemplate GetTemplate(uint id);
     void Load();
     void EnqueueEvaluation(Quest quest);
+    int RemoveQuestTimer(uint ownerId, uint questId);
 }

--- a/AAEmu.Game/Core/Managers/IQuestManager.cs
+++ b/AAEmu.Game/Core/Managers/IQuestManager.cs
@@ -4,7 +4,7 @@ using AAEmu.Game.Models.Game.Quests.Templates;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface IQuestManager
+public interface IQuestManager : ILoadable
 {
     void FailQuest(ICharacter owner, uint questId);
     bool CheckGroupItem(uint groupId, uint itemId);
@@ -15,7 +15,6 @@ public interface IQuestManager
     List<uint> GetGroupItems(uint groupId);
     QuestSupplies GetSupplies(byte level);
     QuestTemplate GetTemplate(uint id);
-    void Load();
     void EnqueueEvaluation(Quest quest);
     int RemoveQuestTimer(uint ownerId, uint questId);
 }

--- a/AAEmu.Game/Core/Managers/IRadarManager.cs
+++ b/AAEmu.Game/Core/Managers/IRadarManager.cs
@@ -1,0 +1,13 @@
+using AAEmu.Game.Models.Game.Char;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IRadarManager
+{
+    void Initialize();
+    void RegisterForPublicTransport(Character player, float checkRange);
+    void RegisterForFishSchool(Character player, float checkRange);
+    void RegisterForShips(Character player, float checkRange);
+    void RadarTick(TimeSpan delta);
+    void UnRegister(Character player);
+}

--- a/AAEmu.Game/Core/Managers/IRadarManager.cs
+++ b/AAEmu.Game/Core/Managers/IRadarManager.cs
@@ -2,9 +2,8 @@ using AAEmu.Game.Models.Game.Char;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface IRadarManager
+public interface IRadarManager : IInitializable
 {
-    void Initialize();
     void RegisterForPublicTransport(Character player, float checkRange);
     void RegisterForFishSchool(Character player, float checkRange);
     void RegisterForShips(Character player, float checkRange);

--- a/AAEmu.Game/Core/Managers/ISaveManager.cs
+++ b/AAEmu.Game/Core/Managers/ISaveManager.cs
@@ -1,0 +1,12 @@
+using AAEmu.Game.Models.Tasks;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface ISaveManager
+{
+    ShutdownTask ShutdownTask { get; set; }
+    void Initialize();
+    System.Threading.Tasks.Task StopAsync();
+    void SaveTickStart();
+    bool DoSave();
+}

--- a/AAEmu.Game/Core/Managers/ISaveManager.cs
+++ b/AAEmu.Game/Core/Managers/ISaveManager.cs
@@ -2,10 +2,9 @@ using AAEmu.Game.Models.Tasks;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface ISaveManager
+public interface ISaveManager : IInitializable
 {
     ShutdownTask ShutdownTask { get; set; }
-    void Initialize();
     System.Threading.Tasks.Task StopAsync();
     void SaveTickStart();
     bool DoSave();

--- a/AAEmu.Game/Core/Managers/IShipyardManager.cs
+++ b/AAEmu.Game/Core/Managers/IShipyardManager.cs
@@ -3,9 +3,8 @@ using AAEmu.Game.Models.Game.Shipyard;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface IShipyardManager
+public interface IShipyardManager : ILoadable, IInitializable
 {
-    void Initialize();
     Shipyard Create(Character owner, ShipyardData shipyardData);
     void ShipyardCompletedTask(Shipyard shipyard);
 }

--- a/AAEmu.Game/Core/Managers/IShipyardManager.cs
+++ b/AAEmu.Game/Core/Managers/IShipyardManager.cs
@@ -1,0 +1,10 @@
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Shipyard;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface IShipyardManager
+{
+    void Initialize();
+    Shipyard Create(Character owner, ShipyardData shipyardData);
+}

--- a/AAEmu.Game/Core/Managers/IShipyardManager.cs
+++ b/AAEmu.Game/Core/Managers/IShipyardManager.cs
@@ -7,4 +7,5 @@ public interface IShipyardManager
 {
     void Initialize();
     Shipyard Create(Character owner, ShipyardData shipyardData);
+    void ShipyardCompletedTask(Shipyard shipyard);
 }

--- a/AAEmu.Game/Core/Managers/ISkillManager.cs
+++ b/AAEmu.Game/Core/Managers/ISkillManager.cs
@@ -4,7 +4,7 @@ using AAEmu.Game.Models.Game.Skills.Templates;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface ISkillManager
+public interface ISkillManager : ILoadable
 {
     event EventHandler OnSkillsLoaded;
 
@@ -26,7 +26,6 @@ public interface ISkillManager
     List<SkillTemplate> GetStartAbilitySkills(AbilityType ability);
     bool IsCommonSkill(uint id);
     bool IsDefaultSkill(uint id);
-    void Load();
     // ushort NextId();
     // void ReleaseId(ushort id);
 }

--- a/AAEmu.Game/Core/Managers/ISubZoneManager.cs
+++ b/AAEmu.Game/Core/Managers/ISubZoneManager.cs
@@ -4,9 +4,8 @@ using AAEmu.Game.Models.Game.World;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface ISubZoneManager
+public interface ISubZoneManager : ILoadable
 {
-    void Load();
     List<uint> GetSubZoneByPosition(WorldTemplate worldTemplate, Vector3 pos);
     List<uint> GetSubZoneByPosition(WorldTemplate worldTemplate, float x, float y);
 }

--- a/AAEmu.Game/Core/Managers/ISubZoneManager.cs
+++ b/AAEmu.Game/Core/Managers/ISubZoneManager.cs
@@ -1,0 +1,6 @@
+namespace AAEmu.Game.Core.Managers;
+
+public interface ISubZoneManager
+{
+    void Load();
+}

--- a/AAEmu.Game/Core/Managers/ISubZoneManager.cs
+++ b/AAEmu.Game/Core/Managers/ISubZoneManager.cs
@@ -1,6 +1,12 @@
+using System.Numerics;
+
+using AAEmu.Game.Models.Game.World;
+
 namespace AAEmu.Game.Core.Managers;
 
 public interface ISubZoneManager
 {
     void Load();
+    List<uint> GetSubZoneByPosition(WorldTemplate worldTemplate, Vector3 pos);
+    List<uint> GetSubZoneByPosition(WorldTemplate worldTemplate, float x, float y);
 }

--- a/AAEmu.Game/Core/Managers/ISusManager.cs
+++ b/AAEmu.Game/Core/Managers/ISusManager.cs
@@ -1,0 +1,17 @@
+using System.Numerics;
+
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface ISusManager
+{
+    bool LogActivity(string category, uint accountId, uint playerId, uint zoneGroup, Vector3 position, string description);
+    bool LogActivity(string category, Character player, string description);
+    bool LogActivity(string category, string description);
+    void AnalyzePlayerDeltaMovement(Character player, float deltaTime);
+    void ResetAnalyzePlayerDeltaMovement(uint playerId);
+    void AnalyzeMountDeltaMovement(Mate pet, float deltaTime);
+    void ResetAnalyzeMountDeltaMovement(uint petId);
+}

--- a/AAEmu.Game/Core/Managers/ITaxationsManager.cs
+++ b/AAEmu.Game/Core/Managers/ITaxationsManager.cs
@@ -2,8 +2,7 @@ using AAEmu.Game.Models.Game.Taxations;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface ITaxationsManager
+public interface ITaxationsManager : ILoadable
 {
     Dictionary<uint, Taxation> Taxations { get; }
-    void Load();
 }

--- a/AAEmu.Game/Core/Managers/ITaxationsManager.cs
+++ b/AAEmu.Game/Core/Managers/ITaxationsManager.cs
@@ -1,0 +1,9 @@
+using AAEmu.Game.Models.Game.Taxations;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface ITaxationsManager
+{
+    Dictionary<uint, Taxation> Taxations { get; }
+    void Load();
+}

--- a/AAEmu.Game/Core/Managers/ITeamManager.cs
+++ b/AAEmu.Game/Core/Managers/ITeamManager.cs
@@ -1,0 +1,11 @@
+using AAEmu.Game.Models.Game.Team;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface ITeamManager
+{
+    void Load();
+    Team GetActiveTeamByUnit(uint unitId);
+    Team GetTeamByObjId(uint objId);
+    Team GetActiveTeam(uint teamId);
+}

--- a/AAEmu.Game/Core/Managers/ITeamManager.cs
+++ b/AAEmu.Game/Core/Managers/ITeamManager.cs
@@ -1,3 +1,4 @@
+using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Team;
 
 namespace AAEmu.Game.Core.Managers;
@@ -8,4 +9,5 @@ public interface ITeamManager
     Team GetActiveTeamByUnit(uint unitId);
     Team GetTeamByObjId(uint objId);
     Team GetActiveTeam(uint teamId);
+    void MemberRemoveFromTeam(Character unit, Character source, RiskyAction leaveType);
 }

--- a/AAEmu.Game/Core/Managers/ITeamManager.cs
+++ b/AAEmu.Game/Core/Managers/ITeamManager.cs
@@ -3,9 +3,8 @@ using AAEmu.Game.Models.Game.Team;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface ITeamManager
+public interface ITeamManager : ILoadable
 {
-    void Load();
     Team GetActiveTeamByUnit(uint unitId);
     Team GetTeamByObjId(uint objId);
     Team GetActiveTeam(uint teamId);

--- a/AAEmu.Game/Core/Managers/ITickManager.cs
+++ b/AAEmu.Game/Core/Managers/ITickManager.cs
@@ -1,0 +1,8 @@
+namespace AAEmu.Game.Core.Managers;
+
+public interface ITickManager
+{
+    TickManager.TickEventHandler OnTick { get; }
+    void Initialize();
+    void Stop();
+}

--- a/AAEmu.Game/Core/Managers/ITimeManager.cs
+++ b/AAEmu.Game/Core/Managers/ITimeManager.cs
@@ -1,0 +1,14 @@
+using AAEmu.Game.Core.Network.Connections;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface ITimeManager : IObservable<float>
+{
+    float GetTime { get; }
+    IDisposable Subscribe(GameConnection connection, IObserver<float> observer);
+    void Start();
+    void Stop();
+    float Get();
+    void Set(float hours);
+    void OnTimeOfDayChange(float newTime, float oldTime);
+}

--- a/AAEmu.Game/Core/Managers/ITimedRewardsManager.cs
+++ b/AAEmu.Game/Core/Managers/ITimedRewardsManager.cs
@@ -1,0 +1,11 @@
+using AAEmu.Game.Core.Network.Connections;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface ITimedRewardsManager
+{
+    void Initialize();
+    void DoTick();
+    void DoDailyAccountLogin(uint accountId);
+    void AddOfflineLabor(GameConnection connection, DateTime lastLoginTime, short currentLabor);
+}

--- a/AAEmu.Game/Core/Managers/ITimedRewardsManager.cs
+++ b/AAEmu.Game/Core/Managers/ITimedRewardsManager.cs
@@ -2,9 +2,8 @@ using AAEmu.Game.Core.Network.Connections;
 
 namespace AAEmu.Game.Core.Managers;
 
-public interface ITimedRewardsManager
+public interface ITimedRewardsManager : IInitializable
 {
-    void Initialize();
     void DoTick();
     void DoDailyAccountLogin(uint accountId);
     void AddOfflineLabor(GameConnection connection, DateTime lastLoginTime, short currentLabor);

--- a/AAEmu.Game/Core/Managers/ITradeManager.cs
+++ b/AAEmu.Game/Core/Managers/ITradeManager.cs
@@ -1,0 +1,9 @@
+using AAEmu.Game.Models.Game.Char;
+
+namespace AAEmu.Game.Core.Managers;
+
+public interface ITradeManager
+{
+    void CanStartTrade(Character owner, Character target);
+    void StartTrade(Character owner, Character target);
+}

--- a/AAEmu.Game/Core/Managers/Id/AuctionIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/AuctionIdManager.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class AuctionIdManager() : IdManager("AuctionIdManager", FirstId, LastId, ObjTables, Exclude)
+public class AuctionIdManager() : IdManager("AuctionIdManager", FirstId, LastId, ObjTables, Exclude), IAuctionIdManager
 {
     private static AuctionIdManager _instance;
     private const uint FirstId = 0x00000001;

--- a/AAEmu.Game/Core/Managers/Id/CharacterIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/CharacterIdManager.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class CharacterIdManager() : IdManager("CharacterIdManager", FirstId, LastId, ObjTables, Exclude)
+public class CharacterIdManager() : IdManager("CharacterIdManager", FirstId, LastId, ObjTables, Exclude), ICharacterIdManager
 {
     private static CharacterIdManager _instance;
     private const uint FirstId = 0x00000001;

--- a/AAEmu.Game/Core/Managers/Id/ContainerIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/ContainerIdManager.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class ContainerIdManager() : IdManager("ContainerIdManager", FirstId, LastId, ObjTables, Exclude)
+public class ContainerIdManager() : IdManager("ContainerIdManager", FirstId, LastId, ObjTables, Exclude), IContainerIdManager
 {
     private static ContainerIdManager _instance;
     private const uint FirstId = 0x00010000; // random value

--- a/AAEmu.Game/Core/Managers/Id/DoodadIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/DoodadIdManager.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class DoodadIdManager() : IdManager("DoodadIdManager", FirstId, LastId, ObjTables, Exclude)
+public class DoodadIdManager() : IdManager("DoodadIdManager", FirstId, LastId, ObjTables, Exclude), IDoodadIdManager
 {
     private static DoodadIdManager _instance;
     private const uint FirstId = 0x00000001;

--- a/AAEmu.Game/Core/Managers/Id/ExpeditionIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/ExpeditionIdManager.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class ExpeditionIdManager() : IdManager("ExpeditionIdManager", FirstId, LastId, ObjTables, Exclude)
+public class ExpeditionIdManager() : IdManager("ExpeditionIdManager", FirstId, LastId, ObjTables, Exclude), IExpeditionIdManager
 {
     private static ExpeditionIdManager _instance;
     private const uint FirstId = 1000; // Based on official packets

--- a/AAEmu.Game/Core/Managers/Id/FamilyIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/FamilyIdManager.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class FamilyIdManager() : IdManager("FamilyIdManager", FirstId, LastId, ObjTables, Exclude, true)
+public class FamilyIdManager() : IdManager("FamilyIdManager", FirstId, LastId, ObjTables, Exclude, true), IFamilyIdManager
 {
     private static FamilyIdManager _instance;
     private const uint FirstId = 0x00000001;

--- a/AAEmu.Game/Core/Managers/Id/FriendIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/FriendIdManager.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class FriendIdManager() : IdManager("FriendIdManager", FirstId, LastId, ObjTables, Exclude)
+public class FriendIdManager() : IdManager("FriendIdManager", FirstId, LastId, ObjTables, Exclude), IFriendIdManager
 {
     private static FriendIdManager _instance;
     private const uint FirstId = 0x00000001;

--- a/AAEmu.Game/Core/Managers/Id/GimmickIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/GimmickIdManager.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class GimmickIdManager() : IdManager("GimmickIdManager", FirstId, LastId, ObjTables, Exclude)
+public class GimmickIdManager() : IdManager("GimmickIdManager", FirstId, LastId, ObjTables, Exclude), IGimmickIdManager
 {
     private static GimmickIdManager _instance;
     private const uint FirstId = 0x0001;

--- a/AAEmu.Game/Core/Managers/Id/HousingIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/HousingIdManager.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class HousingIdManager() : IdManager("HousingIdManager", FirstId, LastId, ObjTables, Exclude)
+public class HousingIdManager() : IdManager("HousingIdManager", FirstId, LastId, ObjTables, Exclude), IHousingIdManager
 {
     private static HousingIdManager _instance;
     private const uint FirstId = 0x00000001;

--- a/AAEmu.Game/Core/Managers/Id/HousingTldManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/HousingTldManager.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class HousingTldManager() : IdManager("HousingTldManager", FirstId, LastId, ObjTables, Exclude)
+public class HousingTldManager() : IdManager("HousingTldManager", FirstId, LastId, ObjTables, Exclude), IHousingTldManager
 {
     private static HousingTldManager _instance;
     private const uint FirstId = 0x00000001;

--- a/AAEmu.Game/Core/Managers/Id/IAuctionIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/IAuctionIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface IAuctionIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/ICharacterIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/ICharacterIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface ICharacterIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/IContainerIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/IContainerIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface IContainerIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/IDoodadIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/IDoodadIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface IDoodadIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/IExpeditionIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/IExpeditionIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface IExpeditionIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/IFamilyIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/IFamilyIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface IFamilyIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/IFriendIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/IFriendIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface IFriendIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/IGimmickIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/IGimmickIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface IGimmickIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/IHousingIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/IHousingIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface IHousingIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/IHousingTldManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/IHousingTldManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface IHousingTldManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/IIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/IIdManager.cs
@@ -1,0 +1,13 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+/// <summary>
+/// Common interface for all ID managers.
+/// </summary>
+public interface IIdManager
+{
+    bool Initialize(bool forceReset = false);
+    uint GetNextId();
+    uint[] GetNextId(int count);
+    void ReleaseId(uint usedObjectId);
+    void ReleaseId(IEnumerable<uint> usedObjectIds);
+}

--- a/AAEmu.Game/Core/Managers/Id/IItemIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/IItemIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface IItemIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/IMailIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/IMailIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface IMailIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/IMateIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/IMateIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface IMateIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/IMusicIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/IMusicIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface IMusicIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/IObjectIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/IObjectIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface IObjectIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/IPrivateBookIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/IPrivateBookIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface IPrivateBookIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/IQuestIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/IQuestIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface IQuestIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/IShipyardIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/IShipyardIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface IShipyardIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/ITaskIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/ITaskIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface ITaskIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/ITeamIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/ITeamIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface ITeamIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/ITlIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/ITlIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface ITlIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/ITradeIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/ITradeIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface ITradeIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/IUccIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/IUccIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface IUccIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/IVisitedSubZoneIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/IVisitedSubZoneIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface IVisitedSubZoneIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/IWorldIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/IWorldIdManager.cs
@@ -1,0 +1,3 @@
+namespace AAEmu.Game.Core.Managers.Id;
+
+public interface IWorldIdManager : IIdManager;

--- a/AAEmu.Game/Core/Managers/Id/ItemIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/ItemIdManager.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class ItemIdManager() : IdManager("ItemIdManager", FirstId, LastId, ObjTables, Exclude)
+public class ItemIdManager() : IdManager("ItemIdManager", FirstId, LastId, ObjTables, Exclude), IItemIdManager
 {
     private static ItemIdManager _instance;
     private const uint FirstId = 0x01000000;

--- a/AAEmu.Game/Core/Managers/Id/MailIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/MailIdManager.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class MailIdManager() : IdManager("MailIdManager", FirstId, LastId, ObjTables, Exclude)
+public class MailIdManager() : IdManager("MailIdManager", FirstId, LastId, ObjTables, Exclude), IMailIdManager
 {
     private static MailIdManager _instance;
     private const uint FirstId = 0x00002710; // 10000, no special reason

--- a/AAEmu.Game/Core/Managers/Id/MateIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/MateIdManager.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class MateIdManager() : IdManager("MateIdManager", FirstId, LastId, ObjTables, Exclude)
+public class MateIdManager() : IdManager("MateIdManager", FirstId, LastId, ObjTables, Exclude), IMateIdManager
 {
     private static MateIdManager _instance;
     private const uint FirstId = 0x00000001;

--- a/AAEmu.Game/Core/Managers/Id/MusicIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/MusicIdManager.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class MusicIdManager() : IdManager("MusicIdManager", FirstId, LastId, ObjTables, Exclude)
+public class MusicIdManager() : IdManager("MusicIdManager", FirstId, LastId, ObjTables, Exclude), IMusicIdManager
 {
     private static MusicIdManager _instance;
     private const uint FirstId = 0x00000001;

--- a/AAEmu.Game/Core/Managers/Id/ObjectIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/ObjectIdManager.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class ObjectIdManager() : IdManager("ObjectIdManager", FirstId, LastId, ObjTables, Exclude)
+public class ObjectIdManager() : IdManager("ObjectIdManager", FirstId, LastId, ObjTables, Exclude), IObjectIdManager
 {
     private static ObjectIdManager _instance;
     private const uint FirstId = 0x00000100;

--- a/AAEmu.Game/Core/Managers/Id/PrivateBookIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/PrivateBookIdManager.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class PrivateBookIdManager() : IdManager("PrivateBookIdManager", FirstId, LastId, ObjTables, Exclude)
+public class PrivateBookIdManager() : IdManager("PrivateBookIdManager", FirstId, LastId, ObjTables, Exclude), IPrivateBookIdManager
 {
     private static PrivateBookIdManager _instance;
     private const uint FirstId = 0x00001000;

--- a/AAEmu.Game/Core/Managers/Id/QuestIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/QuestIdManager.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class QuestIdManager() : IdManager("QuestIdManager", FirstId, LastId, ObjTables, Exclude)
+public class QuestIdManager() : IdManager("QuestIdManager", FirstId, LastId, ObjTables, Exclude), IQuestIdManager
 {
     private static QuestIdManager _instance;
     private const uint FirstId = 0x00000001;

--- a/AAEmu.Game/Core/Managers/Id/ShipyardIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/ShipyardIdManager.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class ShipyardIdManager() : IdManager("ShipyardIdManager", FirstId, LastId, ObjTables, Exclude)
+public class ShipyardIdManager() : IdManager("ShipyardIdManager", FirstId, LastId, ObjTables, Exclude), IShipyardIdManager
 {
     private static ShipyardIdManager _instance;
     private const uint FirstId = 0x00000001;

--- a/AAEmu.Game/Core/Managers/Id/TaskIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/TaskIdManager.cs
@@ -2,7 +2,7 @@ using AAEmu.Game.Utils;
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class TaskIdManager() : IdManager("TaskIdManager", FirstId, LastId, ObjTables, Exclude)
+public class TaskIdManager() : IdManager("TaskIdManager", FirstId, LastId, ObjTables, Exclude), ITaskIdManager
 {
     private static TaskIdManager _instance;
     private const uint FirstId = 0x00000001;

--- a/AAEmu.Game/Core/Managers/Id/TeamIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/TeamIdManager.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class TeamIdManager() : IdManager("TeamIdManager", FirstId, LastId, ObjTables, Exclude)
+public class TeamIdManager() : IdManager("TeamIdManager", FirstId, LastId, ObjTables, Exclude), ITeamIdManager
 {
     private static TeamIdManager _instance;
     private const uint FirstId = 0x00000001;

--- a/AAEmu.Game/Core/Managers/Id/TlIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/TlIdManager.cs
@@ -2,7 +2,7 @@ using AAEmu.Game.Utils;
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class TlIdManager() : IdManager("TlIdManager", FirstId, LastId, ObjTables, Exclude)
+public class TlIdManager() : IdManager("TlIdManager", FirstId, LastId, ObjTables, Exclude), ITlIdManager
 {
     private static TlIdManager _instance;
     private const uint FirstId = 0x00000001;

--- a/AAEmu.Game/Core/Managers/Id/TradeIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/TradeIdManager.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class TradeIdManager() : IdManager("TradeIdManager", FirstId, LastId, ObjTables, Exclude)
+public class TradeIdManager() : IdManager("TradeIdManager", FirstId, LastId, ObjTables, Exclude), ITradeIdManager
 {
     private static TradeIdManager _instance;
     private const uint FirstId = 0x00000001;

--- a/AAEmu.Game/Core/Managers/Id/UccIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/UccIdManager.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class UccIdManager() : IdManager("UccIdManager", FirstId, LastId, ObjTables, Exclude)
+public class UccIdManager() : IdManager("UccIdManager", FirstId, LastId, ObjTables, Exclude), IUccIdManager
 {
     private static UccIdManager _instance;
     private const uint FirstId = 0x00000001;

--- a/AAEmu.Game/Core/Managers/Id/VisitedSubZoneIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/VisitedSubZoneIdManager.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class VisitedSubZoneIdManager() : IdManager("VisitedSubZoneIdMananger", FirstId, LastId, ObjTables, Exclude)
+public class VisitedSubZoneIdManager() : IdManager("VisitedSubZoneIdMananger", FirstId, LastId, ObjTables, Exclude), IVisitedSubZoneIdManager
 {
     private static VisitedSubZoneIdManager _instance;
     private const uint FirstId = 0x00000001;

--- a/AAEmu.Game/Core/Managers/Id/WorldIdManager.cs
+++ b/AAEmu.Game/Core/Managers/Id/WorldIdManager.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Core.Managers.Id;
 
-public class WorldIdManager() : IdManager("WorldIdManager", FirstId, LastId, ObjTables, Exclude)
+public class WorldIdManager() : IdManager("WorldIdManager", FirstId, LastId, ObjTables, Exclude), IWorldIdManager
 {
     private static WorldIdManager _instance;
     private const uint FirstId = 0x00000064;

--- a/AAEmu.Game/Core/Managers/IndunManager.cs
+++ b/AAEmu.Game/Core/Managers/IndunManager.cs
@@ -13,7 +13,7 @@ using NLog;
 namespace AAEmu.Game.Core.Managers;
 
 // ReSharper disable once ClassNeverInstantiated.Global
-public class IndunManager : Singleton<IndunManager>, IIndunManager
+public class IndunManager(ITickManager tickManager, IWorldManager worldManager, IZoneManager zoneManager, ITeamManager teamManager) : Singleton<IndunManager>, IIndunManager
 {
     // ReSharper disable once InconsistentNaming
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
@@ -24,14 +24,14 @@ public class IndunManager : Singleton<IndunManager>, IIndunManager
 
     public void Initialize()
     {
-        TickManager.Instance.OnTick.Subscribe(IndunInfoTick, TimeSpan.FromSeconds(30), true);
+        tickManager.OnTick.Subscribe(IndunInfoTick, TimeSpan.FromSeconds(30), true);
     }
 
     private void IndunInfoTick(TimeSpan delta)
     {
         var sysInstanceCount = 0;
         var dungeonInstanceCount = 0;
-        var worldList = WorldManager.Instance.GetWorlds().ToList();
+        var worldList = worldManager.GetWorlds().ToList();
 
         // Count dungeons
         foreach (var worldInstance in worldList)
@@ -81,7 +81,7 @@ public class IndunManager : Singleton<IndunManager>, IIndunManager
     /// <returns></returns>
     public bool InstanceHasChannels(uint zoneId)
     {
-        var dungeonZone = IndunGameData.Instance.GetDungeonZone(ZoneManager.Instance.GetZoneById(zoneId).GroupId);
+        var dungeonZone = IndunGameData.Instance.GetDungeonZone(zoneManager.GetZoneById(zoneId).GroupId);
         return dungeonZone.SelectChannel;
     }
 
@@ -102,7 +102,7 @@ public class IndunManager : Singleton<IndunManager>, IIndunManager
             return false;
         }
 
-        var zone = ZoneManager.Instance.GetZoneById(zoneId);
+        var zone = zoneManager.GetZoneById(zoneId);
         if (zone == null)
         {
             Logger.Warn($"Requesting non existing system instance for zone {zoneId}, character {character.Name}");
@@ -143,18 +143,18 @@ public class IndunManager : Singleton<IndunManager>, IIndunManager
             Logger.Info($"Player requested a dungeon, but is now offline.");
             return false;
         }
-        var team = TeamManager.Instance.GetTeamByObjId(character.ObjId);
-        var zone = ZoneManager.Instance.GetZoneById(zoneId);
+        var team = teamManager.GetTeamByObjId(character.ObjId);
+        var zone = zoneManager.GetZoneById(zoneId);
 
         // Check valid zone/dungeon
-        var worldTemplate = WorldManager.Instance.GetWorldTemplateByZoneKey(zone.ZoneKey);
+        var worldTemplate = worldManager.GetWorldTemplateByZoneKey(zone.ZoneKey);
         if (worldTemplate == null)
         {
             // Non-existing dungeon zone
             return false;
         }
 
-        var targetZone = ZoneManager.Instance.GetZoneById(zoneId);
+        var targetZone = zoneManager.GetZoneById(zoneId);
         if (targetZone == null)
         {
             // Key does not match any zone
@@ -284,7 +284,7 @@ public class IndunManager : Singleton<IndunManager>, IIndunManager
     private List<Dungeon> GetExistingDungeonsByZoneKey(uint zoneKey)
     {
         var res = new List<Dungeon>();
-        foreach (var worldInstance in WorldManager.Instance.GetWorlds())
+        foreach (var worldInstance in worldManager.GetWorlds())
         {
             if (worldInstance.DungeonInstance == null)
                 continue;
@@ -357,14 +357,14 @@ public class IndunManager : Singleton<IndunManager>, IIndunManager
         dungeon = null;
 
         // Check if we have capacity
-        if (WorldManager.Instance.GetWorlds().Length > AppConfiguration.Instance.World.MaxInstances)
+        if (worldManager.GetWorlds().Length > AppConfiguration.Instance.World.MaxInstances)
         {
             Logger.Warn($"Requesting a new instance would exceeds the allowed ammount, characterId: {character.Id}, zoneGroupId: {dungeonZone.ZoneGroupId}");
             character.SendErrorMessage(ErrorMessageType.NoServerInstanceResource);
             return false;
         }
-        
-        var team = TeamManager.Instance.GetTeamByObjId(character.ObjId);
+
+        var team = teamManager.GetTeamByObjId(character.ObjId);
         Logger.Info($"Requesting instance, characterId: {character.Id}, zoneGroupId: {dungeonZone.ZoneGroupId}");
 
         // Check requirements such as level, item, etc
@@ -393,9 +393,9 @@ public class IndunManager : Singleton<IndunManager>, IIndunManager
     {
         Logger.Info($"Requesting system instance, zoneKey: {zoneKey}, character: {character?.Name ?? "[SYSTEM]"}, channel: {channelId}, override InstanceId: {(overrideInstanceId ? fixedInstanceId.ToString() : "NO")}");
 
-        var team = character != null ? TeamManager.Instance.GetTeamByObjId(character.ObjId) : null;
+        var team = character != null ? teamManager.GetTeamByObjId(character.ObjId) : null;
 
-        var dungeonZone = IndunGameData.Instance.GetDungeonZone(ZoneManager.Instance.GetZoneByKey(zoneKey).GroupId);
+        var dungeonZone = IndunGameData.Instance.GetDungeonZone(zoneManager.GetZoneByKey(zoneKey).GroupId);
         if (dungeonZone == null)
         {
             Logger.Error($"Requesting invalid system instance: , zoneKey: {zoneKey}, character: {character?.Name ?? "[SYSTEM]"}, channel: {channelId}, override InstanceId: {(overrideInstanceId ? fixedInstanceId.ToString() : "NO")}");
@@ -403,7 +403,7 @@ public class IndunManager : Singleton<IndunManager>, IIndunManager
         }
         
         // Check for duplicate system instances
-        foreach (var worldInstance in WorldManager.Instance.GetWorlds())
+        foreach (var worldInstance in worldManager.GetWorlds())
         {
             if (worldInstance.ChannelId == channelId &&
                 worldInstance.DungeonInstance?.GetZoneGroupId == dungeonZone.ZoneGroupId)
@@ -424,7 +424,7 @@ public class IndunManager : Singleton<IndunManager>, IIndunManager
         };
 
         // Check if zones match
-        if (dungeonZone.ZoneGroupId != ZoneManager.Instance.GetZoneByKey(zoneKey)?.GroupId)
+        if (dungeonZone.ZoneGroupId != zoneManager.GetZoneByKey(zoneKey)?.GroupId)
         {
             Logger.Info("[IndunManager] system dungeon request on different area.");
             character?.SendErrorMessage(ErrorMessageType.ProhibitedInInstance);
@@ -498,7 +498,7 @@ public class IndunManager : Singleton<IndunManager>, IIndunManager
         
         // Remove from all possible different types of dungeons
         // System dungeons (mirage/library)
-        foreach (var worldInstance in WorldManager.Instance.GetWorlds().Where(w => w.HasCharacter(character.Id)))
+        foreach (var worldInstance in worldManager.GetWorlds().Where(w => w.HasCharacter(character.Id)))
         {
             
             character.Events.OnDungeonLeave(worldInstance, new OnDungeonLeaveArgs { Player = character });
@@ -510,7 +510,7 @@ public class IndunManager : Singleton<IndunManager>, IIndunManager
         return false;
     }
 
-    public static void DoIndunActions(uint startActionId, WorldInstance worldInstance)
+    public void DoIndunActions(uint startActionId, WorldInstance worldInstance)
     {
         while (true)
         {
@@ -573,7 +573,7 @@ public class IndunManager : Singleton<IndunManager>, IIndunManager
                 {
                     foreach (var (zoneGroupId, entriesList) in zoneAndEntries)
                     {
-                        Logger.Debug($"For player={characterId} ({WorldManager.Instance.GetCharacterById(characterId)?.Name}): {entriesList.Count} entries into dungeon zone group {zoneGroupId} ({ZoneManager.Instance.GetZoneGroupById(zoneGroupId)?.Name})");
+                        Logger.Debug($"For player={characterId} ({worldManager.GetCharacterById(characterId)?.Name}): {entriesList.Count} entries into dungeon zone group {zoneGroupId} ({zoneManager.GetZoneGroupById(zoneGroupId)?.Name})");
                     }
                 }
             }

--- a/AAEmu.Game/Core/Managers/IndunManager.cs
+++ b/AAEmu.Game/Core/Managers/IndunManager.cs
@@ -13,7 +13,7 @@ using NLog;
 namespace AAEmu.Game.Core.Managers;
 
 // ReSharper disable once ClassNeverInstantiated.Global
-public class IndunManager : Singleton<IndunManager>
+public class IndunManager : Singleton<IndunManager>, IIndunManager
 {
     // ReSharper disable once InconsistentNaming
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();

--- a/AAEmu.Game/Core/Managers/InstantGameManager.cs
+++ b/AAEmu.Game/Core/Managers/InstantGameManager.cs
@@ -11,7 +11,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class InstantGameManager : Singleton<InstantGameManager>
+public class InstantGameManager : Singleton<InstantGameManager>, IInstantGameManager
 {
     private static readonly Logger _log = LogManager.GetCurrentClassLogger();
 

--- a/AAEmu.Game/Core/Managers/ItemManager.cs
+++ b/AAEmu.Game/Core/Managers/ItemManager.cs
@@ -27,7 +27,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class ItemManager : Singleton<ItemManager>, IItemManager
+public class ItemManager(ISkillManager skillManager, IItemIdManager itemIdManager, IContainerIdManager containerIdManager, ILocalizationManager localizationManager, ITaskManager taskManager, IWorldManager worldManager) : Singleton<ItemManager>, IItemManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private bool _loaded;
@@ -439,7 +439,7 @@ public class ItemManager : Singleton<ItemManager>, IItemManager
         ItemTimerLock = new();
         LastTimerCheck = DateTime.UtcNow;
 
-        SkillManager.Instance.OnSkillsLoaded += OnSkillsLoaded;
+        skillManager.OnSkillsLoaded += OnSkillsLoaded;
         using (var connection = SQLite.CreateConnection())
         {
             Logger.Info("Loading item templates ...");
@@ -1408,7 +1408,7 @@ public class ItemManager : Singleton<ItemManager>, IItemManager
                     invalidItemCount++;
                     i.Value.Name = "invalid_item_" + i.Value.Id;
                 }
-                i.Value.searchString = (i.Value.Name + " " + LocalizationManager.Instance.Get("items", "name", i.Value.Id)).ToLower();
+                i.Value.searchString = (i.Value.Name + " " + localizationManager.Get("items", "name", i.Value.Id)).ToLower();
             }
 
             Logger.Info($"Loaded {_templates.Count} item templates (with {invalidItemCount} unused) ...");
@@ -1607,7 +1607,7 @@ public class ItemManager : Singleton<ItemManager>, IItemManager
         return (updateCount, deleteCount, containerUpdateCount);
     }
 
-    internal SlotType GetContainerSlotTypeByContainerId(ulong dbId)
+    public SlotType GetContainerSlotTypeByContainerId(ulong dbId)
     {
         _allPersistentContainers.TryGetValue(dbId, out var container);
 
@@ -1689,7 +1689,7 @@ public class ItemManager : Singleton<ItemManager>, IItemManager
         lock (_allPersistentContainers)
         {
             res = _allPersistentContainers.Remove(idToRemove);
-            ContainerIdManager.Instance.ReleaseId(idToRemove);
+            containerIdManager.ReleaseId(idToRemove);
         }
 
         // Remove deleted container from DB
@@ -1874,18 +1874,18 @@ public class ItemManager : Singleton<ItemManager>, IItemManager
 
         Logger.Info("Starting Timed Items Task ...");
         var itemTimerTask = new ItemTimerTask();
-        TaskManager.Instance.Schedule(itemTimerTask, null, TimeSpan.FromSeconds(1));
+        taskManager.Schedule(itemTimerTask, null, TimeSpan.FromSeconds(1));
 
         _loadedUserItems = true;
     }
 
     /// <summary>
-    /// Gets a new itemID for use on new items, will also remove it from the deleted itemIDs list. Use this instead of directly calling ItemIdManager.Instance.GetNextId();
+    /// Gets a new itemID for use on new items, will also remove it from the deleted itemIDs list. Use this instead of directly calling itemIdManager.GetNextId();
     /// </summary>
     /// <returns>A new itemID</returns>
     private ulong GetNewId()
     {
-        var itemId = ItemIdManager.Instance.GetNextId();
+        var itemId = itemIdManager.GetNextId();
         lock (_removedItems)
         {
             if (itemId != 0 && _removedItems.Contains(itemId))
@@ -1895,7 +1895,7 @@ public class ItemManager : Singleton<ItemManager>, IItemManager
     }
 
     /// <summary>
-    /// Releases a itemId for re-use, will also add it to the removed items list, use instead of ItemIdManager.Instance.ReleaseId();
+    /// Releases a itemId for re-use, will also add it to the removed items list, use instead of itemIdManager.ReleaseId();
     /// </summary>
     /// <param name="itemId">itemId of the item to be freed up</param>
     public void ReleaseId(ulong itemId)
@@ -1910,7 +1910,7 @@ public class ItemManager : Singleton<ItemManager>, IItemManager
             _allItems.Remove(itemId);
         }
         // This should be the only place where ItemId ReleaseId should be called directly
-        ItemIdManager.Instance.ReleaseId((uint)itemId);
+        itemIdManager.ReleaseId((uint)itemId);
     }
 
     [Obsolete("You can now use directly linked item containers, and no longer need to load them into the character object")]
@@ -1924,7 +1924,7 @@ public class ItemManager : Singleton<ItemManager>, IItemManager
     {
         foreach (var procTemplate in _itemProcTemplates.Values)
         {
-            procTemplate.SkillTemplate = SkillManager.Instance.GetSkillTemplate(procTemplate.SkillId);
+            procTemplate.SkillTemplate = skillManager.GetSkillTemplate(procTemplate.SkillId);
         }
     }
 
@@ -2021,7 +2021,7 @@ public class ItemManager : Singleton<ItemManager>, IItemManager
         // even before you get the welcome message when logging in. (you can see it in the logs)
         // It only does this for items in your inventory, equipment and warehouse,
         // it is for example possible to have one in your mailbox, and it will immediately expire when you take it out.
-        var onlinePlayers = WorldManager.Instance.GetAllCharacters();
+        var onlinePlayers = worldManager.GetAllCharacters();
         var res = 0;
         foreach (var character in onlinePlayers)
         {

--- a/AAEmu.Game/Core/Managers/ItemManager.cs
+++ b/AAEmu.Game/Core/Managers/ItemManager.cs
@@ -27,7 +27,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class ItemManager : Singleton<ItemManager>
+public class ItemManager : Singleton<ItemManager>, IItemManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private bool _loaded;

--- a/AAEmu.Game/Core/Managers/LocalizationManager.cs
+++ b/AAEmu.Game/Core/Managers/LocalizationManager.cs
@@ -5,7 +5,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class LocalizationManager : Singleton<LocalizationManager>
+public class LocalizationManager : Singleton<LocalizationManager>, ILocalizationManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 

--- a/AAEmu.Game/Core/Managers/MailManager.cs
+++ b/AAEmu.Game/Core/Managers/MailManager.cs
@@ -22,6 +22,7 @@ public class MailManager(IMailIdManager mailIdManager, INameManager nameManager,
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
     public Dictionary<long, BaseMail> _allPlayerMails;
+    public Dictionary<long, BaseMail> AllPlayerMails => _allPlayerMails;
     private List<long> _deletedMailIds = [];
     // Unused: private object _lock = new();
 
@@ -320,13 +321,13 @@ public class MailManager(IMailIdManager mailIdManager, INameManager nameManager,
         return tempMails;
     }
 
-    public static bool NotifyNewMailByNameIfOnline(BaseMail m, string receiverName)
+    public bool NotifyNewMailByNameIfOnline(BaseMail m, string receiverName)
     {
         Logger.Trace($"NotifyNewMailByNameIfOnline() - {receiverName}");
         // If unread and ready to deliver
         if (m.Header.Status != MailStatus.Read && m.Body.RecvDate <= DateTime.UtcNow && m.IsDelivered == false)
         {
-            var player = WorldManager.Instance.GetCharacter(receiverName);
+            var player = worldManager.GetCharacter(receiverName);
             if (player != null)
             {
                 // TODO: Mia mail stuff
@@ -341,10 +342,10 @@ public class MailManager(IMailIdManager mailIdManager, INameManager nameManager,
         return false;
     }
 
-    public static bool NotifyDeleteMailByNameIfOnline(BaseMail m, string receiverName)
+    public bool NotifyDeleteMailByNameIfOnline(BaseMail m, string receiverName)
     {
         Logger.Trace($"NotifyDeleteMailByNameIfOnline() - {receiverName}");
-        var player = WorldManager.Instance.GetCharacter(receiverName);
+        var player = worldManager.GetCharacter(receiverName);
         if (player != null)
         {
             if (m.Header.Status != MailStatus.Read)
@@ -453,7 +454,7 @@ public class MailManager(IMailIdManager mailIdManager, INameManager nameManager,
             }
         }
 
-        if (!HousingManager.PayWeeklyTax(house))
+        if (!HousingManager.Instance.PayWeeklyTax(house))
             Logger.Error("Could not update protection time when paying taxes, mailId {0}", mail.Id);
         else
         {

--- a/AAEmu.Game/Core/Managers/MailManager.cs
+++ b/AAEmu.Game/Core/Managers/MailManager.cs
@@ -17,7 +17,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class MailManager : Singleton<MailManager>
+public class MailManager : Singleton<MailManager>, IMailManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 

--- a/AAEmu.Game/Core/Managers/MailManager.cs
+++ b/AAEmu.Game/Core/Managers/MailManager.cs
@@ -17,7 +17,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class MailManager : Singleton<MailManager>, IMailManager
+public class MailManager(IMailIdManager mailIdManager, INameManager nameManager, IItemManager itemManager, ITaskManager taskManager, IWorldManager worldManager, IHousingManager housingManager, ILocalizationManager localizationManager) : Singleton<MailManager>, IMailManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
@@ -45,7 +45,7 @@ public class MailManager : Singleton<MailManager>, IMailManager
     {
         lock (_deletedMailIds)
         {
-            var Id = MailIdManager.Instance.GetNextId();
+            var Id = mailIdManager.GetNextId();
             if (_deletedMailIds.Contains(Id))
                 _deletedMailIds.Remove(Id);
             return Id;
@@ -55,8 +55,8 @@ public class MailManager : Singleton<MailManager>, IMailManager
     public bool Send(BaseMail mail)
     {
         // Verify Receiver
-        var targetName = NameManager.Instance.GetCharacterName(mail.Header.ReceiverId);
-        var targetId = NameManager.Instance.GetCharacterId(mail.Header.ReceiverName);
+        var targetName = nameManager.GetCharacterName(mail.Header.ReceiverId);
+        var targetId = nameManager.GetCharacterId(mail.Header.ReceiverName);
         if (!string.Equals(targetName, mail.Header.ReceiverName, StringComparison.InvariantCultureIgnoreCase))
         {
             Logger.Debug("Send() - Failed to verify receiver name {0} != {1}", targetName, mail.Header.ReceiverName);
@@ -92,7 +92,7 @@ public class MailManager : Singleton<MailManager>, IMailManager
         {
             if (!_deletedMailIds.Contains(id))
                 _deletedMailIds.Add(id);
-            MailIdManager.Instance.ReleaseId((uint)id);
+            mailIdManager.ReleaseId((uint)id);
         }
         return _allPlayerMails.Remove(id);
     }
@@ -167,7 +167,7 @@ public class MailManager : Singleton<MailManager>, IMailManager
                             var itemId = reader.GetUInt64("attachment" + i.ToString());
                             if (itemId > 0)
                             {
-                                var item = ItemManager.Instance.GetItemByItemId(itemId);
+                                var item = itemManager.GetItemByItemId(itemId);
                                 if (item != null)
                                 {
                                     item.OwnerId = tempMail.Header.ReceiverId;
@@ -206,7 +206,7 @@ public class MailManager : Singleton<MailManager>, IMailManager
         Logger.Info("Loaded {0} player mails", _allPlayerMails.Count);
 
         var mailCheckTask = new MailDeliveryTask();
-        TaskManager.Instance.Schedule(mailCheckTask, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(5));
+        taskManager.Schedule(mailCheckTask, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(5));
     }
 
     public (int, int) Save(MySqlConnection connection, MySqlTransaction transaction)
@@ -297,7 +297,7 @@ public class MailManager : Singleton<MailManager>, IMailManager
     public Dictionary<long, BaseMail> GetCurrentMailList(uint characterId)
     {
         // Try to grab the actual online Character object to send live updates
-        var character = WorldManager.Instance.GetCharacterById(characterId);
+        var character = worldManager.GetCharacterById(characterId);
         var tempMails = _allPlayerMails.Where(
             x => x.Value.Body.RecvDate <= DateTime.UtcNow &&
                  (x.Value.Header.ReceiverId == characterId || 
@@ -388,7 +388,7 @@ public class MailManager : Singleton<MailManager>, IMailManager
 
         var houseId = (uint)(mail.Header.Extra & 0xFFFFFFFF); // Extract house DB Id from Extra
         var houseZoneGroup = (mail.Header.Extra >> 48) & 0xFFFF; // Extract zone group Id from Extra
-        var house = HousingManager.Instance.GetHouseById(houseId);
+        var house = housingManager.GetHouseById(houseId);
 
         if (house == null)
         {
@@ -520,18 +520,18 @@ public class MailManager : Singleton<MailManager>, IMailManager
         return resultList;
     }
 
-    public static List<BaseMail> CreateQuestRewardMails(ICharacter character, Quest quest, List<ItemCreationDefinition> itemCreationDefinitions, int mailCopper)
+    public List<BaseMail> CreateQuestRewardMails(ICharacter character, Quest quest, List<ItemCreationDefinition> itemCreationDefinitions, int mailCopper)
     {
         var resultList = new List<BaseMail>();
 
         MailPlayerToPlayer mail = null;
-        var questName = LocalizationManager.Instance.Get("quest_contexts", "name", quest.TemplateId, quest.TemplateId.ToString());
+        var questName = localizationManager.Get("quest_contexts", "name", quest.TemplateId, quest.TemplateId.ToString());
 
         // Generate a finalized list of all reward items in the mail attachments container of the player
         var totalRewardsItemsList = new List<Item>();
         foreach (var item in itemCreationDefinitions)
         {
-            var itemTemplate = ItemManager.Instance.GetTemplate(item.TemplateId);
+            var itemTemplate = itemManager.GetTemplate(item.TemplateId);
             var itemGrade = itemTemplate.FixedGrade;
             if (itemGrade <= 0)
                 itemGrade = 0;

--- a/AAEmu.Game/Core/Managers/MailManager.cs
+++ b/AAEmu.Game/Core/Managers/MailManager.cs
@@ -17,7 +17,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class MailManager(IMailIdManager mailIdManager, INameManager nameManager, IItemManager itemManager, ITaskManager taskManager, IWorldManager worldManager, IHousingManager housingManager, ILocalizationManager localizationManager) : Singleton<MailManager>, IMailManager
+public class MailManager(IMailIdManager mailIdManager, INameManager nameManager, IItemManager itemManager, ITaskManager taskManager, IWorldManager worldManager, Lazy<IHousingManager> housingManager, ILocalizationManager localizationManager) : Singleton<MailManager>, IMailManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
@@ -389,7 +389,7 @@ public class MailManager(IMailIdManager mailIdManager, INameManager nameManager,
 
         var houseId = (uint)(mail.Header.Extra & 0xFFFFFFFF); // Extract house DB Id from Extra
         var houseZoneGroup = (mail.Header.Extra >> 48) & 0xFFFF; // Extract zone group Id from Extra
-        var house = housingManager.GetHouseById(houseId);
+        var house = housingManager.Value.GetHouseById(houseId);
 
         if (house == null)
         {
@@ -454,7 +454,7 @@ public class MailManager(IMailIdManager mailIdManager, INameManager nameManager,
             }
         }
 
-        if (!HousingManager.Instance.PayWeeklyTax(house))
+        if (!housingManager.Value.PayWeeklyTax(house))
             Logger.Error("Could not update protection time when paying taxes, mailId {0}", mail.Id);
         else
         {

--- a/AAEmu.Game/Core/Managers/ManaRegenManager.cs
+++ b/AAEmu.Game/Core/Managers/ManaRegenManager.cs
@@ -5,7 +5,7 @@ using AAEmu.Game.Models.Game.Skills.Buffs;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class ManaRegenManager : Singleton<ManaRegenManager>, IManaRegenManager
+public class ManaRegenManager(ITickManager tickManager) : Singleton<ManaRegenManager>, IManaRegenManager
 {
     private int UpdateDelay { get; set; } = 200; // Buff tick interval in milliseconds
     private static object Lock { get; } = new();
@@ -14,7 +14,7 @@ public class ManaRegenManager : Singleton<ManaRegenManager>, IManaRegenManager
     public void Initialize()
     {
         Registrations = new Dictionary<uint, ManaRegenTemplate>();
-        TickManager.Instance.OnTick.Subscribe(Tick, TimeSpan.FromMilliseconds(UpdateDelay), true);
+        tickManager.OnTick.Subscribe(Tick, TimeSpan.FromMilliseconds(UpdateDelay), true);
     }
 
     internal void Register(Character player, ManaRegenTemplate template)

--- a/AAEmu.Game/Core/Managers/ManaRegenManager.cs
+++ b/AAEmu.Game/Core/Managers/ManaRegenManager.cs
@@ -5,7 +5,7 @@ using AAEmu.Game.Models.Game.Skills.Buffs;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class ManaRegenManager : Singleton<ManaRegenManager>
+public class ManaRegenManager : Singleton<ManaRegenManager>, IManaRegenManager
 {
     private int UpdateDelay { get; set; } = 200; // Buff tick interval in milliseconds
     private static object Lock { get; } = new();

--- a/AAEmu.Game/Core/Managers/ManagerOrchestrator.cs
+++ b/AAEmu.Game/Core/Managers/ManagerOrchestrator.cs
@@ -1,0 +1,82 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AAEmu.Game.Core.Managers;
+
+public class ManagerOrchestrator(IServiceProvider serviceProvider, IServiceCollection services)
+{
+    /// <summary>
+    /// Builds batches of TInterface instances in topological order derived from constructor dependencies.
+    /// Each batch can be executed in parallel; batches must be executed sequentially.
+    /// </summary>
+    public IReadOnlyList<IReadOnlyList<TInterface>> BuildBatches<TInterface>()
+    {
+        // 1. Collect all concrete types registered as singletons that implement TInterface.
+        //    Exclude factory-registered (ImplementationType == null) redirect registrations.
+        var participatingTypes = services
+            .Where(sd => sd.Lifetime == ServiceLifetime.Singleton
+                      && sd.ImplementationType != null
+                      && typeof(TInterface).IsAssignableFrom(sd.ImplementationType))
+            .Select(sd => sd.ImplementationType!)
+            .Distinct()
+            .ToList();
+
+        // 2. Build adjacency: for each type, which other participating types it depends on
+        //    (derived from constructor parameters, excluding Lazy<T> to avoid false edges from
+        //    circular-dependency break patterns).
+        var typeSet = participatingTypes.ToHashSet();
+        var deps = participatingTypes.ToDictionary(
+            t => t,
+            t => GetConstructorDeps(t, typeSet));
+
+        // 3. Kahn's topological sort → parallel batches
+        var batches = new List<List<Type>>();
+        var remaining = typeSet.ToHashSet();
+        while (remaining.Count > 0)
+        {
+            var batch = remaining
+                .Where(t => deps[t].All(d => !remaining.Contains(d)))
+                .ToList();
+            if (batch.Count == 0)
+                throw new InvalidOperationException(
+                    $"Cycle detected in manager dependency graph among: {string.Join(", ", remaining.Select(t => t.Name))}");
+            batches.Add(batch);
+            foreach (var t in batch)
+                remaining.Remove(t);
+        }
+
+        // 4. Resolve instances
+        return batches
+            .Select(batch => (IReadOnlyList<TInterface>)batch
+                .Select(t => (TInterface)serviceProvider.GetRequiredService(t))
+                .ToList())
+            .ToList();
+    }
+
+    private static List<Type> GetConstructorDeps(Type type, HashSet<Type> participating)
+    {
+        var ctor = type.GetConstructors().MaxBy(c => c.GetParameters().Length);
+        if (ctor is null) return [];
+        return ctor.GetParameters()
+            .Select(p => p.ParameterType)
+            // Skip Lazy<T> — these exist specifically to break circular deps at resolution time
+            .Where(pt => !(pt.IsGenericType && pt.GetGenericTypeDefinition() == typeof(Lazy<>)))
+            // Map each interface parameter to the concrete type in the participating set
+            .Select(pt => participating.FirstOrDefault(t => pt.IsAssignableFrom(t)))
+            .Where(t => t is not null)
+            .ToList()!;
+    }
+
+    /// <summary>Runs Load() on all ILoadable managers in dependency order, parallelising within each batch.</summary>
+    public async Task RunLoadAsync()
+    {
+        foreach (var batch in BuildBatches<ILoadable>())
+            await Task.WhenAll(batch.Select(m => Task.Run(m.Load)));
+    }
+
+    /// <summary>Runs Initialize() on all IInitializable managers in dependency order, parallelising within each batch.</summary>
+    public async Task RunInitializeAsync()
+    {
+        foreach (var batch in BuildBatches<IInitializable>())
+            await Task.WhenAll(batch.Select(m => Task.Run(m.Initialize)));
+    }
+}

--- a/AAEmu.Game/Core/Managers/ModelManager.cs
+++ b/AAEmu.Game/Core/Managers/ModelManager.cs
@@ -6,7 +6,7 @@ using AAEmu.Game.Utils.DB;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class ModelManager : Singleton<ModelManager>
+public class ModelManager : Singleton<ModelManager>, IModelManager
 {
 
     private Dictionary<string, Dictionary<uint, Model>> _models;

--- a/AAEmu.Game/Core/Managers/MusicManager.cs
+++ b/AAEmu.Game/Core/Managers/MusicManager.cs
@@ -10,7 +10,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class MusicManager : Singleton<MusicManager>
+public class MusicManager : Singleton<MusicManager>, IMusicManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 

--- a/AAEmu.Game/Core/Managers/MusicManager.cs
+++ b/AAEmu.Game/Core/Managers/MusicManager.cs
@@ -10,7 +10,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class MusicManager : Singleton<MusicManager>, IMusicManager
+public class MusicManager(IMusicIdManager musicIdManager, IItemManager itemManager) : Singleton<MusicManager>, IMusicManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
@@ -50,7 +50,7 @@ public class MusicManager : Singleton<MusicManager>, IMusicManager
 
     public bool Save(SongData songData)
     {
-        songData.Id = MusicIdManager.Instance.GetNextId();
+        songData.Id = musicIdManager.GetNextId();
 
         using (var connection = MySQL.CreateConnection())
         {
@@ -117,7 +117,7 @@ public class MusicManager : Singleton<MusicManager>, IMusicManager
         // Save to DB
         if (Save(sud))
         {
-            var sheet = (MusicSheetItem)ItemManager.Instance.Create(Item.SheetMusic, 1, 0, true);
+            var sheet = (MusicSheetItem)itemManager.Create(Item.SheetMusic, 1, 0, true);
             sheet.OwnerId = player.Id;
             sheet.MadeUnitId = player.Id;
             sheet.SongId = sud.Id;

--- a/AAEmu.Game/Core/Managers/NameManager.cs
+++ b/AAEmu.Game/Core/Managers/NameManager.cs
@@ -8,10 +8,10 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public partial class NameManager(CharacterManager characterManager = null) : Singleton<NameManager>, INameManager
+public partial class NameManager(ICharacterManager characterManager = null) : Singleton<NameManager>, INameManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
-    private readonly CharacterManager _characterManager = characterManager ?? CharacterManager.Instance;
+    private readonly ICharacterManager _characterManager = characterManager;
     private Regex _characterNameRegex;
     private Dictionary<uint, string> _characterIds = [];
     private Dictionary<string, uint> _characterNames = [];

--- a/AAEmu.Game/Core/Managers/NameManager.cs
+++ b/AAEmu.Game/Core/Managers/NameManager.cs
@@ -8,7 +8,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public partial class NameManager(CharacterManager characterManager = null) : Singleton<NameManager>
+public partial class NameManager(CharacterManager characterManager = null) : Singleton<NameManager>, INameManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private readonly CharacterManager _characterManager = characterManager ?? CharacterManager.Instance;

--- a/AAEmu.Game/Core/Managers/NameManager.cs
+++ b/AAEmu.Game/Core/Managers/NameManager.cs
@@ -8,10 +8,9 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public partial class NameManager(ICharacterManager characterManager = null) : Singleton<NameManager>, INameManager
+public partial class NameManager(Lazy<ICharacterManager> characterManager = null) : Singleton<NameManager>, INameManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
-    private readonly ICharacterManager _characterManager = characterManager;
     private Regex _characterNameRegex;
     private Dictionary<uint, string> _characterIds = [];
     private Dictionary<string, uint> _characterNames = [];
@@ -102,7 +101,7 @@ public partial class NameManager(ICharacterManager characterManager = null) : Si
     {
         if (_characterNames.TryGetValue(name, out var existingId))
         {
-            if (_characterManager.IsCharacterPendingDeletion(name))
+            if (characterManager?.Value.IsCharacterPendingDeletion(name) == true)
                 return CharacterCreateError.Failed;
 
             return CharacterCreateError.NameAlreadyExists;

--- a/AAEmu.Game/Core/Managers/PlotManager.cs
+++ b/AAEmu.Game/Core/Managers/PlotManager.cs
@@ -7,7 +7,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class PlotManager : Singleton<PlotManager>
+public class PlotManager : Singleton<PlotManager>, IPlotManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private bool _loaded = false;

--- a/AAEmu.Game/Core/Managers/PortalManager.cs
+++ b/AAEmu.Game/Core/Managers/PortalManager.cs
@@ -26,7 +26,7 @@ using Portal = AAEmu.Game.Models.Game.Portal;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class PortalManager : Singleton<PortalManager>, IPortalManager
+public class PortalManager(ILocalizationManager localizationManager, IWorldManager worldManager, IZoneManager zoneManager, INpcManager npcManager, IObjectIdManager objectIdManager, ITaskManager taskManager) : Singleton<PortalManager>, IPortalManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
@@ -143,7 +143,7 @@ public class PortalManager : Singleton<PortalManager>, IPortalManager
         if (JsonHelper.TryDeserializeObject(contents, out List<Portal> recalls, out _))
             foreach (var recall in recalls)
             {
-                recall.Name = LocalizationManager.Instance.Get("return_points", "name", recall.Id, recall.Name);
+                recall.Name = localizationManager.Get("return_points", "name", recall.Id, recall.Name);
 
                 var rp = new List<Portal>();
                 if (!_recalls.TryGetValue(recall.SubZoneId, out var value))
@@ -182,7 +182,7 @@ public class PortalManager : Singleton<PortalManager>, IPortalManager
         if (JsonHelper.TryDeserializeObject(contents, out List<Portal> respawns, out _))
             foreach (var respawn in respawns)
             {
-                respawn.ZoneId = WorldManager.Instance.GetZoneId(WorldManager.Instance.GetWorldTemplateByName("main_world"), respawn.X, respawn.Y);
+                respawn.ZoneId = worldManager.GetZoneId(worldManager.GetWorldTemplateByName("main_world"), respawn.X, respawn.Y);
                 if (_respawns.ContainsKey(respawn.SubZoneId))
                 {
                     //
@@ -291,8 +291,8 @@ public class PortalManager : Singleton<PortalManager>, IPortalManager
 
     private bool CheckCanOpenPortal(Character owner, uint targetZoneId)
     {
-        var targetContinent = ZoneManager.Instance.GetTargetIdByZoneId(targetZoneId);
-        var ownerContinent = ZoneManager.Instance.GetTargetIdByZoneId(owner.Transform.ZoneId);
+        var targetContinent = zoneManager.GetTargetIdByZoneId(targetZoneId);
+        var ownerContinent = zoneManager.GetTargetIdByZoneId(owner.Transform.ZoneId);
 
         if (targetContinent == ownerContinent)
         {
@@ -319,7 +319,7 @@ public class PortalManager : Singleton<PortalManager>, IPortalManager
     /// <param name="portalInfo"></param>
     /// <param name="portalEffectObj"></param>
     /// <returns></returns>
-    private static Models.Game.Units.Portal MakePortal(Unit owner, bool isExit, Portal portalInfo, SkillObjectUnk1 portalEffectObj)
+    private Models.Game.Units.Portal MakePortal(Unit owner, bool isExit, Portal portalInfo, SkillObjectUnk1 portalEffectObj)
     {
         // 3891 - Portal Entrance
         // 6949 - Portal Exit
@@ -331,11 +331,11 @@ public class PortalManager : Singleton<PortalManager>, IPortalManager
 
         // TODO: Add support for different types of teleport books
         var templateId = isExit ? 6949u : 3891u;
-        var template = NpcManager.Instance.GetTemplate(templateId);
+        var template = npcManager.GetTemplate(templateId);
         var portalNpc = new Models.Game.Units.Portal
         {
             ParentWorld = owner.ParentWorld,
-            ObjId = ObjectIdManager.Instance.GetNextId(),
+            ObjId = objectIdManager.GetNextId(),
             OwnerId = ((Character)owner).Id,
             TemplateId = templateId,
             Template = template,
@@ -368,7 +368,7 @@ public class PortalManager : Singleton<PortalManager>, IPortalManager
         portalNpc.Spawn();
 
         var killTask = new KillPortalTask(portalNpc);
-        TaskManager.Instance.Schedule(killTask, TimeSpan.FromSeconds(30));
+        taskManager.Schedule(killTask, TimeSpan.FromSeconds(30));
         return portalNpc;
     }
 
@@ -465,7 +465,7 @@ public class PortalManager : Singleton<PortalManager>, IPortalManager
             // Check if it's a closed zone (for non-admins)
             if (character is { AccessLevel: < 100 })
             {
-                var zone = ZoneManager.Instance.GetZoneByKey(value.ZoneId);
+                var zone = zoneManager.GetZoneByKey(value.ZoneId);
                 if (zone is null or { Closed: true })
                 {
                     continue;

--- a/AAEmu.Game/Core/Managers/PortalManager.cs
+++ b/AAEmu.Game/Core/Managers/PortalManager.cs
@@ -26,7 +26,7 @@ using Portal = AAEmu.Game.Models.Game.Portal;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class PortalManager : Singleton<PortalManager>
+public class PortalManager : Singleton<PortalManager>, IPortalManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 

--- a/AAEmu.Game/Core/Managers/PublicFarmManager.cs
+++ b/AAEmu.Game/Core/Managers/PublicFarmManager.cs
@@ -13,7 +13,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class PublicFarmManager : Singleton<PublicFarmManager>
+public class PublicFarmManager : Singleton<PublicFarmManager>, IPublicFarmManager
 {
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 

--- a/AAEmu.Game/Core/Managers/PublicFarmManager.cs
+++ b/AAEmu.Game/Core/Managers/PublicFarmManager.cs
@@ -13,7 +13,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class PublicFarmManager : Singleton<PublicFarmManager>, IPublicFarmManager
+public class PublicFarmManager(ITaskManager taskManager, IWorldManager worldManager, ISubZoneManager subZoneManager) : Singleton<PublicFarmManager>, IPublicFarmManager
 {
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
@@ -30,13 +30,13 @@ public class PublicFarmManager : Singleton<PublicFarmManager>, IPublicFarmManage
         Logger.Info("PublicFarmTickTask: Started");
 
         var lpTickStartTask = new PublicFarmTickStartTask();
-        TaskManager.Instance.Schedule(lpTickStartTask, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
+        taskManager.Schedule(lpTickStartTask, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
     }
 
     public void PublicFarmTick()
     {
         // NOTE: Public farms only available in main_world
-        var world = WorldManager.Instance.GetWorld(WorldManager.DefaultInstanceId);
+        var world = worldManager.GetWorld(WorldManager.DefaultInstanceId);
         var deleted = new List<Doodad>();
         foreach (var doodad in world.SpawnManager?.GetAllPlayerDoodads() ?? [])
         {
@@ -61,13 +61,13 @@ public class PublicFarmManager : Singleton<PublicFarmManager>, IPublicFarmManage
 
     public bool InPublicFarm(WorldTemplate worldTemplate, Vector3 pos)
     {
-        var subZoneList = SubZoneManager.Instance.GetSubZoneByPosition(worldTemplate, pos);
+        var subZoneList = subZoneManager.GetSubZoneByPosition(worldTemplate, pos);
         return subZoneList.Count > 0 && subZoneList.Any(subZoneId => _farmZones.ContainsKey(subZoneId));
     }
 
     private uint GetFarmId(WorldInstance world, Vector3 pos)
     {
-        var subZoneList = SubZoneManager.Instance.GetSubZoneByPosition(world.Template, pos);
+        var subZoneList = subZoneManager.GetSubZoneByPosition(world.Template, pos);
 
         return subZoneList.Count > 0 ? subZoneList.FirstOrDefault(subZoneId => _farmZones.ContainsKey(subZoneId)) : 0;
     }

--- a/AAEmu.Game/Core/Managers/QuestManager.cs
+++ b/AAEmu.Game/Core/Managers/QuestManager.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 
 using AAEmu.Commons.Utils;
+using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game.AI.Enums;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Quests;
@@ -21,7 +22,7 @@ using QuestNpcAiName = AAEmu.Game.Models.Game.Quests.Static.QuestNpcAiName;
 
 namespace AAEmu.Game.Core.Managers;
 
-public partial class QuestManager : Singleton<QuestManager>, IQuestManager
+public partial class QuestManager(ITaskManager taskManager, IZoneManager zoneManager) : Singleton<QuestManager>, IQuestManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private bool _loaded;
@@ -145,7 +146,7 @@ public partial class QuestManager : Singleton<QuestManager>, IQuestManager
             Logger.Info($"EnqueueEvaluation, {quest.Owner.Name} ({quest.Owner.Id}), Quest {quest.TemplateId}");
 
             if (needNewTask)
-                TaskManager.Instance.Schedule(new QuestManagerRunQueueTask(), null, TimeSpan.FromMilliseconds(1));
+                taskManager.Schedule(new QuestManagerRunQueueTask(), null, TimeSpan.FromMilliseconds(1));
         }
     }
 
@@ -259,7 +260,7 @@ public partial class QuestManager : Singleton<QuestManager>, IQuestManager
         // Start daily reset task
         var dailyCron = "0 0 0 */1 * *"; // Crontab
         // TODO: Make sure it obeys server time settings
-        TaskManager.Instance.CronSchedule(new QuestDailyResetTask(), dailyCron);
+        taskManager.CronSchedule(new QuestDailyResetTask(), dailyCron);
     }
 
     /// <summary>
@@ -1955,7 +1956,7 @@ public partial class QuestManager : Singleton<QuestManager>, IQuestManager
         playerTimerTasks.Add(quest.TemplateId, timeoutTask);
 
         // Actually schedule the task
-        TaskManager.Instance.Schedule(timeoutTask, TimeSpan.FromMilliseconds(limitTime));
+        taskManager.Schedule(timeoutTask, TimeSpan.FromMilliseconds(limitTime));
         owner.SendDebugMessage($"[Quest] Quest ({quest.Id}) will end in {limitTime / 60000} minutes.");
         return true;
     }

--- a/AAEmu.Game/Core/Managers/QuestManagerEvents.cs
+++ b/AAEmu.Game/Core/Managers/QuestManagerEvents.cs
@@ -1,5 +1,4 @@
 ﻿using System.Numerics;
-using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Quests.Acts;
@@ -172,7 +171,7 @@ public partial class QuestManager
         if (npc == null)
             return;
 
-        var npcZoneGroupId = ZoneManager.Instance.GetZoneByKey(npc.Transform.ZoneId)?.GroupId ?? 0;
+        var npcZoneGroupId = zoneManager.GetZoneByKey(npc.Transform.ZoneId)?.GroupId ?? 0;
 
         // Individual monster kill
         owner.Events?.OnMonsterHunt(owner, new OnMonsterHuntArgs

--- a/AAEmu.Game/Core/Managers/RadarManager.cs
+++ b/AAEmu.Game/Core/Managers/RadarManager.cs
@@ -11,7 +11,7 @@ using AAEmu.Game.Utils;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class RadarManager : Singleton<RadarManager>
+public class RadarManager : Singleton<RadarManager>, IRadarManager
 {
     private int RadarUpdateDelay { get => 1000; }
     private static object Lock { get; } = new();

--- a/AAEmu.Game/Core/Managers/SaveManager.cs
+++ b/AAEmu.Game/Core/Managers/SaveManager.cs
@@ -11,7 +11,13 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class SaveManager : Singleton<SaveManager>, ISaveManager
+public class SaveManager(
+    ITaskManager taskManager,
+    IHousingManager housingManager,
+    IMailManager mailManager,
+    IItemManager itemManager,
+    IAuctionManager auctionManager,
+    IWorldManager worldManager) : Singleton<SaveManager>, ISaveManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
@@ -50,7 +56,7 @@ public class SaveManager : Singleton<SaveManager>, ISaveManager
     {
         // Logger.Warn("SaveTickStart: Started");
         saveTask = new SaveTickStartTask();
-        TaskManager.Instance.Schedule(saveTask, TimeSpan.FromMinutes(Delay), TimeSpan.FromMinutes(Delay));
+        taskManager.Schedule(saveTask, TimeSpan.FromMinutes(Delay), TimeSpan.FromMinutes(Delay));
     }
 
     public bool DoSave()
@@ -72,17 +78,17 @@ public class SaveManager : Singleton<SaveManager>, ISaveManager
                     using (var transaction = connection.BeginTransaction())
                     {
                         // Houses
-                        var savedHouses = HousingManager.Instance.Save(connection, transaction);
+                        var savedHouses = housingManager.Save(connection, transaction);
                         // Mail
-                        var savedMails = MailManager.Instance.Save(connection, transaction);
+                        var savedMails = mailManager.Save(connection, transaction);
                         // Items
-                        var saveItems = ItemManager.Instance.Save(connection, transaction);
+                        var saveItems = itemManager.Save(connection, transaction);
                         //Auction House
-                        var savedAuctionHouse = AuctionManager.Instance.Save(connection, transaction);
+                        var savedAuctionHouse = auctionManager.Save(connection, transaction);
 
                         // Characters
                         var savedCharacters = 0;
-                        foreach (var c in WorldManager.Instance.GetAllCharacters())
+                        foreach (var c in worldManager.GetAllCharacters())
                         {
                             if (c.Save(connection, transaction))
                                 savedCharacters++;
@@ -92,7 +98,7 @@ public class SaveManager : Singleton<SaveManager>, ISaveManager
 
                         // Slaves
                         var savedSlaves = 0;
-                        foreach (var worldInstance in WorldManager.Instance.GetWorlds())
+                        foreach (var worldInstance in worldManager.GetWorlds())
                         {
                             foreach (var slave in worldInstance.GetAllSlaves())
                             {

--- a/AAEmu.Game/Core/Managers/SaveManager.cs
+++ b/AAEmu.Game/Core/Managers/SaveManager.cs
@@ -11,7 +11,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class SaveManager : Singleton<SaveManager>
+public class SaveManager : Singleton<SaveManager>, ISaveManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 

--- a/AAEmu.Game/Core/Managers/ShipyardManager.cs
+++ b/AAEmu.Game/Core/Managers/ShipyardManager.cs
@@ -15,7 +15,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class ShipyardManager : Singleton<ShipyardManager>, IShipyardManager
+public class ShipyardManager(ITaskManager taskManager, IObjectIdManager objectIdManager, IShipyardIdManager shipyardIdManager, IWorldManager worldManager, ITaxationsManager taxationsManager, ISkillManager skillManager) : Singleton<ShipyardManager>, IShipyardManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
@@ -32,12 +32,12 @@ public class ShipyardManager : Singleton<ShipyardManager>, IShipyardManager
         ShipyardTickStart();
     }
 
-    private static void ShipyardTickStart()
+    private void ShipyardTickStart()
     {
         Logger.Warn("ShipyardUpdateInfoTick: Started");
 
         var shipyardTickStartTask = new ShipyardTickTask();
-        TaskManager.Instance.Schedule(shipyardTickStartTask, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
+        taskManager.Schedule(shipyardTickStartTask, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
     }
 
     public Shipyard Create(Character owner, ShipyardData shipyardData)
@@ -51,8 +51,8 @@ public class ShipyardManager : Singleton<ShipyardManager>, IShipyardManager
         pos.Z = shipyardData.Z;
         pos.Yaw = shipyardData.zRot;
 
-        var objId = ObjectIdManager.Instance.GetNextId();
-        var shipId = ShipyardIdManager.Instance.GetNextId();
+        var objId = objectIdManager.GetNextId();
+        var shipId = shipyardIdManager.GetNextId();
         var shipyard = new Shipyard
         {
             Transform = { InstanceId = owner.ParentWorld.Id }, TemplateId = shipyardData.TemplateId, // duplicate Id
@@ -96,11 +96,11 @@ public class ShipyardManager : Singleton<ShipyardManager>, IShipyardManager
         return shipyard;
     }
 
-    private static bool RemoveRequiredItems(Shipyard shipyard)
+    private bool RemoveRequiredItems(Shipyard shipyard)
     {
-        var character = WorldManager.Instance.GetCharacter(shipyard.ShipyardData.OwnerName);
+        var character = worldManager.GetCharacter(shipyard.ShipyardData.OwnerName);
         var designId = shipyard.Template.OriginItemId;
-        var moneyOwed = TaxationsManager.Instance.taxations[(uint)shipyard.Template.TaxationId].Tax;
+        var moneyOwed = taxationsManager.Taxations[(uint)shipyard.Template.TaxationId].Tax;
 
         if (!character.Inventory.CheckItems(SlotType.Inventory, designId, 1))
         {
@@ -120,8 +120,8 @@ public class ShipyardManager : Singleton<ShipyardManager>, IShipyardManager
         {
             return false;
         }
-        var reagents = SkillManager.Instance.GetSkillReagentsBySkillId(foundItems[0].Template.UseSkillId);
-        var skillProducts = SkillManager.Instance.GetSkillProductsBySkillId(foundItems[0].Template.UseSkillId);
+        var reagents = skillManager.GetSkillReagentsBySkillId(foundItems[0].Template.UseSkillId);
+        var skillProducts = skillManager.GetSkillProductsBySkillId(foundItems[0].Template.UseSkillId);
         if (reagents != null && skillProducts != null)
         {
             if (reagents.Count > 0)
@@ -174,14 +174,14 @@ public class ShipyardManager : Singleton<ShipyardManager>, IShipyardManager
         // Remove Shipyard from Shipyard tables
         _removedShipyards.Add(shipId);
         _shipyard.Remove(shipId);
-        ShipyardIdManager.Instance.ReleaseId(shipId);
-        ObjectIdManager.Instance.ReleaseId(shipyard.ObjId);
+        shipyardIdManager.ReleaseId(shipId);
+        objectIdManager.ReleaseId(shipyard.ObjId);
         shipyard.Delete();
     }
 
     public void ShipyardCompleted(Shipyard shipyard)
     {
-        var character = WorldManager.Instance.GetCharacter(shipyard.ShipyardData.OwnerName);
+        var character = worldManager.GetCharacter(shipyard.ShipyardData.OwnerName);
         var found = character.Inventory.Bag.GetAllItemsByTemplate(shipyard.Template.ItemId, -1, out var foundItems, out _);
         if (found)
         {
@@ -193,9 +193,9 @@ public class ShipyardManager : Singleton<ShipyardManager>, IShipyardManager
         RemoveShipyard(shipyard);
     }
 
-    public static void ShipyardCompletedTask(Shipyard shipyard)
+    public void ShipyardCompletedTask(Shipyard shipyard)
     {
-        var character = WorldManager.Instance.GetCharacter(shipyard.ShipyardData.OwnerName);
+        var character = worldManager.GetCharacter(shipyard.ShipyardData.OwnerName);
         character.Inventory.Bag.AcquireDefaultItem(ItemTaskType.Shipyard, shipyard.Template.ItemId, 1, 0);
         var shipyardCompleteTask = new ShipyardCompleteTask { _shipyard = shipyard };
 
@@ -203,7 +203,7 @@ public class ShipyardManager : Singleton<ShipyardManager>, IShipyardManager
         character.BroadcastPacket(new SCShipyardStatePacket(shipyard.ShipyardData), true);
 
         var animTime = shipyard.Template.CeremonyAnimTime;
-        TaskManager.Instance.Schedule(shipyardCompleteTask, TimeSpan.FromMilliseconds(animTime));
+        taskManager.Schedule(shipyardCompleteTask, TimeSpan.FromMilliseconds(animTime));
     }
 
     public void ShipyardTick()
@@ -214,7 +214,7 @@ public class ShipyardManager : Singleton<ShipyardManager>, IShipyardManager
         }
     }
 
-    private static void UpdateShipyardInfo(Shipyard shipyard)
+    private void UpdateShipyardInfo(Shipyard shipyard)
     {
         var isDecaying = DateTime.UtcNow >= shipyard.ShipyardData.Spawned.AddDays(3);
 
@@ -222,7 +222,7 @@ public class ShipyardManager : Singleton<ShipyardManager>, IShipyardManager
         SetDecayBuff(shipyard, isDecaying);
     }
 
-    private static void SetProtectionBuff(Shipyard shipyard, bool isDecay)
+    private void SetProtectionBuff(Shipyard shipyard, bool isDecay)
     {
         if (!isDecay)
         {
@@ -234,7 +234,7 @@ public class ShipyardManager : Singleton<ShipyardManager>, IShipyardManager
             if (shipyard.Buffs.CheckBuff((uint)BuffConstants.TaxProtection))
                 return;
 
-            var protectionBuffTemplate = SkillManager.Instance.GetBuffTemplate((uint)BuffConstants.TaxProtection);
+            var protectionBuffTemplate = skillManager.GetBuffTemplate((uint)BuffConstants.TaxProtection);
             if (protectionBuffTemplate != null)
             {
                 var casterObj = new SkillCasterUnit(shipyard.ObjId);
@@ -252,21 +252,21 @@ public class ShipyardManager : Singleton<ShipyardManager>, IShipyardManager
         }
     }
 
-    private static void SetDecayBuff(Shipyard shipyard, bool isDecay)
+    private void SetDecayBuff(Shipyard shipyard, bool isDecay)
     {
         if (isDecay)
         {
             if (shipyard.Buffs.CheckBuff((uint)BuffConstants.Deterioration))
             {
                 shipyard.ReduceCurrentHp(shipyard, 7);
-                var character = WorldManager.Instance.GetCharacter(shipyard.ShipyardData.OwnerName);
+                var character = worldManager.GetCharacter(shipyard.ShipyardData.OwnerName);
                 character.SendPacket(new SCUnitStatePacket(shipyard));
                 character.SendPacket(new SCShipyardStatePacket(shipyard.ShipyardData));
 
                 return;
             }
 
-            var protectionBuffTemplate = SkillManager.Instance.GetBuffTemplate((uint)BuffConstants.Deterioration);
+            var protectionBuffTemplate = skillManager.GetBuffTemplate((uint)BuffConstants.Deterioration);
             if (protectionBuffTemplate != null)
             {
                 var casterObj = new SkillCasterUnit(shipyard.ObjId);

--- a/AAEmu.Game/Core/Managers/ShipyardManager.cs
+++ b/AAEmu.Game/Core/Managers/ShipyardManager.cs
@@ -15,7 +15,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class ShipyardManager : Singleton<ShipyardManager>
+public class ShipyardManager : Singleton<ShipyardManager>, IShipyardManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 

--- a/AAEmu.Game/Core/Managers/ShipyardManager.cs
+++ b/AAEmu.Game/Core/Managers/ShipyardManager.cs
@@ -19,15 +19,12 @@ public class ShipyardManager(ITaskManager taskManager, IObjectIdManager objectId
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
-    public Dictionary<uint, ShipyardsTemplate> _shipyardsTemplate;
-    private Dictionary<uint, Shipyard> _shipyard;
-    private List<uint> _removedShipyards;
+    public Dictionary<uint, ShipyardsTemplate> _shipyardsTemplate = [];
+    private Dictionary<uint, Shipyard> _shipyard = [];
+    private List<uint> _removedShipyards = [];
 
     public void Initialize()
     {
-        _shipyardsTemplate = [];
-        _shipyard = [];
-        _removedShipyards = [];
         Logger.Info("Initialising Shipyard Manager...");
         ShipyardTickStart();
     }

--- a/AAEmu.Game/Core/Managers/SkillManager.cs
+++ b/AAEmu.Game/Core/Managers/SkillManager.cs
@@ -17,7 +17,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class SkillManager : Singleton<SkillManager>, ISkillManager
+public class SkillManager(IAnimationManager animationManager, IPlotManager plotManager) : Singleton<SkillManager>, ISkillManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private bool _loaded = false;
@@ -336,7 +336,7 @@ public class SkillManager : Singleton<SkillManager>, ISkillManager
                         var template = new SkillTemplate
                         {
                             Id = reader.GetUInt32("id"), Cost = reader.GetInt32("cost"), Show = reader.GetBoolean("show", true),
-                            FireAnim = AnimationManager.Instance.GetAnimation(reader.GetUInt32("fire_anim_id", 0)),
+                            FireAnim = animationManager.GetAnimation(reader.GetUInt32("fire_anim_id", 0)),
                             AbilityId = (AbilityType)reader.GetByte("ability_id"),
                             ManaCost = reader.GetInt32("mana_cost"),
                             TimingId = reader.GetInt32("timing_id"),
@@ -398,7 +398,7 @@ public class SkillManager : Singleton<SkillManager>, ISkillManager
                         template.AllowToPrisoner = reader.GetBoolean("allow_to_prisoner", true);
                         template.MilestoneId = reader.GetUInt32("milestone_id", 0);
                         template.MatchAnimation = reader.GetBoolean("match_animation", true);
-                        template.Plot = reader.IsDBNull("plot_id") ? null : PlotManager.Instance.GetPlot(reader.GetUInt32("plot_id"));
+                        template.Plot = reader.IsDBNull("plot_id") ? null : plotManager.GetPlot(reader.GetUInt32("plot_id"));
                         template.UseAnimTime = reader.GetBoolean("use_anim_time", true);
                         template.ConsumeLaborPower = reader.GetInt32("consume_lp", 0);
                         template.SourceStun = reader.GetBoolean("source_stun", true);

--- a/AAEmu.Game/Core/Managers/Stream/IUccManager.cs
+++ b/AAEmu.Game/Core/Managers/Stream/IUccManager.cs
@@ -1,6 +1,10 @@
+using AAEmu.Game.Models.Game.Items;
+using AAEmu.Game.Models.Stream;
+
 namespace AAEmu.Game.Core.Managers.Stream;
 
 public interface IUccManager
 {
     void Load();
+    Ucc GetUccFromItem(Item item);
 }

--- a/AAEmu.Game/Core/Managers/Stream/IUccManager.cs
+++ b/AAEmu.Game/Core/Managers/Stream/IUccManager.cs
@@ -1,0 +1,6 @@
+namespace AAEmu.Game.Core.Managers.Stream;
+
+public interface IUccManager
+{
+    void Load();
+}

--- a/AAEmu.Game/Core/Managers/Stream/IUccManager.cs
+++ b/AAEmu.Game/Core/Managers/Stream/IUccManager.cs
@@ -3,8 +3,7 @@ using AAEmu.Game.Models.Stream;
 
 namespace AAEmu.Game.Core.Managers.Stream;
 
-public interface IUccManager
+public interface IUccManager : ILoadable
 {
-    void Load();
     Ucc GetUccFromItem(Item item);
 }

--- a/AAEmu.Game/Core/Managers/Stream/UccManager.cs
+++ b/AAEmu.Game/Core/Managers/Stream/UccManager.cs
@@ -16,7 +16,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers.Stream;
 
-public class UccManager : Singleton<UccManager>
+public class UccManager : Singleton<UccManager>, IUccManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private Dictionary<uint, Ucc> _uploadQueue;

--- a/AAEmu.Game/Core/Managers/SubZoneManager.cs
+++ b/AAEmu.Game/Core/Managers/SubZoneManager.cs
@@ -13,7 +13,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class SubZoneManager : Singleton<SubZoneManager>, ISubZoneManager
+public class SubZoneManager(IWorldManager worldManager, IZoneManager zoneManager) : Singleton<SubZoneManager>, ISubZoneManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
@@ -21,13 +21,13 @@ public class SubZoneManager : Singleton<SubZoneManager>, ISubZoneManager
     {
         #region LoadClientData
 
-        foreach (var world in WorldManager.Instance.GetWorlds())
+        foreach (var world in worldManager.GetWorlds())
         {
-            var zonesList = WorldManager.Instance.GetZoneKeysByWorldId(world.Id);
+            var zonesList = worldManager.GetZoneKeysByWorldId(world.Id);
 
             foreach (var zoneKey in zonesList)
             {
-                var zone = ZoneManager.Instance.GetZoneByKey(zoneKey);
+                var zone = zoneManager.GetZoneByKey(zoneKey);
                 var zoneId = zone.Id;
                 #region subzone
 
@@ -278,7 +278,7 @@ public class SubZoneManager : Singleton<SubZoneManager>, ISubZoneManager
 
     public List<uint> GetHousingZoneByPosition(WorldInstance world, float x, float y)
     {
-        var zoneId = WorldManager.Instance.GetZoneId(world.Template, x, y);
+        var zoneId = worldManager.GetZoneId(world.Template, x, y);
 
         var foundHousingZones = new List<uint>();
 
@@ -314,7 +314,7 @@ public class SubZoneManager : Singleton<SubZoneManager>, ISubZoneManager
 
     public List<uint> GetSubZoneByPosition(WorldTemplate worldTemplate, float x, float y)
     {
-        var zoneId = WorldManager.Instance.GetZoneId(worldTemplate, x, y);
+        var zoneId = worldManager.GetZoneId(worldTemplate, x, y);
 
         var foundSubzones = new List<uint>();
 

--- a/AAEmu.Game/Core/Managers/SubZoneManager.cs
+++ b/AAEmu.Game/Core/Managers/SubZoneManager.cs
@@ -13,7 +13,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class SubZoneManager : Singleton<SubZoneManager>
+public class SubZoneManager : Singleton<SubZoneManager>, ISubZoneManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 

--- a/AAEmu.Game/Core/Managers/SubZoneManager.cs
+++ b/AAEmu.Game/Core/Managers/SubZoneManager.cs
@@ -101,7 +101,7 @@ public class SubZoneManager(IWorldManager worldManager, IZoneManager zoneManager
                                         }
                                     }
 
-                                    var worldOrigins = ZoneManager.GetZoneOriginCell(zoneId);
+                                    var worldOrigins = ZoneManager.Instance.GetZoneOriginCell(zoneId);
 
                                     var cellOffset = new Point { X = (worldOrigins.X + cellXOffset) * 1024f, Y = (worldOrigins.Y + cellYOffset) * 1024f };
 
@@ -223,7 +223,7 @@ public class SubZoneManager(IWorldManager worldManager, IZoneManager zoneManager
                                         }
                                     }
 
-                                    var worldOrigins = ZoneManager.GetZoneOriginCell(zoneId);
+                                    var worldOrigins = ZoneManager.Instance.GetZoneOriginCell(zoneId);
 
                                     var cellOffset = new Point { X = (worldOrigins.X + cellXOffset) * 1024f, Y = (worldOrigins.Y + cellYOffset) * 1024f };
 

--- a/AAEmu.Game/Core/Managers/SusManager.cs
+++ b/AAEmu.Game/Core/Managers/SusManager.cs
@@ -8,7 +8,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class SusManager : Singleton<SusManager>, ISusManager
+public class SusManager(IWorldManager worldManager) : Singleton<SusManager>, ISusManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     public static string CategoryBot => "Bot";
@@ -138,7 +138,7 @@ public class SusManager : Singleton<SusManager>, ISusManager
             var observedSpeed = deltaFlatPos.Length() / deltaTime;
             // var playerCheckSpeed = 5.0 * character.BaseMoveSpeed * character.MoveSpeedMul * 3.0;
             var playerCheckSpeed = 27.5;
-            var petOwner = WorldManager.Instance.GetCharacterByObjId(pet.OwnerObjId);
+            var petOwner = worldManager.GetCharacterByObjId(pet.OwnerObjId);
             if (observedSpeed > playerCheckSpeed)
             {
                 last.skipTime = 15f;

--- a/AAEmu.Game/Core/Managers/SusManager.cs
+++ b/AAEmu.Game/Core/Managers/SusManager.cs
@@ -8,7 +8,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class SusManager : Singleton<SusManager>
+public class SusManager : Singleton<SusManager>, ISusManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     public static string CategoryBot => "Bot";

--- a/AAEmu.Game/Core/Managers/TaskManager2.cs
+++ b/AAEmu.Game/Core/Managers/TaskManager2.cs
@@ -8,7 +8,7 @@ using Task = AAEmu.Game.Models.Tasks.Task;
 namespace AAEmu.Game.Core.Managers;
 
 // ReSharper disable once ClassNeverInstantiated.Global
-public class TaskManager : Singleton<TaskManager>, ITaskManager
+public class TaskManager(ITickManager tickManager) : Singleton<TaskManager>, ITaskManager
 {
     private readonly ConcurrentDictionary<uint, Task> _queue = new();
     private readonly HashSet<uint> _taskIds = [];
@@ -24,7 +24,7 @@ public class TaskManager : Singleton<TaskManager>, ITaskManager
 
     public void Start()
     {
-        TickManager.Instance.OnTick.Subscribe(Tick, TimeSpan.FromMilliseconds(50), true);
+        tickManager.OnTick.Subscribe(Tick, TimeSpan.FromMilliseconds(50), true);
     }
 
     public void Stop()

--- a/AAEmu.Game/Core/Managers/TaxationsManager.cs
+++ b/AAEmu.Game/Core/Managers/TaxationsManager.cs
@@ -6,11 +6,12 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class TaxationsManager : Singleton<TaxationsManager>
+public class TaxationsManager : Singleton<TaxationsManager>, ITaxationsManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
     public Dictionary<uint, Taxation> taxations;
+    public Dictionary<uint, Taxation> Taxations => taxations;
 
     public void Load()
     {

--- a/AAEmu.Game/Core/Managers/TeamManager.cs
+++ b/AAEmu.Game/Core/Managers/TeamManager.cs
@@ -10,7 +10,7 @@ using AAEmu.Game.Models.Game.World.Transform;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class TeamManager : Singleton<TeamManager>
+public class TeamManager : Singleton<TeamManager>, ITeamManager
 {
     /*
      * TODO:

--- a/AAEmu.Game/Core/Managers/TeamManager.cs
+++ b/AAEmu.Game/Core/Managers/TeamManager.cs
@@ -10,7 +10,7 @@ using AAEmu.Game.Models.Game.World.Transform;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class TeamManager : Singleton<TeamManager>, ITeamManager
+public class TeamManager(IWorldManager worldManager, IChatManager chatManager, ITeamIdManager teamIdManager) : Singleton<TeamManager>, ITeamManager
 {
     /*
      * TODO:
@@ -84,7 +84,7 @@ public class TeamManager : Singleton<TeamManager>, ITeamManager
 
     public void AskToJoin(Character owner, string targetName, uint teamId, bool isParty, Character targetObj = null)
     {
-        var target = targetObj ?? WorldManager.Instance.GetCharacter(targetName);
+        var target = targetObj ?? worldManager.GetCharacter(targetName);
         if (target == null) return;
         // TODO - CONFIG INVITE DISABLED
 
@@ -190,20 +190,20 @@ public class TeamManager : Singleton<TeamManager>, ITeamManager
         var activeTeam = GetActiveTeam(teamId);
         if (activeTeam == null || activeTeam.OwnerId != owner.Id) return;
 
-        var t1 = WorldManager.Instance.GetCharacterById(targetId);
-        var t2 = WorldManager.Instance.GetCharacterById(target2Id);
+        var t1 = worldManager.GetCharacterById(targetId);
+        var t2 = worldManager.GetCharacterById(target2Id);
         if (t1 != null)
-            ChatManager.Instance.GetPartyChat(activeTeam, t1).LeaveChannel(t1);
+            chatManager.GetPartyChat(activeTeam, t1).LeaveChannel(t1);
         if (t2 != null)
-            ChatManager.Instance.GetPartyChat(activeTeam, t2).LeaveChannel(t2);
+            chatManager.GetPartyChat(activeTeam, t2).LeaveChannel(t2);
 
         if (activeTeam.MoveMember(targetId, target2Id, fromIndex, toIndex))
         {
             activeTeam.BroadcastPacket(new SCTeamMemberMovedPacket(teamId, targetId, target2Id, fromIndex, toIndex));
             if (t1 != null)
-                ChatManager.Instance.GetPartyChat(activeTeam, t1).JoinChannel(t1);
+                chatManager.GetPartyChat(activeTeam, t1).JoinChannel(t1);
             if (t2 != null)
-                ChatManager.Instance.GetPartyChat(activeTeam, t2).JoinChannel(t2);
+                chatManager.GetPartyChat(activeTeam, t2).JoinChannel(t2);
         }
     }
 
@@ -254,7 +254,7 @@ public class TeamManager : Singleton<TeamManager>, ITeamManager
 
         var newTeam = new Team
         {
-            Id = TeamIdManager.Instance.GetNextId(),
+            Id = teamIdManager.GetNextId(),
             OwnerId = activeInvitation.Owner.Id,
             IsParty = activeInvitation.IsParty
         };
@@ -269,11 +269,11 @@ public class TeamManager : Singleton<TeamManager>, ITeamManager
         newTeam.BroadcastPacket(new SCTeamPingPosPacket(true, activeInvitation.Owner.LocalPingPosition, 0));
         if (!newTeam.IsParty)
         {
-            ChatManager.Instance.GetRaidChat(newTeam).JoinChannel(activeInvitation.Owner);
-            ChatManager.Instance.GetRaidChat(newTeam).JoinChannel(activeInvitation.Target);
+            chatManager.GetRaidChat(newTeam).JoinChannel(activeInvitation.Owner);
+            chatManager.GetRaidChat(newTeam).JoinChannel(activeInvitation.Target);
         }
-        ChatManager.Instance.GetPartyChat(newTeam, activeInvitation.Owner).JoinChannel(activeInvitation.Owner);
-        ChatManager.Instance.GetPartyChat(newTeam, activeInvitation.Target).JoinChannel(activeInvitation.Target);
+        chatManager.GetPartyChat(newTeam, activeInvitation.Owner).JoinChannel(activeInvitation.Owner);
+        chatManager.GetPartyChat(newTeam, activeInvitation.Target).JoinChannel(activeInvitation.Target);
         // Trigger events
         activeInvitation.Owner.Events?.OnTeamJoin(activeInvitation, new OnTeamJoinArgs { Team = newTeam, Player = activeInvitation.Owner });
         activeInvitation.Target.Events?.OnTeamJoin(activeInvitation, new OnTeamJoinArgs { Team = newTeam, Player = activeInvitation.Target });
@@ -289,7 +289,7 @@ public class TeamManager : Singleton<TeamManager>, ITeamManager
 
         var newTeam = new Team
         {
-            Id = TeamIdManager.Instance.GetNextId(),
+            Id = teamIdManager.GetNextId(),
             OwnerId = character.Id,
             IsParty = true
         };
@@ -302,8 +302,8 @@ public class TeamManager : Singleton<TeamManager>, ITeamManager
         newTeam.BroadcastPacket(new SCTeamPingPosPacket(true, character.LocalPingPosition, 0));
 
         if (!newTeam.IsParty)
-            ChatManager.Instance.GetRaidChat(newTeam).JoinChannel(character);
-        ChatManager.Instance.GetPartyChat(newTeam, character).JoinChannel(character);
+            chatManager.GetRaidChat(newTeam).JoinChannel(character);
+        chatManager.GetPartyChat(newTeam, character).JoinChannel(character);
         // Trigger events
         character.Events?.OnTeamJoin(character, new OnTeamJoinArgs { Team = newTeam, Player = character });
     }
@@ -321,8 +321,8 @@ public class TeamManager : Singleton<TeamManager>, ITeamManager
 
         // Remove from ChatManager channels
         if (!activeTeam.IsParty)
-            ChatManager.Instance.GetRaidChat(activeTeam).LeaveChannel(unit);
-        ChatManager.Instance.GetPartyChat(activeTeam, unit).LeaveChannel(unit);
+            chatManager.GetRaidChat(activeTeam).LeaveChannel(unit);
+        chatManager.GetPartyChat(activeTeam, unit).LeaveChannel(unit);
 
         if ((riskyAction == RiskyAction.Leave || riskyAction == RiskyAction.Kick) && activeTeam.RemoveMember(targetId))
         {
@@ -346,7 +346,7 @@ public class TeamManager : Singleton<TeamManager>, ITeamManager
             // Send Leave info the team
             activeTeam.BroadcastPacket(new SCTeamMemberLeavedPacket(teamId, targetId, riskyAction == RiskyAction.Kick));
             // Find the target, and send its leave info
-            var target = WorldManager.Instance.GetCharacterById(targetId);
+            var target = worldManager.GetCharacterById(targetId);
             if (target != null)
             {
                 target.InParty = false;
@@ -374,8 +374,8 @@ public class TeamManager : Singleton<TeamManager>, ITeamManager
                 if (member?.Character != null)
                 {
                     if (!activeTeam.IsParty)
-                        ChatManager.Instance.GetRaidChat(activeTeam).LeaveChannel(member.Character);
-                    ChatManager.Instance.GetPartyChat(activeTeam, member.Character).LeaveChannel(member.Character);
+                        chatManager.GetRaidChat(activeTeam).LeaveChannel(member.Character);
+                    chatManager.GetPartyChat(activeTeam, member.Character).LeaveChannel(member.Character);
 
                     if (member.Character.IsOnline)
                     {
@@ -390,7 +390,7 @@ public class TeamManager : Singleton<TeamManager>, ITeamManager
             _activeTeams.Remove(teamId);
         }
         // TODO: Add this to a timer or trigger instead of calling on a party/raid disband. But is good enough and functional for now
-        ChatManager.Instance.CleanUpChannels();
+        chatManager.CleanUpChannels();
     }
 
     public void MakeTeamOwner(Character unit, uint teamId, uint memberId)
@@ -412,7 +412,7 @@ public class TeamManager : Singleton<TeamManager>, ITeamManager
         activeTeam.BroadcastPacket(new SCTeamBecameRaidTeamPacket(activeTeam.Id));
         foreach (var m in activeTeam.Members)
             if (m != null && m.Character != null)
-                ChatManager.Instance.GetRaidChat(activeTeam).JoinChannel(m.Character);
+                chatManager.GetRaidChat(activeTeam).JoinChannel(m.Character);
         // TODO: Handle raids in dungeons
     }
 
@@ -524,8 +524,8 @@ public class TeamManager : Singleton<TeamManager>, ITeamManager
             return;
         }
         if (!activeTeam.IsParty)
-            ChatManager.Instance.GetRaidChat(activeTeam).LeaveChannel(unit);
-        ChatManager.Instance.GetPartyChat(activeTeam, unit).LeaveChannel(unit);
+            chatManager.GetRaidChat(activeTeam).LeaveChannel(unit);
+        chatManager.GetPartyChat(activeTeam, unit).LeaveChannel(unit);
         AskRiskyTeam(source, activeTeam.Id, unit.Id, leaveType);
     }
 
@@ -552,8 +552,8 @@ public class TeamManager : Singleton<TeamManager>, ITeamManager
         activeTeam.BroadcastPacket(new SCTeamMemberJoinedPacket(activeTeam.Id, newInfo, Team.GetParty(activeTeam.GetIndex(unit.Id))));
         //activeTeam.BroadcastPacket(new SCRefreshTeamMemberPacket(activeTeam.Id, unit.Id, unit.ObjId));
         if (!activeTeam.IsParty)
-            ChatManager.Instance.GetRaidChat(activeTeam).JoinChannel(unit);
-        ChatManager.Instance.GetPartyChat(activeTeam, unit).JoinChannel(unit);
+            chatManager.GetRaidChat(activeTeam).JoinChannel(unit);
+        chatManager.GetPartyChat(activeTeam, unit).JoinChannel(unit);
     }
 
     public void Load()

--- a/AAEmu.Game/Core/Managers/TickManager.cs
+++ b/AAEmu.Game/Core/Managers/TickManager.cs
@@ -5,11 +5,11 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class TickManager : Singleton<TickManager>
+public class TickManager : Singleton<TickManager>, ITickManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     public delegate void OnTickEvent(TimeSpan delta);
-    public TickEventHandler OnTick = new();
+    public TickEventHandler OnTick { get; } = new();
     private bool DoTickLoop = true;
     private Thread TickThread;
 

--- a/AAEmu.Game/Core/Managers/TimeManager.cs
+++ b/AAEmu.Game/Core/Managers/TimeManager.cs
@@ -6,7 +6,7 @@ using AAEmu.Game.Models;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class TimeManager : Singleton<TimeManager>, IObservable<float>
+public class TimeManager : Singleton<TimeManager>, IObservable<float>, ITimeManager
 {
     private readonly List<IObserver<float>> _observers = [];
     private bool _work;

--- a/AAEmu.Game/Core/Managers/TimedRewardsManager.cs
+++ b/AAEmu.Game/Core/Managers/TimedRewardsManager.cs
@@ -9,7 +9,7 @@ namespace AAEmu.Game.Core.Managers;
 /// <summary>
 /// For timed adding credits and loyalty
 /// </summary>
-public class TimedRewardsManager : Singleton<TimedRewardsManager>
+public class TimedRewardsManager : Singleton<TimedRewardsManager>, ITimedRewardsManager
 {
     private const short MaxLabor = 2000;
     private const short MaxLaborPremium = 5000;

--- a/AAEmu.Game/Core/Managers/TradeManager.cs
+++ b/AAEmu.Game/Core/Managers/TradeManager.cs
@@ -24,7 +24,7 @@ public class TradeTemplate
     public int TargetMoneyPutup { get; set; }
 }
 
-public class TradeManager : Singleton<TradeManager>, ITradeManager
+public class TradeManager(ITradeIdManager tradeIdManager, IWorldManager worldManager) : Singleton<TradeManager>, ITradeManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private readonly Dictionary<uint, TradeTemplate> _trades = [];
@@ -78,7 +78,7 @@ public class TradeManager : Singleton<TradeManager>, ITradeManager
     {
         if (IsTrading(owner.ObjId) || IsTrading(target.ObjId)) return;
 
-        var nextId = TradeIdManager.Instance.GetNextId();
+        var nextId = tradeIdManager.GetNextId();
         var template = new TradeTemplate
         {
             Id = nextId,
@@ -107,12 +107,12 @@ public class TradeManager : Singleton<TradeManager>, ITradeManager
         tradeId = tradeId == 0 ? GetTradeId(objId) : tradeId;
         if (tradeId == 0)
         {
-            WorldManager.Instance.GetCharacterByObjId(objId)?.SendPacket(new SCTradeCanceledPacket(reason, true));
+            worldManager.GetCharacterByObjId(objId)?.SendPacket(new SCTradeCanceledPacket(reason, true));
             return;
         }
 
-        var owner = WorldManager.Instance.GetCharacterByObjId(_trades[tradeId].OwnerObjId);
-        var target = WorldManager.Instance.GetCharacterByObjId(_trades[tradeId].TargetObjId);
+        var owner = worldManager.GetCharacterByObjId(_trades[tradeId].OwnerObjId);
+        var target = worldManager.GetCharacterByObjId(_trades[tradeId].TargetObjId);
         _trades.Remove(tradeId);
 
         Logger.Info("Trade Id:{4} between {0}({1}) - {2}({3}) is canceled.", owner.Name, owner.ObjId, target.Name, target.ObjId, tradeId);
@@ -128,8 +128,8 @@ public class TradeManager : Singleton<TradeManager>, ITradeManager
         if (tradeId != 0 && item.Count >= amount)
         {
             var isOwnerWhoAdd = _trades[tradeId].OwnerObjId.Equals(character.ObjId);
-            var owner = WorldManager.Instance.GetCharacterByObjId(_trades[tradeId].OwnerObjId);
-            var target = WorldManager.Instance.GetCharacterByObjId(_trades[tradeId].TargetObjId);
+            var owner = worldManager.GetCharacterByObjId(_trades[tradeId].OwnerObjId);
+            var target = worldManager.GetCharacterByObjId(_trades[tradeId].TargetObjId);
             if (isOwnerWhoAdd)
             {
                 Logger.Info("Trade Id:{0} {1}({2}) added item ({3}-{4}) Amount: {5}.", tradeId, owner.Name, owner.ObjId, slotType, slot, amount);
@@ -160,8 +160,8 @@ public class TradeManager : Singleton<TradeManager>, ITradeManager
         if (tradeId != 0 && character.Money >= moneyAmount)
         {
             var isOwnerWhoAdd = _trades[tradeId].OwnerObjId.Equals(character.ObjId);
-            var owner = WorldManager.Instance.GetCharacterByObjId(_trades[tradeId].OwnerObjId);
-            var target = WorldManager.Instance.GetCharacterByObjId(_trades[tradeId].TargetObjId);
+            var owner = worldManager.GetCharacterByObjId(_trades[tradeId].OwnerObjId);
+            var target = worldManager.GetCharacterByObjId(_trades[tradeId].TargetObjId);
             if (isOwnerWhoAdd)
             {
                 Logger.Info("Trade Id:{0} {1}({2}) changed Money: {3}.", tradeId, owner.Name, owner.ObjId, moneyAmount);
@@ -193,8 +193,8 @@ public class TradeManager : Singleton<TradeManager>, ITradeManager
         if (tradeId != 0 && item != null)
         {
             var isOwnerWhoAdd = _trades[tradeId].OwnerObjId.Equals(character.ObjId);
-            var owner = WorldManager.Instance.GetCharacterByObjId(_trades[tradeId].OwnerObjId);
-            var target = WorldManager.Instance.GetCharacterByObjId(_trades[tradeId].TargetObjId);
+            var owner = worldManager.GetCharacterByObjId(_trades[tradeId].OwnerObjId);
+            var target = worldManager.GetCharacterByObjId(_trades[tradeId].TargetObjId);
             if (isOwnerWhoAdd)
             {
                 Logger.Info("Trade Id:{0} {1}({2}) tookdown item ({3}-{4}).", tradeId, owner.Name, owner.ObjId, slotType, slot);
@@ -232,8 +232,8 @@ public class TradeManager : Singleton<TradeManager>, ITradeManager
             if (isOwnerWhoAdd && _trades[tradeId].LockOwner && _lock) return;
             if (!isOwnerWhoAdd && _trades[tradeId].LockTarget && _lock) return;
 
-            var owner = WorldManager.Instance.GetCharacterByObjId(_trades[tradeId].OwnerObjId);
-            var target = WorldManager.Instance.GetCharacterByObjId(_trades[tradeId].TargetObjId);
+            var owner = worldManager.GetCharacterByObjId(_trades[tradeId].OwnerObjId);
+            var target = worldManager.GetCharacterByObjId(_trades[tradeId].TargetObjId);
 
             if (!_lock)
             {
@@ -271,8 +271,8 @@ public class TradeManager : Singleton<TradeManager>, ITradeManager
             // Check if both locked
             if (!_trades[tradeId].LockOwner && !_trades[tradeId].LockTarget) return;
 
-            var owner = WorldManager.Instance.GetCharacterByObjId(_trades[tradeId].OwnerObjId);
-            var target = WorldManager.Instance.GetCharacterByObjId(_trades[tradeId].TargetObjId);
+            var owner = worldManager.GetCharacterByObjId(_trades[tradeId].OwnerObjId);
+            var target = worldManager.GetCharacterByObjId(_trades[tradeId].TargetObjId);
 
             if (isOwnerWhoAdd)
             {

--- a/AAEmu.Game/Core/Managers/TradeManager.cs
+++ b/AAEmu.Game/Core/Managers/TradeManager.cs
@@ -24,7 +24,7 @@ public class TradeTemplate
     public int TargetMoneyPutup { get; set; }
 }
 
-public class TradeManager : Singleton<TradeManager>
+public class TradeManager : Singleton<TradeManager>, ITradeManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private readonly Dictionary<uint, TradeTemplate> _trades = [];

--- a/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
@@ -28,7 +28,18 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers.UnitManagers;
 
-public class CharacterManager : Singleton<CharacterManager>, ICharacterManager
+public class CharacterManager(
+    IWorldManager worldManager,
+    IAccountManager accountManager,
+    INameManager nameManager,
+    ICharacterIdManager characterIdManager,
+    IFactionManager factionManager,
+    ISkillManager skillManager,
+    IItemManager itemManager,
+    IHousingManager housingManager,
+    IFamilyManager familyManager,
+    IMailManager mailManager,
+    ITaskManager taskManager) : Singleton<CharacterManager>, ICharacterManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
@@ -389,7 +400,7 @@ public class CharacterManager : Singleton<CharacterManager>, ICharacterManager
                 var point = charTemplate.Pos.Clone();
                 // Recalculate ZoneId as this isn't included in the config
                 // Always use main_world Id for this
-                point.ZoneId = WorldManager.Instance.GetZoneId(WorldManager.Instance.GetWorldTemplateByName("main_world"), charTemplate.Pos.X, charTemplate.Pos.Y);
+                point.ZoneId = worldManager.GetZoneId(worldManager.GetWorldTemplateByName("main_world"), charTemplate.Pos.X, charTemplate.Pos.Y);
                 // Convert the json's degrees to rads
                 point.Roll = point.Roll.DegToRad();
                 point.Pitch = point.Pitch.DegToRad();
@@ -416,7 +427,7 @@ public class CharacterManager : Singleton<CharacterManager>, ICharacterManager
         Logger.Info("Loaded {0} character templates", _templates.Count);
     }
 
-    public static void PlayerRoll(Character player, int max)
+    public void PlayerRoll(Character player, int max)
     {
         var roll = Random.Shared.Next(1, max);
         player.BroadcastPacket(new SCChatMessagePacket(ChatType.System, $"{player.Name} rolled {roll}."), true);
@@ -424,14 +435,14 @@ public class CharacterManager : Singleton<CharacterManager>, ICharacterManager
 
     public int GetEffectiveAccessLevel(Character character)
     {
-        var accountDetails = AccountManager.Instance.GetAccountDetails(character.AccountId);
+        var accountDetails = accountManager.GetAccountDetails(character.AccountId);
         return Math.Max(character.AccessLevel, accountDetails.AccessLevel);
     }
 
     public void Create(GameConnection connection, string name, Race race, Gender gender, uint[] bodyItems, UnitCustomModelParams customModel, AbilityType ability1, AbilityType ability2, AbilityType ability3, byte level)
     {
         name = name.NormalizeName();
-        var nameValidationCode = NameManager.Instance.ValidateCharacterName(name);
+        var nameValidationCode = nameManager.ValidateCharacterName(name);
         if (nameValidationCode != CharacterCreateError.Ok)
         {
             connection.SendPacket(new SCCharacterCreationFailedPacket(nameValidationCode));
@@ -445,17 +456,17 @@ public class CharacterManager : Singleton<CharacterManager>, ICharacterManager
             Logger.Error($"User tried to make a new character that has 2nd and/or 3rd ability already set. Account {connection.AccountId}, Name {name}, Class {ability1}, {ability2}, {ability3}");
         }
 
-        var accountDetails = AccountManager.Instance.GetAccountDetails(connection.AccountId);
+        var accountDetails = accountManager.GetAccountDetails(connection.AccountId);
 
         // Get default access level for all users 
         var useAccessLevel = AppConfiguration.Instance.Account.AccessLevelDefault;
 
         // If it's the first character created, use first character access level settings 
-        if (NameManager.Instance.NoNamesRegistered())
+        if (nameManager.NoNamesRegistered())
             useAccessLevel = Math.Max(AppConfiguration.Instance.Account.AccessLevelFirstCharacter, useAccessLevel);
 
-        var characterId = CharacterIdManager.Instance.GetNextId();
-        NameManager.Instance.AddCharacter(characterId, name, connection.AccountId);
+        var characterId = characterIdManager.GetNextId();
+        nameManager.AddCharacter(characterId, name, connection.AccountId);
         var template = GetTemplate(race, gender);
 
         var character = new Character(customModel)
@@ -466,7 +477,7 @@ public class CharacterManager : Singleton<CharacterManager>, ICharacterManager
         };
         character.Transform.ApplyWorldSpawnPosition(template.SpawnPosition);
         character.Level = level;
-        character.Faction = FactionManager.Instance.GetFaction(template.FactionId);
+        character.Faction = factionManager.GetFaction(template.FactionId);
         character.FactionName = "";
         character.AccessLevel = useAccessLevel;
         // character.LaborPower = (short)AppConfiguration.Instance.Labor.Default;
@@ -514,7 +525,7 @@ public class CharacterManager : Singleton<CharacterManager>, ICharacterManager
         foreach (var item in items.Supplies)
         {
             character.Inventory.Bag.AcquireDefaultItem(ItemTaskType.Invalid, item.Id, item.Amount, item.Grade);
-            //var createdItem = ItemManager.Instance.Create(item.Id, item.Amount, item.Grade);
+            //var createdItem = itemManager.Create(item.Id, item.Amount, item.Grade);
             //character.Inventory.AddItem(Models.Game.Items.Actions.ItemTaskType.Invalid, createdItem);
 
             character.SetAction(slot, ActionSlotType.ItemType, item.Id);
@@ -526,7 +537,7 @@ public class CharacterManager : Singleton<CharacterManager>, ICharacterManager
             foreach (var item in items.Supplies)
             {
                 character.Inventory.Bag.AcquireDefaultItem(ItemTaskType.Invalid, item.Id, item.Amount, item.Grade);
-                //var createdItem = ItemManager.Instance.Create(item.Id, item.Amount, item.Grade);
+                //var createdItem = itemManager.Create(item.Id, item.Amount, item.Grade);
                 //character.Inventory.AddItem(ItemTaskType.Invalid, createdItem);
 
                 character.SetAction(slot, ActionSlotType.ItemType, item.Id);
@@ -541,7 +552,7 @@ public class CharacterManager : Singleton<CharacterManager>, ICharacterManager
             character.Actability.Actabilities.Add(id, new Actability(actabilityTemplate));
 
         character.Skills = new CharacterSkills(character);
-        foreach (var skill in SkillManager.Instance.GetDefaultSkills())
+        foreach (var skill in skillManager.GetDefaultSkills())
         {
             if (!skill.AddToSlot)
                 continue;
@@ -551,7 +562,7 @@ public class CharacterManager : Singleton<CharacterManager>, ICharacterManager
         slot = 1;
         while (character.Slots[slot].Type != ActionSlotType.None)
             slot++;
-        foreach (var skill in SkillManager.Instance.GetStartAbilitySkills(character.Ability1))
+        foreach (var skill in skillManager.GetStartAbilitySkills(character.Ability1))
         {
             character.Skills.AddSkill(skill, 1, false);
             character.SetAction(slot, ActionSlotType.Spell, skill.Id);
@@ -578,8 +589,8 @@ public class CharacterManager : Singleton<CharacterManager>, ICharacterManager
             // There is no actual response for internal DB saving error for the client.
             // Just send a generic Failed error (Name already in use for pending deletion)
             connection.SendPacket(new SCCharacterCreationFailedPacket(CharacterCreateError.Failed));
-            CharacterIdManager.Instance.ReleaseId(characterId);
-            NameManager.Instance.RemoveCharacterId(characterId);
+            characterIdManager.ReleaseId(characterId);
+            nameManager.RemoveCharacterId(characterId);
             // TODO release items...
             DeleteCharacterAssets(character, true);
         }
@@ -590,11 +601,11 @@ public class CharacterManager : Singleton<CharacterManager>, ICharacterManager
     /// </summary>
     /// <param name="character">Character to delete assets from</param>
     /// <param name="fullWipe">Do owned items need to be actually deleted</param>
-    public static void DeleteCharacterAssets(Character character, bool fullWipe)
+    public void DeleteCharacterAssets(Character character, bool fullWipe)
     {
         // Demolish owned houses
         var myHouses = new Dictionary<uint, House>();
-        if (HousingManager.Instance.GetByCharacterId(myHouses, character.Id) > 0)
+        if (housingManager.GetByCharacterId(myHouses, character.Id) > 0)
         {
             foreach (var (houseId, house) in myHouses)
             {
@@ -602,7 +613,7 @@ public class CharacterManager : Singleton<CharacterManager>, ICharacterManager
                 // force expire the house
                 // This should technically kill the house, and return the minimum amount of furniture
                 house.ProtectionEndDate = DateTime.UtcNow.AddDays(-21);
-                HousingManager.UpdateTaxInfo(house);
+                housingManager.UpdateTaxInfo(house);
             }
         }
 
@@ -612,14 +623,14 @@ public class CharacterManager : Singleton<CharacterManager>, ICharacterManager
 
         // Remove from Family
         if (character.Family > 0)
-            FamilyManager.Instance.LeaveFamily(character);
+            familyManager.LeaveFamily(character);
 
         // TODO: Remove from player nation
         // TODO: Delete leadership
 
         // Return all mails to sender (if needed)
         // The main reason we do this is so other people's items wouldn't get delete if fullWipe is enabled
-        foreach (var (mailId, mail) in MailManager.Instance._allPlayerMails)
+        foreach (var (mailId, mail) in mailManager.AllPlayerMails)
         {
             if (mail.CanReturnMail() && !mail.ReturnToSender())
                 Logger.Warn(
@@ -644,7 +655,7 @@ public class CharacterManager : Singleton<CharacterManager>, ICharacterManager
     /// <param name="gameConnection"></param>
     /// <param name="dbConnection"></param>
     /// <returns>Returns true if a character was marked deleted, otherwise false</returns>
-    public static bool CheckForDeletedCharactersDeletion(Character character, GameConnection gameConnection, MySqlConnection dbConnection)
+    public bool CheckForDeletedCharactersDeletion(Character character, GameConnection gameConnection, MySqlConnection dbConnection)
     {
         if (character.DeleteTime > DateTime.MinValue && character.DeleteTime <= DateTime.UtcNow)
         {
@@ -655,8 +666,8 @@ public class CharacterManager : Singleton<CharacterManager>, ICharacterManager
                 if (AppConfiguration.Instance.Account.DeleteReleaseName)
                 {
                     deletedName = "!" + character.Name;
-                    NameManager.Instance.RemoveCharacterId(character.Id);
-                    NameManager.Instance.AddCharacter(character.Id, deletedName, character.AccountId);
+                    nameManager.RemoveCharacterId(character.Id);
+                    nameManager.AddCharacter(character.Id, deletedName, character.AccountId);
                 }
 
                 command.Connection = dbConnection;
@@ -691,7 +702,7 @@ public class CharacterManager : Singleton<CharacterManager>, ICharacterManager
         return false;
     }
 
-    public static void CheckForDeletedCharacters()
+    public void CheckForDeletedCharacters()
     {
         var nextCheckTime = DateTime.MaxValue;
         var deleteList = new List<(uint, uint)>(); // charId, accountId
@@ -749,7 +760,7 @@ public class CharacterManager : Singleton<CharacterManager>, ICharacterManager
         if (nextCheckTime < DateTime.MaxValue)
         {
             var deleteCheckTask = new CharacterDeleteTask();
-            TaskManager.Instance?.Schedule(deleteCheckTask, nextCheckTime - DateTime.UtcNow);
+            taskManager.Schedule(deleteCheckTask, nextCheckTime - DateTime.UtcNow);
             Logger.Debug("CheckForDeletedCharacters - Next delete scheduled at " + nextCheckTime.ToString());
         }
         else
@@ -758,7 +769,7 @@ public class CharacterManager : Singleton<CharacterManager>, ICharacterManager
         }
     }
 
-    public static void SetDeleteCharacter(GameConnection gameConnection, uint characterId)
+    public void SetDeleteCharacter(GameConnection gameConnection, uint characterId)
     {
         if (gameConnection.Characters.TryGetValue(characterId, out var character))
         {
@@ -806,7 +817,7 @@ public class CharacterManager : Singleton<CharacterManager>, ICharacterManager
         CheckForDeletedCharacters();
     }
 
-    public static void SetRestoreCharacter(GameConnection gameConnection, uint characterId)
+    public void SetRestoreCharacter(GameConnection gameConnection, uint characterId)
     {
         if (gameConnection.Characters.TryGetValue(characterId, out var character))
         {
@@ -864,12 +875,12 @@ public class CharacterManager : Singleton<CharacterManager>, ICharacterManager
         return result;
     }
 
-    private static void SetEquipItemTemplate(Inventory inventory, uint templateId, EquipmentItemSlot slot, byte grade)
+    private void SetEquipItemTemplate(Inventory inventory, uint templateId, EquipmentItemSlot slot, byte grade)
     {
         Item item = null;
         if (templateId > 0)
         {
-            item = ItemManager.Instance.Create(templateId, 1, grade);
+            item = itemManager.Create(templateId, 1, grade);
             item.SlotType = SlotType.Equipment;
             item.Slot = (int)slot;
         }
@@ -942,6 +953,6 @@ public class CharacterManager : Singleton<CharacterManager>, ICharacterManager
     public void StartOnlineTracking()
     {
         var onlineTrackerTasks = new CharacterOnlineTrackingTask();
-        TaskManager.Instance.Schedule(onlineTrackerTasks, TimeSpan.Zero, CharacterOnlineTrackingTask.CheckPrecision);
+        taskManager.Schedule(onlineTrackerTasks, TimeSpan.Zero, CharacterOnlineTrackingTask.CheckPrecision);
     }
 }

--- a/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
@@ -28,7 +28,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers.UnitManagers;
 
-public class CharacterManager : Singleton<CharacterManager>
+public class CharacterManager : Singleton<CharacterManager>, ICharacterManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 

--- a/AAEmu.Game/Core/Managers/UnitManagers/DoodadManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/DoodadManager.cs
@@ -32,7 +32,7 @@ using NLog;
 namespace AAEmu.Game.Core.Managers.UnitManagers;
 
 // ReSharper disable once ClassNeverInstantiated.Global
-public class DoodadManager : Singleton<DoodadManager>, IDoodadManager
+public class DoodadManager(IObjectIdManager objectIdManager, IDoodadIdManager doodadIdManager, IItemManager itemManager, IHousingManager housingManager, ISusManager susManager) : Singleton<DoodadManager>, IDoodadManager
 {
     private Dictionary<uint, DoodadFuncGroups> _allFuncGroups;
 
@@ -2802,7 +2802,7 @@ public class DoodadManager : Singleton<DoodadManager>, IDoodadManager
         }
         doodad.ParentWorld = parentWorld;
 
-        doodad.ObjId = bcId > 0 ? bcId : ObjectIdManager.Instance.GetNextId();
+        doodad.ObjId = bcId > 0 ? bcId : objectIdManager.GetNextId();
         doodad.TemplateId = template.Id; // copy the templateId
         doodad.Template = template;
         doodad.OwnerObjId = ownerObject?.ObjId ?? 0;
@@ -2985,12 +2985,12 @@ public class DoodadManager : Singleton<DoodadManager>, IDoodadManager
     /// <summary>
     /// Saves and creates a doodad
     /// </summary>
-    public static Doodad CreatePlayerDoodad(Character character, uint id, float x, float y, float z, float zRot, float scale, ulong itemId, FarmType farmType = FarmType.Invalid)
+    public Doodad CreatePlayerDoodad(Character character, uint id, float x, float y, float z, float zRot, float scale, ulong itemId, FarmType farmType = FarmType.Invalid)
     {
         Logger.Warn($"{character.Name} is placing a doodad {id} at position {x} {y} {z}");
 
         // NOTE: If you would ever want to use player housing outside of main_world, you'll need to modify this
-        var targetHouse = HousingManager.Instance.GetHouseAtLocation(x, y);
+        var targetHouse = housingManager.GetHouseAtLocation(x, y);
 
         // Create doodad
         var doodad = Instance.Create(character.ParentWorld, 0, id, character, true);
@@ -3023,7 +3023,7 @@ public class DoodadManager : Singleton<DoodadManager>, IDoodadManager
         }
 
         // Consume item
-        var items = ItemManager.Instance.GetItemIdsFromDoodad(id);
+        var items = itemManager.GetItemIdsFromDoodad(id);
         var preferredItem = character.Inventory.Bag.GetItemByItemId(itemId);
 
         if (preferredItem == null)
@@ -3059,12 +3059,12 @@ public class DoodadManager : Singleton<DoodadManager>, IDoodadManager
         return doodad;
     }
 
-    public static bool OpenCofferDoodad(Character character, uint objId)
+    public bool OpenCofferDoodad(Character character, uint objId)
     {
         var doodad = character.ParentWorld.GetDoodad(objId);
         if (doodad is not DoodadCoffer coffer)
         {
-            SusManager.Instance.LogActivity(SusManager.CategoryCheating, character, $"{character.Name} tried to open doodad {objId} as a Coffer");
+            susManager.LogActivity(SusManager.CategoryCheating, character, $"{character.Name} tried to open doodad {objId} as a Coffer");
             return false;
         }
 
@@ -3088,12 +3088,12 @@ public class DoodadManager : Singleton<DoodadManager>, IDoodadManager
         return true;
     }
 
-    public static bool CloseCofferDoodad(Character character, uint objId)
+    public bool CloseCofferDoodad(Character character, uint objId)
     {
         var doodad = character.ParentWorld.GetDoodad(objId);
         if (doodad is not DoodadCoffer coffer)
         {
-            SusManager.Instance.LogActivity(SusManager.CategoryCheating, character, $"{character.Name} tried to close doodad {objId} as a Coffer");
+            susManager.LogActivity(SusManager.CategoryCheating, character, $"{character.Name} tried to close doodad {objId} as a Coffer");
             return false;
         }
 
@@ -3182,25 +3182,25 @@ public class DoodadManager : Singleton<DoodadManager>, IDoodadManager
                 return;
             }
         }
-        DoodadIdManager.Instance.ReleaseId(dbId); // Free up the Id
+        doodadIdManager.ReleaseId(dbId); // Free up the Id
 
         // Handle attached items
         if (attachedItemId > 0)
         {
-            var item = ItemManager.Instance.GetItemByItemId(attachedItemId);
+            var item = itemManager.GetItemByItemId(attachedItemId);
             if (item != null)
             {
                 item._holdingContainer = null;
-                ItemManager.Instance.ReleaseId(item.Id);
+                itemManager.ReleaseId(item.Id);
             }
         }
 
         // Delete attached container
         if (attachedContainer > 0)
         {
-            var container = ItemManager.Instance.GetItemContainerByDbId(attachedContainer);
+            var container = itemManager.GetItemContainerByDbId(attachedContainer);
             if (container != null)
-                ItemManager.Instance.DeleteItemContainer(container);
+                itemManager.DeleteItemContainer(container);
         }
     }
 

--- a/AAEmu.Game/Core/Managers/UnitManagers/DoodadManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/DoodadManager.cs
@@ -32,7 +32,7 @@ using NLog;
 namespace AAEmu.Game.Core.Managers.UnitManagers;
 
 // ReSharper disable once ClassNeverInstantiated.Global
-public class DoodadManager : Singleton<DoodadManager>
+public class DoodadManager : Singleton<DoodadManager>, IDoodadManager
 {
     private Dictionary<uint, DoodadFuncGroups> _allFuncGroups;
 

--- a/AAEmu.Game/Core/Managers/UnitManagers/DoodadManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/DoodadManager.cs
@@ -32,7 +32,7 @@ using NLog;
 namespace AAEmu.Game.Core.Managers.UnitManagers;
 
 // ReSharper disable once ClassNeverInstantiated.Global
-public class DoodadManager(IObjectIdManager objectIdManager, IDoodadIdManager doodadIdManager, IItemManager itemManager, IHousingManager housingManager, ISusManager susManager) : Singleton<DoodadManager>, IDoodadManager
+public class DoodadManager(IObjectIdManager objectIdManager, IDoodadIdManager doodadIdManager, IItemManager itemManager, Lazy<IHousingManager> housingManager, ISusManager susManager) : Singleton<DoodadManager>, IDoodadManager
 {
     private Dictionary<uint, DoodadFuncGroups> _allFuncGroups;
 
@@ -2990,7 +2990,7 @@ public class DoodadManager(IObjectIdManager objectIdManager, IDoodadIdManager do
         Logger.Warn($"{character.Name} is placing a doodad {id} at position {x} {y} {z}");
 
         // NOTE: If you would ever want to use player housing outside of main_world, you'll need to modify this
-        var targetHouse = housingManager.GetHouseAtLocation(x, y);
+        var targetHouse = housingManager.Value.GetHouseAtLocation(x, y);
 
         // Create doodad
         var doodad = Instance.Create(character.ParentWorld, 0, id, character, true);

--- a/AAEmu.Game/Core/Managers/UnitManagers/ICharacterManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/ICharacterManager.cs
@@ -5,6 +5,8 @@ using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Units;
 
+using MySql.Data.MySqlClient;
+
 namespace AAEmu.Game.Core.Managers.UnitManagers;
 
 public interface ICharacterManager
@@ -21,4 +23,10 @@ public interface ICharacterManager
     void Create(GameConnection connection, string name, Race race, Gender gender, uint[] bodyItems, UnitCustomModelParams customModel, AbilityType ability1, AbilityType ability2, AbilityType ability3, byte level);
     bool IsCharacterPendingDeletion(string name);
     void StartOnlineTracking();
+    void PlayerRoll(Character player, int max);
+    void DeleteCharacterAssets(Character character, bool fullWipe);
+    bool CheckForDeletedCharactersDeletion(Character character, GameConnection gameConnection, MySqlConnection dbConnection);
+    void CheckForDeletedCharacters();
+    void SetDeleteCharacter(GameConnection gameConnection, uint characterId);
+    void SetRestoreCharacter(GameConnection gameConnection, uint characterId);
 }

--- a/AAEmu.Game/Core/Managers/UnitManagers/ICharacterManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/ICharacterManager.cs
@@ -9,7 +9,7 @@ using MySql.Data.MySqlClient;
 
 namespace AAEmu.Game.Core.Managers.UnitManagers;
 
-public interface ICharacterManager
+public interface ICharacterManager : ILoadable
 {
     CharacterTemplate GetTemplate(Race race, Gender gender);
     AppellationTemplate GetAppellationsTemplate(uint id);
@@ -18,7 +18,6 @@ public interface ICharacterManager
     uint GetActabilityIdByCategoryId(uint id);
     ExpertLimit GetExpertLimit(int step);
     ExpandExpertLimit GetExpandExpertLimit(int step);
-    void Load();
     int GetEffectiveAccessLevel(Character character);
     void Create(GameConnection connection, string name, Race race, Gender gender, uint[] bodyItems, UnitCustomModelParams customModel, AbilityType ability1, AbilityType ability2, AbilityType ability3, byte level);
     bool IsCharacterPendingDeletion(string name);

--- a/AAEmu.Game/Core/Managers/UnitManagers/ICharacterManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/ICharacterManager.cs
@@ -1,0 +1,24 @@
+using AAEmu.Game.Core.Network.Connections;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Char.Templates;
+using AAEmu.Game.Models.Game.Items;
+using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.Game.Core.Managers.UnitManagers;
+
+public interface ICharacterManager
+{
+    CharacterTemplate GetTemplate(Race race, Gender gender);
+    AppellationTemplate GetAppellationsTemplate(uint id);
+    List<Expand> GetExpands(int step);
+    ActabilityTemplate GetActability(uint id);
+    uint GetActabilityIdByCategoryId(uint id);
+    ExpertLimit GetExpertLimit(int step);
+    ExpandExpertLimit GetExpandExpertLimit(int step);
+    void Load();
+    int GetEffectiveAccessLevel(Character character);
+    void Create(GameConnection connection, string name, Race race, Gender gender, uint[] bodyItems, UnitCustomModelParams customModel, AbilityType ability1, AbilityType ability2, AbilityType ability3, byte level);
+    bool IsCharacterPendingDeletion(string name);
+    void StartOnlineTracking();
+}

--- a/AAEmu.Game/Core/Managers/UnitManagers/IDoodadManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/IDoodadManager.cs
@@ -6,11 +6,10 @@ using MySql.Data.MySqlClient;
 
 namespace AAEmu.Game.Core.Managers.UnitManagers;
 
-public interface IDoodadManager
+public interface IDoodadManager : ILoadable
 {
     bool Exist(uint templateId);
     DoodadTemplate GetTemplate(uint id);
-    void Load();
     Doodad Create(WorldInstance parentWorld, uint bcId, uint templateId, GameObject ownerObject = null, bool skipPhaseInitialization = false);
     DoodadFunc GetFunc(uint funcId);
     DoodadFunc GetFunc(uint funcGroupId, uint skillId);

--- a/AAEmu.Game/Core/Managers/UnitManagers/IDoodadManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/IDoodadManager.cs
@@ -1,0 +1,28 @@
+using AAEmu.Game.Models.Game.DoodadObj;
+using AAEmu.Game.Models.Game.DoodadObj.Templates;
+using AAEmu.Game.Models.Game.World;
+
+using MySql.Data.MySqlClient;
+
+namespace AAEmu.Game.Core.Managers.UnitManagers;
+
+public interface IDoodadManager
+{
+    bool Exist(uint templateId);
+    DoodadTemplate GetTemplate(uint id);
+    void Load();
+    Doodad Create(WorldInstance parentWorld, uint bcId, uint templateId, GameObject ownerObject = null, bool skipPhaseInitialization = false);
+    DoodadFunc GetFunc(uint funcId);
+    DoodadFunc GetFunc(uint funcGroupId, uint skillId);
+    List<DoodadFunc> GetFuncsForGroup(uint funcGroupId);
+    List<DoodadPhaseFunc> GetPhaseFunc(uint funcGroupId);
+    DoodadFuncTemplate GetFuncTemplate(uint funcId, string funcType);
+    DoodadPhaseFuncTemplate GetPhaseFuncTemplate(uint funcId, string funcType);
+    List<DoodadFuncGroups> GetDoodadFuncGroups(uint doodadTemplateId);
+    List<uint> GetDoodadFuncGroupsId(uint doodadTemplateId);
+    List<DoodadFunc> GetDoodadFuncs(uint doodadFuncGroupId);
+    List<DoodadPhaseFunc> GetDoodadPhaseFuncs(uint funcGroupId);
+    List<uint> GetDoodadFuncConsumeChangerItemList(uint doodadFuncConsumeChangerId);
+    void DeleteDoodadById(MySqlConnection connection, MySqlTransaction transaction, uint dbId);
+    List<uint> GetTreasureChestTemplateIds();
+}

--- a/AAEmu.Game/Core/Managers/UnitManagers/INpcManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/INpcManager.cs
@@ -4,14 +4,13 @@ using AAEmu.Game.Models.Game.World;
 
 namespace AAEmu.Game.Core.Managers.UnitManagers;
 
-public interface INpcManager
+public interface INpcManager : ILoadable
 {
     bool Exist(uint templateId);
     NpcTemplate GetTemplate(uint templateId);
     Dictionary<uint, NpcTemplate> GetAllTemplates();
     MerchantGoods GetGoods(uint id);
     Npc Create(WorldInstance parentWorld, uint objectId, uint id);
-    void Load();
     void LoadAiParams();
     void BindSkillsToTemplate(uint templateId, List<NpcSkill> skills);
 }

--- a/AAEmu.Game/Core/Managers/UnitManagers/INpcManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/INpcManager.cs
@@ -1,0 +1,17 @@
+using AAEmu.Game.Models.Game.Merchant;
+using AAEmu.Game.Models.Game.NPChar;
+using AAEmu.Game.Models.Game.World;
+
+namespace AAEmu.Game.Core.Managers.UnitManagers;
+
+public interface INpcManager
+{
+    bool Exist(uint templateId);
+    NpcTemplate GetTemplate(uint templateId);
+    Dictionary<uint, NpcTemplate> GetAllTemplates();
+    MerchantGoods GetGoods(uint id);
+    Npc Create(WorldInstance parentWorld, uint objectId, uint id);
+    void Load();
+    void LoadAiParams();
+    void BindSkillsToTemplate(uint templateId, List<NpcSkill> skills);
+}

--- a/AAEmu.Game/Core/Managers/UnitManagers/NpcManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/NpcManager.cs
@@ -20,7 +20,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers.UnitManagers;
 
-public class NpcManager : Singleton<NpcManager>, INpcManager
+public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelManager, IFactionManager factionManager, IItemManager itemManager, IAIManager aiManager) : Singleton<NpcManager>, INpcManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private bool _loaded = false;
@@ -77,13 +77,13 @@ public class NpcManager : Singleton<NpcManager>, INpcManager
         var npc = new Npc
         {
             ParentWorld = parentWorld,
-            ObjId = objectId > 0 ? objectId : ObjectIdManager.Instance.GetNextId(),
+            ObjId = objectId > 0 ? objectId : objectIdManager.GetNextId(),
             TemplateId = id, // duplicate Id
             Id = id,
             Template = template,
             ModelId = template.ModelId,
-            CanFly = ModelManager.Instance.IsFlyOrSwim(template.ModelId),
-            Faction = FactionManager.Instance.GetFaction(template.FactionId),
+            CanFly = modelManager.IsFlyOrSwim(template.ModelId),
+            Faction = factionManager.GetFaction(template.FactionId),
             Level = template.Level,
             Patrol = null
         };
@@ -136,7 +136,7 @@ public class NpcManager : Singleton<NpcManager>, INpcManager
                 return npc;
 
             npc.Ai = ai;
-            AIManager.Instance.AddAi(ai);
+            aiManager.AddAi(ai);
             npc.Ai.Start();
         }
 
@@ -184,14 +184,14 @@ public class NpcManager : Singleton<NpcManager>, INpcManager
                 break;
         }
 
-        var modelType = ModelManager.Instance.GetModelType(template.ModelId);
+        var modelType = modelManager.GetModelType(template.ModelId);
 
         // choose randomly from the list totalCustomId
         if (modelParamsId != 0 && modelType != null && modelType.SubType == "ActorModel")
         {
             // Get all possible hair item_ids that match this model
             var hairsForThisModel = new List<uint>();
-            foreach (var item in ItemManager.Instance.GetAllItems())
+            foreach (var item in itemManager.GetAllItems())
                 if (item is BodyPartTemplate bpt && bpt.ModelId == template.ModelId && bpt.SlotTypeId == (uint)EquipmentItemSlotType.Hair)
                     hairsForThisModel.Add(bpt.ItemId);
 
@@ -782,7 +782,7 @@ public class NpcManager : Singleton<NpcManager>, INpcManager
         }
     }
 
-    private static void SetEquipItemTemplate(Npc npc, uint templateId, EquipmentItemSlot slot, byte grade = 0, bool npcOnly = false)
+    private void SetEquipItemTemplate(Npc npc, uint templateId, EquipmentItemSlot slot, byte grade = 0, bool npcOnly = false)
     {
         if (npcOnly && npc.Equipment.GetItemBySlot((int)slot) != null)
             return;
@@ -790,7 +790,7 @@ public class NpcManager : Singleton<NpcManager>, INpcManager
         Item item = null;
         if (templateId > 0)
         {
-            item = ItemManager.Instance.Create(templateId, 1, grade, false);
+            item = itemManager.Create(templateId, 1, grade, false);
             item.SlotType = SlotType.Equipment;
             item.Slot = (int)slot;
         }

--- a/AAEmu.Game/Core/Managers/UnitManagers/NpcManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/NpcManager.cs
@@ -20,7 +20,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers.UnitManagers;
 
-public class NpcManager : Singleton<NpcManager>
+public class NpcManager : Singleton<NpcManager>, INpcManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private bool _loaded = false;

--- a/AAEmu.Game/Core/Managers/World/AreaTriggerManager.cs
+++ b/AAEmu.Game/Core/Managers/World/AreaTriggerManager.cs
@@ -4,7 +4,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers.World;
 
-public class AreaTriggerManager : Singleton<AreaTriggerManager>
+public class AreaTriggerManager : Singleton<AreaTriggerManager>, IAreaTriggerManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 

--- a/AAEmu.Game/Core/Managers/World/EnterWorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/EnterWorldManager.cs
@@ -1,4 +1,5 @@
 ﻿using AAEmu.Commons.Utils;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Connections;
 using AAEmu.Game.Core.Network.Login;
 using AAEmu.Game.Core.Packets.G2C;
@@ -14,19 +15,21 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers.World;
 
-public class EnterWorldManager : Singleton<EnterWorldManager>, IEnterWorldManager
+public class EnterWorldManager(
+    IAccountManager accountManager,
+    IStreamManager streamManager,
+    IQuestManager questManager,
+    ITeamManager teamManager,
+    IChatManager chatManager,
+    IFamilyManager familyManager,
+    IWorldManager worldManager) : Singleton<EnterWorldManager>, IEnterWorldManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
     /// <summary>
     /// List of connected accounts (connection token, accountId)
     /// </summary>
-    private readonly Dictionary<uint, uint> _accounts;
-
-    protected EnterWorldManager()
-    {
-        _accounts = [];
-    }
+    private readonly Dictionary<uint, uint> _accounts = [];
 
     /// <summary>
     /// Adds an account to the connection list and notifies the login server the client is connected
@@ -38,7 +41,7 @@ public class EnterWorldManager : Singleton<EnterWorldManager>, IEnterWorldManage
         var connection = LoginNetwork.Instance.GetConnection();
         var gsId = AppConfiguration.Instance.Id;
 
-        if (AccountManager.Instance.Contains(accountId))
+        if (accountManager.Contains(accountId))
             connection.SendPacket(new GLPlayerEnterPacket(connectionId, gsId, 1));
         else
         {
@@ -65,8 +68,8 @@ public class EnterWorldManager : Singleton<EnterWorldManager>, IEnterWorldManage
                 connection.AccountId = accountId;
                 connection.State = GameState.Lobby;
 
-                AccountManager.Instance.Add(connection);
-                StreamManager.Instance.AddToken(connection.AccountId, connection.Id);
+                accountManager.Add(connection);
+                streamManager.AddToken(connection.AccountId, connection.Id);
 
                 var port = AppConfiguration.Instance.StreamNetwork.Port;
                 var gm = connection.GetAttribute("gmFlag") != null;
@@ -94,7 +97,7 @@ public class EnterWorldManager : Singleton<EnterWorldManager>, IEnterWorldManage
     /// </summary>
     /// <param name="connection"></param>
     /// <param name="leaveWorldTargetType"></param>
-    public static void Leave(GameConnection connection, LeaveWorldTargetType leaveWorldTargetType)
+    public void Leave(GameConnection connection, LeaveWorldTargetType leaveWorldTargetType)
     {
         switch (leaveWorldTargetType)
         {
@@ -129,7 +132,7 @@ public class EnterWorldManager : Singleton<EnterWorldManager>, IEnterWorldManage
                     connection.LeaveTask = Task.Run(async () =>
                     {
                         await Task.Delay(logoutTime, token);
-                        LeaveWorldTask(connection, leaveWorldTargetType, connection.ActiveChar);
+                        Instance.LeaveWorldTask(connection, leaveWorldTargetType, connection.ActiveChar);
                     }, token);
                 }
 
@@ -158,7 +161,7 @@ public class EnterWorldManager : Singleton<EnterWorldManager>, IEnterWorldManage
     /// <param name="connection"></param>
     /// <param name="leaveWorldTarget"></param>
     /// <param name="activeChar"></param>
-    public static void LeaveWorldTask(GameConnection connection, LeaveWorldTargetType leaveWorldTarget, Character activeChar)
+    public void LeaveWorldTask(GameConnection connection, LeaveWorldTargetType leaveWorldTarget, Character activeChar)
     {
         if (activeChar != null)
         {
@@ -167,7 +170,7 @@ public class EnterWorldManager : Singleton<EnterWorldManager>, IEnterWorldManage
             activeChar.LeaveTime = DateTime.UtcNow;
 
             // Remove all remaining quest timer tasks
-            QuestManager.Instance.RemoveQuestTimer(activeChar.Id, 0);
+            questManager.RemoveQuestTimer(activeChar.Id, 0);
 
             // Despawn and unmount everybody from owned Mates
             activeChar.ParentWorld.MateManager.RemoveAndDespawnAllActiveOwnedMates(activeChar);
@@ -177,14 +180,14 @@ public class EnterWorldManager : Singleton<EnterWorldManager>, IEnterWorldManage
             activeChar.ForceDismount(/*AttachUnitReason.PrefabChanged*/); // Dismounting a mount because of unsummoning sends "10" for this
 
             // Remove from Team (raid/party)
-            TeamManager.Instance.MemberRemoveFromTeam(activeChar, activeChar, RiskyAction.Leave);
+            teamManager.MemberRemoveFromTeam(activeChar, activeChar, RiskyAction.Leave);
 
             // Remove from all Chat
-            ChatManager.Instance.LeaveAllChannels(activeChar);
+            chatManager.LeaveAllChannels(activeChar);
 
             // Handle Family
             if (activeChar.Family > 0)
-                FamilyManager.Instance.OnCharacterLogout(activeChar);
+                familyManager.OnCharacterLogout(activeChar);
 
             // Handle Guild
             activeChar.Expedition?.OnCharacterLogout(activeChar);
@@ -204,7 +207,7 @@ public class EnterWorldManager : Singleton<EnterWorldManager>, IEnterWorldManage
                 subscriber.Dispose();
 
             // Remove from server
-            WorldManager.Instance.TryRemoveCharacter(activeChar.ObjId);
+            worldManager.TryRemoveCharacter(activeChar.ObjId);
         }
 
         GameConnection.SaveAndRemoveFromWorld(activeChar);

--- a/AAEmu.Game/Core/Managers/World/EnterWorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/EnterWorldManager.cs
@@ -14,7 +14,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers.World;
 
-public class EnterWorldManager : Singleton<EnterWorldManager>
+public class EnterWorldManager : Singleton<EnterWorldManager>, IEnterWorldManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 

--- a/AAEmu.Game/Core/Managers/World/FactionManager.cs
+++ b/AAEmu.Game/Core/Managers/World/FactionManager.cs
@@ -8,7 +8,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers.World;
 
-public class FactionManager : Singleton<FactionManager>, IFactionManager
+public class FactionManager(ILocalizationManager localizationManager) : Singleton<FactionManager>, IFactionManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private bool _loaded = false;
@@ -48,7 +48,7 @@ public class FactionManager : Singleton<FactionManager>, IFactionManager
                         var faction = new SystemFaction
                         {
                             Id = (FactionsEnum)reader.GetUInt32("id"),
-                            Name = LocalizationManager.Instance.Get("system_factions", "name", reader.GetUInt32("id")),
+                            Name = localizationManager.Get("system_factions", "name", reader.GetUInt32("id")),
                             OwnerName = reader.GetString("owner_name"),
                             UnitOwnerType = (sbyte)reader.GetInt16("owner_type_id"),
                             OwnerId = reader.GetUInt32("owner_id"),

--- a/AAEmu.Game/Core/Managers/World/FactionManager.cs
+++ b/AAEmu.Game/Core/Managers/World/FactionManager.cs
@@ -8,7 +8,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers.World;
 
-public class FactionManager : Singleton<FactionManager>
+public class FactionManager : Singleton<FactionManager>, IFactionManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private bool _loaded = false;

--- a/AAEmu.Game/Core/Managers/World/IAreaTriggerManager.cs
+++ b/AAEmu.Game/Core/Managers/World/IAreaTriggerManager.cs
@@ -2,9 +2,8 @@ using AAEmu.Game.Models.Game.World;
 
 namespace AAEmu.Game.Core.Managers.World;
 
-public interface IAreaTriggerManager
+public interface IAreaTriggerManager : IInitializable
 {
-    void Initialize();
     void AddAreaTrigger(AreaTrigger trigger);
     void RemoveAreaTrigger(AreaTrigger trigger);
     void Tick(TimeSpan delta);

--- a/AAEmu.Game/Core/Managers/World/IAreaTriggerManager.cs
+++ b/AAEmu.Game/Core/Managers/World/IAreaTriggerManager.cs
@@ -1,0 +1,11 @@
+using AAEmu.Game.Models.Game.World;
+
+namespace AAEmu.Game.Core.Managers.World;
+
+public interface IAreaTriggerManager
+{
+    void Initialize();
+    void AddAreaTrigger(AreaTrigger trigger);
+    void RemoveAreaTrigger(AreaTrigger trigger);
+    void Tick(TimeSpan delta);
+}

--- a/AAEmu.Game/Core/Managers/World/IEnterWorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/IEnterWorldManager.cs
@@ -1,0 +1,9 @@
+using AAEmu.Game.Core.Network.Connections;
+
+namespace AAEmu.Game.Core.Managers.World;
+
+public interface IEnterWorldManager
+{
+    void AddAccount(uint accountId, uint connectionId);
+    void Login(GameConnection connection, uint accountId, uint token);
+}

--- a/AAEmu.Game/Core/Managers/World/IEnterWorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/IEnterWorldManager.cs
@@ -1,4 +1,6 @@
 using AAEmu.Game.Core.Network.Connections;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.StaticValues;
 
 namespace AAEmu.Game.Core.Managers.World;
 
@@ -6,4 +8,6 @@ public interface IEnterWorldManager
 {
     void AddAccount(uint accountId, uint connectionId);
     void Login(GameConnection connection, uint accountId, uint token);
+    void Leave(GameConnection connection, LeaveWorldTargetType leaveWorldTargetType);
+    void LeaveWorldTask(GameConnection connection, LeaveWorldTargetType leaveWorldTarget, Character activeChar);
 }

--- a/AAEmu.Game/Core/Managers/World/IFactionManager.cs
+++ b/AAEmu.Game/Core/Managers/World/IFactionManager.cs
@@ -3,9 +3,8 @@ using AAEmu.Game.Models.StaticValues;
 
 namespace AAEmu.Game.Core.Managers.World;
 
-public interface IFactionManager
+public interface IFactionManager : ILoadable
 {
-    void Load();
     SystemFaction GetFaction(FactionsEnum id);
     void AddFaction(SystemFaction faction);
 }

--- a/AAEmu.Game/Core/Managers/World/IFactionManager.cs
+++ b/AAEmu.Game/Core/Managers/World/IFactionManager.cs
@@ -1,0 +1,11 @@
+using AAEmu.Game.Models.Game.Faction;
+using AAEmu.Game.Models.StaticValues;
+
+namespace AAEmu.Game.Core.Managers.World;
+
+public interface IFactionManager
+{
+    void Load();
+    SystemFaction GetFaction(FactionsEnum id);
+    void AddFaction(SystemFaction faction);
+}

--- a/AAEmu.Game/Core/Managers/World/ISpecialtyManager.cs
+++ b/AAEmu.Game/Core/Managers/World/ISpecialtyManager.cs
@@ -1,6 +1,3 @@
 namespace AAEmu.Game.Core.Managers.World;
 
-public interface ISpecialtyManager
-{
-    void Load();
-}
+public interface ISpecialtyManager : ILoadable;

--- a/AAEmu.Game/Core/Managers/World/ISpecialtyManager.cs
+++ b/AAEmu.Game/Core/Managers/World/ISpecialtyManager.cs
@@ -1,0 +1,6 @@
+namespace AAEmu.Game.Core.Managers.World;
+
+public interface ISpecialtyManager
+{
+    void Load();
+}

--- a/AAEmu.Game/Core/Managers/World/IStreamManager.cs
+++ b/AAEmu.Game/Core/Managers/World/IStreamManager.cs
@@ -1,0 +1,10 @@
+using AAEmu.Game.Core.Network.Connections;
+
+namespace AAEmu.Game.Core.Managers.World;
+
+public interface IStreamManager
+{
+    void AddToken(uint accountId, uint connectionId);
+    void RemoveToken(uint token);
+    void Login(StreamConnection connection, uint accountId, uint token);
+}

--- a/AAEmu.Game/Core/Managers/World/IWorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/IWorldManager.cs
@@ -27,4 +27,7 @@ public interface IWorldManager
     List<uint> GetZoneKeysByWorldId(uint worldId);
 
     void BroadcastPacketToServer(GamePacket packet);
+    Character GetTargetOrSelf(Character character, string targetName, out int firstNonNameArgument);
+    bool TryRemoveCharacter(uint playerObjId);
+    void Initialize();
 }

--- a/AAEmu.Game/Core/Managers/World/IWorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/IWorldManager.cs
@@ -12,4 +12,6 @@ public interface IWorldManager
     WorldInstance CreateWorldInstance(WorldTemplate worldTemplate, uint channelId, bool overrideInstanceId = false, uint fixedInstanceId = 0, Character notifyPlayer = null);
 
     WorldTemplate CreateWorldTemplate(string worldName);
+
+    Character GetCharacterByObjId(uint id);
 }

--- a/AAEmu.Game/Core/Managers/World/IWorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/IWorldManager.cs
@@ -1,4 +1,5 @@
-﻿using AAEmu.Game.Models.Game.Char;
+﻿using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.World;
 
 namespace AAEmu.Game.Core.Managers.World;
@@ -14,4 +15,16 @@ public interface IWorldManager
     WorldTemplate CreateWorldTemplate(string worldName);
 
     Character GetCharacterByObjId(uint id);
+    Character GetCharacterById(uint id);
+    Character GetCharacter(string name);
+    List<Character> GetAllCharacters();
+
+    uint GetZoneId(WorldTemplate worldTemplate, float x, float y);
+    WorldTemplate GetWorldTemplateByName(string worldName);
+    WorldTemplate GetWorldTemplateByZoneKey(uint zoneKey);
+    WorldInstance[] GetWorlds();
+    WorldInstance GetWorld(uint worldInstanceId);
+    List<uint> GetZoneKeysByWorldId(uint worldId);
+
+    void BroadcastPacketToServer(GamePacket packet);
 }

--- a/AAEmu.Game/Core/Managers/World/IZoneManager.cs
+++ b/AAEmu.Game/Core/Managers/World/IZoneManager.cs
@@ -1,0 +1,14 @@
+using AAEmu.Game.Models.Game.World.Zones;
+
+namespace AAEmu.Game.Core.Managers.World;
+
+public interface IZoneManager
+{
+    void Load();
+    ZoneConflict[] GetConflicts();
+    Zone GetZoneById(uint zoneId);
+    Zone GetZoneByKey(uint zoneKey);
+    ZoneGroup GetZoneGroupById(uint zoneId);
+    List<uint> GetZoneKeysInZoneGroupById(uint zoneGroupId);
+    uint GetTargetIdByZoneId(uint zoneId);
+}

--- a/AAEmu.Game/Core/Managers/World/IZoneManager.cs
+++ b/AAEmu.Game/Core/Managers/World/IZoneManager.cs
@@ -1,3 +1,6 @@
+using System.Numerics;
+
+using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.World.Zones;
 
 namespace AAEmu.Game.Core.Managers.World;
@@ -11,4 +14,8 @@ public interface IZoneManager
     ZoneGroup GetZoneGroupById(uint zoneId);
     List<uint> GetZoneKeysInZoneGroupById(uint zoneGroupId);
     uint GetTargetIdByZoneId(uint zoneId);
+    Vector2 GetZoneOriginCell(uint zoneId);
+    Vector3 ConvertToWorldCoordinates(uint zoneId, Vector3 point);
+    bool DoodadHasMatchingClimate(Doodad doodad);
+    List<Climate> GetClimatesByZone(Zone zone);
 }

--- a/AAEmu.Game/Core/Managers/World/IZoneManager.cs
+++ b/AAEmu.Game/Core/Managers/World/IZoneManager.cs
@@ -1,13 +1,11 @@
 using System.Numerics;
-
 using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.World.Zones;
 
 namespace AAEmu.Game.Core.Managers.World;
 
-public interface IZoneManager
+public interface IZoneManager : ILoadable
 {
-    void Load();
     ZoneConflict[] GetConflicts();
     Zone GetZoneById(uint zoneId);
     Zone GetZoneByKey(uint zoneKey);

--- a/AAEmu.Game/Core/Managers/World/SpecialtyManager.cs
+++ b/AAEmu.Game/Core/Managers/World/SpecialtyManager.cs
@@ -13,7 +13,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers.World;
 
-public class SpecialtyManager : Singleton<SpecialtyManager>
+public class SpecialtyManager : Singleton<SpecialtyManager>, ISpecialtyManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 

--- a/AAEmu.Game/Core/Managers/World/SphereQuestManager.cs
+++ b/AAEmu.Game/Core/Managers/World/SphereQuestManager.cs
@@ -299,7 +299,7 @@ public class SphereQuestManager(WorldInstance parent) : ISphereQuestManager
                         sphere.Radius = float.Parse(l4.AsSpan(7), NumberStyles.Float, CultureInfo.InvariantCulture);
                         // конвертируем координаты из локальных в мировые, сразу при считывании из файла пути
                         // convert coordinates from local to world, immediately when reading the path from the file
-                        sphere.Xyz = ZoneManager.ConvertToWorldCoordinates(zoneId, sphere.Xyz);
+                        sphere.Xyz = ZoneManager.Instance.ConvertToWorldCoordinates(zoneId, sphere.Xyz);
                         if (!sphereQuests.TryGetValue(sphere.ComponentId, out var value))
                         {
                             var sphereList = new List<SphereQuest> { sphere };

--- a/AAEmu.Game/Core/Managers/World/StreamManager.cs
+++ b/AAEmu.Game/Core/Managers/World/StreamManager.cs
@@ -7,12 +7,7 @@ namespace AAEmu.Game.Core.Managers.World;
 
 public class StreamManager : Singleton<StreamManager>, IStreamManager
 {
-    private readonly Dictionary<uint, uint> _accounts;
-
-    protected StreamManager()
-    {
-        _accounts = [];
-    }
+    private readonly Dictionary<uint, uint> _accounts = [];
 
     public static void Load()
     {

--- a/AAEmu.Game/Core/Managers/World/StreamManager.cs
+++ b/AAEmu.Game/Core/Managers/World/StreamManager.cs
@@ -5,7 +5,7 @@ using AAEmu.Game.Models.Game.DoodadObj;
 
 namespace AAEmu.Game.Core.Managers.World;
 
-public class StreamManager : Singleton<StreamManager>
+public class StreamManager : Singleton<StreamManager>, IStreamManager
 {
     private readonly Dictionary<uint, uint> _accounts;
 

--- a/AAEmu.Game/Core/Managers/World/WorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/WorldManager.cs
@@ -7,6 +7,7 @@ using AAEmu.Commons.Exceptions;
 using AAEmu.Commons.IO;
 using AAEmu.Commons.Utils;
 using AAEmu.Game.Core.Managers.Id;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.IO;
@@ -27,7 +28,12 @@ using NLog;
 namespace AAEmu.Game.Core.Managers.World;
 
 // ReSharper disable once ClassNeverInstantiated.Global
-public class WorldManager : Singleton<WorldManager>, IWorldManager
+public class WorldManager(
+    ITickManager tickManager,
+    IWorldIdManager worldIdManager,
+    Lazy<IZoneManager> zoneManager,
+    Lazy<IIndunManager> indunManager,
+    Lazy<IFamilyManager> familyManager) : Singleton<WorldManager>, IWorldManager
 {
     /// <summary>
     /// Default World and Instance ID that will be assigned to all Transforms as a Default value
@@ -243,7 +249,7 @@ public class WorldManager : Singleton<WorldManager>, IWorldManager
         {
             foreach (var zoneKey in worldTemplate.ZoneKeys)
             {
-                var zone = ZoneManager.Instance.GetZoneByKey(zoneKey);
+                var zone = zoneManager.Value.GetZoneByKey(zoneKey);
                 if (zone.GroupId == zoneGroupId)
                     return worldTemplate;
             }
@@ -354,7 +360,7 @@ public class WorldManager : Singleton<WorldManager>, IWorldManager
 
     public void Initialize()
     {
-        TickManager.Instance.OnTick.Subscribe(ActiveRegionTick, TimeSpan.FromSeconds(1));
+        tickManager.OnTick.Subscribe(ActiveRegionTick, TimeSpan.FromSeconds(1));
     }
 
     /// <summary>
@@ -376,7 +382,7 @@ public class WorldManager : Singleton<WorldManager>, IWorldManager
         // Load initial instances according to config
         foreach (var dungeonLoadConfig in AppConfiguration.Instance.Dungeons.AutoCreate)
         {
-            _ = IndunManager.Instance.CreateSystemInstance(null, GetWorldTemplateByName(dungeonLoadConfig.Name).ZoneKeys.First(), dungeonLoadConfig.Channel, true, dungeonLoadConfig.Id);
+            _ = indunManager.Value.CreateSystemInstance(null, GetWorldTemplateByName(dungeonLoadConfig.Name).ZoneKeys.First(), dungeonLoadConfig.Channel, true, dungeonLoadConfig.Id);
         }
         Logger.Info($"Created static instances in {DateTime.UtcNow.Subtract(createInstanceStartTime)} ({GameService.TimeSinceStart} since server start)");
     }
@@ -414,7 +420,7 @@ public class WorldManager : Singleton<WorldManager>, IWorldManager
         }
 
         // Create a new instance
-        var world = new WorldInstance(worldTemplate, channelId, overrideInstanceId, overrideInstanceId ? fixedInstanceId : WorldIdManager.Instance.GetNextId());
+        var world = new WorldInstance(worldTemplate, channelId, overrideInstanceId, overrideInstanceId ? fixedInstanceId : worldIdManager.GetNextId());
         _worlds.Add(world.Id, world);
 
         notifyPlayer?.SendPacket(new SCProcessingInstancePacket((int)world.Template.ZoneKeys[0]));
@@ -857,15 +863,15 @@ public class WorldManager : Singleton<WorldManager>, IWorldManager
     /// <param name="TargetName">Possible target name</param>
     /// <param name="FirstNonNameArgument">Returns 1 if TargetName was a valid online character, 0 otherwise</param>
     /// <returns></returns>
-    public static Character GetTargetOrSelf(Character character, string TargetName, out int FirstNonNameArgument)
+    public Character GetTargetOrSelf(Character character, string targetName, out int firstNonNameArgument)
     {
-        FirstNonNameArgument = 0;
-        if (!string.IsNullOrWhiteSpace(TargetName))
+        firstNonNameArgument = 0;
+        if (!string.IsNullOrWhiteSpace(targetName))
         {
-            var player = Instance.GetCharacter(TargetName);
+            var player = GetCharacter(targetName);
             if (player != null)
             {
-                FirstNonNameArgument = 1;
+                firstNonNameArgument = 1;
                 return player;
             }
         }
@@ -1139,7 +1145,7 @@ public class WorldManager : Singleton<WorldManager>, IWorldManager
         // Family stuff
         if (character.Family > 0)
         {
-            FamilyManager.Instance.OnCharacterLogin(character);
+            familyManager.Value.OnCharacterLogin(character);
         }
     }
 

--- a/AAEmu.Game/Core/Managers/World/ZoneManager.cs
+++ b/AAEmu.Game/Core/Managers/World/ZoneManager.cs
@@ -10,7 +10,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers.World;
 
-public class ZoneManager : Singleton<ZoneManager>, IZoneManager
+public class ZoneManager(IWorldManager worldManager) : Singleton<ZoneManager>, IZoneManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
@@ -207,9 +207,9 @@ public class ZoneManager : Singleton<ZoneManager>, IZoneManager
         }
     }
 
-    public static Vector2 GetZoneOriginCell(uint zoneId)
+    public Vector2 GetZoneOriginCell(uint zoneId)
     {
-        var world = WorldManager.Instance.GetWorldTemplateByZoneKey(zoneId);
+        var world = worldManager.GetWorldTemplateByZoneKey(zoneId);
         if (world?.XmlWorldZones.TryGetValue(zoneId, out var xmlZone) ?? false)
         {
             return new Vector2(xmlZone.OriginX, xmlZone.OriginY);
@@ -223,7 +223,7 @@ public class ZoneManager : Singleton<ZoneManager>, IZoneManager
     /// <param name="zoneId">zoneKey</param>
     /// <param name="point">offset inside the zone</param>
     /// <returns></returns>
-    public static Vector3 ConvertToWorldCoordinates(uint zoneId, Vector3 point)
+    public Vector3 ConvertToWorldCoordinates(uint zoneId, Vector3 point)
     {
         var origin = GetZoneOriginCell(zoneId);
 
@@ -249,7 +249,7 @@ public class ZoneManager : Singleton<ZoneManager>, IZoneManager
     /// </summary>
     /// <param name="doodad"></param>
     /// <returns>Returns true if the doodad can have a growth time bonus, false if out of climate, or no climate defined for the doodad</returns>
-    public static bool DoodadHasMatchingClimate(Doodad doodad)
+    public bool DoodadHasMatchingClimate(Doodad doodad)
     {
         // If no climate defined, then don't give a bonus
         if (doodad.Template.ClimateId == Climate.Any || doodad.Template.ClimateId == Climate.Any)
@@ -259,13 +259,13 @@ public class ZoneManager : Singleton<ZoneManager>, IZoneManager
         if (doodad.Transform.ZoneId <= 0)
         {
             // If ZoneId wasn't set yet, calculate it
-            var zoneId = WorldManager.Instance.GetZoneId(doodad.ParentWorld.Template, doodad.Transform.World.Position.X, doodad.Transform.World.Position.Y);
+            var zoneId = worldManager.GetZoneId(doodad.ParentWorld.Template, doodad.Transform.World.Position.X, doodad.Transform.World.Position.Y);
             doodad.Transform.ZoneId = zoneId;
         }
-        var zone = ZoneManager.Instance.GetZoneByKey(doodad.Transform.ZoneId);
+        var zone = GetZoneByKey(doodad.Transform.ZoneId);
 
         // Get the climates list for this zone
-        var zoneClimates = ZoneManager.Instance.GetClimatesByZone(zone);
+        var zoneClimates = GetClimatesByZone(zone);
 
         // Check if it's in there
         return zoneClimates.Contains(doodad.Template.ClimateId);

--- a/AAEmu.Game/Core/Managers/World/ZoneManager.cs
+++ b/AAEmu.Game/Core/Managers/World/ZoneManager.cs
@@ -10,7 +10,7 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers.World;
 
-public class ZoneManager : Singleton<ZoneManager>
+public class ZoneManager : Singleton<ZoneManager>, IZoneManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 

--- a/AAEmu.Game/Core/Network/Connections/GameConnection.cs
+++ b/AAEmu.Game/Core/Network/Connections/GameConnection.cs
@@ -157,7 +157,7 @@ public class GameConnection
                 var character = Character.Load(connection, id, AccountId);
                 if (character == null)
                     continue; // TODO ...
-                if (!CharacterManager.CheckForDeletedCharactersDeletion(character, this, connection))
+                if (!CharacterManager.Instance.CheckForDeletedCharactersDeletion(character, this, connection))
                 {
                     Characters.Add(character.Id, character);
                 }

--- a/AAEmu.Game/Core/Packets/C2G/CSCancelCharacterDeletePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSCancelCharacterDeletePacket.cs
@@ -9,6 +9,6 @@ public class CSCancelCharacterDeletePacket() : GamePacket(CSOffsets.CSCancelChar
     public override void Read(PacketStream stream)
     {
         var characterId = stream.ReadUInt32();
-        CharacterManager.SetRestoreCharacter(Connection, characterId);
+        CharacterManager.Instance.SetRestoreCharacter(Connection, characterId);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSCofferInteractionPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSCofferInteractionPacket.cs
@@ -15,7 +15,7 @@ public class CSCofferInteractionPacket() : GamePacket(CSOffsets.CSCofferInteract
         Logger.Warn("CofferInteraction, cofferObjId: {0}, opening: {1}", cofferObjId, opening);
         if (opening)
         {
-            if (!DoodadManager.OpenCofferDoodad(Connection.ActiveChar, cofferObjId))
+            if (!DoodadManager.Instance.OpenCofferDoodad(Connection.ActiveChar, cofferObjId))
             {
                 Logger.Warn($"{Connection.ActiveChar.Name} failed to Open coffer objId {cofferObjId}");
                 // If it failed, the coffer is likely in use by somebody else
@@ -24,7 +24,7 @@ public class CSCofferInteractionPacket() : GamePacket(CSOffsets.CSCofferInteract
         }
         else
         {
-            if (!DoodadManager.CloseCofferDoodad(Connection.ActiveChar, cofferObjId))
+            if (!DoodadManager.Instance.CloseCofferDoodad(Connection.ActiveChar, cofferObjId))
                 Logger.Warn($"{Connection.ActiveChar.Name} failed to Close coffer objId {cofferObjId}");
         }
     }

--- a/AAEmu.Game/Core/Packets/C2G/CSCreateDoodadPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSCreateDoodadPacket.cs
@@ -27,7 +27,7 @@ public class CSCreateDoodadPacket() : GamePacket(CSOffsets.CSCreateDoodadPacket,
         if (!InPublicFarm)
         {
             Logger.Warn("CreateDoodad, Id: {0}, X: {1}, Y: {2}, Z: {3}, zRot: {4}  ItemId: {5}", id, x, y, z, zRot, itemId);
-            DoodadManager.CreatePlayerDoodad(Connection.ActiveChar, id, x, y, z, zRot, scale, itemId);
+            DoodadManager.Instance.CreatePlayerDoodad(Connection.ActiveChar, id, x, y, z, zRot, scale, itemId);
         }
         else
         {
@@ -35,7 +35,7 @@ public class CSCreateDoodadPacket() : GamePacket(CSOffsets.CSCreateDoodadPacket,
             if (PublicFarmManager.Instance.CanPlace(Connection.ActiveChar, farmType, id))
             {
                 Logger.Warn("CreateFarmDoodad, Id: {0}, X: {1}, Y: {2}, Z: {3}, zRot: {4}  ItemId: {5}", id, x, y, z, zRot, itemId);
-                DoodadManager.CreatePlayerDoodad(Connection.ActiveChar, id, x, y, z, zRot, scale, itemId, farmType);
+                DoodadManager.Instance.CreatePlayerDoodad(Connection.ActiveChar, id, x, y, z, zRot, scale, itemId, farmType);
             }
         }
     }

--- a/AAEmu.Game/Core/Packets/C2G/CSDeleteCharacterPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSDeleteCharacterPacket.cs
@@ -9,6 +9,6 @@ public class CSDeleteCharacterPacket() : GamePacket(CSOffsets.CSDeleteCharacterP
     public override void Read(PacketStream stream)
     {
         var characterId = stream.ReadUInt32();
-        CharacterManager.SetDeleteCharacter(Connection, characterId);
+        CharacterManager.Instance.SetDeleteCharacter(Connection, characterId);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSDismissExpeditionPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSDismissExpeditionPacket.cs
@@ -10,6 +10,6 @@ public class CSDismissExpeditionPacket() : GamePacket(CSOffsets.CSDismissExpedit
     {
         Logger.Debug("DismissExpedition");
         // Empty struct
-        ExpeditionManager.Disband(Connection.ActiveChar);
+        ExpeditionManager.Instance.Disband(Connection.ActiveChar);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSFamilyInviteMemberPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSFamilyInviteMemberPacket.cs
@@ -13,6 +13,6 @@ public class CSFamilyInviteMemberPacket() : GamePacket(CSOffsets.CSFamilyInviteM
 
         Logger.Debug("FamilyInviteMember, Name: {0}, Title: {1}", name, title);
 
-        FamilyManager.InviteToFamily(Connection.ActiveChar, name, title);
+        FamilyManager.Instance.InviteToFamily(Connection.ActiveChar, name, title);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSInviteToExpeditionPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSInviteToExpeditionPacket.cs
@@ -11,6 +11,6 @@ public class CSInviteToExpeditionPacket() : GamePacket(CSOffsets.CSInviteToExped
         var name = stream.ReadString();
 
         Logger.Debug("InviteToExpedition, Name: {0}", name);
-        ExpeditionManager.Invite(Connection, name);
+        ExpeditionManager.Instance.Invite(Connection, name);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSKickFromExpeditionPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSKickFromExpeditionPacket.cs
@@ -11,6 +11,6 @@ public class CSKickFromExpeditionPacket() : GamePacket(CSOffsets.CSKickFromExped
         var id = stream.ReadUInt32(); // type(id)
 
         Logger.Debug("KickFromExpedition, Id: {0}", id);
-        ExpeditionManager.Kick(Connection, id);
+        ExpeditionManager.Instance.Kick(Connection, id);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSLeaveWorldPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSLeaveWorldPacket.cs
@@ -10,6 +10,6 @@ public class CSLeaveWorldPacket() : GamePacket(CSOffsets.CSLeaveWorldPacket, 1)
     public override void Read(PacketStream stream)
     {
         var leaveWorldTarget = (LeaveWorldTargetType)stream.ReadByte();
-        EnterWorldManager.Leave(Connection, leaveWorldTarget);
+        EnterWorldManager.Instance.Leave(Connection, leaveWorldTarget);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSRollDicePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSRollDicePacket.cs
@@ -10,6 +10,6 @@ public class CSRollDicePacket() : GamePacket(CSOffsets.CSRollDicePacket, 1)
     {
 
         var max = stream.ReadUInt32();
-        CharacterManager.PlayerRoll(Connection.ActiveChar, int.Parse(max.ToString()));
+        CharacterManager.Instance.PlayerRoll(Connection.ActiveChar, int.Parse(max.ToString()));
     }
 }

--- a/AAEmu.Game/GameData/Framework/GameDataManager.cs
+++ b/AAEmu.Game/GameData/Framework/GameDataManager.cs
@@ -1,16 +1,41 @@
-﻿using System.Reflection;
+using System.Reflection;
 using AAEmu.Commons.Utils;
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Utils.DB;
 using NLog;
 
 namespace AAEmu.Game.GameData.Framework;
 
-public class GameDataManager : Singleton<GameDataManager>, IGameDataManager
+/// <summary>
+/// Orchestrates all <see cref="IGameDataLoader"/> implementations.
+/// The constructor deps (Localization, Taxations, Item, Quest, Zone) are declared here
+/// so the <see cref="ManagerOrchestrator"/> knows those managers must complete their
+/// <c>Load()</c> before <c>GameDataManager.Load()</c> runs — their data is accessed by
+/// individual game-data loaders (HousingGameData, SphereGameData, etc.) via static Instance.
+/// </summary>
+public class GameDataManager(
+    ILocalizationManager localizationManager,
+    ITaxationsManager taxationsManager,
+    IItemManager itemManager,
+    IQuestManager questManager,
+    IZoneManager zoneManager
+) : Singleton<GameDataManager>, IGameDataManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private readonly List<IGameDataLoader> _loaders = [];
     private bool _loadedGameData = false;
     private bool _postLoadedGameData = false;
+
+    // Stored so DI keeps references alive and to suppress CS9113 (unread primary ctor param).
+    private readonly ILocalizationManager _localizationManager = localizationManager;
+    private readonly ITaxationsManager _taxationsManager = taxationsManager;
+    private readonly IItemManager _itemManager = itemManager;
+    private readonly IQuestManager _questManager = questManager;
+    private readonly IZoneManager _zoneManager = zoneManager;
+
+    /// <inheritdoc cref="ILoadable.Load"/>
+    public void Load() => LoadGameData();
 
     public void LoadGameData()
     {

--- a/AAEmu.Game/GameData/Framework/GameDataManager.cs
+++ b/AAEmu.Game/GameData/Framework/GameDataManager.cs
@@ -5,7 +5,7 @@ using NLog;
 
 namespace AAEmu.Game.GameData.Framework;
 
-public class GameDataManager : Singleton<GameDataManager>
+public class GameDataManager : Singleton<GameDataManager>, IGameDataManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private readonly List<IGameDataLoader> _loaders = [];

--- a/AAEmu.Game/GameData/Framework/IGameDataManager.cs
+++ b/AAEmu.Game/GameData/Framework/IGameDataManager.cs
@@ -1,0 +1,7 @@
+namespace AAEmu.Game.GameData.Framework;
+
+public interface IGameDataManager
+{
+    void LoadGameData();
+    void PostLoadGameData();
+}

--- a/AAEmu.Game/GameData/Framework/IGameDataManager.cs
+++ b/AAEmu.Game/GameData/Framework/IGameDataManager.cs
@@ -1,6 +1,8 @@
+using AAEmu.Game.Core.Managers;
+
 namespace AAEmu.Game.GameData.Framework;
 
-public interface IGameDataManager
+public interface IGameDataManager : ILoadable
 {
     void LoadGameData();
     void PostLoadGameData();

--- a/AAEmu.Game/GameData/TransferGameData.cs
+++ b/AAEmu.Game/GameData/TransferGameData.cs
@@ -195,7 +195,7 @@ public class TransferGameData : Singleton<TransferGameData>, IGameDataLoader
 
                                     // конвертируем координаты из локальных в мировые, сразу при считывании из файла пути
                                     // convert coordinates from local to world, immediately when reading the path from the file
-                                    var vec = ZoneManager.ConvertToWorldCoordinates(zoneId, xyz);
+                                    var vec = ZoneManager.Instance.ConvertToWorldCoordinates(zoneId, xyz);
                                     var pos = new WorldSpawnPosition
                                     {
                                         X = vec.X,

--- a/AAEmu.Game/GameService.cs
+++ b/AAEmu.Game/GameService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 
+using AAEmu.Commons.Utils;
 using AAEmu.Commons.Utils.DB;
 using AAEmu.Commons.Utils.Updater;
 using AAEmu.Game.Core.Managers;
@@ -27,6 +28,11 @@ public sealed class GameService : IHostedService, IDisposable
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     public static DateTime StartTime { get; private set; } = DateTime.UtcNow;
     public static TimeSpan TimeSinceStart => DateTime.UtcNow.Subtract(StartTime);
+
+    public GameService(IServiceProvider serviceProvider)
+    {
+        SingletonContainer.ServiceProvider = serviceProvider;
+    }
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {

--- a/AAEmu.Game/GameService.cs
+++ b/AAEmu.Game/GameService.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 
 using AAEmu.Commons.Utils;
 using AAEmu.Commons.Utils.DB;
@@ -29,9 +29,12 @@ public sealed class GameService : IHostedService, IDisposable
     public static DateTime StartTime { get; private set; } = DateTime.UtcNow;
     public static TimeSpan TimeSinceStart => DateTime.UtcNow.Subtract(StartTime);
 
-    public GameService(IServiceProvider serviceProvider)
+    private readonly ManagerOrchestrator _orchestrator;
+
+    public GameService(IServiceProvider serviceProvider, ManagerOrchestrator orchestrator)
     {
         SingletonContainer.ServiceProvider = serviceProvider;
+        _orchestrator = orchestrator;
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)
@@ -58,37 +61,25 @@ public sealed class GameService : IHostedService, IDisposable
         }
 
         var stopWatch = new Stopwatch();
-
         stopWatch.Start();
 
-        // Ticks and Tasks
+        // --- Stage 0: Infrastructure ---
         TickManager.Instance.Initialize();
         TaskIdManager.Instance.Initialize();
         TaskManager.Instance.Initialize();
 
-        // World
+        // --- World base (explicit: needed before all other Load() calls) ---
         WorldIdManager.Instance.Initialize();
         WorldManager.Instance.Load();
-
-        // Feature Sets 
-        ExperienceManager.Instance.Load();
         FeaturesManager.Initialize();
-        LocalizationManager.Instance.Load();
 
+        // --- ID managers ---
         ObjectIdManager.Instance.Initialize();
         TradeIdManager.Instance.Initialize();
-
-        ZoneManager.Instance.Load();
-        // TODO: Implement lazy loading for heightmaps
-        var heightmapTask = Task.Run(() =>
-        {
-            WorldManager.Instance.LoadHeightmaps();
-        }, cancellationToken);
-
         ContainerIdManager.Instance.Initialize();
         ItemIdManager.Instance.Initialize();
         DoodadIdManager.Instance.Initialize();
-        ChatManager.Instance.Initialize();
+        ChatManager.Instance.Initialize();  // unmigrated
         CharacterIdManager.Instance.Initialize();
         FamilyIdManager.Instance.Initialize();
         ExpeditionIdManager.Instance.Initialize();
@@ -104,62 +95,26 @@ public sealed class GameService : IHostedService, IDisposable
         UccIdManager.Instance.Initialize();
         MusicIdManager.Instance.Initialize();
         ShipyardIdManager.Instance.Initialize();
-        ShipyardManager.Instance.Initialize();
         // SkillTlIdManager.Instance.Initialize();
         AuctionIdManager.Instance.Initialize();
         GimmickIdManager.Instance.Initialize();
-        IndunManager.Instance.Initialize();
-        TaxationsManager.Instance.Load();
-
-        GameDataManager.Instance.LoadGameData();
-        QuestManager.Instance.Load();
-
-        FormulaManager.Instance.Load();
-        AiPathsManager.Instance.Load();
-
         TlIdManager.Instance.Initialize();
-        SpecialtyManager.Instance.Load();
-        ItemManager.Instance.Load();
+
+        // --- Stage 1: Pre-load special steps ---
+        // TODO: Implement lazy loading for heightmaps
+        var heightmapTask = Task.Run(WorldManager.Instance.LoadHeightmaps, cancellationToken);
+        AnimationManager.Instance.Load();  // unmigrated; must complete before SkillManager.Load()
+
+        // --- Stage 2: Orchestrated parallel Load() ---
+        // Managers implementing ILoadable are sorted by constructor dep graph and run in parallel batches.
+        await _orchestrator.RunLoadAsync();
+
+        // --- Stage 3: Post-load special steps ---
+        GameDataManager.Instance.PostLoadGameData();
         ItemManager.Instance.LoadUserItems();
-        AnimationManager.Instance.Load();
-        PlotManager.Instance.Load();
-        SkillManager.Instance.Load();
-        CraftManager.Instance.Load();
-        // MateManager.Instance.Load();
-        // SlaveManager.Instance.Load(); // Moved to WorldInstance
-        TeamManager.Instance.Load();
-        AuctionManager.Instance.Load();
-        MailManager.Instance.Load();
-        ExpressTextManager.Instance.Load();
-
-        NameManager.Instance.Load();
-        FactionManager.Instance.Load();
-        ExpeditionManager.Instance.Load();
-        CharacterManager.Instance.Load();
-        FamilyManager.Instance.Load();
-        PortalManager.Instance.Load();
-        FriendMananger.Instance.Load();
-        ModelManager.Instance.Load();
-
-        AIManager.Instance.Initialize();
-
-        GameScheduleManager.Instance.Load();
-        NpcManager.Instance.Load();
-
-        DoodadManager.Instance.Load();
-        ShipyardManager.Instance.Load();
-
-        SubZoneManager.Instance.Load();
-        PublicFarmManager.Instance.Load();
-
-        // SpawnManager.Instance.Load(); // Moved to world instance
-
-        AccessLevelManager.Instance.Load();
-        CashShopManager.Instance.Load();
         CashShopManager.Instance.EnabledShop();
-        UccManager.Instance.Load();
-        MusicManager.Instance.Load();
 
+        // --- Scripts ---
         if (AppConfiguration.Instance.Scripts.LoadStrategy == ScriptsConfig.LoadStrategyType.Compilation)
         {
             ScriptCompiler.Compile();
@@ -167,38 +122,27 @@ public sealed class GameService : IHostedService, IDisposable
         else
         {
             // (Preferred for debugging)
-            // Use reflection to load scripts 
+            // Use reflection to load scripts
             ScriptReflector.Reflect();
         }
 
         TimeManager.Instance.Start();
         TaskManager.Instance.Start();
 
-        // LaborPowerManager.Initialize();
-        TimedRewardsManager.Instance.Initialize();
-        AccountManager.Instance.Initialize();
+        // --- Stage 4: Orchestrated parallel Initialize() ---
+        DuelManager.Initialize();       // explicit – static call
+        SpecialtyManager.Initialize();  // explicit – static call
+        await _orchestrator.RunInitializeAsync();
 
-        DuelManager.Initialize();
-        InstantGameManager.Instance.Initialize();
-        SaveManager.Instance.Initialize();
-        AreaTriggerManager.Instance.Initialize();
-        SpecialtyManager.Initialize();
-        CashShopManager.Instance.Initialize();
-        GameDataManager.Instance.PostLoadGameData();
-        FishSchoolManager.Instance.Initialize();
-        RadarManager.Instance.Initialize();
-        ManaRegenManager.Instance.Initialize();
-        PublicFarmManager.Instance.Initialize();
-
+        // --- Stage 5: World creation + network ---
         if (heightmapTask != null && !heightmapTask.IsCompleted)
         {
             Logger.Info("Waiting on heightmaps to be loaded before proceeding, please wait ...");
             await heightmapTask;
         }
 
-        // Start main_world and other static instance
+        // Start main_world and other static instances
         WorldManager.Instance.CreateStaticInstances();
-
         WorldManager.Instance.Initialize();
 
         CharacterManager.Instance.CheckForDeletedCharacters();

--- a/AAEmu.Game/GameService.cs
+++ b/AAEmu.Game/GameService.cs
@@ -176,6 +176,7 @@ public sealed class GameService : IHostedService, IDisposable
 
         // LaborPowerManager.Initialize();
         TimedRewardsManager.Instance.Initialize();
+        AccountManager.Instance.Initialize();
 
         DuelManager.Initialize();
         InstantGameManager.Instance.Initialize();
@@ -200,7 +201,7 @@ public sealed class GameService : IHostedService, IDisposable
 
         WorldManager.Instance.Initialize();
 
-        CharacterManager.CheckForDeletedCharacters();
+        CharacterManager.Instance.CheckForDeletedCharacters();
         CharacterManager.Instance.StartOnlineTracking();
 
         GameNetwork.Instance.Start();

--- a/AAEmu.Game/Models/Game/AI/v2/Behaviors/Common/RunCommandSetBehavior.cs
+++ b/AAEmu.Game/Models/Game/AI/v2/Behaviors/Common/RunCommandSetBehavior.cs
@@ -98,10 +98,11 @@ public class RunCommandSetBehavior : BaseCombatBehavior
                 break;
             case AiCommandCategory.UseSkill:
                 Ai.AiSkillId = aiCommand.Param1;
+                var owner = Ai.Owner; // capture once to avoid race with concurrent unit despawn
                 var skillTemplate = SkillManager.Instance.GetSkillTemplate(Ai.AiSkillId);
-                if (skillTemplate != null && Ai.Owner.UseSkill(Ai.AiSkillId, Ai.Owner.CurrentTarget as Unit ?? Ai.Owner) == SkillResult.Success)
+                if (owner != null && skillTemplate != null && owner.UseSkill(Ai.AiSkillId, owner.CurrentTarget as Unit ?? owner) == SkillResult.Success)
                 {
-                    var coolDown = SkillManager.GetAttackDelay(skillTemplate, Ai.Owner, false, 0.0);
+                    var coolDown = SkillManager.GetAttackDelay(skillTemplate, owner, false, 0.0);
                     Ai.AiCurrentCommandRunTime = TimeSpan.FromMilliseconds(coolDown);
                 }
                 break;

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -2775,7 +2775,7 @@ public partial class Character : Unit, ICharacter
             LastPacketActivityTime = DateTime.UtcNow;
 
             // Remove character
-            EnterWorldManager.LeaveWorldTask(null, LeaveWorldTargetType.CharacterSelect, this);
+            EnterWorldManager.Instance.LeaveWorldTask(null, LeaveWorldTargetType.CharacterSelect, this);
 
             // If this character is still linked, then unlink it from the connection
             if (Connection != null && Connection.ActiveChar == this)

--- a/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
@@ -762,7 +762,7 @@ public class Doodad : BaseUnit
     {
         // Apply Climate settings
         var growTime = Template.TotalDoodadGrowthTime / AppConfiguration.Instance.World.GrowthRate;
-        if (Template.TotalDoodadGrowthTime > 0 && ZoneManager.DoodadHasMatchingClimate(this))
+        if (Template.TotalDoodadGrowthTime > 0 && ZoneManager.Instance.DoodadHasMatchingClimate(this))
         {
             growTime = (int)Math.Round(growTime * 0.73f);
         }

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncClimateReact.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncClimateReact.cs
@@ -12,7 +12,7 @@ public class DoodadFuncClimateReact : DoodadPhaseFuncTemplate
     {
         Logger.Trace("DoodadFuncClimateReact");
 
-        var inMatchingClimate = ZoneManager.DoodadHasMatchingClimate(owner);
+        var inMatchingClimate = ZoneManager.Instance.DoodadHasMatchingClimate(owner);
 
         // If no match, just move on to the next check
         if (!inMatchingClimate || NextPhase <= 0)

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncCoffer.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncCoffer.cs
@@ -16,9 +16,9 @@ public class DoodadFuncCoffer : DoodadPhaseFuncTemplate
         owner.ToNextPhase = false;
         if (caster is Character character && owner is DoodadCoffer coffer)
             if (coffer.OpenedBy?.Id == character.Id)
-                DoodadManager.CloseCofferDoodad(character, owner.ObjId);
+                DoodadManager.Instance.CloseCofferDoodad(character, owner.ObjId);
             else
-                DoodadManager.OpenCofferDoodad(character, owner.ObjId);
+                DoodadManager.Instance.OpenCofferDoodad(character, owner.ObjId);
         Logger.Trace("DoodadFuncCoffer");
         return false;
     }

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncGrowth.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncGrowth.cs
@@ -19,7 +19,7 @@ public class DoodadFuncGrowth : DoodadPhaseFuncTemplate
         // TODO: Add doodad scaling transformation
         owner.Scale = StartScale / 1000f;
         var customDelay = Delay / AppConfiguration.Instance.World.GrowthRate; // decrease delay
-        if (ZoneManager.DoodadHasMatchingClimate(owner))
+        if (ZoneManager.Instance.DoodadHasMatchingClimate(owner))
             customDelay = customDelay * 0.73f;
         var timeLeft = customDelay;
 

--- a/AAEmu.Game/Models/Game/Indun/Dungeon.cs
+++ b/AAEmu.Game/Models/Game/Indun/Dungeon.cs
@@ -675,7 +675,7 @@ public class Dungeon
 
                 if (radiusCount == 0 && room.GetRoomPlayerCount(World.Id) != 0)
                 {
-                    IndunManager.DoIndunActions(ev.StartActionId, World);
+                    IndunManager.Instance.DoIndunActions(ev.StartActionId, World);
                 }
 
                 room.SetRoomPlayerCount(World.Id, (uint)radiusCount);

--- a/AAEmu.Game/Models/Game/Indun/Events/IndunEventNpcKilleds.cs
+++ b/AAEmu.Game/Models/Game/Indun/Events/IndunEventNpcKilleds.cs
@@ -24,6 +24,6 @@ internal class IndunEventNpcKilleds : IndunEvent
         if (npc.TemplateId != NpcId) { return; }
 
         Logger.Warn($"IndunEventNpcKilleds - {NpcId}, {Id}");
-        IndunManager.DoIndunActions(StartActionId, world);
+        IndunManager.Instance.DoIndunActions(StartActionId, world);
     }
 }

--- a/AAEmu.Game/Models/Game/Mails/BaseMail.cs
+++ b/AAEmu.Game/Models/Game/Mails/BaseMail.cs
@@ -74,7 +74,7 @@ public class BaseMail
         Send();
 
         if (originalSender != null && originalSender.IsOnline)
-            MailManager.NotifyNewMailByNameIfOnline(this, originalSender.Name);
+            MailManager.Instance.NotifyNewMailByNameIfOnline(this, originalSender.Name);
 
         // TODO
         return true;

--- a/AAEmu.Game/Models/Game/Portal.cs
+++ b/AAEmu.Game/Models/Game/Portal.cs
@@ -25,7 +25,7 @@ public class Portal : PacketMarshaler
         stream.Write(Id);
         stream.Write(Name); // TODO max length 128
         stream.Write(ZoneId);
-        var origin = ZoneId != 0 ? ZoneManager.GetZoneOriginCell(ZoneId) : Vector2.Zero;
+        var origin = ZoneId != 0 ? ZoneManager.Instance.GetZoneOriginCell(ZoneId) : Vector2.Zero;
         var offX = X - origin.X * 1024f;
         var offY = Y - origin.Y * 1024f;
         stream.Write(offX);

--- a/AAEmu.Game/Models/Game/Quests/Quest.cs
+++ b/AAEmu.Game/Models/Game/Quests/Quest.cs
@@ -310,7 +310,7 @@ public partial class Quest : PacketMarshaler
             // TODO: Add a way to distribute honor or vocation badges in mail as well
             if (Owner.Inventory.Bag.FreeSlotCount < QuestRewardItemsPool.Count)
             {
-                var mails = MailManager.CreateQuestRewardMails(Owner, this, QuestRewardItemsPool, QuestRewardCoinsPool);
+                var mails = MailManager.Instance.CreateQuestRewardMails(Owner, this, QuestRewardItemsPool, QuestRewardCoinsPool);
                 QuestRewardCoinsPool = 0; // Coins will be distributed in mail if any mail needed to be sent, so set to zero again
                 foreach (var mail in mails)
                     if (!mail.Send())

--- a/AAEmu.Game/Models/Game/Skills/Buff.cs
+++ b/AAEmu.Game/Models/Game/Skills/Buff.cs
@@ -79,10 +79,10 @@ public class Buff
                 _count = (int)(time / Tick + 0.5f + 1);
             else
                 _count = -1;
-            EffectTaskManager.AddDispelTask(this, Tick);
+            EffectTaskManager.Instance.AddDispelTask(this, Tick);
         }
         else
-            EffectTaskManager.AddDispelTask(this, GetTimeLeft());
+            EffectTaskManager.Instance.AddDispelTask(this, GetTimeLeft());
     }
 
     public void ScheduleEffect(bool replace)
@@ -112,10 +112,10 @@ public class Buff
                             _count = (int)(time / Tick + 0.5f + 1);
                         else
                             _count = -1;
-                        EffectTaskManager.AddDispelTask(this, Tick);
+                        EffectTaskManager.Instance.AddDispelTask(this, Tick);
                     }
                     else
-                        EffectTaskManager.AddDispelTask(this, GetTimeLeft());
+                        EffectTaskManager.Instance.AddDispelTask(this, GetTimeLeft());
 
                     if (Template.FactionId > 0 && Owner is Unit owner)
                     {

--- a/AAEmu.Game/Models/Game/Skills/Effects/CraftEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/CraftEffect.cs
@@ -137,7 +137,7 @@ public class CraftEffect : EffectTemplate
                     {
                         if (sy.ShipyardData.OwnerName == caster.Name)
                         {
-                            ShipyardManager.ShipyardCompletedTask(sy);
+                            ShipyardManager.Instance.ShipyardCompletedTask(sy);
                         }
                         else
                             character.SendErrorMessage(ErrorMessageType.NoPermissionToLoot);

--- a/AAEmu.Game/Models/Tasks/Characters/CharacterDeleteTask.cs
+++ b/AAEmu.Game/Models/Tasks/Characters/CharacterDeleteTask.cs
@@ -12,7 +12,7 @@ public class CharacterDeleteTask : Task
         {
             try
             {
-                CharacterManager.CheckForDeletedCharacters();
+                CharacterManager.Instance.CheckForDeletedCharacters();
             }
             catch
             {

--- a/AAEmu.Game/Models/Tasks/Skills/DispelTask.cs
+++ b/AAEmu.Game/Models/Tasks/Skills/DispelTask.cs
@@ -21,6 +21,6 @@ public class DispelTask(Buff buff) : Task
         {
             return;
         }
-        EffectTaskManager.AddDispelTask(eff, eff.Tick);
+        EffectTaskManager.Instance.AddDispelTask(eff, eff.Tick);
     }
 }

--- a/AAEmu.Game/Program.cs
+++ b/AAEmu.Game/Program.cs
@@ -370,6 +370,22 @@ public static class Program
 
                 services.AddSingleton(_ => WorldIdManager.Instance);
                 services.AddSingleton<IWorldIdManager>(sp => sp.GetRequiredService<WorldIdManager>());
+
+                // -- Lazy<T> wrappers for circular-dep break patterns --
+                // MS DI does NOT auto-wrap registered types in Lazy<T>; they must be registered explicitly.
+                // WorldManager takes these three as Lazy<T> to break the circular dependency.
+                services.AddSingleton(sp => new Lazy<IZoneManager>(sp.GetRequiredService<IZoneManager>));
+                services.AddSingleton(sp => new Lazy<IIndunManager>(sp.GetRequiredService<IIndunManager>));
+                services.AddSingleton(sp => new Lazy<IFamilyManager>(sp.GetRequiredService<IFamilyManager>));
+                // NameManager ↔ CharacterManager circular dep: NameManager takes Lazy<ICharacterManager>.
+                services.AddSingleton(sp => new Lazy<ICharacterManager>(sp.GetRequiredService<ICharacterManager>));
+                // HousingManager ↔ MailManager circular dep: MailManager takes Lazy<IHousingManager>.
+                services.AddSingleton(sp => new Lazy<IHousingManager>(sp.GetRequiredService<IHousingManager>));
+
+                // -- Orchestrator --
+                // Expose the ServiceCollection itself so ManagerOrchestrator can inspect registrations.
+                services.AddSingleton(_ => services);
+                services.AddSingleton<ManagerOrchestrator>();
             });
 
         try

--- a/AAEmu.Game/Program.cs
+++ b/AAEmu.Game/Program.cs
@@ -1,6 +1,12 @@
 ﻿using System.Reflection;
 using AAEmu.Commons.IO;
 using AAEmu.Commons.Utils.DB;
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.Id;
+using AAEmu.Game.Core.Managers.Stream;
+using AAEmu.Game.Core.Managers.UnitManagers;
+using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.GameData.Framework;
 using AAEmu.Game.Models;
 using AAEmu.Game.Services;
 using AAEmu.Game.Services.WebApi;
@@ -98,9 +104,272 @@ public static class Program
             .ConfigureServices((hostContext, services) =>
             {
                 services.AddOptions();
+
+                // -- Hosted services --
                 services.AddSingleton<IHostedService, GameService>();
                 services.AddSingleton<IHostedService, WebApiService>();
                 services.AddSingleton<IHostedService, DiscordBotService>();
+
+                // -- Singleton<T>-based managers (AAEmu.Game.Core.Managers) --
+                services.AddSingleton<AccessLevelManager>();
+                services.AddSingleton<IAccessLevelManager>(sp => sp.GetRequiredService<AccessLevelManager>());
+
+                services.AddSingleton<AccountManager>();
+                services.AddSingleton<IAccountManager>(sp => sp.GetRequiredService<AccountManager>());
+
+                services.AddSingleton<AIManager>();
+                services.AddSingleton<IAIManager>(sp => sp.GetRequiredService<AIManager>());
+
+                services.AddSingleton<AiPathsManager>();
+                services.AddSingleton<IAiPathsManager>(sp => sp.GetRequiredService<AiPathsManager>());
+
+                services.AddSingleton<AnimationManager>();
+                services.AddSingleton<IAnimationManager>(sp => sp.GetRequiredService<AnimationManager>());
+
+                services.AddSingleton<AuctionManager>();
+                services.AddSingleton<IAuctionManager>(sp => sp.GetRequiredService<AuctionManager>());
+
+                services.AddSingleton<CashShopManager>();
+                services.AddSingleton<ICashShopManager>(sp => sp.GetRequiredService<CashShopManager>());
+
+                services.AddSingleton<ChatManager>();
+                services.AddSingleton<IChatManager>(sp => sp.GetRequiredService<ChatManager>());
+
+                services.AddSingleton<CommandManager>();
+                services.AddSingleton<ICommandManager>(sp => sp.GetRequiredService<CommandManager>());
+
+                services.AddSingleton<CraftManager>();
+                services.AddSingleton<ICraftManager>(sp => sp.GetRequiredService<CraftManager>());
+
+                services.AddSingleton<DuelManager>();
+                services.AddSingleton<IDuelManager>(sp => sp.GetRequiredService<DuelManager>());
+
+                services.AddSingleton<EffectTaskManager>();
+                services.AddSingleton<IEffectTaskManager>(sp => sp.GetRequiredService<EffectTaskManager>());
+
+                services.AddSingleton<ExpeditionManager>();
+                services.AddSingleton<IExpeditionManager>(sp => sp.GetRequiredService<ExpeditionManager>());
+
+                services.AddSingleton<ExperienceManager>();
+                services.AddSingleton<IExperienceManager>(sp => sp.GetRequiredService<ExperienceManager>());
+
+                services.AddSingleton<ExpressTextManager>();
+                services.AddSingleton<IExpressTextManager>(sp => sp.GetRequiredService<ExpressTextManager>());
+
+                services.AddSingleton<FamilyManager>();
+                services.AddSingleton<IFamilyManager>(sp => sp.GetRequiredService<FamilyManager>());
+
+                services.AddSingleton<FeaturesManager>();
+                services.AddSingleton<IFeaturesManager>(sp => sp.GetRequiredService<FeaturesManager>());
+
+                services.AddSingleton<FishSchoolManager>();
+                services.AddSingleton<IFishSchoolManager>(sp => sp.GetRequiredService<FishSchoolManager>());
+
+                services.AddSingleton<FormulaManager>();
+                services.AddSingleton<IFormulaManager>(sp => sp.GetRequiredService<FormulaManager>());
+
+                services.AddSingleton<FriendMananger>();
+                services.AddSingleton<IFriendManager>(sp => sp.GetRequiredService<FriendMananger>());
+
+                services.AddSingleton<GameScheduleManager>();
+                services.AddSingleton<IGameScheduleManager>(sp => sp.GetRequiredService<GameScheduleManager>());
+
+                services.AddSingleton<HousingManager>();
+                services.AddSingleton<IHousingManager>(sp => sp.GetRequiredService<HousingManager>());
+
+                services.AddSingleton<IndunManager>();
+                services.AddSingleton<IIndunManager>(sp => sp.GetRequiredService<IndunManager>());
+
+                services.AddSingleton<InstantGameManager>();
+                services.AddSingleton<IInstantGameManager>(sp => sp.GetRequiredService<InstantGameManager>());
+
+                services.AddSingleton<ItemManager>();
+                services.AddSingleton<IItemManager>(sp => sp.GetRequiredService<ItemManager>());
+
+                services.AddSingleton<LocalizationManager>();
+                services.AddSingleton<ILocalizationManager>(sp => sp.GetRequiredService<LocalizationManager>());
+
+                services.AddSingleton<MailManager>();
+                services.AddSingleton<IMailManager>(sp => sp.GetRequiredService<MailManager>());
+
+                services.AddSingleton<ManaRegenManager>();
+                services.AddSingleton<IManaRegenManager>(sp => sp.GetRequiredService<ManaRegenManager>());
+
+                services.AddSingleton<ModelManager>();
+                services.AddSingleton<IModelManager>(sp => sp.GetRequiredService<ModelManager>());
+
+                services.AddSingleton<MusicManager>();
+                services.AddSingleton<IMusicManager>(sp => sp.GetRequiredService<MusicManager>());
+
+                services.AddSingleton<NameManager>();
+                services.AddSingleton<INameManager>(sp => sp.GetRequiredService<NameManager>());
+
+                services.AddSingleton<PlotManager>();
+                services.AddSingleton<IPlotManager>(sp => sp.GetRequiredService<PlotManager>());
+
+                services.AddSingleton<PortalManager>();
+                services.AddSingleton<IPortalManager>(sp => sp.GetRequiredService<PortalManager>());
+
+                services.AddSingleton<PublicFarmManager>();
+                services.AddSingleton<IPublicFarmManager>(sp => sp.GetRequiredService<PublicFarmManager>());
+
+                services.AddSingleton<QuestManager>();
+                services.AddSingleton<IQuestManager>(sp => sp.GetRequiredService<QuestManager>());
+
+                services.AddSingleton<RadarManager>();
+                services.AddSingleton<IRadarManager>(sp => sp.GetRequiredService<RadarManager>());
+
+                services.AddSingleton<SaveManager>();
+                services.AddSingleton<ISaveManager>(sp => sp.GetRequiredService<SaveManager>());
+
+                services.AddSingleton<ShipyardManager>();
+                services.AddSingleton<IShipyardManager>(sp => sp.GetRequiredService<ShipyardManager>());
+
+                services.AddSingleton<SkillManager>();
+                services.AddSingleton<ISkillManager>(sp => sp.GetRequiredService<SkillManager>());
+
+                services.AddSingleton<SubZoneManager>();
+                services.AddSingleton<ISubZoneManager>(sp => sp.GetRequiredService<SubZoneManager>());
+
+                services.AddSingleton<SusManager>();
+                services.AddSingleton<ISusManager>(sp => sp.GetRequiredService<SusManager>());
+
+                services.AddSingleton<TaskManager>();
+                services.AddSingleton<ITaskManager>(sp => sp.GetRequiredService<TaskManager>());
+
+                services.AddSingleton<TaxationsManager>();
+                services.AddSingleton<ITaxationsManager>(sp => sp.GetRequiredService<TaxationsManager>());
+
+                services.AddSingleton<TeamManager>();
+                services.AddSingleton<ITeamManager>(sp => sp.GetRequiredService<TeamManager>());
+
+                services.AddSingleton<TickManager>();
+                services.AddSingleton<ITickManager>(sp => sp.GetRequiredService<TickManager>());
+
+                services.AddSingleton<TimedRewardsManager>();
+                services.AddSingleton<ITimedRewardsManager>(sp => sp.GetRequiredService<TimedRewardsManager>());
+
+                services.AddSingleton<TimeManager>();
+                services.AddSingleton<ITimeManager>(sp => sp.GetRequiredService<TimeManager>());
+
+                services.AddSingleton<TradeManager>();
+                services.AddSingleton<ITradeManager>(sp => sp.GetRequiredService<TradeManager>());
+
+                // -- Singleton<T>-based managers (AAEmu.Game.Core.Managers.UnitManagers) --
+                services.AddSingleton<CharacterManager>();
+                services.AddSingleton<ICharacterManager>(sp => sp.GetRequiredService<CharacterManager>());
+
+                services.AddSingleton<DoodadManager>();
+                services.AddSingleton<IDoodadManager>(sp => sp.GetRequiredService<DoodadManager>());
+
+                services.AddSingleton<NpcManager>();
+                services.AddSingleton<INpcManager>(sp => sp.GetRequiredService<NpcManager>());
+
+                // -- Singleton<T>-based managers (AAEmu.Game.Core.Managers.World) --
+                services.AddSingleton<AreaTriggerManager>();
+                services.AddSingleton<IAreaTriggerManager>(sp => sp.GetRequiredService<AreaTriggerManager>());
+
+                services.AddSingleton<EnterWorldManager>();
+                services.AddSingleton<IEnterWorldManager>(sp => sp.GetRequiredService<EnterWorldManager>());
+
+                services.AddSingleton<FactionManager>();
+                services.AddSingleton<IFactionManager>(sp => sp.GetRequiredService<FactionManager>());
+
+                services.AddSingleton<SpecialtyManager>();
+                services.AddSingleton<ISpecialtyManager>(sp => sp.GetRequiredService<SpecialtyManager>());
+
+                services.AddSingleton<StreamManager>();
+                services.AddSingleton<IStreamManager>(sp => sp.GetRequiredService<StreamManager>());
+
+                services.AddSingleton<WorldManager>();
+                services.AddSingleton<IWorldManager>(sp => sp.GetRequiredService<WorldManager>());
+
+                services.AddSingleton<ZoneManager>();
+                services.AddSingleton<IZoneManager>(sp => sp.GetRequiredService<ZoneManager>());
+
+                // -- Singleton<T>-based managers (AAEmu.Game.Core.Managers.Stream) --
+                services.AddSingleton<UccManager>();
+                services.AddSingleton<IUccManager>(sp => sp.GetRequiredService<UccManager>());
+
+                // -- Singleton<T>-based managers (AAEmu.Game.GameData.Framework) --
+                services.AddSingleton<GameDataManager>();
+                services.AddSingleton<IGameDataManager>(sp => sp.GetRequiredService<GameDataManager>());
+
+                // -- IdManagers (own static Instance, factory pattern) --
+                services.AddSingleton(_ => AuctionIdManager.Instance);
+                services.AddSingleton<IAuctionIdManager>(sp => sp.GetRequiredService<AuctionIdManager>());
+
+                services.AddSingleton(_ => CharacterIdManager.Instance);
+                services.AddSingleton<ICharacterIdManager>(sp => sp.GetRequiredService<CharacterIdManager>());
+
+                services.AddSingleton(_ => ContainerIdManager.Instance);
+                services.AddSingleton<IContainerIdManager>(sp => sp.GetRequiredService<ContainerIdManager>());
+
+                services.AddSingleton(_ => DoodadIdManager.Instance);
+                services.AddSingleton<IDoodadIdManager>(sp => sp.GetRequiredService<DoodadIdManager>());
+
+                services.AddSingleton(_ => ExpeditionIdManager.Instance);
+                services.AddSingleton<IExpeditionIdManager>(sp => sp.GetRequiredService<ExpeditionIdManager>());
+
+                services.AddSingleton(_ => FamilyIdManager.Instance);
+                services.AddSingleton<IFamilyIdManager>(sp => sp.GetRequiredService<FamilyIdManager>());
+
+                services.AddSingleton(_ => FriendIdManager.Instance);
+                services.AddSingleton<IFriendIdManager>(sp => sp.GetRequiredService<FriendIdManager>());
+
+                services.AddSingleton(_ => GimmickIdManager.Instance);
+                services.AddSingleton<IGimmickIdManager>(sp => sp.GetRequiredService<GimmickIdManager>());
+
+                services.AddSingleton(_ => HousingIdManager.Instance);
+                services.AddSingleton<IHousingIdManager>(sp => sp.GetRequiredService<HousingIdManager>());
+
+                services.AddSingleton(_ => HousingTldManager.Instance);
+                services.AddSingleton<IHousingTldManager>(sp => sp.GetRequiredService<HousingTldManager>());
+
+                services.AddSingleton(_ => ItemIdManager.Instance);
+                services.AddSingleton<IItemIdManager>(sp => sp.GetRequiredService<ItemIdManager>());
+
+                services.AddSingleton(_ => MailIdManager.Instance);
+                services.AddSingleton<IMailIdManager>(sp => sp.GetRequiredService<MailIdManager>());
+
+                services.AddSingleton(_ => MateIdManager.Instance);
+                services.AddSingleton<IMateIdManager>(sp => sp.GetRequiredService<MateIdManager>());
+
+                services.AddSingleton(_ => MusicIdManager.Instance);
+                services.AddSingleton<IMusicIdManager>(sp => sp.GetRequiredService<MusicIdManager>());
+
+                services.AddSingleton(_ => ObjectIdManager.Instance);
+                services.AddSingleton<IObjectIdManager>(sp => sp.GetRequiredService<ObjectIdManager>());
+
+                services.AddSingleton(_ => PrivateBookIdManager.Instance);
+                services.AddSingleton<IPrivateBookIdManager>(sp => sp.GetRequiredService<PrivateBookIdManager>());
+
+                services.AddSingleton(_ => QuestIdManager.Instance);
+                services.AddSingleton<IQuestIdManager>(sp => sp.GetRequiredService<QuestIdManager>());
+
+                services.AddSingleton(_ => ShipyardIdManager.Instance);
+                services.AddSingleton<IShipyardIdManager>(sp => sp.GetRequiredService<ShipyardIdManager>());
+
+                services.AddSingleton(_ => TaskIdManager.Instance);
+                services.AddSingleton<ITaskIdManager>(sp => sp.GetRequiredService<TaskIdManager>());
+
+                services.AddSingleton(_ => TeamIdManager.Instance);
+                services.AddSingleton<ITeamIdManager>(sp => sp.GetRequiredService<TeamIdManager>());
+
+                services.AddSingleton(_ => TlIdManager.Instance);
+                services.AddSingleton<ITlIdManager>(sp => sp.GetRequiredService<TlIdManager>());
+
+                services.AddSingleton(_ => TradeIdManager.Instance);
+                services.AddSingleton<ITradeIdManager>(sp => sp.GetRequiredService<TradeIdManager>());
+
+                services.AddSingleton(_ => UccIdManager.Instance);
+                services.AddSingleton<IUccIdManager>(sp => sp.GetRequiredService<UccIdManager>());
+
+                services.AddSingleton(_ => VisitedSubZoneIdManager.Instance);
+                services.AddSingleton<IVisitedSubZoneIdManager>(sp => sp.GetRequiredService<VisitedSubZoneIdManager>());
+
+                services.AddSingleton(_ => WorldIdManager.Instance);
+                services.AddSingleton<IWorldIdManager>(sp => sp.GetRequiredService<WorldIdManager>());
             });
 
         try

--- a/AAEmu.Game/Scripts/Commands/AddBadges.cs
+++ b/AAEmu.Game/Scripts/Commands/AddBadges.cs
@@ -34,7 +34,7 @@ public class AddBadges : ICommand
             return;
         }
 
-        var targetPlayer = WorldManager.GetTargetOrSelf(character, args[0], out var firstArg);
+        var targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out var firstArg);
 
         if (!int.TryParse(args[firstArg], out var vpToAdd))
         {

--- a/AAEmu.Game/Scripts/Commands/AddGold.cs
+++ b/AAEmu.Game/Scripts/Commands/AddGold.cs
@@ -35,7 +35,7 @@ public class AddGold : ICommand
             return;
         }
 
-        var targetPlayer = WorldManager.GetTargetOrSelf(character, args[0], out var firstarg);
+        var targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out var firstarg);
 
         var argGold = 0;
         var argSilver = 0;

--- a/AAEmu.Game/Scripts/Commands/AddLabor.cs
+++ b/AAEmu.Game/Scripts/Commands/AddLabor.cs
@@ -39,7 +39,7 @@ public class AddLabor : ICommand
             return;
         }
 
-        var targetPlayer = WorldManager.GetTargetOrSelf(character, args[0], out var firstArg);
+        var targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out var firstArg);
 
         short amount = 0;
 

--- a/AAEmu.Game/Scripts/Commands/AddPortals.cs
+++ b/AAEmu.Game/Scripts/Commands/AddPortals.cs
@@ -34,7 +34,7 @@ public class AddPortals : ICommand
             return;
         }
 
-        var targetPlayer = WorldManager.GetTargetOrSelf(character, args[0], out var firstArg);
+        var targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out var firstArg);
 
         var portalName = args[firstArg + 0];
         var position = character.Transform.CloneAsSpawnPosition();

--- a/AAEmu.Game/Scripts/Commands/AddXP.cs
+++ b/AAEmu.Game/Scripts/Commands/AddXP.cs
@@ -33,7 +33,7 @@ public class AddXP : ICommand
             return;
         }
 
-        var targetPlayer = WorldManager.GetTargetOrSelf(character, args[0], out var firstArg);
+        var targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out var firstArg);
 
         var xpToAdd = 0;
         if (int.TryParse(args[firstArg + 0], out var parseXp))

--- a/AAEmu.Game/Scripts/Commands/ChangeLevel.cs
+++ b/AAEmu.Game/Scripts/Commands/ChangeLevel.cs
@@ -38,7 +38,7 @@ public class ChangeLevel : ICommand
             return;
         }
 
-        var targetPlayer = WorldManager.GetTargetOrSelf(character, args[0], out var firstArg);
+        var targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out var firstArg);
 
         byte level = 0;
         if (byte.TryParse(args[firstArg + 0], out var parseLevel))

--- a/AAEmu.Game/Scripts/Commands/CofferActions.cs
+++ b/AAEmu.Game/Scripts/Commands/CofferActions.cs
@@ -104,7 +104,7 @@ public class CofferActions : ICommand
                     $"[|nd;@DOODAD_NAME({coffer.TemplateId})|r][{coffer.ItemContainer.ContainerType}] {coffer.ItemContainer.Items.Count} entries");
                 break;
             case "close":
-                if (!DoodadManager.CloseCofferDoodad(null, coffer.ObjId))
+                if (!DoodadManager.Instance.CloseCofferDoodad(null, coffer.ObjId))
                 {
                     CommandManager.SendErrorText(this, messageOutput, $"Failed to close coffer {coffer.ObjId} ?");
                 }

--- a/AAEmu.Game/Scripts/Commands/Fly.cs
+++ b/AAEmu.Game/Scripts/Commands/Fly.cs
@@ -51,7 +51,7 @@ public class Fly : ICommand
         var firstArg = 0;
         if (args.Length > 0)
         {
-            targetPlayer = WorldManager.GetTargetOrSelf(character, args[0], out firstArg);
+            targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out firstArg);
         }
 
         var isFlying = !GetCacheState(targetPlayer.Id); // We cache the playerId, not the ObjectId

--- a/AAEmu.Game/Scripts/Commands/GetPosition.cs
+++ b/AAEmu.Game/Scripts/Commands/GetPosition.cs
@@ -44,7 +44,7 @@ public class GetPosition : ICommand
             var targetPlayer = character;
             if (args.Length > 0)
             {
-                targetPlayer = WorldManager.GetTargetOrSelf(character, args[0], out var firstArg);
+                targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out var firstArg);
             }
 
             var pos = targetPlayer.Transform.CloneAsSpawnPosition();

--- a/AAEmu.Game/Scripts/Commands/Height.cs
+++ b/AAEmu.Game/Scripts/Commands/Height.cs
@@ -30,7 +30,7 @@ public class Height : ICommand
         var targetPlayer = character;
         if (args.Length > 0)
         {
-            targetPlayer = WorldManager.GetTargetOrSelf(character, args[0], out var firstArg);
+            targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out var firstArg);
         }
 
         var floorHeight = WorldManager.Instance.GetHeight(targetPlayer.Transform.ZoneId, targetPlayer.Transform.World.Position.X, targetPlayer.Transform.World.Position.Y, targetPlayer.Transform.World.Position.Z);

--- a/AAEmu.Game/Scripts/Commands/Kill.cs
+++ b/AAEmu.Game/Scripts/Commands/Kill.cs
@@ -29,7 +29,7 @@ public class Kill : ICommand
 
     public void Execute(Character character, string[] args, IMessageOutput messageOutput)
     {
-        var targetPlayer = WorldManager.GetTargetOrSelf(character, null, out var _);
+        var targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, null, out var _);
         var playerTarget = character.CurrentTarget;
         if (playerTarget is Unit aUnit)
         {

--- a/AAEmu.Game/Scripts/Commands/Kit.cs
+++ b/AAEmu.Game/Scripts/Commands/Kit.cs
@@ -84,7 +84,7 @@ public class AddKit : ICommand
             return;
         }
 
-        var targetPlayer = WorldManager.GetTargetOrSelf(character, args[0], out var firstArg);
+        var targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out var firstArg);
 
         var kitName = string.Empty;
         var itemsAdded = 0;

--- a/AAEmu.Game/Scripts/Commands/Move.cs
+++ b/AAEmu.Game/Scripts/Commands/Move.cs
@@ -39,7 +39,7 @@ public class Move : ICommand
         var firstArg = 0;
         if (args.Length > 0)
         {
-            targetPlayer = WorldManager.GetTargetOrSelf(character, args[0], out firstArg);
+            targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out firstArg);
         }
 
         var moveToMe = targetPlayer != character && args.Length == 2 && args[1].Equals("tome", System.StringComparison.CurrentCultureIgnoreCase);

--- a/AAEmu.Game/Scripts/Commands/Revive.cs
+++ b/AAEmu.Game/Scripts/Commands/Revive.cs
@@ -29,7 +29,7 @@ public class Revive : ICommand
 
     public void Execute(Character character, string[] args, IMessageOutput messageOutput)
     {
-        var targetPlayer = WorldManager.GetTargetOrSelf(character, args.Length > 0 ? args[0] : null, out var _);
+        var targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args.Length > 0 ? args[0] : null, out var _);
         if (targetPlayer != null)
         {
             if (targetPlayer.Hp == 0)

--- a/AAEmu.Game/Scripts/Commands/ShowInventory.cs
+++ b/AAEmu.Game/Scripts/Commands/ShowInventory.cs
@@ -64,7 +64,7 @@ public class ShowInventory : ICommand
             var firstarg = 0;
             if (args.Length > 0)
             {
-                targetPlayer = WorldManager.GetTargetOrSelf(character, args[0], out firstarg);
+                targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out firstarg);
             }
 
             var containerId = SlotType.Inventory;

--- a/AAEmu.Game/Scripts/Commands/TestHeight.cs
+++ b/AAEmu.Game/Scripts/Commands/TestHeight.cs
@@ -40,7 +40,7 @@ public class TestHeight : ICommand
         var firstarg = 0;
         if (args.Length > 0)
         {
-            targetPlayer = WorldManager.GetTargetOrSelf(character, args[0], out firstarg);
+            targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out firstarg);
         }
 
         if (args.Length > firstarg && args[firstarg] == "testpos")

--- a/AAEmu.Game/Scripts/Commands/TestHouse.cs
+++ b/AAEmu.Game/Scripts/Commands/TestHouse.cs
@@ -88,25 +88,25 @@ public class TestHouse : ICommand
             else if (a0 == "settaxpaid")
             {
                 house.ProtectionEndDate = DateTime.UtcNow.AddDays(21);
-                HousingManager.UpdateTaxInfo(house);
+                HousingManager.Instance.UpdateTaxInfo(house);
                 CommandManager.SendNormalText(this, messageOutput, $"Set {house.Name} as tax paid");
             }
             else if (a0 == "settaxdue")
             {
                 house.ProtectionEndDate = DateTime.UtcNow.AddDays(14);
-                HousingManager.UpdateTaxInfo(house);
+                HousingManager.Instance.UpdateTaxInfo(house);
                 CommandManager.SendNormalText(this, messageOutput, $"Set {house.Name} as tax due");
             }
             else if (a0 == "settaxoverdue")
             {
                 house.ProtectionEndDate = DateTime.UtcNow.AddDays(7);
-                HousingManager.UpdateTaxInfo(house);
+                HousingManager.Instance.UpdateTaxInfo(house);
                 CommandManager.SendNormalText(this, messageOutput, $"Set {house.Name} as tax overdue");
             }
             else if (a0 == "setdemosoon")
             {
                 house.ProtectionEndDate = DateTime.UtcNow.AddSeconds(20);
-                HousingManager.UpdateTaxInfo(house);
+                HousingManager.Instance.UpdateTaxInfo(house);
                 CommandManager.SendNormalText(this, messageOutput,
                     $"Set {house.Name} to demolished in about 20 seconds");
             }
@@ -159,7 +159,7 @@ public class TestHouse : ICommand
                         return;
                     }
 
-                    if (HousingManager.SetForSale(house, price, buyerId, null))
+                    if (HousingManager.Instance.SetForSale(house, price, buyerId, null))
                     {
                         CommandManager.SendNormalText(this, messageOutput,
                             $"Setting {house.Name} for sale with a price of {price} to buy for {buyer}.");
@@ -178,7 +178,7 @@ public class TestHouse : ICommand
                     }
 
                     // Remove sale (for GM commands we don't return certificates)
-                    if (HousingManager.CancelForSale(house, false))
+                    if (HousingManager.Instance.CancelForSale(house, false))
                     {
                         CommandManager.SendNormalText(this, messageOutput, $"{house.Name} is no longer for sale");
                     }

--- a/AAEmu.UnitTests/Commons/Utils/SingletonTests.cs
+++ b/AAEmu.UnitTests/Commons/Utils/SingletonTests.cs
@@ -1,0 +1,38 @@
+using System.Diagnostics.CodeAnalysis;
+using AAEmu.Commons.Utils;
+using Xunit;
+
+namespace AAEmu.UnitTests.Commons.Utils;
+
+public class SingletonTests
+{
+    [SuppressMessage("ReSharper", "ClassNeverInstantiated.Local")]
+    private sealed class LeafSingleton : Singleton<LeafSingleton>
+    {
+        // parameterless constructor — DI fallback works
+    }
+
+    [SuppressMessage("ReSharper", "ClassNeverInstantiated.Local")]
+    private sealed class DependentSingleton : Singleton<DependentSingleton>
+    {
+        // No parameterless constructor — must be resolved from DI
+        public DependentSingleton([SuppressMessage("ReSharper", "UnusedParameter.Local")] object dep) { }
+    }
+
+    [Fact]
+    public void Instance_WithParameterlessConstructor_ReturnsInstance()
+    {
+        // Reset by assigning via DI path isn't needed — just ensure it constructs
+        // (may already be set from a previous test run; that's fine)
+        var instance = LeafSingleton.Instance;
+        Assert.NotNull(instance);
+    }
+
+    [Fact]
+    public void Instance_WithNoParameterlessConstructor_ThrowsInvalidOperationException()
+    {
+        // SingletonContainer.ServiceProvider is null in unit tests
+        // so OnInit() reflection fallback is invoked, which should throw
+        Assert.Throws<InvalidOperationException>(() => _ = DependentSingleton.Instance);
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/AccountManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/AccountManagerTests.cs
@@ -1,0 +1,33 @@
+using AAEmu.Game.Core.Managers;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class AccountManagerTests
+{
+    [Fact]
+    public void Constructor_DoesNotCallDeps()
+    {
+        var mockTick = new Mock<ITickManager>();
+        var mockTimedRewards = new Mock<ITimedRewardsManager>();
+
+        var manager = new AccountManager(mockTick.Object, mockTimedRewards.Object);
+
+        Assert.NotNull(manager);
+        mockTick.VerifyNoOtherCalls();
+        mockTimedRewards.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public void Initialize_AccessesOnTickProperty()
+    {
+        var mockTick = new Mock<ITickManager>();
+        mockTick.Setup(t => t.OnTick).Returns(new TickManager.TickEventHandler());
+
+        var manager = new AccountManager(mockTick.Object, new Mock<ITimedRewardsManager>().Object);
+        manager.Initialize();
+
+        mockTick.Verify(t => t.OnTick, Times.Once);
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/AuctionManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/AuctionManagerTests.cs
@@ -1,0 +1,27 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.Id;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class AuctionManagerTests
+{
+    [Fact]
+    public void Constructor_DoesNotCallDeps()
+    {
+        var mockItem = new Mock<IItemManager>();
+        var mockName = new Mock<INameManager>();
+        var mockAuctionId = new Mock<IAuctionIdManager>();
+        var mockLocale = new Mock<ILocalizationManager>();
+        var mockTask = new Mock<ITaskManager>();
+        var manager = new AuctionManager(mockItem.Object, mockName.Object, mockAuctionId.Object, mockLocale.Object, mockTask.Object);
+
+        Assert.NotNull(manager);
+        mockItem.VerifyNoOtherCalls();
+        mockName.VerifyNoOtherCalls();
+        mockAuctionId.VerifyNoOtherCalls();
+        mockLocale.VerifyNoOtherCalls();
+        mockTask.VerifyNoOtherCalls();
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/CashShopManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/CashShopManagerTests.cs
@@ -1,0 +1,20 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class CashShopManagerTests
+{
+    [Fact]
+    public void DisableShop_CallsGetAllCharacters()
+    {
+        var mockWorld = new Mock<IWorldManager>();
+        mockWorld.Setup(w => w.GetAllCharacters()).Returns([]);
+        var manager = new CashShopManager(mockWorld.Object, new Mock<IAccountManager>().Object, new Mock<ILocalizationManager>().Object);
+        manager.DisableShop();
+
+        mockWorld.Verify(w => w.GetAllCharacters(), Times.Once);
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/CharacterManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/CharacterManagerTests.cs
@@ -1,0 +1,53 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.Id;
+using AAEmu.Game.Core.Managers.UnitManagers;
+using AAEmu.Game.Core.Managers.World;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class CharacterManagerTests
+{
+    [Fact]
+    public void Constructor_DoesNotCallDeps()
+    {
+        var mockWorld = new Mock<IWorldManager>();
+        var mockAccount = new Mock<IAccountManager>();
+        var mockName = new Mock<INameManager>();
+        var mockCharId = new Mock<ICharacterIdManager>();
+        var mockFaction = new Mock<IFactionManager>();
+        var mockSkill = new Mock<ISkillManager>();
+        var mockItem = new Mock<IItemManager>();
+        var mockHousing = new Mock<IHousingManager>();
+        var mockFamily = new Mock<IFamilyManager>();
+        var mockMail = new Mock<IMailManager>();
+        var mockTask = new Mock<ITaskManager>();
+
+        var manager = new CharacterManager(
+            mockWorld.Object,
+            mockAccount.Object,
+            mockName.Object,
+            mockCharId.Object,
+            mockFaction.Object,
+            mockSkill.Object,
+            mockItem.Object,
+            mockHousing.Object,
+            mockFamily.Object,
+            mockMail.Object,
+            mockTask.Object);
+
+        Assert.NotNull(manager);
+        mockWorld.VerifyNoOtherCalls();
+        mockAccount.VerifyNoOtherCalls();
+        mockName.VerifyNoOtherCalls();
+        mockCharId.VerifyNoOtherCalls();
+        mockFaction.VerifyNoOtherCalls();
+        mockSkill.VerifyNoOtherCalls();
+        mockItem.VerifyNoOtherCalls();
+        mockHousing.VerifyNoOtherCalls();
+        mockFamily.VerifyNoOtherCalls();
+        mockMail.VerifyNoOtherCalls();
+        mockTask.VerifyNoOtherCalls();
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/EffectTaskManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/EffectTaskManagerTests.cs
@@ -1,0 +1,40 @@
+using AAEmu.Game.Core.Managers;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class EffectTaskManagerTests
+{
+    [Fact]
+    public void AddDispelTask_CallsTaskManagerSchedule()
+    {
+        var mockTaskManager = new Mock<ITaskManager>();
+        mockTaskManager
+            .Setup(t => t.Schedule(It.IsAny<AAEmu.Game.Models.Tasks.Task>(), It.IsAny<TimeSpan?>(), It.IsAny<TimeSpan?>(), It.IsAny<int>()))
+            .Returns(true);
+
+        var manager = new EffectTaskManager(mockTaskManager.Object);
+        manager.AddDispelTask(null, 250.0);
+
+        mockTaskManager.Verify(
+            t => t.Schedule(It.IsAny<AAEmu.Game.Models.Tasks.Task>(), TimeSpan.FromMilliseconds(250.0), null, -1),
+            Times.Once);
+    }
+
+    [Fact]
+    public void AddDispelTask_WithDifferentInterval_PassesCorrectTimeSpan()
+    {
+        var mockTaskManager = new Mock<ITaskManager>();
+        mockTaskManager
+            .Setup(t => t.Schedule(It.IsAny<AAEmu.Game.Models.Tasks.Task>(), It.IsAny<TimeSpan?>(), It.IsAny<TimeSpan?>(), It.IsAny<int>()))
+            .Returns(true);
+
+        var manager = new EffectTaskManager(mockTaskManager.Object);
+        manager.AddDispelTask(null, 1000.0);
+
+        mockTaskManager.Verify(
+            t => t.Schedule(It.IsAny<AAEmu.Game.Models.Tasks.Task>(), TimeSpan.FromMilliseconds(1000.0), null, -1),
+            Times.Once);
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/EnterWorldManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/EnterWorldManagerTests.cs
@@ -1,0 +1,39 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class EnterWorldManagerTests
+{
+    [Fact]
+    public void Constructor_DoesNotCallDeps()
+    {
+        var mockAccount = new Mock<IAccountManager>();
+        var mockStream = new Mock<IStreamManager>();
+        var mockQuest = new Mock<IQuestManager>();
+        var mockTeam = new Mock<ITeamManager>();
+        var mockChat = new Mock<IChatManager>();
+        var mockFamily = new Mock<IFamilyManager>();
+        var mockWorld = new Mock<IWorldManager>();
+
+        var manager = new EnterWorldManager(
+            mockAccount.Object,
+            mockStream.Object,
+            mockQuest.Object,
+            mockTeam.Object,
+            mockChat.Object,
+            mockFamily.Object,
+            mockWorld.Object);
+
+        Assert.NotNull(manager);
+        mockAccount.VerifyNoOtherCalls();
+        mockStream.VerifyNoOtherCalls();
+        mockQuest.VerifyNoOtherCalls();
+        mockTeam.VerifyNoOtherCalls();
+        mockChat.VerifyNoOtherCalls();
+        mockFamily.VerifyNoOtherCalls();
+        mockWorld.VerifyNoOtherCalls();
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/ExpeditionManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/ExpeditionManagerTests.cs
@@ -1,0 +1,26 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.Id;
+using AAEmu.Game.Core.Managers.World;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class ExpeditionManagerTests
+{
+    [Fact]
+    public void Constructor_DoesNotCallDeps()
+    {
+        var mockExpId = new Mock<IExpeditionIdManager>();
+        var mockTeam = new Mock<ITeamManager>();
+        var mockWorld = new Mock<IWorldManager>();
+        var mockChat = new Mock<IChatManager>();
+        var manager = new ExpeditionManager(mockExpId.Object, mockTeam.Object, mockWorld.Object, mockChat.Object);
+
+        Assert.NotNull(manager);
+        mockExpId.VerifyNoOtherCalls();
+        mockTeam.VerifyNoOtherCalls();
+        mockWorld.VerifyNoOtherCalls();
+        mockChat.VerifyNoOtherCalls();
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/FamilyManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/FamilyManagerTests.cs
@@ -1,0 +1,24 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.Id;
+using AAEmu.Game.Core.Managers.World;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class FamilyManagerTests
+{
+    [Fact]
+    public void Constructor_DoesNotCallDeps()
+    {
+        var mockWorld = new Mock<IWorldManager>();
+        var mockChat = new Mock<IChatManager>();
+        var mockFamilyId = new Mock<IFamilyIdManager>();
+        var manager = new FamilyManager(mockWorld.Object, mockChat.Object, mockFamilyId.Object);
+
+        Assert.NotNull(manager);
+        mockWorld.VerifyNoOtherCalls();
+        mockChat.VerifyNoOtherCalls();
+        mockFamilyId.VerifyNoOtherCalls();
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/HousingManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/HousingManagerTests.cs
@@ -1,0 +1,63 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.Id;
+using AAEmu.Game.Core.Managers.Stream;
+using AAEmu.Game.Core.Managers.UnitManagers;
+using AAEmu.Game.Core.Managers.World;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class HousingManagerTests
+{
+    [Fact]
+    public void Constructor_DoesNotCallDeps()
+    {
+        var mockObjectId = new Mock<IObjectIdManager>();
+        var mockFaction = new Mock<IFactionManager>();
+        var mockLocale = new Mock<ILocalizationManager>();
+        var mockWorld = new Mock<IWorldManager>();
+        var mockTask = new Mock<ITaskManager>();
+        var mockSkill = new Mock<ISkillManager>();
+        var mockHousingId = new Mock<IHousingIdManager>();
+        var mockHousingTld = new Mock<IHousingTldManager>();
+        var mockItem = new Mock<IItemManager>();
+        var mockMail = new Mock<IMailManager>();
+        var mockName = new Mock<INameManager>();
+        var mockZone = new Mock<IZoneManager>();
+        var mockDoodad = new Mock<IDoodadManager>();
+        var mockUcc = new Mock<IUccManager>();
+
+        var manager = new HousingManager(
+            mockObjectId.Object,
+            mockFaction.Object,
+            mockLocale.Object,
+            mockWorld.Object,
+            mockTask.Object,
+            mockSkill.Object,
+            mockHousingId.Object,
+            mockHousingTld.Object,
+            mockItem.Object,
+            mockMail.Object,
+            mockName.Object,
+            mockZone.Object,
+            mockDoodad.Object,
+            mockUcc.Object);
+
+        Assert.NotNull(manager);
+        mockObjectId.VerifyNoOtherCalls();
+        mockFaction.VerifyNoOtherCalls();
+        mockLocale.VerifyNoOtherCalls();
+        mockWorld.VerifyNoOtherCalls();
+        mockTask.VerifyNoOtherCalls();
+        mockSkill.VerifyNoOtherCalls();
+        mockHousingId.VerifyNoOtherCalls();
+        mockHousingTld.VerifyNoOtherCalls();
+        mockItem.VerifyNoOtherCalls();
+        mockMail.VerifyNoOtherCalls();
+        mockName.VerifyNoOtherCalls();
+        mockZone.VerifyNoOtherCalls();
+        mockDoodad.VerifyNoOtherCalls();
+        mockUcc.VerifyNoOtherCalls();
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/IndunManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/IndunManagerTests.cs
@@ -1,0 +1,20 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class IndunManagerTests
+{
+    [Fact]
+    public void Initialize_SubscribesToTickManager()
+    {
+        var mockTick = new Mock<ITickManager>();
+        mockTick.SetupGet(t => t.OnTick).Returns(new TickManager.TickEventHandler());
+        var manager = new IndunManager(mockTick.Object, new Mock<IWorldManager>().Object, new Mock<IZoneManager>().Object, new Mock<ITeamManager>().Object);
+        manager.Initialize();
+
+        mockTick.VerifyGet(t => t.OnTick, Times.Once);
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/ItemManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/ItemManagerTests.cs
@@ -1,0 +1,30 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.Id;
+using AAEmu.Game.Core.Managers.World;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class ItemManagerTests
+{
+    [Fact]
+    public void Constructor_DoesNotCallDeps()
+    {
+        var mockSkill = new Mock<ISkillManager>();
+        var mockItemId = new Mock<IItemIdManager>();
+        var mockContainerId = new Mock<IContainerIdManager>();
+        var mockLocale = new Mock<ILocalizationManager>();
+        var mockTask = new Mock<ITaskManager>();
+        var mockWorld = new Mock<IWorldManager>();
+        var manager = new ItemManager(mockSkill.Object, mockItemId.Object, mockContainerId.Object, mockLocale.Object, mockTask.Object, mockWorld.Object);
+
+        Assert.NotNull(manager);
+        mockSkill.VerifyNoOtherCalls();
+        mockItemId.VerifyNoOtherCalls();
+        mockContainerId.VerifyNoOtherCalls();
+        mockLocale.VerifyNoOtherCalls();
+        mockTask.VerifyNoOtherCalls();
+        mockWorld.VerifyNoOtherCalls();
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/MailManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/MailManagerTests.cs
@@ -18,7 +18,7 @@ public class MailManagerTests
         var mockWorld = new Mock<IWorldManager>();
         var mockHousing = new Mock<IHousingManager>();
         var mockLocale = new Mock<ILocalizationManager>();
-        var manager = new MailManager(mockMailId.Object, mockName.Object, mockItem.Object, mockTask.Object, mockWorld.Object, mockHousing.Object, mockLocale.Object);
+        var manager = new MailManager(mockMailId.Object, mockName.Object, mockItem.Object, mockTask.Object, mockWorld.Object, new Lazy<IHousingManager>(() => mockHousing.Object), mockLocale.Object);
 
         Assert.NotNull(manager);
         mockMailId.VerifyNoOtherCalls();

--- a/AAEmu.UnitTests/Game/Core/Managers/MailManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/MailManagerTests.cs
@@ -1,0 +1,32 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.Id;
+using AAEmu.Game.Core.Managers.World;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class MailManagerTests
+{
+    [Fact]
+    public void Constructor_DoesNotCallDeps()
+    {
+        var mockMailId = new Mock<IMailIdManager>();
+        var mockName = new Mock<INameManager>();
+        var mockItem = new Mock<IItemManager>();
+        var mockTask = new Mock<ITaskManager>();
+        var mockWorld = new Mock<IWorldManager>();
+        var mockHousing = new Mock<IHousingManager>();
+        var mockLocale = new Mock<ILocalizationManager>();
+        var manager = new MailManager(mockMailId.Object, mockName.Object, mockItem.Object, mockTask.Object, mockWorld.Object, mockHousing.Object, mockLocale.Object);
+
+        Assert.NotNull(manager);
+        mockMailId.VerifyNoOtherCalls();
+        mockName.VerifyNoOtherCalls();
+        mockItem.VerifyNoOtherCalls();
+        mockTask.VerifyNoOtherCalls();
+        mockWorld.VerifyNoOtherCalls();
+        mockHousing.VerifyNoOtherCalls();
+        mockLocale.VerifyNoOtherCalls();
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/MailTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/MailTests.cs
@@ -1,11 +1,15 @@
-﻿using AAEmu.Commons.Utils;
+﻿using System.Reflection;
+using AAEmu.Commons.Utils;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.Id;
+using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Mails;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.UnitTests.Utils.Mocks;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using Xunit;
 
 namespace AAEmu.UnitTests.Game.Core.Managers;
@@ -32,6 +36,26 @@ public sealed class MailTests : IDisposable
         NameManager.Instance.Load([], [], []);
         NameManager.Instance.AddCharacter(_character.Id, _character.Name, 1);
         MailIdManager.Instance.Initialize();
+
+        // Reset cached MailManager instance from any previous test
+        typeof(Singleton<MailManager>)
+            .GetField("_instance", BindingFlags.Static | BindingFlags.NonPublic)
+            ?.SetValue(null, null);
+
+        // Create MailManager with real leaf deps + mocked non-critical deps
+        var mailManager = new MailManager(
+            MailIdManager.Instance,
+            NameManager.Instance,
+            Mock.Of<IItemManager>(),
+            Mock.Of<ITaskManager>(),
+            Mock.Of<IWorldManager>(),
+            Mock.Of<IHousingManager>(),
+            Mock.Of<ILocalizationManager>());
+
+        var services = new ServiceCollection();
+        services.AddSingleton(mailManager);
+        SingletonContainer.ServiceProvider = services.BuildServiceProvider();
+
         MailManager.Instance._allPlayerMails = [];
     }
 
@@ -41,6 +65,11 @@ public sealed class MailTests : IDisposable
         MailManager.Instance._allPlayerMails = null;
         _character = null;
         _mails = null;
+
+        SingletonContainer.ServiceProvider = null;
+        typeof(Singleton<MailManager>)
+            .GetField("_instance", BindingFlags.Static | BindingFlags.NonPublic)
+            ?.SetValue(null, null);
     }
 
     [Fact]

--- a/AAEmu.UnitTests/Game/Core/Managers/MailTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/MailTests.cs
@@ -49,7 +49,7 @@ public sealed class MailTests : IDisposable
             Mock.Of<IItemManager>(),
             Mock.Of<ITaskManager>(),
             Mock.Of<IWorldManager>(),
-            Mock.Of<IHousingManager>(),
+            new Lazy<IHousingManager>(() => Mock.Of<IHousingManager>()),
             Mock.Of<ILocalizationManager>());
 
         var services = new ServiceCollection();

--- a/AAEmu.UnitTests/Game/Core/Managers/ManaRegenManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/ManaRegenManagerTests.cs
@@ -1,0 +1,21 @@
+using AAEmu.Game.Core.Managers;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class ManaRegenManagerTests
+{
+    [Fact]
+    public void Initialize_SubscribesToTickManager()
+    {
+        var mockTick = new Mock<ITickManager>();
+        var handler = new TickManager.TickEventHandler();
+        mockTick.SetupGet(t => t.OnTick).Returns(handler);
+
+        var manager = new ManaRegenManager(mockTick.Object);
+        manager.Initialize();
+
+        mockTick.VerifyGet(t => t.OnTick, Times.Once);
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/ManagerOrchestratorTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/ManagerOrchestratorTests.cs
@@ -1,0 +1,202 @@
+using AAEmu.Game.Core.Managers;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+/// <summary>
+/// Unit tests for ManagerOrchestrator — DAG building, topological sort, Lazy skipping, cycle detection.
+/// These tests use private stub types so they have no external DB/file dependencies.
+/// </summary>
+public class ManagerOrchestratorTests
+{
+    // -------------------------------------------------------------------------
+    // Stub interfaces / concrete types used across tests
+    // -------------------------------------------------------------------------
+
+    private interface IA : ILoadable;
+    private interface IB : ILoadable;
+    private interface IC : ILoadable;
+
+    /// <summary>A has no dependencies.</summary>
+    private class A : IA { public void Load() { } }
+
+    /// <summary>B depends on A (takes IA in its constructor).</summary>
+    private class B(IA a) : IB { public void Load() { } }
+
+    /// <summary>C depends on B (takes IB in its constructor).</summary>
+    private class C(IB b) : IC { public void Load() { } }
+
+    // For cycle detection
+    private interface IX : ILoadable;
+    private interface IY : ILoadable;
+
+    private class CycleX(IY y) : IX { public void Load() { } }
+    private class CycleY(IX x) : IY { public void Load() { } }
+
+    // For Lazy<T> skip test
+    private interface IP : ILoadable;
+    private interface IQ : ILoadable;
+
+    /// <summary>P takes Q as Lazy&lt;IQ&gt; — should NOT create a dependency edge.</summary>
+    private class P(Lazy<IQ> q) : IP { public void Load() { } }
+    private class Q : IQ { public void Load() { } }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static (ManagerOrchestrator orchestrator, IServiceProvider sp) Build(Action<IServiceCollection> configure)
+    {
+        var services = new ServiceCollection();
+        configure(services);
+        services.AddSingleton<IServiceCollection>(_ => services);
+        services.AddSingleton<ManagerOrchestrator>();
+        var sp = services.BuildServiceProvider();
+        return (sp.GetRequiredService<ManagerOrchestrator>(), sp);
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void BuildBatches_ProducesCorrectTopologicalOrder()
+    {
+        // A → (no deps)  →  batch 0
+        // B → depends on A → batch 1
+        // C → depends on B → batch 2
+        var (orchestrator, _) = Build(services =>
+        {
+            services.AddSingleton<A>();
+            services.AddSingleton<IA>(sp => sp.GetRequiredService<A>());
+            services.AddSingleton<B>();
+            services.AddSingleton<IB>(sp => sp.GetRequiredService<B>());
+            services.AddSingleton<C>();
+            services.AddSingleton<IC>(sp => sp.GetRequiredService<C>());
+        });
+
+        var batches = orchestrator.BuildBatches<ILoadable>();
+
+        Assert.Equal(3, batches.Count);
+
+        // Each batch should have exactly one manager
+        Assert.Single(batches[0]);
+        Assert.Single(batches[1]);
+        Assert.Single(batches[2]);
+
+        // Verify order: A first, then B, then C
+        Assert.IsType<A>(batches[0][0]);
+        Assert.IsType<B>(batches[1][0]);
+        Assert.IsType<C>(batches[2][0]);
+    }
+
+    [Fact]
+    public void BuildBatches_IndependentManagersAreInSameBatch()
+    {
+        // A and Q have no constructor deps on each other → both in batch 0
+        var (orchestrator, _) = Build(services =>
+        {
+            services.AddSingleton<A>();
+            services.AddSingleton<IA>(sp => sp.GetRequiredService<A>());
+            services.AddSingleton<Q>();
+            services.AddSingleton<IQ>(sp => sp.GetRequiredService<Q>());
+        });
+
+        var batches = orchestrator.BuildBatches<ILoadable>();
+
+        Assert.Single(batches);
+        Assert.Equal(2, batches[0].Count);
+    }
+
+    [Fact]
+    public void BuildBatches_ThrowsOnCycle()
+    {
+        // CycleX depends on IY, CycleY depends on IX → cycle
+        var (orchestrator, _) = Build(services =>
+        {
+            services.AddSingleton<CycleX>();
+            services.AddSingleton<IX>(sp => sp.GetRequiredService<CycleX>());
+            services.AddSingleton<CycleY>();
+            services.AddSingleton<IY>(sp => sp.GetRequiredService<CycleY>());
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() => orchestrator.BuildBatches<ILoadable>());
+        Assert.Contains("Cycle detected", ex.Message);
+    }
+
+    [Fact]
+    public void BuildBatches_SkipsLazyDependencies()
+    {
+        // P takes Lazy<IQ> — this should NOT be treated as a dependency on Q.
+        // Therefore both P and Q have no unresolved deps and appear in batch 0.
+        var (orchestrator, _) = Build(services =>
+        {
+            services.AddSingleton<Q>();
+            services.AddSingleton<IQ>(sp => sp.GetRequiredService<Q>());
+            // Register Lazy<IQ> explicitly so DI can satisfy P's constructor
+            services.AddSingleton(sp => new Lazy<IQ>(sp.GetRequiredService<IQ>));
+            services.AddSingleton<P>();
+            services.AddSingleton<IP>(sp => sp.GetRequiredService<P>());
+        });
+
+        var batches = orchestrator.BuildBatches<ILoadable>();
+
+        // Both should be in the first (and only) batch
+        Assert.Single(batches);
+        Assert.Equal(2, batches[0].Count);
+    }
+
+    [Fact]
+    public void BuildBatches_EmptyRegistrations_ReturnsEmptyList()
+    {
+        var (orchestrator, _) = Build(_ => { });
+
+        var batches = orchestrator.BuildBatches<ILoadable>();
+
+        Assert.Empty(batches);
+    }
+
+    [Fact]
+    public void BuildBatches_ExcludesFactoryRegistrations()
+    {
+        // Only factory-registered (no ImplementationType) — should be excluded
+        var (orchestrator, _) = Build(services =>
+        {
+            // Factory lambda → ImplementationType == null → excluded
+            services.AddSingleton<IA>(_ => new A());
+        });
+
+        var batches = orchestrator.BuildBatches<ILoadable>();
+
+        Assert.Empty(batches);
+    }
+
+    [Fact]
+    public async Task RunLoadAsync_CallsLoadOnAllManagers()
+    {
+        var loadCalled = new List<string>();
+
+        // Register the list as a service so TrackingA can be type-registered (ImplementationType != null).
+        // Factory lambdas produce ImplementationType == null and are excluded by the orchestrator.
+        var services = new ServiceCollection();
+        services.AddSingleton(loadCalled);
+        services.AddSingleton<TrackingA>();
+        services.AddSingleton<IServiceCollection>(_ => services);
+        services.AddSingleton<ManagerOrchestrator>();
+        var sp = services.BuildServiceProvider();
+        var orchestrator = sp.GetRequiredService<ManagerOrchestrator>();
+
+        await orchestrator.RunLoadAsync();
+
+        Assert.Contains("A", loadCalled);
+    }
+
+    // Tracking helper — injected via type registration so ImplementationType is set in the descriptor.
+    private class TrackingA(List<string> log) : ILoadable
+    {
+        public void Load() => log.Add("A");
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/MusicManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/MusicManagerTests.cs
@@ -1,0 +1,21 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.Id;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class MusicManagerTests
+{
+    [Fact]
+    public void Constructor_DoesNotCallDeps()
+    {
+        var mockMusicId = new Mock<IMusicIdManager>();
+        var mockItem = new Mock<IItemManager>();
+        var manager = new MusicManager(mockMusicId.Object, mockItem.Object);
+
+        Assert.NotNull(manager);
+        mockMusicId.VerifyNoOtherCalls();
+        mockItem.VerifyNoOtherCalls();
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/Name/NameManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/Name/NameManagerTests.cs
@@ -76,7 +76,7 @@ public sealed class NameManagerTests : IDisposable
         var charId = 1u;
         var charAccount = 1000u;
         var charName = "TestName".NormalizeName();
-        var mockCharacterManager = new Mock<CharacterManager>();
+        var mockCharacterManager = new Mock<ICharacterManager>();
         mockCharacterManager.Setup(x => x.IsCharacterPendingDeletion(charName)).Returns(false);
         var sut = new NameManager(mockCharacterManager.Object);
 
@@ -98,7 +98,7 @@ public sealed class NameManagerTests : IDisposable
         var charId = 1u;
         var charAccount = 1000u;
         var charName = "TestName".NormalizeName();
-        var mockCharacterManager = new Mock<CharacterManager>();
+        var mockCharacterManager = new Mock<ICharacterManager>();
         mockCharacterManager.Setup(x => x.IsCharacterPendingDeletion(charName)).Returns(true);
         var sut = new NameManager(mockCharacterManager.Object);
 
@@ -140,7 +140,7 @@ public sealed class NameManagerTests : IDisposable
     {
         // Arrange
         var charName = providedName.NormalizeName();
-        var mockCharacterManager = new Mock<CharacterManager>();
+        var mockCharacterManager = new Mock<ICharacterManager>();
         var sut = new NameManager(mockCharacterManager.Object);
 
         sut.Load([], [], []);
@@ -159,7 +159,7 @@ public sealed class NameManagerTests : IDisposable
         var charId = 1u;
         var charAccount = 1000u;
         var charName = "TestName".NormalizeName();
-        var mockCharacterManager = new Mock<CharacterManager>();
+        var mockCharacterManager = new Mock<ICharacterManager>();
         mockCharacterManager.Setup(x => x.IsCharacterPendingDeletion(charName)).Returns(true);
         var sut = new NameManager(mockCharacterManager.Object);
 

--- a/AAEmu.UnitTests/Game/Core/Managers/Name/NameManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/Name/NameManagerTests.cs
@@ -78,7 +78,7 @@ public sealed class NameManagerTests : IDisposable
         var charName = "TestName".NormalizeName();
         var mockCharacterManager = new Mock<ICharacterManager>();
         mockCharacterManager.Setup(x => x.IsCharacterPendingDeletion(charName)).Returns(false);
-        var sut = new NameManager(mockCharacterManager.Object);
+        var sut = new NameManager(new Lazy<ICharacterManager>(() => mockCharacterManager.Object));
 
         sut.Load([], [], []);
 
@@ -100,7 +100,7 @@ public sealed class NameManagerTests : IDisposable
         var charName = "TestName".NormalizeName();
         var mockCharacterManager = new Mock<ICharacterManager>();
         mockCharacterManager.Setup(x => x.IsCharacterPendingDeletion(charName)).Returns(true);
-        var sut = new NameManager(mockCharacterManager.Object);
+        var sut = new NameManager(new Lazy<ICharacterManager>(() => mockCharacterManager.Object));
 
         sut.Load([], [], []);
 
@@ -141,7 +141,7 @@ public sealed class NameManagerTests : IDisposable
         // Arrange
         var charName = providedName.NormalizeName();
         var mockCharacterManager = new Mock<ICharacterManager>();
-        var sut = new NameManager(mockCharacterManager.Object);
+        var sut = new NameManager(new Lazy<ICharacterManager>(() => mockCharacterManager.Object));
 
         sut.Load([], [], []);
 
@@ -161,7 +161,7 @@ public sealed class NameManagerTests : IDisposable
         var charName = "TestName".NormalizeName();
         var mockCharacterManager = new Mock<ICharacterManager>();
         mockCharacterManager.Setup(x => x.IsCharacterPendingDeletion(charName)).Returns(true);
-        var sut = new NameManager(mockCharacterManager.Object);
+        var sut = new NameManager(new Lazy<ICharacterManager>(() => mockCharacterManager.Object));
 
         sut.Load([], [], []);
 

--- a/AAEmu.UnitTests/Game/Core/Managers/PortalManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/PortalManagerTests.cs
@@ -1,0 +1,31 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.Id;
+using AAEmu.Game.Core.Managers.UnitManagers;
+using AAEmu.Game.Core.Managers.World;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class PortalManagerTests
+{
+    [Fact]
+    public void Constructor_DoesNotCallDeps()
+    {
+        var mockLocale = new Mock<ILocalizationManager>();
+        var mockWorld = new Mock<IWorldManager>();
+        var mockZone = new Mock<IZoneManager>();
+        var mockNpc = new Mock<INpcManager>();
+        var mockObjId = new Mock<IObjectIdManager>();
+        var mockTask = new Mock<ITaskManager>();
+        var manager = new PortalManager(mockLocale.Object, mockWorld.Object, mockZone.Object, mockNpc.Object, mockObjId.Object, mockTask.Object);
+
+        Assert.NotNull(manager);
+        mockLocale.VerifyNoOtherCalls();
+        mockWorld.VerifyNoOtherCalls();
+        mockZone.VerifyNoOtherCalls();
+        mockNpc.VerifyNoOtherCalls();
+        mockObjId.VerifyNoOtherCalls();
+        mockTask.VerifyNoOtherCalls();
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/PublicFarmManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/PublicFarmManagerTests.cs
@@ -1,0 +1,22 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
+using Moq;
+using Xunit;
+using AaEmuTask = AAEmu.Game.Models.Tasks.Task;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class PublicFarmManagerTests
+{
+    [Fact]
+    public void Initialize_SchedulesTick()
+    {
+        var mockTask = new Mock<ITaskManager>();
+        mockTask.Setup(t => t.Schedule(It.IsAny<AaEmuTask>(), It.IsAny<TimeSpan?>(), It.IsAny<TimeSpan?>(), It.IsAny<int>())).Returns(true);
+        var manager = new PublicFarmManager(mockTask.Object, new Mock<IWorldManager>().Object, new Mock<ISubZoneManager>().Object);
+        manager.Load();
+        manager.Initialize();
+
+        mockTask.Verify(t => t.Schedule(It.IsAny<AaEmuTask>(), It.IsAny<TimeSpan?>(), It.IsAny<TimeSpan?>(), It.IsAny<int>()), Times.Once);
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/QuestManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/QuestManagerTests.cs
@@ -1,0 +1,59 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Quests;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class QuestManagerTests
+{
+    private static QuestManager CreateManager(ITaskManager taskManager = null, IZoneManager zoneManager = null)
+    {
+        return new QuestManager(
+            taskManager ?? Mock.Of<ITaskManager>(),
+            zoneManager ?? Mock.Of<IZoneManager>());
+    }
+
+    [Fact]
+    public void GetTemplate_BeforeLoad_ReturnsNull()
+    {
+        var manager = CreateManager();
+
+        var result = manager.GetTemplate(999);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void AddQuestTimer_CallsTaskManagerSchedule()
+    {
+        var mockTaskManager = new Mock<ITaskManager>();
+        mockTaskManager
+            .Setup(t => t.Schedule(It.IsAny<AAEmu.Game.Models.Tasks.Task>(), It.IsAny<TimeSpan?>(), It.IsAny<TimeSpan?>(), It.IsAny<int>()))
+            .Returns(true);
+
+        var manager = CreateManager(taskManager: mockTaskManager.Object);
+
+        var mockOwner = new Mock<ICharacter>();
+        mockOwner.SetupGet(c => c.Id).Returns(1u);
+        mockOwner.Setup(c => c.SendDebugMessage(It.IsAny<string>()));
+
+        var quest = new Quest(
+            null,
+            mockOwner.Object,
+            Mock.Of<IQuestManager>(),
+            Mock.Of<ITaskManager>(),
+            Mock.Of<ISkillManager>(),
+            Mock.Of<IExpressTextManager>(),
+            Mock.Of<IWorldManager>()) { TemplateId = 42u };
+
+        var result = manager.AddQuestTimer(mockOwner.Object, quest, 60_000);
+
+        Assert.True(result);
+        mockTaskManager.Verify(
+            t => t.Schedule(It.IsAny<AAEmu.Game.Models.Tasks.Task>(), TimeSpan.FromMilliseconds(60_000), null, -1),
+            Times.Once);
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/SaveManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/SaveManagerTests.cs
@@ -1,0 +1,36 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class SaveManagerTests
+{
+    [Fact]
+    public void Constructor_DoesNotCallDeps()
+    {
+        var mockTask = new Mock<ITaskManager>();
+        var mockHousing = new Mock<IHousingManager>();
+        var mockMail = new Mock<IMailManager>();
+        var mockItem = new Mock<IItemManager>();
+        var mockAuction = new Mock<IAuctionManager>();
+        var mockWorld = new Mock<IWorldManager>();
+
+        var manager = new SaveManager(
+            mockTask.Object,
+            mockHousing.Object,
+            mockMail.Object,
+            mockItem.Object,
+            mockAuction.Object,
+            mockWorld.Object);
+
+        Assert.NotNull(manager);
+        mockTask.VerifyNoOtherCalls();
+        mockHousing.VerifyNoOtherCalls();
+        mockMail.VerifyNoOtherCalls();
+        mockItem.VerifyNoOtherCalls();
+        mockAuction.VerifyNoOtherCalls();
+        mockWorld.VerifyNoOtherCalls();
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/ShipyardManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/ShipyardManagerTests.cs
@@ -1,0 +1,28 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.Id;
+using AAEmu.Game.Core.Managers.World;
+using Moq;
+using Xunit;
+using AaEmuTask = AAEmu.Game.Models.Tasks.Task;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class ShipyardManagerTests
+{
+    [Fact]
+    public void Initialize_SchedulesTick()
+    {
+        var mockTask = new Mock<ITaskManager>();
+        mockTask.Setup(t => t.Schedule(It.IsAny<AaEmuTask>(), It.IsAny<TimeSpan?>(), It.IsAny<TimeSpan?>(), It.IsAny<int>())).Returns(true);
+        var manager = new ShipyardManager(
+            mockTask.Object,
+            new Mock<IObjectIdManager>().Object,
+            new Mock<IShipyardIdManager>().Object,
+            new Mock<IWorldManager>().Object,
+            new Mock<ITaxationsManager>().Object,
+            new Mock<ISkillManager>().Object);
+        manager.Initialize();
+
+        mockTask.Verify(t => t.Schedule(It.IsAny<AaEmuTask>(), It.IsAny<TimeSpan?>(), It.IsAny<TimeSpan?>(), It.IsAny<int>()), Times.Once);
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/SkillManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/SkillManagerTests.cs
@@ -1,0 +1,26 @@
+using AAEmu.Game.Core.Managers;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class SkillManagerTests
+{
+    /// <summary>
+    /// Verifies SkillManager can be constructed with injected deps.
+    /// IAnimationManager and IPlotManager are only called during Load() which
+    /// requires a SQLite DB — covered by integration tests.
+    /// </summary>
+    [Fact]
+    public void Constructor_WithMockedDependencies_DoesNotThrow()
+    {
+        var mockAnimation = new Mock<IAnimationManager>();
+        var mockPlot = new Mock<IPlotManager>();
+
+        var manager = new SkillManager(mockAnimation.Object, mockPlot.Object);
+
+        Assert.NotNull(manager);
+        mockAnimation.VerifyNoOtherCalls();
+        mockPlot.VerifyNoOtherCalls();
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/SubZoneManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/SubZoneManagerTests.cs
@@ -1,0 +1,20 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class SubZoneManagerTests
+{
+    [Fact]
+    public void Load_CallsGetWorlds()
+    {
+        var mockWorld = new Mock<IWorldManager>();
+        mockWorld.Setup(w => w.GetWorlds()).Returns([]);
+        var manager = new SubZoneManager(mockWorld.Object, new Mock<IZoneManager>().Object);
+        manager.Load();
+
+        mockWorld.Verify(w => w.GetWorlds(), Times.Once);
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/SusManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/SusManagerTests.cs
@@ -1,0 +1,32 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class SusManagerTests
+{
+    [Fact]
+    public void Constructor_WithMockedWorldManager_DoesNotThrow()
+    {
+        var mockWorldManager = new Mock<IWorldManager>();
+
+        var manager = new SusManager(mockWorldManager.Object);
+
+        Assert.NotNull(manager);
+        mockWorldManager.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public void ResetAnalyzePlayerDeltaMovement_DoesNotCallWorldManager()
+    {
+        var mockWorldManager = new Mock<IWorldManager>();
+        var manager = new SusManager(mockWorldManager.Object);
+
+        // Should not throw and should not call worldManager
+        manager.ResetAnalyzePlayerDeltaMovement(playerId: 42u);
+
+        mockWorldManager.VerifyNoOtherCalls();
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/TaskManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/TaskManagerTests.cs
@@ -1,0 +1,49 @@
+using AAEmu.Game.Core.Managers;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class TaskManagerTests
+{
+    [Fact]
+    public void Start_SubscribesToTickManager()
+    {
+        var mockTick = new Mock<ITickManager>();
+        var handler = new TickManager.TickEventHandler();
+        mockTick.SetupGet(t => t.OnTick).Returns(handler);
+
+        var manager = new TaskManager(mockTick.Object);
+        manager.Start();
+
+        mockTick.VerifyGet(t => t.OnTick, Times.Once);
+    }
+
+    [Fact]
+    public void Schedule_ReturnsTrue_WhenTaskIsQueued()
+    {
+        var mockTick = new Mock<ITickManager>();
+        mockTick.SetupGet(t => t.OnTick).Returns(new TickManager.TickEventHandler());
+
+        var manager = new TaskManager(mockTick.Object);
+        var task = Mock.Of<AAEmu.Game.Models.Tasks.Task>();
+
+        var result = manager.Schedule(task, TimeSpan.FromSeconds(60));
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Cancel_ReturnsFalse_WhenTaskNotInQueue()
+    {
+        var mockTick = new Mock<ITickManager>();
+        mockTick.SetupGet(t => t.OnTick).Returns(new TickManager.TickEventHandler());
+
+        var manager = new TaskManager(mockTick.Object);
+        var task = Mock.Of<AAEmu.Game.Models.Tasks.Task>();
+
+        var result = manager.Cancel(task);
+
+        Assert.False(result);
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/TeamManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/TeamManagerTests.cs
@@ -1,0 +1,24 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.Id;
+using AAEmu.Game.Core.Managers.World;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class TeamManagerTests
+{
+    [Fact]
+    public void Constructor_DoesNotCallDeps()
+    {
+        var mockWorld = new Mock<IWorldManager>();
+        var mockChat = new Mock<IChatManager>();
+        var mockTeamId = new Mock<ITeamIdManager>();
+        var manager = new TeamManager(mockWorld.Object, mockChat.Object, mockTeamId.Object);
+
+        Assert.NotNull(manager);
+        mockWorld.VerifyNoOtherCalls();
+        mockChat.VerifyNoOtherCalls();
+        mockTeamId.VerifyNoOtherCalls();
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/TradeManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/TradeManagerTests.cs
@@ -1,0 +1,22 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.Id;
+using AAEmu.Game.Core.Managers.World;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class TradeManagerTests
+{
+    [Fact]
+    public void Constructor_DoesNotCallDeps()
+    {
+        var mockTradeId = new Mock<ITradeIdManager>();
+        var mockWorld = new Mock<IWorldManager>();
+        var manager = new TradeManager(mockTradeId.Object, mockWorld.Object);
+
+        Assert.NotNull(manager);
+        mockTradeId.VerifyNoOtherCalls();
+        mockWorld.VerifyNoOtherCalls();
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/UnitManagers/DoodadManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/UnitManagers/DoodadManagerTests.cs
@@ -16,7 +16,7 @@ public class DoodadManagerTests
         var mockItem = new Mock<IItemManager>();
         var mockHousing = new Mock<IHousingManager>();
         var mockSus = new Mock<ISusManager>();
-        var manager = new DoodadManager(mockObjId.Object, mockDoodadId.Object, mockItem.Object, mockHousing.Object, mockSus.Object);
+        var manager = new DoodadManager(mockObjId.Object, mockDoodadId.Object, mockItem.Object, new Lazy<IHousingManager>(() => mockHousing.Object), mockSus.Object);
 
         Assert.NotNull(manager);
         mockObjId.VerifyNoOtherCalls();

--- a/AAEmu.UnitTests/Game/Core/Managers/UnitManagers/DoodadManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/UnitManagers/DoodadManagerTests.cs
@@ -1,0 +1,28 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.Id;
+using AAEmu.Game.Core.Managers.UnitManagers;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers.UnitManagers;
+
+public class DoodadManagerTests
+{
+    [Fact]
+    public void Constructor_DoesNotCallDeps()
+    {
+        var mockObjId = new Mock<IObjectIdManager>();
+        var mockDoodadId = new Mock<IDoodadIdManager>();
+        var mockItem = new Mock<IItemManager>();
+        var mockHousing = new Mock<IHousingManager>();
+        var mockSus = new Mock<ISusManager>();
+        var manager = new DoodadManager(mockObjId.Object, mockDoodadId.Object, mockItem.Object, mockHousing.Object, mockSus.Object);
+
+        Assert.NotNull(manager);
+        mockObjId.VerifyNoOtherCalls();
+        mockDoodadId.VerifyNoOtherCalls();
+        mockItem.VerifyNoOtherCalls();
+        mockHousing.VerifyNoOtherCalls();
+        mockSus.VerifyNoOtherCalls();
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/UnitManagers/NpcManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/UnitManagers/NpcManagerTests.cs
@@ -1,0 +1,29 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.Id;
+using AAEmu.Game.Core.Managers.UnitManagers;
+using AAEmu.Game.Core.Managers.World;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers.UnitManagers;
+
+public class NpcManagerTests
+{
+    [Fact]
+    public void Constructor_DoesNotCallDeps()
+    {
+        var mockObjId = new Mock<IObjectIdManager>();
+        var mockModel = new Mock<IModelManager>();
+        var mockFaction = new Mock<IFactionManager>();
+        var mockItem = new Mock<IItemManager>();
+        var mockAI = new Mock<IAIManager>();
+        var manager = new NpcManager(mockObjId.Object, mockModel.Object, mockFaction.Object, mockItem.Object, mockAI.Object);
+
+        Assert.NotNull(manager);
+        mockObjId.VerifyNoOtherCalls();
+        mockModel.VerifyNoOtherCalls();
+        mockFaction.VerifyNoOtherCalls();
+        mockItem.VerifyNoOtherCalls();
+        mockAI.VerifyNoOtherCalls();
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/World/FactionManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/World/FactionManagerTests.cs
@@ -1,0 +1,25 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
+using Moq;
+using Xunit;
+
+namespace AAEmu.UnitTests.Game.Core.Managers.World;
+
+public class FactionManagerTests
+{
+    /// <summary>
+    /// Verifies that FactionManager can be constructed with an injected ILocalizationManager.
+    /// The mock is called during Load() which requires a SQLite DB, so mock verification
+    /// is covered by integration tests.
+    /// </summary>
+    [Fact]
+    public void Constructor_WithMockedLocalizationManager_DoesNotThrow()
+    {
+        var mockLocalization = new Mock<ILocalizationManager>();
+
+        var manager = new FactionManager(mockLocalization.Object);
+
+        Assert.NotNull(manager);
+        mockLocalization.VerifyNoOtherCalls();
+    }
+}

--- a/AAEmu.UnitTests/Services/GameServiceTests.cs
+++ b/AAEmu.UnitTests/Services/GameServiceTests.cs
@@ -1,4 +1,6 @@
 ﻿using AAEmu.Game;
+using AAEmu.Game.Core.Managers;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
 
@@ -41,7 +43,9 @@ public class GameServiceTests
     public void GameService_ImplementsIHostedService()
     {
         // Arrange
-        using var service = new GameService(Moq.Mock.Of<IServiceProvider>());
+        var sp = Moq.Mock.Of<IServiceProvider>();
+        var orchestrator = new ManagerOrchestrator(sp, new ServiceCollection());
+        using var service = new GameService(sp, orchestrator);
 
         // Assert
         Assert.IsAssignableFrom<IHostedService>(service);
@@ -51,7 +55,9 @@ public class GameServiceTests
     public void GameService_ImplementsIDisposable()
     {
         // Arrange
-        using var service = new GameService(Moq.Mock.Of<IServiceProvider>());
+        var sp = Moq.Mock.Of<IServiceProvider>();
+        var orchestrator = new ManagerOrchestrator(sp, new ServiceCollection());
+        using var service = new GameService(sp, orchestrator);
 
         // Assert
         Assert.IsAssignableFrom<IDisposable>(service);
@@ -61,7 +67,9 @@ public class GameServiceTests
     public async Task Dispose_DoesNotThrow()
     {
         // Arrange
-        using var service = new GameService(Moq.Mock.Of<IServiceProvider>());
+        var sp = Moq.Mock.Of<IServiceProvider>();
+        var orchestrator = new ManagerOrchestrator(sp, new ServiceCollection());
+        using var service = new GameService(sp, orchestrator);
 
         // Act & Assert
         service.Dispose();

--- a/AAEmu.UnitTests/Services/GameServiceTests.cs
+++ b/AAEmu.UnitTests/Services/GameServiceTests.cs
@@ -41,7 +41,7 @@ public class GameServiceTests
     public void GameService_ImplementsIHostedService()
     {
         // Arrange
-        using var service = new GameService();
+        using var service = new GameService(Moq.Mock.Of<IServiceProvider>());
 
         // Assert
         Assert.IsAssignableFrom<IHostedService>(service);
@@ -51,7 +51,7 @@ public class GameServiceTests
     public void GameService_ImplementsIDisposable()
     {
         // Arrange
-        using var service = new GameService();
+        using var service = new GameService(Moq.Mock.Of<IServiceProvider>());
 
         // Assert
         Assert.IsAssignableFrom<IDisposable>(service);
@@ -61,7 +61,7 @@ public class GameServiceTests
     public async Task Dispose_DoesNotThrow()
     {
         // Arrange
-        using var service = new GameService();
+        using var service = new GameService(Moq.Mock.Of<IServiceProvider>());
 
         // Act & Assert
         service.Dispose();

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />


### PR DESCRIPTION
## DI Migration

Seems to still work... 🤞 Main motivation is the difficulty of testing code that relies on static singletons, but other benefits include faster loading. Removing all static access to singletons is a much longer term goal that touches a lot of files, so isn't attempted here. If it's too large to review as-is, it can probably be broken up into separate PRs per commit with a bit of extra work (some bugs only got fixed in the last commit, but were introduced with earlier ones). Most changes are small and simple (extracting an interface, using the constructor parameter instead of static `Instance` property, etc.) Now on to the AI-generated stuff:

⚠️ Co-Authored-By: Claude Sonnet 4.6 - under my direction and reviewed by me.

This PR modernises the game server's manager layer by migrating from a static singleton pattern to constructor-based dependency injection, then replacing the hand-maintained boot sequence with an automatic dependency-ordered loader.

---

### Why constructor DI?

The previous pattern — every manager a static singleton, dependencies resolved inline via `Manager.Instance` — works but has several compounding costs:

**Testability.** Static singletons cannot be substituted. Constructor injection means a test can pass a `Mock<ISkillManager>` instead of the real implementation, with no global state leaking between tests.

**Hidden dependencies.** When a manager calls `OtherManager.Instance` inside its methods, that dependency is invisible from the outside. Constructor parameters make every dependency explicit and auditable at a glance.

**Automatic load ordering.** `GameService.cs` previously contained a hand-maintained sequence of ~50 `Load()` and `Initialize()` calls ordered by tribal knowledge. With constructor DI, ordering is derived automatically from the dependency graph — and managers with no dependency on each other can be loaded in parallel.

**Cycle visibility.** Circular dependencies between static singletons fail silently at runtime. The orchestrator throws a clear exception naming the cycle at startup, turning a latent bug into an immediate, actionable error.

---

### Phase 1 — DI Bridge & Interface Extraction

Extracted an `IManager` interface for every game manager and registered all managers in the DI container alongside their existing `Singleton<T>.Instance` accessor. No behaviour changed — this was purely additive scaffolding that allowed subsequent phases to work incrementally.

---

### Phase 2 — Simple Managers (1–3 deps)

Converted managers with one to three dependencies to C# 12 primary constructors. Dependencies are now declared explicitly in the constructor signature and injected by the DI container rather than resolved via `Manager.Instance` inside method bodies.

---

### Phase 3 — Medium Managers (2–7 deps)

Same conversion for managers with moderate dependency counts, including cases where static helper methods had to be converted to instance methods to access primary constructor parameters.

---

### Phase 4 — High-Complexity Managers

Converted the heaviest managers (WorldManager, CharacterManager, SlaveManager, SpawnManager, etc.). Introduced `Lazy<T>` to break construction-time circular dependencies between WorldManager and ZoneManager/IndunManager/FamilyManager, which MS DI cannot resolve automatically.

---

### Phase 5 — DAG-Based Parallel Orchestration

Replaced the ~50-line hand-ordered sequence of `Load()` and `Initialize()` calls in `GameService` with a `ManagerOrchestrator` that:

- Reads the dependency graph directly from constructor signatures (already established by Phases 1–4)
- Performs a topological sort (Kahn's algorithm) to derive a safe execution order
- Runs managers with no outstanding dependencies in parallel via `Task.WhenAll`

Additional fixes made during integration testing:

- Broke remaining circular dependencies with `Lazy<T>`: `NameManager ↔ CharacterManager`, `HousingManager ↔ MailManager`, `HousingManager ↔ DoodadManager`
- Fixed `ShipyardManager` field initializers that were placed in `Initialize()` but needed by `Load()`, which runs in an earlier stage
- Made `CommandManager`, `StreamManager`, and `DuelManager` constructors `public` so MS DI can instantiate them
- Fixed a thread-safety bug in `GimmickManager` where write methods were missing the lock held by the reader
- Fixed a race condition in `RunCommandSetBehavior` where `Ai.Owner` could be nulled by a concurrent despawn between a skill use call and the subsequent cooldown calculation
