### PR TITLE
[Game] Enforce mother faction check for Party and Raid invitations

### DIFF
--- a/AAEmu.Game/Core/Managers/TeamManager.cs
+++ b/AAEmu.Game/Core/Managers/TeamManager.cs
@@ -77,7 +77,8 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
 
         foreach (var character in characters)
         {
-            if (!character.InParty)
+            // Skip players from a different mother faction (e.g. Nuia, Haranya, Pirate)
+            if (!character.InParty && character.Faction.MotherId == owner.Faction.MotherId)
                 AskToJoin(owner, "", teamId, false, character);
         }
     }
@@ -87,6 +88,13 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
         var target = targetObj ?? worldManager.GetCharacter(targetName);
         if (target == null) return;
         // TODO - CONFIG INVITE DISABLED
+
+        // Check if both players are in the same mother faction (e.g. Nuia, Haranya, Pirate)
+        if (owner.Faction.MotherId != target.Faction.MotherId)
+        {
+            owner.SendErrorMessage(ErrorMessageType.TeamInviteRefused);
+            return;
+        }
 
         var activeTeam = GetActiveTeam(teamId);
         if (GetActiveInvitation(target.Id) != null)


### PR DESCRIPTION
Added checks to ensure players are from the same mother faction before inviting to a team.

Locally tested seems to work fine

Tested with /partyinvite and /raidinvite and Radius Invite 

Firrans can Still Invite Harani
Elfs Still can Invite Nuians
Pirates can only invite Pirates

Hope all is oke with this PR. 