### PR TITLE
feat(ci): add stale triage workflow for inactive issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,40 @@
+name: Stale Triage
+
+on:
+  schedule:
+    - cron: '30 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark and close stale issues and PRs
+        uses: actions/stale@v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 90
+          days-before-close: 60
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: pinned,security,help wanted,good first issue,never-stale
+          exempt-pr-labels: pinned,security,never-stale
+          exempt-draft-pr: true
+          remove-stale-when-updated: true
+          operations-per-run: 200
+          stale-issue-message: >
+            This issue has been automatically marked as stale due to inactivity.
+            If this is still relevant, please comment or update the issue within 60 days.
+          close-issue-message: >
+            Closing this issue due to prolonged inactivity.
+            Please reopen if this is still relevant with updated context.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale due to inactivity.
+            Please push updates or comment within 60 days to keep it open.
+          close-pr-message: >
+            Closing this pull request due to prolonged inactivity.
+            Please reopen if work should continue.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a new GitHub Actions workflow to automate stale triage for inactive issues and pull requests using `actions/stale@v10`.

Configured policy:
- Mark issues and PRs as stale after 90 days of inactivity.
- Close stale issues and PRs after 60 additional days of inactivity.
- Exempt core labels (`pinned`, `security`, `help wanted`, `good first issue`, `never-stale`).
- Exempt draft PRs.
- Allow manual execution via `workflow_dispatch`.

## Related Issue
Closes #1372

## Motivation and Context
The repository currently relies on manual cleanup of inactive issues and PRs. This change introduces consistent lifecycle automation to keep the backlog actionable while protecting critical or intentionally long-lived items through label-based exemptions.

## How Has This Been Tested?
- Verified workflow YAML structure and syntax manually.
- Confirmed this change is isolated to one workflow file.
- Did not run runtime/integration tests since the change only introduces GitHub Actions configuration.
- Ran this workflow on my own fork and verified it works as intended.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
