### PR TITLE
chore(login): Make OTLP exporter conditional and export traces and metrics

### DIFF
--- a/AAEmu.Login/AAEmu.Login.csproj
+++ b/AAEmu.Login/AAEmu.Login.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="NLog.Extensions.Logging" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
     <PackageReference Include="OSVersionExt.NetStd" />
   </ItemGroup>
 

--- a/AAEmu.Login/Config.json
+++ b/AAEmu.Login/Config.json
@@ -1,4 +1,10 @@
 {
+	"Logging": {
+		"LogLevel": {
+			"Microsoft.AspNetCore.Hosting.Diagnostics": "Warning",
+			"Microsoft.AspNetCore.Routing.EndpointMiddleware": "Warning"
+		}
+	},
 	"SecretKey": "test",
 	"AutoAccount": true,
 	"SkipHostResolve": false,

--- a/AAEmu.Login/Program.cs
+++ b/AAEmu.Login/Program.cs
@@ -15,6 +15,8 @@ using NLog;
 using NLog.Config;
 using NLog.Extensions.Logging;
 using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
 using OSVersionExtension;
 
 namespace AAEmu.Login;
@@ -71,16 +73,27 @@ public static class Program
             .AddEnvironmentVariables()
             .AddCommandLine(args);
 
+        var otlpEndpoint = builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
+
         // Configure services
         builder.Logging.ClearProviders()
-            .AddNLog()
-            .AddOpenTelemetry(logging =>
-            {
-                logging.IncludeFormattedMessage = true;
-                logging.IncludeScopes = true;
-            });
-        builder.Services.AddOpenTelemetry()
-            .UseOtlpExporter();
+            .AddNLog();
+
+        if (otlpEndpoint is not null)
+        {
+            builder.Services.AddOpenTelemetry()
+                .WithLogging(null, options =>
+                {
+                    options.IncludeFormattedMessage = true;
+                    options.IncludeScopes = true;
+                })
+                .WithTracing(tracing => tracing
+                    .AddAspNetCoreInstrumentation(options =>
+                        options.Filter = ctx => !ctx.Request.Path.StartsWithSegments("/health")))
+                .WithMetrics(metrics => metrics
+                    .AddAspNetCoreInstrumentation())
+                .UseOtlpExporter();
+        }
         builder.Services.AddOptions();
         builder.Services.AddOptionsWithValidateOnStart<AppConfiguration>()
             .BindConfiguration("")

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,6 +30,7 @@
     <PackageVersion Include="NetCoreServer" Version="8.0.7" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
     <PackageVersion Include="OSVersionExt.NetStd" Version="3.0.1" />
     <PackageVersion Include="System.Drawing.Primitives" Version="4.3.0" />
     <PackageVersion Include="System.Numerics.Vectors" Version="4.6.0" />


### PR DESCRIPTION
Adds ASP.NET Core tracing and metrics instrumentation, and only registers the OTLP exporter (logging, tracing, metrics) when `OTEL_EXPORTER_OTLP_ENDPOINT` is set, avoiding the shutdown delay when no collector is configured.

Sets `Microsoft.AspNetCore.Hosting.Diagnostics` and `EndpointMiddleware` log level to Warning to suppress routine 200 OK request logs (health check polling) while still surfacing errors.