### PR TITLE
fix(game): skip context packets for tutorial quests

### DIFF
--- a/AAEmu.Game/Core/Managers/QuestManager.cs
+++ b/AAEmu.Game/Core/Managers/QuestManager.cs
@@ -24,6 +24,7 @@ namespace AAEmu.Game.Core.Managers;
 
 public partial class QuestManager(ITaskManager taskManager, IZoneManager zoneManager) : Singleton<QuestManager>, IQuestManager
 {
+    private static uint QuestCategoryTutorial => 45;
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private bool _loaded;
     private readonly Dictionary<uint, QuestTemplate> _questTemplates = [];
@@ -504,7 +505,9 @@ public partial class QuestManager(ITaskManager taskManager, IZoneManager zoneMan
                 UseCompleteMessage = reader.GetBoolean("use_complete_message", true),
                 GradeId = reader.GetUInt32("grade_id", 0)
             };
-            _questTemplates.Add(template.Id, template);
+            // Skip "loading" tutorial quests
+            if (template.CategoryId != QuestCategoryTutorial)
+                _questTemplates.Add(template.Id, template);
         }
     }
 

--- a/AAEmu.Game/Models/Game/Quests/Templates/IQuestTemplate.cs
+++ b/AAEmu.Game/Models/Game/Quests/Templates/IQuestTemplate.cs
@@ -5,6 +5,7 @@ namespace AAEmu.Game.Models.Game.Quests.Templates;
 public interface IQuestTemplate
 {
     uint Id { get; set; }
+    uint CategoryId { get; set; }
     bool LetItDone { get; set; }
     byte Level { get; set; }
     bool Repeatable { get; set; }


### PR DESCRIPTION
Tutorial quests (Category 45) should not trigger quest updates anymore.
This is achieved by simply not letting the server load them. The tutorial packets work with the quest IDs independently, and thus don't really required to be loaded.
