### PR TITLE
fix(game): Null exception while mount owner dies

### DIFF
--- a/AAEmu.Game/Core/Managers/MateManager.cs
+++ b/AAEmu.Game/Core/Managers/MateManager.cs
@@ -223,7 +223,7 @@ public class MateManager(WorldInstance parentWorldInstance)
         }
         else
         {
-            Logger.Warn($"UnMountMate. No valid seat entry, mountTlId: {mateInfo.TlId}, characterObjId: {0}, attachPoint: {attachPoint}, reason: {reason}");
+            Logger.Debug($"UnMountMate. No valid seat entry, mountTlId: {mateInfo.TlId}, characterObjId: {0}, attachPoint: {attachPoint}, reason: {reason}");
         }
     }
 

--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -496,7 +496,7 @@ public class Unit : BaseUnit, IUnit
         // if we died sitting on a horse
         if (character.Hp > 0) { return; }
 
-        var mateList = character.ParentWorld.MateManager.GetActiveMates(character.Id);
+        var mateList = character.ParentWorld.MateManager.GetActiveMates(character.Id).ToList();
         foreach (var mate in mateList)
         {
             character.Mates.DespawnMate(mate.TlId);


### PR DESCRIPTION
While bug #1288 was already fixed in commit 3e01d6f, it did result in a null exception if the mount did not have all seats taken.
This commit fixes that and also lowers one of the related warnings to debug.
