### PR TITLE
fix(game): resolve NPC spawner loading order and clean up related code

### DIFF
--- a/AAEmu.Game/Core/Managers/UnitManagers/INpcManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/INpcManager.cs
@@ -10,7 +10,7 @@ public interface INpcManager : ILoadable
     NpcTemplate GetTemplate(uint templateId);
     Dictionary<uint, NpcTemplate> GetAllTemplates();
     MerchantGoods GetGoods(uint id);
-    Npc Create(WorldInstance parentWorld, uint objectId, uint id);
+    Npc Create(WorldInstance parentWorld, uint objectId, uint templateId);
     void LoadAiParams();
     void BindSkillsToTemplate(uint templateId, List<NpcSkill> skills);
 }

--- a/AAEmu.Game/Core/Managers/UnitManagers/NpcManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/NpcManager.cs
@@ -23,52 +23,102 @@ namespace AAEmu.Game.Core.Managers.UnitManagers;
 public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelManager, IFactionManager factionManager, IItemManager itemManager, IAIManager aiManager) : Singleton<NpcManager>, INpcManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
-    private bool _loaded = false;
+    private bool Loaded { get; set; }
 
-    private Dictionary<uint, NpcTemplate> _templates;
-    private Dictionary<uint, MerchantGoods> _goods;
-    private Dictionary<uint, TotalCharacterCustom> _totalCharacterCustoms;
-    private Dictionary<uint, Dictionary<uint, List<BodyPartTemplate>>> _itemBodyParts;
-    private Dictionary<uint, List<uint>> _tccLookup;
-    // you can provide a seed here if you want NPCs to more reliable retain their appearance between reboots, or leave out the seed to get it random every time
+    /// <summary>
+    /// This seed gets used to populate the random values for humanoid NPCs that don't have a look defined for them.
+    /// You can provide a seed here if you want NPCs to more reliable retain their appearance between reboots, or leave out the seed to get it random every time
+    /// </summary>
     private readonly Random _loadCustomRandom = new(123456789);
-    public Dictionary<uint, NpcSpawnerNpc> _npcSpawnerNpc;    // npcSpawnerId, nsn
-    public Dictionary<uint, NpcSpawnerTemplate> _npcSpawners; // npcSpawnerId, template
-    public Dictionary<uint, List<uint>> _npcMemberAndSpawnerId; // memberId, List<npcSpawnerId>
-    private static Dictionary<uint, Creature> _creatures = new();
+    /// <summary>
+    /// NPC Templates
+    /// </summary>
+    private Dictionary<uint, NpcTemplate> Templates { get; } = [];
+    /// <summary>
+    /// List of goods a merchant sells
+    /// </summary>
+    private Dictionary<uint, MerchantGoods> Goods { get; } = [];
+    /// <summary>
+    /// Definitions for custom looks of humanoid NPCs
+    /// </summary>
+    private Dictionary<uint, TotalCharacterCustom> TotalCharacterCustoms { get; } = [];
+    /// <summary>
+    /// List of body parts for a given ModelId, BodyPartTypeId, list of BodyPartTemplates
+    /// </summary>
+    private Dictionary<uint, Dictionary<uint, List<BodyPartTemplate>>> ItemBodyParts { get; } = [];
 
+    /// <summary>
+    /// Cached list of TotalCharacterCustoms
+    /// </summary>
+    private Dictionary<uint, List<uint>> TccLookup { get; } = [];
+    /// <summary>
+    /// Equip Body Parts packs
+    /// </summary>
+    private Dictionary<uint, EquipBodyPartPack> EquipPackBodyParts { get; } = [];
+    /// <summary>
+    /// Contains a list of NPC (names) loaded from data/creatures.xml, Used for getting default names in NPC related GM commands
+    /// </summary>
+    private static Dictionary<uint, Creature> Creatures { get; set; } = [];
+
+    /// <summary>
+    /// Returns the default name of a NPC as defined in data/creatures.xml
+    /// </summary>
+    /// <param name="id"></param>
+    /// <returns></returns>
     public static string GetSpawnName(uint id)
     {
-        return _creatures.TryGetValue(id, out var creature) ? creature.Title : string.Empty;
+        return Creatures.TryGetValue(id, out var creature) ? creature.Title : string.Empty;
     }
 
+    /// <summary>
+    /// Checks if a given NPC Template exists
+    /// </summary>
+    /// <param name="templateId"></param>
+    /// <returns></returns>
     public bool Exist(uint templateId)
     {
-        return _templates.ContainsKey(templateId);
+        return Templates.ContainsKey(templateId);
     }
 
+    /// <summary>
+    /// Returns the NpcTemplate for a given templateId
+    /// </summary>
+    /// <param name="templateId"></param>
+    /// <returns></returns>
     public NpcTemplate GetTemplate(uint templateId)
     {
-        if (_templates.TryGetValue(templateId, out var template))
-            return template;
-        return null;
+        return Templates.GetValueOrDefault(templateId);
     }
 
+    /// <summary>
+    /// Returns the dictionary of loaded Templates
+    /// </summary>
+    /// <returns></returns>
     public Dictionary<uint, NpcTemplate> GetAllTemplates()
     {
-        return _templates;
+        return Templates;
     }
 
+    /// <summary>
+    /// Returns a definition of goods for a given Npc merchant
+    /// </summary>
+    /// <param name="id"></param>
+    /// <returns></returns>
     public MerchantGoods GetGoods(uint id)
     {
-        if (_goods.TryGetValue(id, out var goods))
-            return goods;
-        return null;
+        return Goods.GetValueOrDefault(id);
     }
 
-    public Npc Create(WorldInstance parentWorld, uint objectId, uint id)
+    /// <summary>
+    /// Creates a new NPC
+    /// </summary>
+    /// <param name="parentWorld">World Instance to add this NPC to</param>
+    /// <param name="objectId">Optional ObjId ot use, generate a new one if zero</param>
+    /// <param name="templateId">NPC Template to use for creation</param>
+    /// <returns></returns>
+    public Npc Create(WorldInstance parentWorld, uint objectId, uint templateId)
     {
-        var template = GetTemplate(id);
+        var template = GetTemplate(templateId);
         if (template == null)
         {
             return null;
@@ -78,8 +128,8 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
         {
             ParentWorld = parentWorld,
             ObjId = objectId > 0 ? objectId : objectIdManager.GetNextId(),
-            TemplateId = id, // duplicate Id
-            Id = id,
+            TemplateId = templateId, // duplicate Id
+            Id = templateId,
             Template = template,
             ModelId = template.ModelId,
             CanFly = modelManager.IsFlyOrSwim(template.ModelId),
@@ -95,6 +145,24 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
             template.HairId = templ.HairId;
             template.ModelParams = templ.ModelParams;
             template.BodyItems = templ.BodyItems;
+        }
+
+        // TODO: Check if we need to override some body parts if template.EquipBodiesId is set or not
+        if (template.EquipBodiesId > 0 && EquipPackBodyParts.TryGetValue(template.EquipBodiesId, out _)) // var equipBodyPartPack))
+        {
+            /*
+                if (equipBodyPartPack.HairColorId > 0)
+                    template.ModelParams.SetHairColorId(equipBodyPartPack.HairColorId);
+                if (equipBodyPartPack.FaceId > 0)
+                    template.BodyItems[(uint)EquipmentItemSlotType.Face] = (equipBodyPartPack.FaceId, false);
+                if (equipBodyPartPack.HairId > 0)
+                    template.BodyItems[(uint)EquipmentItemSlotType.Hair] = (equipBodyPartPack.HairId, false);
+                if (equipBodyPartPack.BeardId > 0)
+                    template.BodyItems[(uint)EquipmentItemSlotType.Beard] = (equipBodyPartPack.BeardId, false);
+                if (equipBodyPartPack.SkinColorId > 0)
+                    template.ModelParams.SetSkinColorId(equipBodyPartPack.SkinColorId);
+                // if (equipBodyPartPack.BodyDiffuseMapId > 0)
+            */
         }
 
         SetEquipItemTemplate(npc, template.Items.Headgear, EquipmentItemSlot.Head);
@@ -143,9 +211,14 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
         return npc;
     }
 
+    /// <summary>
+    /// Returns a new NpcTemplate with a random Npc look based on the TotalCharacterCustoms list. Only fields related to look will be populated.
+    /// </summary>
+    /// <param name="template"></param>
+    /// <returns></returns>
     private NpcTemplate LoadCustom(NpcTemplate template)
     {
-        var _template = new NpcTemplate();
+        var randomTemplate = new NpcTemplate();
         var totalCustomId = template.TotalCustomId;
 
         if (totalCustomId != 0 || template.FactionId == FactionsEnum.Monstrosity || template.FactionId == FactionsEnum.Animal) // 115 - Monstrosity, 116 - Animal
@@ -162,7 +235,7 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
                 modelParamsId = (Gender)template.Gender == Gender.Male ? (byte)10 : (byte)11;
                 break;
             case Race.Dwarf: // Dwarf male
-                             //modelParamsId = (Gender)template.Gender == Gender.Male ? (byte)14 : (byte)15;
+                // modelParamsId = (Gender)template.Gender == Gender.Male ? (byte)14 : (byte)15;
                 break;
             case Race.Elf: // Elf male
                 modelParamsId = (Gender)template.Gender == Gender.Male ? (byte)16 : (byte)17;
@@ -174,33 +247,40 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
                 modelParamsId = (Gender)template.Gender == Gender.Male ? (byte)20 : (byte)21;
                 break;
             case Race.Warborn: // Warborn male
-                               //modelParamsId = (Gender)template.Gender == Gender.Male ? (byte)24 : (byte)25;
+                // modelParamsId = (Gender)template.Gender == Gender.Male ? (byte)24 : (byte)25;
                 break;
             case Race.Fairy:
+                // Not implemented
                 break;
             case Race.Returned:
+                // Not implemented
                 break;
             default:
-                break;
+                // Invalid
+                return template;
         }
 
         var modelType = modelManager.GetModelType(template.ModelId);
 
         // choose randomly from the list totalCustomId
-        if (modelParamsId != 0 && modelType != null && modelType.SubType == "ActorModel")
+        if (modelParamsId != 0 && modelType is { SubType: "ActorModel" })
         {
             // Get all possible hair item_ids that match this model
             var hairsForThisModel = new List<uint>();
             foreach (var item in itemManager.GetAllItems())
+            {
                 if (item is BodyPartTemplate bpt && bpt.ModelId == template.ModelId && bpt.SlotTypeId == (uint)EquipmentItemSlotType.Hair)
+                {
                     hairsForThisModel.Add(bpt.ItemId);
+                }
+            }
 
             if (hairsForThisModel.Count > 0)
             {
                 // TODO: Slow, but I don't know of a better way to do this atm
-                var possibleTotalCustoms = (from tc in _totalCharacterCustoms
-                                            where tc.Value.ModelId == modelParamsId && hairsForThisModel.Contains(tc.Value.HairId)
-                                            select tc.Value.Id).ToList();
+                var possibleTotalCustoms = (from tc in TotalCharacterCustoms
+                    where tc.Value.ModelId == modelParamsId && hairsForThisModel.Contains(tc.Value.HairId)
+                    select tc.Value.Id).ToList();
 
                 // If anything in result, pick something random from it
                 if (possibleTotalCustoms.Count > 0)
@@ -221,45 +301,45 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
 
         if (totalCustomId > 0)
         {
-            var tc = _totalCharacterCustoms[totalCustomId];
+            var tc = TotalCharacterCustoms[totalCustomId];
 
-            _template.HairId = tc.HairId;
+            randomTemplate.HairId = tc.HairId;
 
-            _template.ModelParams = new UnitCustomModelParams(UnitCustomModelType.Face);
-            _template.ModelParams
+            randomTemplate.ModelParams = new UnitCustomModelParams(UnitCustomModelType.Face);
+            randomTemplate.ModelParams
                 .SetModelId(tc.ModelId)
                 .SetHairColorId(tc.HairColorId)
                 .SetSkinColorId(tc.SkinColorId);
 
-            _template.ModelParams.Face.MovableDecalAssetId = tc.FaceMovableDecalAssetId;
-            _template.ModelParams.Face.MovableDecalScale = tc.FaceMovableDecalScale;
-            _template.ModelParams.Face.MovableDecalRotate = tc.FaceMovableDecalRotate;
-            _template.ModelParams.Face.MovableDecalMoveX = tc.FaceMovableDecalMoveX;
-            _template.ModelParams.Face.MovableDecalMoveY = tc.FaceMovableDecalMoveY;
+            randomTemplate.ModelParams.Face.MovableDecalAssetId = tc.FaceMovableDecalAssetId;
+            randomTemplate.ModelParams.Face.MovableDecalScale = tc.FaceMovableDecalScale;
+            randomTemplate.ModelParams.Face.MovableDecalRotate = tc.FaceMovableDecalRotate;
+            randomTemplate.ModelParams.Face.MovableDecalMoveX = tc.FaceMovableDecalMoveX;
+            randomTemplate.ModelParams.Face.MovableDecalMoveY = tc.FaceMovableDecalMoveY;
 
-            _template.ModelParams.Face.SetFixedDecalAsset(0, tc.FaceFixedDecalAsset0Id, tc.FaceFixedDecalAsset0Weight);
-            _template.ModelParams.Face.SetFixedDecalAsset(1, tc.FaceFixedDecalAsset1Id, tc.FaceFixedDecalAsset1Weight);
-            _template.ModelParams.Face.SetFixedDecalAsset(2, tc.FaceFixedDecalAsset2Id, tc.FaceFixedDecalAsset2Weight);
-            _template.ModelParams.Face.SetFixedDecalAsset(3, tc.FaceFixedDecalAsset3Id, tc.FaceFixedDecalAsset3Weight);
+            randomTemplate.ModelParams.Face.SetFixedDecalAsset(0, tc.FaceFixedDecalAsset0Id, tc.FaceFixedDecalAsset0Weight);
+            randomTemplate.ModelParams.Face.SetFixedDecalAsset(1, tc.FaceFixedDecalAsset1Id, tc.FaceFixedDecalAsset1Weight);
+            randomTemplate.ModelParams.Face.SetFixedDecalAsset(2, tc.FaceFixedDecalAsset2Id, tc.FaceFixedDecalAsset2Weight);
+            randomTemplate.ModelParams.Face.SetFixedDecalAsset(3, tc.FaceFixedDecalAsset3Id, tc.FaceFixedDecalAsset3Weight);
 
-            _template.ModelParams.Face.DiffuseMapId = tc.FaceDiffuseMapId;
-            _template.ModelParams.Face.NormalMapId = tc.FaceNormalMapId;
-            _template.ModelParams.Face.EyelashMapId = tc.FaceEyelashMapId;
-            _template.ModelParams.Face.LipColor = tc.LipColor;
-            _template.ModelParams.Face.LeftPupilColor = tc.LeftPupilColor;
-            _template.ModelParams.Face.RightPupilColor = tc.RightPupilColor;
-            _template.ModelParams.Face.EyebrowColor = tc.EyebrowColor;
-            _template.ModelParams.Face.MovableDecalWeight = tc.FaceMovableDecalWeight;
-            _template.ModelParams.Face.NormalMapWeight = tc.FaceNormalMapWeight;
-            _template.ModelParams.Face.DecoColor = tc.DecoColor;
-            _template.ModelParams.Face.Modifier = tc.Modifier;
+            randomTemplate.ModelParams.Face.DiffuseMapId = tc.FaceDiffuseMapId;
+            randomTemplate.ModelParams.Face.NormalMapId = tc.FaceNormalMapId;
+            randomTemplate.ModelParams.Face.EyelashMapId = tc.FaceEyelashMapId;
+            randomTemplate.ModelParams.Face.LipColor = tc.LipColor;
+            randomTemplate.ModelParams.Face.LeftPupilColor = tc.LeftPupilColor;
+            randomTemplate.ModelParams.Face.RightPupilColor = tc.RightPupilColor;
+            randomTemplate.ModelParams.Face.EyebrowColor = tc.EyebrowColor;
+            randomTemplate.ModelParams.Face.MovableDecalWeight = tc.FaceMovableDecalWeight;
+            randomTemplate.ModelParams.Face.NormalMapWeight = tc.FaceNormalMapWeight;
+            randomTemplate.ModelParams.Face.DecoColor = tc.DecoColor;
+            randomTemplate.ModelParams.Face.Modifier = tc.Modifier;
         }
         else
         {
-            _template.ModelParams = new UnitCustomModelParams(UnitCustomModelType.Skin);
+            randomTemplate.ModelParams = new UnitCustomModelParams(UnitCustomModelType.Skin);
         }
 
-        foreach (var (modelId, ibp) in _itemBodyParts)
+        foreach (var (modelId, ibp) in ItemBodyParts)
         {
             if (modelId != template.ModelId) { continue; }
 
@@ -271,18 +351,18 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
                 switch (slotTypeId)
                 {
                     case (byte)EquipmentItemSlotType.Face:
-                        _template.BodyItems[rbp.SlotTypeId - 23] = (rbp.ItemId, rbp.NpcOnly);
+                        randomTemplate.BodyItems[rbp.SlotTypeId - 23] = (rbp.ItemId, rbp.NpcOnly);
                         break;
                     case (byte)EquipmentItemSlotType.Hair:
                         if (rbp.ItemId == template.HairId)
                         {
-                            _template.BodyItems[rbp.SlotTypeId - 23] = (rbp.ItemId, rbp.NpcOnly);
+                            randomTemplate.BodyItems[rbp.SlotTypeId - 23] = (rbp.ItemId, rbp.NpcOnly);
                         }
                         else
                         {
                             if (template.HairId != 0)
                             {
-                                _template.BodyItems[rbp.SlotTypeId - 23] = (template.HairId, rbp.NpcOnly);
+                                randomTemplate.BodyItems[rbp.SlotTypeId - 23] = (template.HairId, rbp.NpcOnly);
                             }
                         }
 
@@ -291,7 +371,7 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
                     case (byte)EquipmentItemSlotType.Body:
                     case (byte)EquipmentItemSlotType.Glasses:
                     case (byte)EquipmentItemSlotType.Tail:
-                        _template.BodyItems[rbp.SlotTypeId - 23] = (rbp.ItemId, rbp.NpcOnly);
+                        randomTemplate.BodyItems[rbp.SlotTypeId - 23] = (rbp.ItemId, rbp.NpcOnly);
                         break;
                 }
             }
@@ -299,20 +379,22 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
 
         //Logger.Info("Loaded npc {0} random hair {1} and hairColor {2}", template.ModelId, _template.HairId, _template.ModelParams.HairColorId);
 
-        return _template;
+        return randomTemplate;
     }
 
+    
     public void Load()
     {
-        if (_loaded)
+        if (Loaded)
             return;
 
-        _templates = [];
-        _goods = [];
-        _tccLookup = [];
-        _totalCharacterCustoms = [];
-        _itemBodyParts = [];
-        _creatures = Creature.GetAllCreatures();
+        Templates.Clear();
+        Goods.Clear();
+        TccLookup.Clear();
+        TotalCharacterCustoms.Clear();
+        ItemBodyParts.Clear();
+        EquipPackBodyParts.Clear();
+        Creatures = Creature.GetAllCreatures();
 
         Logger.Info("Loading npc templates...");
         using (var connection = SQLite.CreateConnection())
@@ -364,24 +446,24 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
                         custom.FaceNormalMapWeight = reader.GetFloat("face_normal_map_weight");
                         custom.DecoColor = reader.GetUInt32("deco_color");
 
-                        _totalCharacterCustoms.Add(custom.Id, custom);
+                        TotalCharacterCustoms.Add(custom.Id, custom);
                     }
                 }
 
                 // Create a cached reference list by Model ID
-                foreach (var c in _totalCharacterCustoms)
+                foreach (var c in TotalCharacterCustoms)
                 {
-                    if (!_tccLookup.ContainsKey(c.Value.ModelId))
-                        _tccLookup.Add(c.Value.ModelId, []);
-                    _tccLookup[c.Value.ModelId].Add(c.Value.Id);
+                    if (!TccLookup.ContainsKey(c.Value.ModelId))
+                        TccLookup.Add(c.Value.ModelId, []);
+                    TccLookup[c.Value.ModelId].Add(c.Value.Id);
                 }
 
+                // Pre-Load body parts
                 command.CommandText = "SELECT * FROM item_body_parts";
                 command.Prepare();
                 using (var sqliteReader = command.ExecuteReader())
                 using (var reader = new SQLiteWrapperReader(sqliteReader))
                 {
-                    // Pre-Load body parts
                     while (reader.Read())
                     {
                         var bp = new BodyPartTemplate();
@@ -403,11 +485,11 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
                             slotBodyTemplates.Add(bp);
                         }
 
-                        if (!_itemBodyParts.TryAdd(bp.ModelId, slotBodyParts))
+                        if (!ItemBodyParts.TryAdd(bp.ModelId, slotBodyParts))
                         {
-                            if (!_itemBodyParts[bp.ModelId].TryGetValue(bp.SlotTypeId, out var itemBodyTemplate))
+                            if (!ItemBodyParts[bp.ModelId].TryGetValue(bp.SlotTypeId, out var itemBodyTemplate))
                             {
-                                _itemBodyParts[bp.ModelId].Add(bp.SlotTypeId, bodyParts);
+                                ItemBodyParts[bp.ModelId].Add(bp.SlotTypeId, bodyParts);
                             }
                             else
                             {
@@ -417,6 +499,7 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
                     }
                 }
 
+                // Load the actual Npc list
                 command.CommandText = "SELECT * from npcs";
                 command.Prepare();
                 using (var sqliteDataReader = command.ExecuteReader())
@@ -491,13 +574,13 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
                             ReturnWhenEnterHousingArea = reader.GetBoolean("return_when_enter_housing_area", true),
                             LookConverter = reader.GetBoolean("look_converter", true),
                             UseDDCMSMountSkill = reader.GetBoolean("use_ddcms_mount_skill", true),
-                            CrowdEffect = reader.GetBoolean("crowd_effect", true)
+                            CrowdEffect = reader.GetBoolean("crowd_effect", true),
+                            EquipBodiesId = reader.GetUInt32("equip_bodies_id", 0),
+                            EquipClothsId = reader.GetUInt32("equip_cloths_id", 0),
+                            EquipWeaponsId = reader.GetUInt32("equip_weapons_id", 0),
+                            TotalCustomId = reader.GetUInt32("total_custom_id", 0)
                         };
 
-                        var bodyPack = reader.GetInt32("equip_bodies_id", 0);
-                        var clothPack = reader.GetInt32("equip_cloths_id", 0);
-                        var weaponPack = reader.GetInt32("equip_weapons_id", 0);
-                        template.TotalCustomId = reader.GetUInt32("total_custom_id", 0);
                         using (var command2 = connection.CreateCommand())
                         {
                             command2.CommandText = "SELECT char_race_id, char_gender_id FROM characters WHERE model_id = @model_id";
@@ -514,14 +597,14 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
                             }
                         }
 
-                        _templates.Add(template.Id, template);
+                        Templates.Add(template.Id, template);
 
-                        if (clothPack > 0)
+                        if (template.EquipClothsId > 0)
                         {
                             using (var command2 = connection.CreateCommand())
                             {
                                 command2.CommandText = "SELECT * FROM equip_pack_cloths WHERE id=@id";
-                                command2.Parameters.AddWithValue("id", clothPack);
+                                command2.Parameters.AddWithValue("id", template.EquipClothsId);
                                 command2.Prepare();
                                 using (var sqliteReader2 = command2.ExecuteReader())
                                 using (var reader2 = new SQLiteWrapperReader(sqliteReader2))
@@ -557,12 +640,12 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
                             }
                         }
 
-                        if (weaponPack > 0)
+                        if (template.EquipWeaponsId > 0)
                         {
                             using (var command2 = connection.CreateCommand())
                             {
                                 command2.CommandText = "SELECT * FROM equip_pack_weapons WHERE id=@id";
-                                command2.Parameters.AddWithValue("id", weaponPack);
+                                command2.Parameters.AddWithValue("id", template.EquipWeaponsId);
                                 command2.Prepare();
                                 using (var sqliteReader2 = command2.ExecuteReader())
                                 using (var reader2 = new SQLiteWrapperReader(sqliteReader2))
@@ -582,7 +665,7 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
                             }
                         }
 
-                        if (template.TotalCustomId > 0 && _totalCharacterCustoms.TryGetValue(template.TotalCustomId, out var tc))
+                        if (template.TotalCustomId > 0 && TotalCharacterCustoms.TryGetValue(template.TotalCustomId, out var tc))
                         {
                             template.HairId = tc.HairId;
 
@@ -647,7 +730,7 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
                             }
                         }
 
-                        foreach (var (modelId, ibp) in _itemBodyParts)
+                        foreach (var (modelId, ibp) in ItemBodyParts)
                         {
                             if (modelId != template.ModelId) { continue; }
 
@@ -688,6 +771,35 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
                 }
             }
 
+            // This table seems to no longer be in some of the later versions
+            // Load body part packs (probably not used)
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT * FROM equip_pack_body_parts";
+                command.Prepare();
+                using (var sqliteDataReader = command.ExecuteReader())
+                using (var reader = new SQLiteWrapperReader(sqliteDataReader))
+                {
+                    while (reader.Read())
+                    {
+                        var template = new EquipBodyPartPack
+                        {
+                            Id = reader.GetUInt32("id"),
+                            Name = reader.GetString("name"),
+                            ModelId = reader.GetUInt32("model_id"),
+                            HairColorId = reader.GetUInt32("hair_color_id"),
+                            FaceId = reader.GetUInt32("face_id"),
+                            HairId = reader.GetUInt32("hair_id"),
+                            BeardId = reader.GetUInt32("beard_id"),
+                            SkinColorId = reader.GetUInt32("skin_color_id"),
+                            BodyDiffuseMapId =  reader.GetUInt32("body_diffuse_map_id"),
+                        };
+                        EquipPackBodyParts.Add(template.Id, template);
+                    }
+                }
+            }
+
+            // Load Unit modifiers for NPCs
             using (var command = connection.CreateCommand())
             {
                 command.CommandText = "SELECT * FROM unit_modifiers WHERE owner_type='Npc'";
@@ -698,7 +810,7 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
                     while (reader.Read())
                     {
                         var npcId = reader.GetUInt32("owner_id");
-                        if (!_templates.TryGetValue(npcId, out var npc))
+                        if (!Templates.TryGetValue(npcId, out var npc))
                             continue;
                         var template = new BonusTemplate
                         {
@@ -711,6 +823,7 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
                 }
             }
 
+            // Load initial Npc buffs
             using (var command = connection.CreateCommand())
             {
                 command.CommandText = "SELECT * FROM npc_initial_buffs";
@@ -721,13 +834,14 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
                     {
                         var id = reader.GetUInt32("npc_id");
                         var buffId = reader.GetUInt32("buff_id");
-                        if (!_templates.TryGetValue(id, out var template))
+                        if (!Templates.TryGetValue(id, out var template))
                             continue;
                         template.Buffs.Add(buffId);
                     }
                 }
             }
 
+            // Load merchant list
             using (var command = connection.CreateCommand())
             {
                 command.CommandText = "SELECT * FROM merchants";
@@ -737,14 +851,17 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
                     while (reader.Read())
                     {
                         var id = reader.GetUInt32("npc_id");
-                        if (!_templates.TryGetValue(id, out var template))
+                        if (!Templates.TryGetValue(id, out var template))
                             continue;
                         template.MerchantPackId = reader.GetUInt32("merchant_pack_id");
                     }
                 }
             }
 
-            Logger.Info("Loaded {0} npc templates", _templates.Count);
+            // Done loading main Npc data
+            Logger.Info($"Loaded {Templates.Count} npc templates");
+
+            // Loading merchant stuff
             Logger.Info("Loading merchant packs...");
             using (var command = connection.CreateCommand())
             {
@@ -755,33 +872,44 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
                     while (reader.Read())
                     {
                         var id = reader.GetUInt32("merchant_pack_id");
-                        if (!_goods.ContainsKey(id))
-                            _goods.Add(id, new MerchantGoods(id));
+                        if (!Goods.ContainsKey(id))
+                            Goods.Add(id, new MerchantGoods(id));
 
                         var itemId = reader.GetUInt32("item_id");
                         var grade = reader.GetByte("grade_id");
 
-                        _goods[id].AddItemToStock(itemId, grade);
+                        Goods[id].AddItemToStock(itemId, grade);
                     }
                 }
             }
 
-            Logger.Info("Loaded {0} merchant packs", _goods.Count);
+            Logger.Info($"Loaded {Goods.Count} merchant packs");
         }
 
-        NpcGameData.Instance.LoadMemberAndSpawnerTemplateIds();
+        // NpcGameData.Instance.LoadMemberAndSpawnerTemplateIds();
 
-        _loaded = true;
+        Loaded = true;
     }
 
+    /// <summary>
+    /// Load AI settings from AiGameData into the Npc templates
+    /// </summary>
     public void LoadAiParams()
     {
-        foreach (var npc in _templates.Values)
+        foreach (var npc in Templates.Values)
         {
             npc.AiParams = AiGameData.Instance.GetAiParamsForId((uint)npc.NpcAiParamId);
         }
     }
 
+    /// <summary>
+    /// Populate items based on Npc template Id and slot
+    /// </summary>
+    /// <param name="npc"></param>
+    /// <param name="templateId"></param>
+    /// <param name="slot"></param>
+    /// <param name="grade"></param>
+    /// <param name="npcOnly"></param>
     private void SetEquipItemTemplate(Npc npc, uint templateId, EquipmentItemSlot slot, byte grade = 0, bool npcOnly = false)
     {
         if (npcOnly && npc.Equipment.GetItemBySlot((int)slot) != null)
@@ -799,9 +927,14 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
         npc.Equipment.AddOrMoveExistingItem(0, item, (int)slot);
     }
 
+    /// <summary>
+    /// Attaches a list of skills to a Npc template
+    /// </summary>
+    /// <param name="templateId"></param>
+    /// <param name="skills"></param>
     public void BindSkillsToTemplate(uint templateId, List<NpcSkill> skills)
     {
-        if (!_templates.TryGetValue(templateId, out var value))
+        if (!Templates.TryGetValue(templateId, out var value))
             return;
         value.BindSkills(skills);
     }

--- a/AAEmu.Game/Core/Managers/World/SpawnManager.cs
+++ b/AAEmu.Game/Core/Managers/World/SpawnManager.cs
@@ -36,20 +36,20 @@ public class SpawnManager(WorldInstance parentWorld)
     private bool _work = true;
     private readonly object _lock = new();
     private readonly object _lockSpawner = new();
-    private HashSet<GameObject> _respawns = [];
-    private HashSet<GameObject> _despawns = [];
+    private HashSet<GameObject> Respawns { get; } = [];
+    private HashSet<GameObject> Despawns { get; } = [];
 
-    private Dictionary<uint, List<NpcSpawner>> _npcSpawners = []; // (idx, List<NpcSpawner>)
-    private Dictionary<uint, List<NpcSpawner>> _npcEventSpawners = []; // (idx, List<NpcSpawner>)
-    private Dictionary<uint, DoodadSpawner> _doodadSpawners = [];
-    private Dictionary<uint, TransferSpawner> _transferSpawners = [];
-    private Dictionary<uint, GimmickSpawner> _gimmickSpawners = [];
-    private Dictionary<uint, SlaveSpawner> _slaveSpawners = [];
-    private List<Doodad> _playerDoodads = [];
+    private Dictionary<uint, List<NpcSpawner>> NpcSpawners { get; } = []; // (idx, List<NpcSpawner>)
+    private Dictionary<uint, List<NpcSpawner>> NpcEventSpawners { get; } = []; // (idx, List<NpcSpawner>)
+    private Dictionary<uint, DoodadSpawner> DoodadSpawners { get; } = [];
+    private Dictionary<uint, TransferSpawner> TransferSpawners { get; } = [];
+    private Dictionary<uint, GimmickSpawner> GimmickSpawners { get; } = [];
+    private Dictionary<uint, SlaveSpawner> SlaveSpawners { get; } = [];
+    private List<Doodad> PlayerDoodads { get; } = [];
 
     private uint _nextId = 1u;
     // Shared across all SpawnManager instances — all write into the global NpcGameData singleton
-    private static uint _fakeSpawnerId = 9000001u;
+    private static uint s_fakeSpawnerId = 9000001u;
 
     public List<Task> SpawnTasks { get; init; } = [];
 
@@ -58,7 +58,7 @@ public class SpawnManager(WorldInstance parentWorld)
     /// </summary>
     public void AddNpcSpawner(NpcSpawner npcSpawner)
     {
-        lock (_npcSpawners)
+        lock (NpcSpawners)
         {
             if (npcSpawner.NpcSpawnerIds is [0])
                 npcSpawner.NpcSpawnerIds = [];
@@ -66,13 +66,14 @@ public class SpawnManager(WorldInstance parentWorld)
             // check for manually entered NpcSpawnerId
             if (npcSpawner.NpcSpawnerIds.Count == 0)
             {
-                var npcSpawnerIds = NpcGameData.Instance.GetSpawnerIds(npcSpawner.UnitId);
+                var gameDataNpcSpawnerIds = NpcGameData.Instance.GetSpawnerIds(npcSpawner.UnitId);
                 var spawners = new List<NpcSpawner>();
-                if (npcSpawnerIds == null)
+                if (gameDataNpcSpawnerIds == null || gameDataNpcSpawnerIds.Count == 0)
                 {
+                    // No pre-defined spawner found, create a new one
                     Logger.Trace($"SpawnerIds for Npc={npcSpawner.UnitId} doesn't exist");
                     Logger.Trace($"Generate Spawner for Npc={npcSpawner.UnitId}...");
-                    var id = _fakeSpawnerId;
+                    var id = s_fakeSpawnerId;
                     npcSpawner.ParentWorld = World;
                     npcSpawner.NpcSpawnerIds.Add(id);
                     npcSpawner.Id = id;
@@ -93,11 +94,12 @@ public class SpawnManager(WorldInstance parentWorld)
                     NpcGameData.Instance.AddNpcSpawnerNpc(tmpNpc);
                     NpcGameData.Instance.AddMemberAndSpawnerTemplateIds(tmpNpc);
                     NpcGameData.Instance.AddNpcSpawner(npcSpawner.Template);
-                    _fakeSpawnerId++;
+                    s_fakeSpawnerId++;
                 }
                 else
                 {
-                    foreach (var id in npcSpawnerIds)
+                    // There were spawners found in the game data that define this NPC
+                    foreach (var id in gameDataNpcSpawnerIds)
                     {
                         var spawner = NpcSpawner.Clone(npcSpawner);
                         var template = NpcGameData.Instance.GetNpcSpawnerTemplate(id);
@@ -117,7 +119,7 @@ public class SpawnManager(WorldInstance parentWorld)
                     }
                 }
 
-                _npcSpawners.TryAdd(_nextId, spawners);
+                NpcSpawners.TryAdd(_nextId, spawners);
             }
             else
             {
@@ -135,7 +137,7 @@ public class SpawnManager(WorldInstance parentWorld)
                 }
 
                 spawners.Add(npcSpawner);
-                _npcEventSpawners.TryAdd(_nextId, spawners);
+                NpcEventSpawners.TryAdd(_nextId, spawners);
                 _nextId++;
             }
         }
@@ -144,12 +146,13 @@ public class SpawnManager(WorldInstance parentWorld)
     /// <summary>
     /// Spawn all Npcs for this world template into this instance
     /// </summary>
+    // ReSharper disable once UnusedMember.Local
     private void SpawnAllNpcs()
     {
         var spawnStartTime = DateTime.UtcNow;
-        Logger.Info($"Spawning {_npcSpawners.Count} NPC spawners in world {World}");
+        Logger.Info($"Spawning {NpcSpawners.Count} NPC spawners in world {World}");
         var count = 0;
-        foreach (var spawners in _npcSpawners.Values)
+        foreach (var spawners in NpcSpawners.Values)
         {
             foreach (var spawner in spawners)
             {
@@ -254,15 +257,15 @@ public class SpawnManager(WorldInstance parentWorld)
         if (_loaded)
             return;
 
-        lock (_respawns) _respawns = [];
-        lock (_despawns) _despawns = [];
-        _npcSpawners = [];
-        _npcEventSpawners = [];
-        _doodadSpawners = [];
-        _transferSpawners = [];
-        _gimmickSpawners = [];
-        _slaveSpawners = [];
-        _playerDoodads = [];
+        lock (Respawns) Respawns.Clear();
+        lock (Despawns) Despawns.Clear();
+        NpcSpawners.Clear();
+        NpcEventSpawners.Clear();
+        DoodadSpawners.Clear();
+        TransferSpawners.Clear();
+        GimmickSpawners.Clear();
+        SlaveSpawners.Clear();
+        PlayerDoodads.Clear();
 
         Logger.Info($"Loading spawn data for {World} ...");
         var worldPath = Path.Combine(FileManager.AppPath, "Data", "Worlds", World.Template.Name);
@@ -347,7 +350,7 @@ public class SpawnManager(WorldInstance parentWorld)
                     npcSpawnerFromFile.ParentWorld = World;
 
                     // Check for duplication by UnitId and Position
-                    if (_npcSpawners.Values.SelectMany(spawners => spawners)
+                    if (NpcSpawners.Values.SelectMany(spawners => spawners)
                         .Any(spawner => spawner.UnitId == npcSpawnerFromFile.UnitId &&
                                         Math.Abs(spawner.Position.X - npcSpawnerFromFile.Position.X) < 2f &&
                                         Math.Abs(spawner.Position.Y - npcSpawnerFromFile.Position.Y) < 2f
@@ -396,7 +399,7 @@ public class SpawnManager(WorldInstance parentWorld)
 
     private bool LoadDoodadSpawns(string worldPath)
     {
-        _doodadSpawners = new Dictionary<uint, DoodadSpawner>();
+        DoodadSpawners.Clear();
         string[] doodadFiles;
         try
         {
@@ -429,7 +432,7 @@ public class SpawnManager(WorldInstance parentWorld)
                     spawner.ParentWorld = World;
 
                     // Check for duplication by UnitId and Position
-                    if (_doodadSpawners.Values
+                    if (DoodadSpawners.Values
                         .Any(existingSpawner => existingSpawner.UnitId == spawner.UnitId &&
                                                 Math.Abs(existingSpawner.Position.X - spawner.Position.X) < 0.01f &&
                                                 Math.Abs(existingSpawner.Position.Y - spawner.Position.Y) < 0.01f &&
@@ -450,7 +453,7 @@ public class SpawnManager(WorldInstance parentWorld)
                     spawner.Position.Yaw = spawner.Position.Yaw.DegToRad();
                     spawner.Position.Pitch = spawner.Position.Pitch.DegToRad();
                     spawner.Position.Roll = spawner.Position.Roll.DegToRad();
-                    if (_doodadSpawners.TryAdd(_nextId, spawner))
+                    if (DoodadSpawners.TryAdd(_nextId, spawner))
                     {
                         _nextId++;
                     }
@@ -467,7 +470,7 @@ public class SpawnManager(WorldInstance parentWorld)
 
     private bool LoadTransferSpawns(string worldPath)
     {
-        _transferSpawners = new Dictionary<uint, TransferSpawner>();
+        TransferSpawners.Clear();
         string[] transferFiles;
         try
         {
@@ -513,7 +516,7 @@ public class SpawnManager(WorldInstance parentWorld)
                     spawner.Position.Yaw = spawner.Position.Yaw.DegToRad();
                     spawner.Position.Pitch = spawner.Position.Pitch.DegToRad();
                     spawner.Position.Roll = spawner.Position.Roll.DegToRad();
-                    if (_transferSpawners.TryAdd(_nextId, spawner))
+                    if (TransferSpawners.TryAdd(_nextId, spawner))
                     {
                         _nextId++;
                     }
@@ -529,7 +532,7 @@ public class SpawnManager(WorldInstance parentWorld)
 
     private bool LoadGimmickSpawns(string worldPath)
     {
-        _gimmickSpawners = new Dictionary<uint, GimmickSpawner>();
+        GimmickSpawners.Clear();
         string[] gimmickFiles;
         try
         {
@@ -571,7 +574,7 @@ public class SpawnManager(WorldInstance parentWorld)
                     spawner.Id = _nextId;
                     spawner.Position.WorldId = World.Id;
                     spawner.Position.ZoneId = WorldManager.Instance.GetZoneId(World.Template, spawner.Position.X, spawner.Position.Y);
-                    if (_gimmickSpawners.TryAdd(_nextId, spawner))
+                    if (GimmickSpawners.TryAdd(_nextId, spawner))
                     {
                         _nextId++;
                     }
@@ -587,7 +590,7 @@ public class SpawnManager(WorldInstance parentWorld)
 
     private bool LoadSlaveSpawns(string worldPath)
     {
-        _slaveSpawners = new Dictionary<uint, SlaveSpawner>();
+        SlaveSpawners.Clear();
         string[] slaveFiles;
         try
         {
@@ -632,7 +635,7 @@ public class SpawnManager(WorldInstance parentWorld)
                     spawner.Position.Yaw = spawner.Position.Yaw.DegToRad();
                     spawner.Position.Pitch = spawner.Position.Pitch.DegToRad();
                     spawner.Position.Roll = spawner.Position.Roll.DegToRad();
-                    if (_slaveSpawners.TryAdd(_nextId, spawner))
+                    if (SlaveSpawners.TryAdd(_nextId, spawner))
                     {
                         _nextId++;
                     }
@@ -648,22 +651,22 @@ public class SpawnManager(WorldInstance parentWorld)
 
     public List<Doodad> GetPlayerDoodads(uint charId)
     {
-        return _playerDoodads.Where(d => d.OwnerId == charId).ToList();
+        return PlayerDoodads.Where(d => d.OwnerId == charId).ToList();
     }
 
     public List<Doodad> GetAllPlayerDoodads()
     {
-        return _playerDoodads;
+        return PlayerDoodads;
     }
 
     public void RemovePlayerDoodad(Doodad doodad)
     {
-        _playerDoodads.Remove(doodad);
+        PlayerDoodads.Remove(doodad);
     }
 
     public void AddPlayerDoodad(Doodad doodad)
     {
-        _playerDoodads.Add(doodad);
+        PlayerDoodads.Add(doodad);
     }
 
     /// <summary>
@@ -748,7 +751,7 @@ public class SpawnManager(WorldInstance parentWorld)
                     if (parentDoodad > 0)
                     {
                         // var pDoodad = WorldManager.Instance.GetDoodadByDbId(parentDoodad);
-                        var pDoodad = _playerDoodads.FirstOrDefault(d => d.DbId == parentDoodad);
+                        var pDoodad = PlayerDoodads.FirstOrDefault(d => d.DbId == parentDoodad);
                         if (pDoodad == null)
                         {
                             Logger.Warn($"Unable to place doodad {dbId} can't find it's parent doodad {parentDoodad}");
@@ -812,7 +815,7 @@ public class SpawnManager(WorldInstance parentWorld)
 
                     doodad.InitDoodad();
 
-                    _playerDoodads.Add(doodad);
+                    PlayerDoodads.Add(doodad);
                     spawnCount++;
 
                     if (doSpawn)
@@ -836,9 +839,9 @@ public class SpawnManager(WorldInstance parentWorld)
         SpawnTasks.Add(Task.Run(() =>
         {
             var spawnStartTime = DateTime.UtcNow;
-            Logger.Info($"Spawning {_doodadSpawners.Count} Doodads in world {World}");
+            Logger.Info($"Spawning {DoodadSpawners.Count} Doodads in world {World}");
             var count = 0;
-            foreach (var spawner in _doodadSpawners.Values)
+            foreach (var spawner in DoodadSpawners.Values)
             {
                 spawner.Spawn(0);
                 count++;
@@ -858,9 +861,9 @@ public class SpawnManager(WorldInstance parentWorld)
         SpawnTasks.Add(Task.Run(() =>
         {
             var spawnStartTime = DateTime.UtcNow;
-            Logger.Info($"Spawning {_transferSpawners.Count} Transfers in world {World}");
+            Logger.Info($"Spawning {TransferSpawners.Count} Transfers in world {World}");
             var count = 0;
-            foreach (var spawner in _transferSpawners.Values)
+            foreach (var spawner in TransferSpawners.Values)
             {
                 spawner.SpawnAll();
                 count++;
@@ -877,9 +880,9 @@ public class SpawnManager(WorldInstance parentWorld)
         SpawnTasks.Add(Task.Run(() =>
         {
             var spawnStartTime = DateTime.UtcNow;
-            Logger.Info($"Spawning {_gimmickSpawners.Count} Gimmicks in world {World}");
+            Logger.Info($"Spawning {GimmickSpawners.Count} Gimmicks in world {World}");
             var count = 0;
-            foreach (var spawner in _gimmickSpawners.Values)
+            foreach (var spawner in GimmickSpawners.Values)
             {
                 spawner.Spawn(0);
                 count++;
@@ -896,9 +899,9 @@ public class SpawnManager(WorldInstance parentWorld)
         SpawnTasks.Add(Task.Run(() =>
         {
             var spawnStartTime = DateTime.UtcNow;
-            Logger.Info($"Spawning {_slaveSpawners.Count} Slaves in world {World}");
+            Logger.Info($"Spawning {SlaveSpawners.Count} Slaves in world {World}");
             var count = 0;
-            foreach (var spawner in _slaveSpawners.Values)
+            foreach (var spawner in SlaveSpawners.Values)
             {
                 spawner.World = World;
                 spawner.Spawn(0);
@@ -916,10 +919,10 @@ public class SpawnManager(WorldInstance parentWorld)
         SpawnTasks.Add(Task.Run(() =>
         {
             var spawnStartTime = DateTime.UtcNow;
-            if (_playerDoodads.Count > 0)
-                Logger.Info($"Spawning {_playerDoodads.Count} Player Doodads");
+            if (PlayerDoodads.Count > 0)
+                Logger.Info($"Spawning {PlayerDoodads.Count} Player Doodads");
             var count = 0;
-            foreach (var doodad in _playerDoodads)
+            foreach (var doodad in PlayerDoodads)
             {
                 if (doodad.Spawner == null)
                 {
@@ -950,42 +953,42 @@ public class SpawnManager(WorldInstance parentWorld)
 
     public void AddRespawn(GameObject obj)
     {
-        lock (_respawns)
+        lock (Respawns)
         {
-            _respawns.Add(obj);
+            Respawns.Add(obj);
         }
     }
 
     private void RemoveRespawn(GameObject obj)
     {
-        lock (_respawns)
+        lock (Respawns)
         {
-            _respawns.Remove(obj);
+            Respawns.Remove(obj);
         }
     }
 
     public void AddDespawn(GameObject obj)
     {
-        lock (_despawns)
+        lock (Despawns)
         {
-            _despawns.Add(obj);
+            Despawns.Add(obj);
         }
     }
 
     private void RemoveDespawn(GameObject obj)
     {
-        lock (_despawns)
+        lock (Despawns)
         {
-            _despawns.Remove(obj);
+            Despawns.Remove(obj);
         }
     }
 
     private HashSet<GameObject> GetRespawnsReady()
     {
         HashSet<GameObject> temp;
-        lock (_respawns)
+        lock (Respawns)
         {
-            temp = [.. _respawns];
+            temp = [.. Respawns];
         }
 
         var res = new HashSet<GameObject>();
@@ -998,9 +1001,9 @@ public class SpawnManager(WorldInstance parentWorld)
     private HashSet<GameObject> GetDespawnsReady()
     {
         HashSet<GameObject> temp;
-        lock (_despawns)
+        lock (Despawns)
         {
-            temp = [.. _despawns];
+            temp = [.. Despawns];
         }
 
         var res = new HashSet<GameObject>();
@@ -1087,9 +1090,9 @@ public class SpawnManager(WorldInstance parentWorld)
     public Dictionary<uint, List<NpcSpawner>> GetAllSpawners()
     {
         Dictionary<uint, List<NpcSpawner>> temp;
-        lock (_npcSpawners)
+        lock (NpcSpawners)
         {
-            temp = _npcSpawners.ToDictionary(
+            temp = NpcSpawners.ToDictionary(
                 entry => entry.Key,
                 entry => entry.Value.ToList()
             );
@@ -1102,7 +1105,7 @@ public class SpawnManager(WorldInstance parentWorld)
     {
         var ret = new List<NpcSpawner>();
 
-        foreach (var (_, spawners) in _npcEventSpawners)
+        foreach (var (_, spawners) in NpcEventSpawners)
         {
             foreach (var spawner in spawners)
             {
@@ -1180,13 +1183,13 @@ public class SpawnManager(WorldInstance parentWorld)
 
     public bool CloneNpcEventSpawners(byte from, byte to)
     {
-        _npcEventSpawners.TryGetValue(from, out var value);
-        return _npcEventSpawners.TryAdd(to, value);
+        NpcEventSpawners.TryGetValue(from, out var value);
+        return NpcEventSpawners.TryAdd(to, value);
     }
 
     public bool RemoveNpcEventSpawners(byte from)
     {
-        return _npcEventSpawners.Remove(from, out _);
+        return NpcEventSpawners.Remove(from, out _);
     }
 
     /// <summary>
@@ -1198,14 +1201,14 @@ public class SpawnManager(WorldInstance parentWorld)
         var chestTemplateIds = DoodadManager.Instance.GetTreasureChestTemplateIds();
         if (chestTemplateIds == null)
             return [];
-        return _doodadSpawners.Values.Where(ds => chestTemplateIds.Contains(ds.RespawnDoodadTemplateId) || chestTemplateIds.Contains(ds.UnitId)).ToList();
+        return DoodadSpawners.Values.Where(ds => chestTemplateIds.Contains(ds.RespawnDoodadTemplateId) || chestTemplateIds.Contains(ds.UnitId)).ToList();
     }
 
     public void DeleteAllSpawners()
     {
         // First remove all owned spawns and disable the spawner
         // Npc
-        foreach (var npcSpawners in _npcSpawners.Values.SelectMany(x => x).ToList())
+        foreach (var npcSpawners in NpcSpawners.Values.SelectMany(x => x).ToList())
         {
             foreach (var npc in npcSpawners.SpawnedNpcs.Values.SelectMany(n => n).ToList())
             {
@@ -1215,10 +1218,10 @@ public class SpawnManager(WorldInstance parentWorld)
             npcSpawners.SpawnedNpcs.Clear();
             npcSpawners.ParentWorld = null;
         }
-        _npcSpawners.Clear();
+        NpcSpawners.Clear();
 
         // Doodad
-        foreach (var doodadSpawner in _doodadSpawners.Values.ToList())
+        foreach (var doodadSpawner in DoodadSpawners.Values.ToList())
         {
             foreach (var doodad in doodadSpawner._spawned.ToList())
             {
@@ -1227,10 +1230,10 @@ public class SpawnManager(WorldInstance parentWorld)
             doodadSpawner._spawned.Clear();
             doodadSpawner.ParentWorld = null;
         }
-        _doodadSpawners.Clear();
+        DoodadSpawners.Clear();
         
         // Gimmick
-        _gimmickSpawners.Clear();
+        GimmickSpawners.Clear();
         foreach (var (_ , gimmick) in World.GimmickManager._activeGimmicks.ToList())
         {
             gimmick.Delete();

--- a/AAEmu.Game/GameData/NpcGameData.cs
+++ b/AAEmu.Game/GameData/NpcGameData.cs
@@ -11,21 +11,41 @@ using Microsoft.Data.Sqlite;
 namespace AAEmu.Game.GameData;
 
 [GameData]
+// ReSharper disable once ClassNeverInstantiated.Global
 public class NpcGameData : Singleton<NpcGameData>, IGameDataLoader
 {
-    private Dictionary<uint, List<NpcSkill>> _skillsForNpc = [];
-    private Dictionary<uint, List<NpcPassiveBuff>> _passivesForNpc = [];
-    public Dictionary<uint, NpcSpawnerNpc> _npcSpawnerTemplateNpcs = [];      // Id, nsn
-    public Dictionary<uint, NpcSpawnerTemplate> _npcSpawnerTemplates = [];    // NpcSpawnerTemplateId, template
-    public Dictionary<uint, List<uint>> _npcMemberAndSpawnerTemplateIds = []; // memberId, List<npcSpawnerId>
+    /// <summary>
+    /// List of skill for NpcTemplateIds
+    /// </summary>
+    private Dictionary<uint, List<NpcSkill>> SkillsForNpc { get; } = [];
+    /// <summary>
+    /// Passive buffs for NpcTemplateid
+    /// </summary>
+    private Dictionary<uint, List<NpcPassiveBuff>> PassivesForNpc { get; } = [];
+    /// <summary>
+    /// List of NpcSpawnerNpcs by NpcSpawnerId
+    /// </summary>
+    private Dictionary<uint, NpcSpawnerNpc> NpcSpawnerTemplateNpcs { get; } = [];
+    /// <summary>
+    /// List of NpcSpawnerTemplates by Id
+    /// </summary>
+    private Dictionary<uint, NpcSpawnerTemplate> NpcSpawnerTemplates { get; } = [];
+    /// <summary>
+    /// List of SpawnerTemplateIds grouped by NpcTempalteId
+    /// </summary>
+    private Dictionary<uint, List<uint>> NpcMemberAndSpawnerTemplateIds { get; } = [];
 
+    /// <summary>
+    /// Loads static Npc related data
+    /// </summary>
+    /// <param name="connection"></param>
     public void Load(SqliteConnection connection)
     {
-        _skillsForNpc = [];
-        _passivesForNpc = [];
-        _npcSpawnerTemplateNpcs = [];
-        _npcSpawnerTemplates = [];
-        _npcMemberAndSpawnerTemplateIds = [];
+        SkillsForNpc.Clear();
+        PassivesForNpc.Clear();
+        NpcSpawnerTemplateNpcs.Clear();
+        NpcSpawnerTemplates.Clear();
+        NpcMemberAndSpawnerTemplateIds.Clear();
 
         using (var command = connection.CreateCommand())
         {
@@ -46,10 +66,10 @@ public class NpcGameData : Singleton<NpcGameData>, IGameDataLoader
                     SkillUseParam2 = reader.GetFloat("skill_use_param2")
                 };
 
-                if (!_skillsForNpc.ContainsKey(template.OwnerId))
-                    _skillsForNpc.Add(template.OwnerId, []);
+                if (!SkillsForNpc.ContainsKey(template.OwnerId))
+                    SkillsForNpc.Add(template.OwnerId, []);
 
-                _skillsForNpc[template.OwnerId].Add(template);
+                SkillsForNpc[template.OwnerId].Add(template);
             }
         }
 
@@ -69,10 +89,10 @@ public class NpcGameData : Singleton<NpcGameData>, IGameDataLoader
                     PassiveBuffId = reader.GetUInt32("passive_buff_id")
                 };
 
-                if (!_passivesForNpc.ContainsKey(template.OwnerId))
-                    _passivesForNpc.Add(template.OwnerId, []);
+                if (!PassivesForNpc.ContainsKey(template.OwnerId))
+                    PassivesForNpc.Add(template.OwnerId, []);
 
-                _passivesForNpc[template.OwnerId].Add(template);
+                PassivesForNpc[template.OwnerId].Add(template);
             }
         }
 
@@ -104,7 +124,7 @@ public class NpcGameData : Singleton<NpcGameData>, IGameDataLoader
                     SpawnDelayMax = reader.GetFloat("spawn_delay_max"),
                     Npcs = []
                 };
-                _npcSpawnerTemplates.Add(template.Id, template);
+                NpcSpawnerTemplates.Add(template.Id, template);
             }
         }
 
@@ -125,96 +145,133 @@ public class NpcGameData : Singleton<NpcGameData>, IGameDataLoader
                     Weight = reader.GetFloat("weight")
                 };
 
-                _npcSpawnerTemplateNpcs.Add(nsn.Id, nsn);
-                _npcSpawnerTemplates[nsn.NpcSpawnerTemplateId].Npcs.Add(nsn);
+                NpcSpawnerTemplateNpcs.Add(nsn.Id, nsn);
+                NpcSpawnerTemplates[nsn.NpcSpawnerTemplateId].Npcs.Add(nsn);
             }
         }
     }
 
+    /// <summary>
+    /// Process data after all other data has been loaded
+    /// </summary>
     public void PostLoad()
     {
-        foreach (var (templateId, skills) in _skillsForNpc)
+        foreach (var (templateId, skills) in SkillsForNpc)
         {
             NpcManager.Instance.BindSkillsToTemplate(templateId, skills);
         }
 
-        foreach (var passiveBuff in _passivesForNpc.Values.SelectMany(i => i))
+        foreach (var passiveBuff in PassivesForNpc.Values.SelectMany(i => i))
         {
             if (passiveBuff.PassiveBuff != null)
                 continue;
             passiveBuff.PassiveBuff = SkillManager.Instance.GetPassiveBuffTemplate(passiveBuff.PassiveBuffId);
         }
 
-        foreach (var (templateId, passives) in _passivesForNpc)
+        foreach (var (templateId, passives) in PassivesForNpc)
         {
             var template = NpcManager.Instance.GetTemplate(templateId);
             template?.PassiveBuffs.AddRange(passives);
         }
+
+        LoadMemberAndSpawnerTemplateIds();
     }
 
-    public void LoadMemberAndSpawnerTemplateIds()
+    /// <summary>
+    /// Creates a cahced list of NpcSpawners by NpcTemplateId
+    /// </summary>
+    private void LoadMemberAndSpawnerTemplateIds()
     {
-        _npcMemberAndSpawnerTemplateIds = [];
-        var npcMemberAndSpawnerId = new Dictionary<uint, List<uint>>();
+        NpcMemberAndSpawnerTemplateIds.Clear();
 
-        foreach (var nsn in _npcSpawnerTemplateNpcs.Values)
+        foreach (var (_, npcSpawnerNpc) in NpcSpawnerTemplateNpcs)
         {
-            if (!_npcMemberAndSpawnerTemplateIds.TryGetValue(nsn.MemberId, out var value))
+            if (!NpcMemberAndSpawnerTemplateIds.TryGetValue(npcSpawnerNpc.MemberId, out var value))
             {
-                _npcMemberAndSpawnerTemplateIds.Add(nsn.MemberId, [nsn.NpcSpawnerTemplateId]);
+                NpcMemberAndSpawnerTemplateIds.Add(npcSpawnerNpc.MemberId, [npcSpawnerNpc.NpcSpawnerTemplateId]);
             }
             else
             {
-                value.Add(nsn.NpcSpawnerTemplateId);
+                value.Add(npcSpawnerNpc.NpcSpawnerTemplateId);
             }
         }
     }
 
+    /// <summary>
+    /// Gets a list of SpawnerIds for a given NpcTemplateId
+    /// </summary>
+    /// <param name="memberId"></param>
+    /// <returns></returns>
     public List<uint> GetSpawnerIds(uint memberId)
     {
-        _npcMemberAndSpawnerTemplateIds.TryGetValue(memberId, out var list);
-
-        return list;
+        return NpcMemberAndSpawnerTemplateIds.GetValueOrDefault(memberId);
     }
 
+    /// <summary>
+    /// Returns a NpcSpawnerTemplate for a given Id
+    /// </summary>
+    /// <param name="npcSpawnerTemplateId"></param>
+    /// <returns></returns>
     public NpcSpawnerTemplate GetNpcSpawnerTemplate(uint npcSpawnerTemplateId)
     {
-        _npcSpawnerTemplates.TryGetValue(npcSpawnerTemplateId, out var template);
-
-        return template;
+        return NpcSpawnerTemplates.GetValueOrDefault(npcSpawnerTemplateId);
     }
 
+    /// <summary>
+    /// Rturns the first NpcSpawnerNpc from a given NpcSpawnerTemplateId
+    /// </summary>
+    /// <param name="spawnerId"></param>
+    /// <returns></returns>
     public NpcSpawnerNpc GetNpcSpawnerNpc(uint spawnerId)
     {
-        //_npcSpawnerTemplateNpcs.TryGetValue(spawnerId, out var nsn);
-        return _npcSpawnerTemplateNpcs.Values.FirstOrDefault(nsn => nsn.NpcSpawnerTemplateId == spawnerId);
+        return NpcSpawnerTemplateNpcs.Values.FirstOrDefault(nsn => nsn.NpcSpawnerTemplateId == spawnerId);
     }
 
+    /// <summary>
+    /// Gets Non-Player skills list for a given NpcTempalte and situational trigger/condition
+    /// </summary>
+    /// <param name="npcId"></param>
+    /// <param name="skillCondition"></param>
+    /// <returns></returns>
     public List<NpcSkill> GetNpSkills(uint npcId, SkillUseConditionKind skillCondition = SkillUseConditionKind.None)
     {
-        if (_skillsForNpc.TryGetValue(npcId, out var value))
+        if (SkillsForNpc.TryGetValue(npcId, out var value))
         {
             if (skillCondition == SkillUseConditionKind.None)
-                return _skillsForNpc[npcId];
+                return SkillsForNpc[npcId];
             return value.Where(npSkill => npSkill.SkillUseCondition == skillCondition).ToList();
         }
 
         return null;
     }
 
+    /// <summary>
+    /// Register a NpcSpawnerTemplate
+    /// </summary>
+    /// <param name="template"></param>
     public void AddNpcSpawner(NpcSpawnerTemplate template)
     {
-        _npcSpawnerTemplates.Add(template.Id, template);
+        NpcSpawnerTemplates.Add(template.Id, template);
     }
+
+    /// <summary>
+    /// Regsiters a NpcSpawnerNpc into cache
+    /// </summary>
+    /// <param name="nsn"></param>
     public void AddNpcSpawnerNpc(NpcSpawnerNpc nsn)
     {
-        _npcSpawnerTemplateNpcs.Add(nsn.Id, nsn);
+        NpcSpawnerTemplateNpcs.Add(nsn.Id, nsn);
     }
+
+    /// <summary>
+    /// Registers a NpcSpawnerNpc to the cache of Npcs
+    /// </summary>
+    /// <param name="nsn"></param>
     public void AddMemberAndSpawnerTemplateIds(NpcSpawnerNpc nsn)
     {
-        if (!_npcMemberAndSpawnerTemplateIds.ContainsKey(nsn.MemberId))
-            _npcMemberAndSpawnerTemplateIds.Add(nsn.MemberId, [nsn.NpcSpawnerTemplateId]);
+        if (!NpcMemberAndSpawnerTemplateIds.TryGetValue(nsn.MemberId, out var npcMemberAndSpawnerTemplate))
+            NpcMemberAndSpawnerTemplateIds.Add(nsn.MemberId, [nsn.NpcSpawnerTemplateId]);
         else
-            _npcMemberAndSpawnerTemplateIds[nsn.MemberId].Add(nsn.NpcSpawnerTemplateId);
+            npcMemberAndSpawnerTemplate.Add(nsn.NpcSpawnerTemplateId);
     }
 }

--- a/AAEmu.Game/Models/Game/Items/Templates/EquipBodyPartPack.cs
+++ b/AAEmu.Game/Models/Game/Items/Templates/EquipBodyPartPack.cs
@@ -1,0 +1,14 @@
+﻿namespace AAEmu.Game.Models.Game.Items.Templates;
+
+public class EquipBodyPartPack
+{
+    public uint Id { get; set; }
+    public string Name { get; set; }
+    public uint ModelId { get; set; }
+    public uint HairColorId { get; set; }
+    public uint FaceId { get; set; }
+    public uint HairId { get; set; }
+    public uint BeardId { get; set; }
+    public uint SkinColorId { get; set; }
+    public uint BodyDiffuseMapId { get; set; }
+}

--- a/AAEmu.Game/Models/Game/NPChar/NpcSpawnerNpc.cs
+++ b/AAEmu.Game/Models/Game/NPChar/NpcSpawnerNpc.cs
@@ -10,15 +10,29 @@ namespace AAEmu.Game.Models.Game.NPChar;
 
 public class NpcSpawnerNpc : Spawner<Npc>
 {
+    // ReSharper disable once InconsistentNaming
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-    public uint NpcSpawnerTemplateId { get; set; } // spawner template id
-    public uint MemberId { get; set; } // npc template id
-    public string MemberType { get; set; } // 'Npc'
-    public float Weight { get; set; }
+    /// <summary>
+    /// NpcSpawnerTemplateId
+    /// </summary>
+    public uint NpcSpawnerTemplateId { get; init; }
+    /// <summary>
+    /// NpcTemplateId
+    /// </summary>
+    public uint MemberId { get; set; }
+    /// <summary>
+    /// MemberType should be "Npc" here
+    /// </summary>
+    public string MemberType { get; set; }
+    /// <summary>
+    /// Spawn priority weight
+    /// </summary>
+    public float Weight { get; init; }
 
     public NpcSpawnerNpc()
     {
+        //
     }
 
     /// <summary>
@@ -30,27 +44,40 @@ public class NpcSpawnerNpc : Spawner<Npc>
         NpcSpawnerTemplateId = spawnerTemplateId;
     }
 
-    public NpcSpawnerNpc(uint spawnerTemplateId, uint memberId)
+    public NpcSpawnerNpc(uint spawnerTemplateId, uint npcTemplateId)
     {
         NpcSpawnerTemplateId = spawnerTemplateId;
-        MemberId = memberId;
+        MemberId = npcTemplateId;
         MemberType = "Npc";
     }
 
-    public List<Npc> Spawn(NpcSpawner npcSpawner, uint ownerID = 0)
+    /// <summary>
+    /// Spawns Npcs from a NpcSpawner
+    /// </summary>
+    /// <param name="npcSpawner"></param>
+    /// <param name="ownerId"></param>
+    /// <returns>List of newly spawned NPCs</returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    public List<Npc> Spawn(NpcSpawner npcSpawner, uint ownerId = 0)
     {
         switch (MemberType)
         {
             case "Npc":
-                return SpawnNpc(npcSpawner, ownerID);
+                return SpawnNpc(npcSpawner, ownerId);
             case "NpcGroup":
-                return SpawnNpcGroup(npcSpawner, ownerID);
+                return SpawnNpcGroup(npcSpawner, ownerId);
             default:
                 throw new InvalidOperationException($"Tried spawning an unsupported line from NpcSpawnerNpc - Id: {Id}");
         }
     }
 
-    private List<Npc> SpawnNpc(NpcSpawner npcSpawner, uint ownerID = 0)
+    /// <summary>
+    /// Internal Spawn Npc function for Spawn
+    /// </summary>
+    /// <param name="npcSpawner"></param>
+    /// <param name="ownerId"></param>
+    /// <returns></returns>
+    private List<Npc> SpawnNpc(NpcSpawner npcSpawner, uint ownerId = 0)
     {
         var npcs = new List<Npc>();
         var npc = NpcManager.Instance.Create(npcSpawner.ParentWorld, 0, MemberId);
@@ -61,7 +88,7 @@ public class NpcSpawnerNpc : Spawner<Npc>
         }
 
         npc.ParentWorld = npcSpawner.ParentWorld;
-        npc.OwnerId = ownerID;
+        npc.OwnerId = ownerId;
 
         npc.RegisterNpcEvents();
 
@@ -110,8 +137,14 @@ public class NpcSpawnerNpc : Spawner<Npc>
         return npcs;
     }
 
-    private List<Npc> SpawnNpcGroup(NpcSpawner npcSpawner, uint ownerID = 0)
+    /// <summary>
+    /// Internal Spawn NpcGroup function for Spawn
+    /// </summary>
+    /// <param name="npcSpawner"></param>
+    /// <param name="ownerId"></param>
+    /// <returns></returns>
+    private List<Npc> SpawnNpcGroup(NpcSpawner npcSpawner, uint ownerId = 0)
     {
-        return SpawnNpc(npcSpawner, ownerID);
+        return SpawnNpc(npcSpawner, ownerId);
     }
 }

--- a/AAEmu.Game/Models/Game/NPChar/NpcTemplate.cs
+++ b/AAEmu.Game/Models/Game/NPChar/NpcTemplate.cs
@@ -81,6 +81,9 @@ public class NpcTemplate
     public byte Race { get; set; }
     public byte Gender { get; set; }
     public uint MerchantPackId { get; set; }
+    public uint EquipBodiesId { get; set; }
+    public uint EquipClothsId { get; set; }
+    public uint EquipWeaponsId { get; set; }
 
     public uint HairId { get; set; } = 0;
     public UnitCustomModelParams ModelParams { get; set; } = new();

--- a/AAEmu.Game/Scripts/Commands/Around.cs
+++ b/AAEmu.Game/Scripts/Commands/Around.cs
@@ -8,6 +8,7 @@ using AAEmu.Game.Models.Game.Gimmicks;
 using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.World;
+using AAEmu.Game.Utils;
 using AAEmu.Game.Utils.Scripts;
 
 namespace AAEmu.Game.Scripts.Commands;
@@ -32,8 +33,7 @@ public class Around : ICommand
                "Note: Only lists objects in viewing range of you (recommended maximum radius of 100).";
     }
 
-    private static int ShowObjectData(Character character, GameObject go, int index, string indexPrefix, bool verbose,
-        IMessageOutput messageOutput)
+    private static int ShowObjectData(GameObject go, int index, string indexPrefix, bool verbose, IMessageOutput messageOutput)
     {
         var indexStr = indexPrefix;
         if (indexStr != string.Empty)
@@ -73,7 +73,7 @@ public class Around : ICommand
         // Cycle Children
         for (var i = 0; i < go.Transform.Children.Count; i++)
         {
-            ShowObjectData(character, go.Transform.Children[i]?.GameObject, i, indexStr, verbose, messageOutput);
+            ShowObjectData(go.Transform.Children[i]?.GameObject, i, indexStr, verbose, messageOutput);
         }
 
         return 1 + go.Transform.Children.Count;
@@ -165,8 +165,35 @@ public class Around : ICommand
                 // character.SendMessage(sb.ToString());
                 messageOutput.SendMessage($"[{CommandNames[0]}] Character count: {characters.Count}");
                 break;
+            case "npcspawner":
+                // Grab all spawner info and put them into one list
+                var npcSpawners = character.ParentWorld.SpawnManager.GetAllSpawners().Values.SelectMany(x => x).ToList();
 
-            case "all":
+                messageOutput.SendMessage($"[{CommandNames[0]}] NPC Spawners");
+                var si = 0;
+                foreach (var npcSpawner in npcSpawners)
+                {
+                    if (MathUtil.GetDistance(npcSpawner.Position.AsPositionVector(), character.Transform.World.Position) > radius)
+                    {
+                        continue;
+                    }
+                    si++;
+                    messageOutput.SendMessage($"#{si + 1} -> TemplateId: {npcSpawner.Template.Id}");
+                    foreach (var npcSpawnerSpawnableNpc in npcSpawner.SpawnableNpcs)
+                    {
+                        messageOutput.SendMessage($"#{si + 1} -> Spawnable NPC: {npcSpawnerSpawnableNpc.MemberId} - {npcSpawnerSpawnableNpc.MemberType} - @NPC_NAME({npcSpawnerSpawnableNpc.MemberId})");
+                    }
+                    if (verbose)
+                    {
+                        messageOutput.SendMessage($"#{si + 1} -> {npcSpawner.Position.AsPositionVector()}");
+                    }
+                }
+
+                // character.SendMessage(sb.ToString());
+                messageOutput.SendMessage($"[{CommandNames[0]}] NPC Spawner count: {si}");
+                break;
+
+            // case "all":
             default:
                 var go = WorldManager.GetAround<GameObject>(character, radius);
 
@@ -176,7 +203,7 @@ public class Around : ICommand
                 {
                     if (go[i].Transform.Parent == null)
                     {
-                        c += ShowObjectData(character, go[i], i, "", verbose, messageOutput);
+                        c += ShowObjectData(go[i], i, "", verbose, messageOutput);
                     }
                 }
 

--- a/AAEmu.sln.DotSettings
+++ b/AAEmu.sln.DotSettings
@@ -21,6 +21,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Cutdowning/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cutdownings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cutdowns/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ddcms/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Despawn/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dictrict/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=disenchantable/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
- Move NPC member and spawner ID mapping into `NpcGameData.PostLoad` to ensure correct initialization order during the boot sequence.
- Cleaned up `NpcManager`, `SpawnManager`, and `NpcGameData` to follow standard C# property naming conventions and improve code organization.
- Updated `SpawnManager` logic to better handle dynamic spawner generation when pre-defined templates are missing.
- Enhance the `around` command to support NPC spawner inspection for better debugging.
- Add support for equipment pack IDs within NPC templates. (currently not used)
