### PR TITLE
chore: add example local config files for Game and Login servers

### DIFF
--- a/AAEmu.Game/ExampleConfig.Local.json
+++ b/AAEmu.Game/ExampleConfig.Local.json
@@ -1,0 +1,20 @@
+{
+    "LoginNetwork": {
+        "Host": "127.0.0.1",
+        "Port": "1234"
+    },
+    "Connections": {
+        "MySQLProvider": {
+            "Database": "aaemu_game",
+            "Host": "127.0.0.1",
+            "Password": "password",
+            "Port": "3306",
+            "User": "root"
+        }
+    },
+    "ClientData": {
+        "Sources": [
+            "C:\\Users\\username\\Downloads\\Trion_1.2_(r208022)_BROC_FULL_PATCHED_CLIENT\\game_pak"
+        ]
+    }
+}

--- a/AAEmu.Login/ExampleConfig.Local.json
+++ b/AAEmu.Login/ExampleConfig.Local.json
@@ -1,0 +1,19 @@
+{
+    "Connections": {
+        "MySQLProvider": {
+            "Database": "aaemu_login",
+            "Host": "127.0.0.1",
+            "Password": "password",
+            "Port": "3306",
+            "User": "root"
+        }
+    },
+    "GameServers": [
+        {
+            "Host": "127.0.0.1",
+            "Id": 1,
+            "Name": "AAEmu",
+            "Port": 1239
+        }
+    ]
+}


### PR DESCRIPTION
As it still trips people up not knowing what to put in their `Config.Local.json`, this adds back example versions of these files.

I expect for most users who aren't also developers, they'd probably be better off with something like the docker-compose.yaml file, which could use pre-built container images uploaded to GitHub Container Registry. Might be worth going in that direction with https://github.com/AAEmu/AAEmu/pull/1374 so there's not even any need to clone the repo - just download a .zip from the Releases page and run the install script inside, then use docker compose and let it pull the images from GitHub.