### PR TITLE
feat(login): Migrate password storage to ASP.NET Core PasswordHasher

### DIFF
--- a/AAEmu.Login.IntegrationTests/LoginControllerIntegrationTests.cs
+++ b/AAEmu.Login.IntegrationTests/LoginControllerIntegrationTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using AAEmu.Commons.Utils.DB;
 using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.PacketHandlers.C2L;
+using AAEmu.Login.Core.Services;
 using AAEmu.Login.Models;
 using AAEmu.Login.Utils;
 using Microsoft.Extensions.Logging;
@@ -29,6 +30,12 @@ public class LoginControllerIntegrationTests : IAsyncLifetime
     private static LoginController CreateController(bool autoAccount = false)
     {
         var gameController = new Mock<IGameController>();
+        var passwordService = new Mock<IPasswordService>();
+        passwordService.Setup(p => p.VerifyPassword(It.IsAny<string>(), It.IsAny<Password>()))
+            .Returns((string stored, Password provided) =>
+                stored == provided.Value ? PasswordVerificationResult.Success : PasswordVerificationResult.Failed);
+        passwordService.Setup(p => p.HashForStorage(It.IsAny<Password>()))
+            .Returns((Password p) => p.Value);
         var appConfig = Options.Create(new AppConfiguration
         {
             SecretKey = "test-key", AutoAccount = autoAccount, GameServers = []
@@ -36,7 +43,7 @@ public class LoginControllerIntegrationTests : IAsyncLifetime
         var connectionFactory = new Mock<IMySqlConnectionFactory>();
         connectionFactory.Setup(f => f.CreateConnection()).Returns(MySQL.CreateConnection);
         var logger = new Mock<ILogger<LoginController>>();
-        return new LoginController(gameController.Object, appConfig, connectionFactory.Object, logger.Object);
+        return new LoginController(gameController.Object, passwordService.Object, appConfig, connectionFactory.Object, logger.Object);
     }
 
     private static async Task InsertUser(string username, string password, bool banned = false, int banReason = 0)
@@ -58,7 +65,7 @@ public class LoginControllerIntegrationTests : IAsyncLifetime
     {
         var controller = CreateController(autoAccount: false);
 
-        var result = await controller.Login("no_such_user", "pass", _ipAddress, TestContext.Current.CancellationToken);
+        var result = await controller.Login("no_such_user", Password.FromPlaintext("pass"), _ipAddress, TestContext.Current.CancellationToken);
 
         Assert.False(result.Success);
         Assert.Equal(LoginDeniedReason.BadResponse, result.DenialReason);
@@ -69,7 +76,7 @@ public class LoginControllerIntegrationTests : IAsyncLifetime
     {
         var controller = CreateController(autoAccount: true);
 
-        var result = await controller.Login("autouser", "newpass", _ipAddress, TestContext.Current.CancellationToken);
+        var result = await controller.Login("autouser", Password.FromPlaintext("newpass"), _ipAddress, TestContext.Current.CancellationToken);
 
         Assert.True(result.Success);
         Assert.NotEqual(default, result.AccountId);
@@ -82,7 +89,7 @@ public class LoginControllerIntegrationTests : IAsyncLifetime
         var controller = CreateController();
 
         var result =
-            await controller.Login("alice", "mypassword", _ipAddress, TestContext.Current.CancellationToken);
+            await controller.Login("alice", Password.FromPlaintext("mypassword"), _ipAddress, TestContext.Current.CancellationToken);
 
         Assert.True(result.Success);
     }
@@ -93,7 +100,7 @@ public class LoginControllerIntegrationTests : IAsyncLifetime
         await InsertUser("bob", "correctpass");
         var controller = CreateController();
 
-        var result = await controller.Login("bob", "wrongpass", _ipAddress, TestContext.Current.CancellationToken);
+        var result = await controller.Login("bob", Password.FromPlaintext("wrongpass"), _ipAddress, TestContext.Current.CancellationToken);
 
         Assert.False(result.Success);
         Assert.Equal(LoginDeniedReason.BadResponse, result.DenialReason);
@@ -105,7 +112,7 @@ public class LoginControllerIntegrationTests : IAsyncLifetime
         await InsertUser("banned_user", "pass", banned: true, banReason: 5);
         var controller = CreateController();
 
-        var result = await controller.Login("banned_user", "pass", _ipAddress, TestContext.Current.CancellationToken);
+        var result = await controller.Login("banned_user", Password.FromPlaintext("pass"), _ipAddress, TestContext.Current.CancellationToken);
 
         Assert.False(result.Success);
         Assert.Equal(LoginDeniedReason.TryTradeCashTemporal, result.DenialReason);
@@ -117,7 +124,7 @@ public class LoginControllerIntegrationTests : IAsyncLifetime
         await InsertUser("tracker", "pass");
         var controller = CreateController();
  
-        var result = await controller.Login("tracker", "pass", _ipAddress, TestContext.Current.CancellationToken);
+        var result = await controller.Login("tracker", Password.FromPlaintext("pass"), _ipAddress, TestContext.Current.CancellationToken);
         Assert.True(result.Success);
 
         // Verify the DB was updated

--- a/AAEmu.Login/Core/Authentication/PasswordAuthFlow.cs
+++ b/AAEmu.Login/Core/Authentication/PasswordAuthFlow.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Services;
 
 namespace AAEmu.Login.Core.Authentication;
 
@@ -11,7 +12,7 @@ namespace AAEmu.Login.Core.Authentication;
 public class PasswordAuthFlow(
     ILoginController loginController,
     string username,
-    string password,
+    Password password,
     IPAddress clientIp) : IAuthenticationFlow
 {
     public async Task<AuthFlowResult> StartAsync(ILoginClient client, CancellationToken cancellationToken)

--- a/AAEmu.Login/Core/Controllers/ILoginController.cs
+++ b/AAEmu.Login/Core/Controllers/ILoginController.cs
@@ -1,5 +1,7 @@
-﻿using System.Net;
+using System.Net;
 using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.PacketHandlers.C2L;
+using AAEmu.Login.Core.Services;
 using AAEmu.Login.Models;
 
 namespace AAEmu.Login.Core.Controllers;
@@ -18,8 +20,8 @@ public interface ILoginController
     /// Eu Method Auth
     /// </summary>
     /// <param name="username">The username.</param>
-    /// <param name="password">The password sent by the client.</param>
+    /// <param name="password">The password sent by the client, with its encoding kind.</param>
     /// <param name="ip">The client IP address for recording.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task<LoginResult> Login(string username, string password, IPAddress ip, CancellationToken cancellationToken);
+    Task<LoginResult> Login(string username, Password password, IPAddress ip, CancellationToken cancellationToken);
 }

--- a/AAEmu.Login/Core/Controllers/LoginController.cs
+++ b/AAEmu.Login/Core/Controllers/LoginController.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.PacketHandlers.C2L;
 using AAEmu.Login.Core.Packets.L2G;
+using AAEmu.Login.Core.Services;
 using AAEmu.Login.Models;
 using AAEmu.Login.Utils;
 using Microsoft.Extensions.Options;
@@ -13,6 +14,7 @@ namespace AAEmu.Login.Core.Controllers;
 
 public partial class LoginController(
     IGameController gameController,
+    IPasswordService passwordService,
     IOptions<AppConfiguration> appConfig,
     IMySqlConnectionFactory connectionFactory,
     ILogger<LoginController> logger) : ILoginController
@@ -71,7 +73,7 @@ public partial class LoginController(
     /// <summary>
     /// Eu Method Auth
     /// </summary>
-    public async Task<LoginResult> Login(string username, string password, IPAddress ip,
+    public async Task<LoginResult> Login(string username, Password password, IPAddress ip,
         CancellationToken cancellationToken)
     {
         await using var connect = connectionFactory.CreateConnection();
@@ -91,7 +93,8 @@ public partial class LoginController(
         }
 
         var storedPassword = reader.GetString("password");
-        if (password != storedPassword)
+        var verificationResult = passwordService.VerifyPassword(storedPassword, password);
+        if (verificationResult == PasswordVerificationResult.Failed)
         {
             return new LoginResult(false, default, LoginDeniedReason.BadResponse);
         }
@@ -113,8 +116,18 @@ public partial class LoginController(
         #region update account
 
         command.Parameters.Clear();
-        command.CommandText =
-            "UPDATE `users` SET last_ip = @last_ip, last_login = @last_login, updated_at = @updated_at WHERE id = @id";
+        if (verificationResult == PasswordVerificationResult.SuccessRehashNeeded && password.Kind == PasswordKind.Plaintext)
+        {
+            var newHash = passwordService.HashForStorage(password);
+            command.CommandText =
+                "UPDATE `users` SET password = @password, last_ip = @last_ip, last_login = @last_login, updated_at = @updated_at WHERE id = @id";
+            command.Parameters.AddWithValue("@password", newHash);
+        }
+        else
+        {
+            command.CommandText =
+                "UPDATE `users` SET last_ip = @last_ip, last_login = @last_login, updated_at = @updated_at WHERE id = @id";
+        }
         command.Parameters.AddWithValue("@id", accountId.Value);
         command.Parameters.AddWithValue("@last_ip", ip);
         command.Parameters.AddWithValue("@last_login", ((DateTimeOffset)lastLogin).ToUnixTimeSeconds());
@@ -130,17 +143,19 @@ public partial class LoginController(
         return new LoginResult(true, accountId, default);
     }
 
-    private async Task<LoginResult> CreateAndLoginInvalid(string username, string password, IPAddress clientIp,
-        MySqlConnection connection)
+    private async Task<LoginResult> CreateAndLoginInvalid(string username, Password password,
+        IPAddress clientIp, MySqlConnection connection)
     {
         if (!UsernameRegex().IsMatch(username))
             return new LoginResult(false, default, LoginDeniedReason.BadAccount);
+
+        var passwordHash = passwordService.HashForStorage(password);
 
         await using var command = connection.CreateCommand();
         command.CommandText =
             "INSERT into users (username, password, email, last_ip, last_login, created_at, updated_at) VALUES (@username, @password, @email, @last_ip, @last_login, @created_at, @updated_at)";
         command.Parameters.AddWithValue("@username", username);
-        command.Parameters.AddWithValue("@password", password);
+        command.Parameters.AddWithValue("@password", passwordHash);
         command.Parameters.AddWithValue("@email", "");
         command.Parameters.AddWithValue("@last_ip", clientIp);
         command.Parameters.AddWithValue("@last_login", ((DateTimeOffset)DateTime.UtcNow).ToUnixTimeSeconds());

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthMailRuPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthMailRuPacketHandler.cs
@@ -2,6 +2,7 @@ using AAEmu.Login.Core.Authentication;
 using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.Packets.C2L;
+using AAEmu.Login.Core.Services;
 
 namespace AAEmu.Login.Core.PacketHandlers.C2L;
 
@@ -15,8 +16,8 @@ public class CARequestAuthMailRuPacketHandler(ILoginController loginController)
     public async Task Execute(CARequestAuthMailRuPacket packet, ILoginSession session,
         CancellationToken cancellationToken)
     {
-        var tokenBase64 = Convert.ToBase64String(packet.Token!);
-        var flow = new PasswordAuthFlow(loginController, packet.Id!, tokenBase64, session.Connection.Ip);
+        var tokenHex = Convert.ToHexString(packet.Token!);
+        var flow = new PasswordAuthFlow(loginController, packet.Id!, Password.FromSha256Hex(tokenHex), session.Connection.Ip);
         await session.AuthenticateAsync(flow, cancellationToken);
     }
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthTrionPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthTrionPacketHandler.cs
@@ -1,8 +1,8 @@
-using AAEmu.Commons.Utils;
 using AAEmu.Login.Core.Authentication;
 using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.Packets.C2L;
+using AAEmu.Login.Core.Services;
 
 namespace AAEmu.Login.Core.PacketHandlers.C2L;
 
@@ -16,9 +16,8 @@ public class CARequestAuthTrionPacketHandler(ILoginController loginController)
     public async Task Execute(CARequestAuthTrionPacket packet, ILoginSession session,
         CancellationToken cancellationToken)
     {
-        var passwordBytes = Helpers.StringToByteArray(packet.Password!);
-        var passwordBase64 = Convert.ToBase64String(passwordBytes);
-        var flow = new PasswordAuthFlow(loginController, packet.Username!, passwordBase64, session.Connection.Ip);
+        var flow = new PasswordAuthFlow(loginController, packet.Username!,
+            Password.FromSha256Hex(packet.Password!), session.Connection.Ip);
         await session.AuthenticateAsync(flow, cancellationToken);
     }
 }

--- a/AAEmu.Login/Core/Services/IPasswordService.cs
+++ b/AAEmu.Login/Core/Services/IPasswordService.cs
@@ -1,0 +1,58 @@
+namespace AAEmu.Login.Core.Services;
+
+/// <summary>
+/// Result of a password verification operation against a stored hash.
+/// </summary>
+public enum PasswordVerificationResult
+{
+    /// <summary>
+    /// The password did not match.
+    /// </summary>
+    Failed,
+
+    /// <summary>
+    /// The password matched and is stored in the current format.
+    /// </summary>
+    Success,
+
+    /// <summary>
+    /// The password matched but is stored in a legacy format and should be rehashed.
+    /// </summary>
+    SuccessRehashNeeded
+}
+
+/// <summary>
+/// Provides password hashing and verification services with support for migrating from legacy formats.
+/// </summary>
+public interface IPasswordService
+{
+    /// <summary>
+    /// Produces a value suitable for storage in the database for the given password.
+    /// </summary>
+    /// <param name="password">The password to hash.</param>
+    /// <returns>
+    /// For <see cref="PasswordKind.Plaintext"/>, a PBKDF2 hash string.
+    /// For <see cref="PasswordKind.Sha256Hex"/>, a Base64-encoded representation of the raw SHA-256 bytes
+    /// (the legacy DB format), so that a subsequent plaintext login can verify it via legacy comparison.
+    /// </returns>
+    string HashForStorage(Password password);
+
+    /// <summary>
+    /// Verifies a password against a stored hash.
+    /// </summary>
+    /// <param name="storedHash">The hash stored in the database.</param>
+    /// <param name="password">The password to verify, with its encoding kind.</param>
+    /// <returns>
+    /// <see cref="PasswordVerificationResult.Success"/> if the password matches and no rehash is needed,
+    /// <see cref="PasswordVerificationResult.SuccessRehashNeeded"/> if the password matches but uses a legacy format,
+    /// or <see cref="PasswordVerificationResult.Failed"/> if the password does not match.
+    /// </returns>
+    PasswordVerificationResult VerifyPassword(string storedHash, Password password);
+
+    /// <summary>
+    /// Determines whether a stored hash uses the legacy format (Base64-encoded raw bytes).
+    /// </summary>
+    /// <param name="storedHash">The hash stored in the database.</param>
+    /// <returns><c>true</c> if the hash is in legacy format; otherwise, <c>false</c>.</returns>
+    bool IsLegacyFormat(string storedHash);
+}

--- a/AAEmu.Login/Core/Services/Password.cs
+++ b/AAEmu.Login/Core/Services/Password.cs
@@ -1,0 +1,29 @@
+namespace AAEmu.Login.Core.Services;
+
+/// <summary>
+/// Identifies how a password value is encoded.
+/// </summary>
+public enum PasswordKind
+{
+    /// <summary>
+    /// The password is plaintext.
+    /// </summary>
+    Plaintext,
+
+    /// <summary>
+    /// The password is a hex-encoded SHA-256 hash.
+    /// </summary>
+    Sha256Hex
+}
+
+/// <summary>
+/// A typed wrapper for a password value that carries its encoding.
+/// </summary>
+public readonly record struct Password(string Value, PasswordKind Kind)
+{
+    /// <summary>Creates a <see cref="Password"/> from a plaintext string.</summary>
+    public static Password FromPlaintext(string value) => new(value, PasswordKind.Plaintext);
+
+    /// <summary>Creates a <see cref="Password"/> from a hex-encoded SHA-256 string.</summary>
+    public static Password FromSha256Hex(string hex) => new(hex, PasswordKind.Sha256Hex);
+}

--- a/AAEmu.Login/Core/Services/PasswordService.cs
+++ b/AAEmu.Login/Core/Services/PasswordService.cs
@@ -1,0 +1,89 @@
+using System.Buffers;
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.Identity;
+
+namespace AAEmu.Login.Core.Services;
+
+public class PasswordService(IPasswordHasher<string> passwordHasher) : IPasswordService
+{
+    // Legacy format: Base64-encoded 32 bytes = exactly 44 characters (with padding)
+    private const int LegacyBase64Length = 44;
+    private const int LegacyHashByteLength = 32;
+
+    public string HashForStorage(Password password) => password.Kind switch
+    {
+        // AAEmu Launcher sends hex-encoded SHA-256. Convert hex → bytes → Base64 so the result
+        // is stored in the legacy DB format. A subsequent plaintext login can then verify it
+        // via SHA-256 computation, and SuccessRehashNeeded will trigger a PBKDF2 upgrade.
+        PasswordKind.Sha256Hex => Convert.ToBase64String(Convert.FromHexString(password.Value)),
+        PasswordKind.Plaintext => passwordHasher.HashPassword(string.Empty, password.Value),
+        _ => throw new ArgumentOutOfRangeException(nameof(password))
+    };
+
+    public PasswordVerificationResult VerifyPassword(string storedHash, Password password)
+    {
+        if (IsLegacyFormat(storedHash))
+        {
+            var matches = password.Kind == PasswordKind.Sha256Hex
+                ? VerifyLegacyPassword(storedHash, password.Value)
+                : VerifyLegacyPasswordFromPlaintext(storedHash, password.Value);
+
+            return matches
+                ? PasswordVerificationResult.SuccessRehashNeeded
+                : PasswordVerificationResult.Failed;
+        }
+
+        var result = passwordHasher.VerifyHashedPassword(string.Empty, storedHash, password.Value);
+        return result switch
+        {
+            Microsoft.AspNetCore.Identity.PasswordVerificationResult.Success => PasswordVerificationResult.Success,
+            Microsoft.AspNetCore.Identity.PasswordVerificationResult.SuccessRehashNeeded => PasswordVerificationResult
+                .SuccessRehashNeeded,
+            _ => PasswordVerificationResult.Failed
+        };
+    }
+
+    public bool IsLegacyFormat(string storedHash)
+    {
+        if (storedHash.Length != LegacyBase64Length)
+            return false;
+
+        Span<byte> buffer = stackalloc byte[LegacyHashByteLength];
+        return Convert.TryFromBase64String(storedHash, buffer, out var bytesWritten)
+               && bytesWritten == LegacyHashByteLength;
+    }
+
+    private static bool VerifyLegacyPasswordFromPlaintext(string storedHash, string plaintext)
+    {
+        Span<byte> storedBytes = stackalloc byte[LegacyHashByteLength];
+        if (!Convert.TryFromBase64String(storedHash, storedBytes, out var bytesWritten)
+            || bytesWritten != LegacyHashByteLength)
+        {
+            return false;
+        }
+
+        Span<byte> computedHash = stackalloc byte[LegacyHashByteLength];
+        SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(plaintext), computedHash);
+
+        return CryptographicOperations.FixedTimeEquals(computedHash, storedBytes[..bytesWritten]);
+    }
+
+    private static bool VerifyLegacyPassword(string storedHash, string passwordHex)
+    {
+        Span<byte> storedBytes = stackalloc byte[LegacyHashByteLength];
+        if (!Convert.TryFromBase64String(storedHash, storedBytes, out var bytesWritten)
+            || bytesWritten != LegacyHashByteLength)
+        {
+            return false;
+        }
+
+        Span<byte> passwordBytes = stackalloc byte[LegacyHashByteLength];
+        if (Convert.FromHexString(passwordHex, passwordBytes, out _, out var hexBytesWritten) != OperationStatus.Done ||
+            hexBytesWritten != LegacyHashByteLength)
+        {
+            return false;
+        }
+
+        return CryptographicOperations.FixedTimeEquals(passwordBytes, storedBytes[..bytesWritten]);
+    }
+}

--- a/AAEmu.Login/Program.cs
+++ b/AAEmu.Login/Program.cs
@@ -6,11 +6,13 @@ using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Internal;
 using AAEmu.Login.Core.Network.Login;
 using AAEmu.Login.Core.PacketHandlers;
+using AAEmu.Login.Core.Services;
 using AAEmu.Login.Models;
 using AAEmu.Login.Utils;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using MySql.Data.MySqlClient;
+using Microsoft.AspNetCore.Identity;
 using NLog;
 using NLog.Config;
 using NLog.Extensions.Logging;
@@ -114,6 +116,11 @@ public static class Program
 
         builder.Services.AddHostedService<MySqlInitializer>();
         builder.Services.AddHostedService<LoginService>();
+
+        builder.Services.Configure<PasswordHasherOptions>(options =>
+            options.IterationCount = 600_000); // OWASP recommended in 2026: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html
+        builder.Services.AddSingleton<IPasswordHasher<string>, PasswordHasher<string>>();
+        builder.Services.AddSingleton<IPasswordService, PasswordService>();
 
         builder.Services.AddSingleton<IGameController, GameController>();
         builder.Services.AddSingleton<ILoginController, LoginController>();

--- a/AAEmu.UnitTests/Login/Core/Services/PasswordServiceTests.cs
+++ b/AAEmu.UnitTests/Login/Core/Services/PasswordServiceTests.cs
@@ -1,0 +1,279 @@
+using AAEmu.Login.Core.Services;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+using PasswordVerificationResult = AAEmu.Login.Core.Services.PasswordVerificationResult;
+
+namespace AAEmu.UnitTests.Login.Core.Services;
+
+public class PasswordServiceTests
+{
+    private readonly PasswordService _sut;
+    private readonly PasswordHasher<string> _passwordHasher;
+
+    public PasswordServiceTests()
+    {
+        var options = Options.Create(new PasswordHasherOptions());
+        _passwordHasher = new PasswordHasher<string>(options);
+        _sut = new PasswordService(_passwordHasher);
+    }
+
+    [Fact]
+    public void IsLegacyFormat_Base64Encoded32Bytes_ReturnsTrue()
+    {
+        // Arrange - 32 bytes encoded as Base64 = 44 characters
+        var legacyHash = Convert.ToBase64String(new byte[32]);
+
+        // Act
+        var result = _sut.IsLegacyFormat(legacyHash);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsLegacyFormat_Base64Encoded32BytesWithContent_ReturnsTrue()
+    {
+        // Arrange - real SHA256 hash (32 bytes) as Base64
+        var sha256Bytes = new byte[32];
+        for (var i = 0; i < 32; i++) sha256Bytes[i] = (byte)i;
+        var legacyHash = Convert.ToBase64String(sha256Bytes);
+
+        // Act
+        var result = _sut.IsLegacyFormat(legacyHash);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(44, legacyHash.Length);
+    }
+
+    [Fact]
+    public void IsLegacyFormat_NewFormatHash_ReturnsFalse()
+    {
+        // Arrange - new format hash from PasswordHasher
+        var newHash = _passwordHasher.HashPassword(string.Empty, "test");
+
+        // Act
+        var result = _sut.IsLegacyFormat(newHash);
+
+        // Assert
+        Assert.False(result);
+        Assert.True(newHash.Length >= 84);
+    }
+
+    [Fact]
+    public void IsLegacyFormat_WrongLength_ReturnsFalse()
+    {
+        // Arrange - wrong length string
+        var wrongLengthHash = "shortstring";
+
+        // Act
+        var result = _sut.IsLegacyFormat(wrongLengthHash);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsLegacyFormat_InvalidBase64_ReturnsFalse()
+    {
+        // Arrange - 44 characters but not valid Base64 that decodes to 32 bytes
+        var invalidBase64 = new string('!', 44);
+
+        // Act
+        var result = _sut.IsLegacyFormat(invalidBase64);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void HashForStorage_Plaintext_ReturnsNewFormatHash()
+    {
+        // Arrange
+        var password = Password.FromPlaintext("mypassword123");
+
+        // Act
+        var hash = _sut.HashForStorage(password);
+
+        // Assert
+        Assert.False(_sut.IsLegacyFormat(hash));
+        Assert.True(hash.Length >= 84);
+    }
+
+    [Fact]
+    public void HashForStorage_Sha256Hex_ReturnsLegacyBase64Format()
+    {
+        // Arrange - 32 bytes as a hex string (legacy format)
+        var passwordBytes = new byte[32];
+        for (var i = 0; i < 32; i++) passwordBytes[i] = (byte)i;
+        var hex = Convert.ToHexString(passwordBytes);
+        var expectedBase64 = Convert.ToBase64String(passwordBytes);
+
+        // Act
+        var hash = _sut.HashForStorage(Password.FromSha256Hex(hex));
+
+        // Assert - must be the legacy Base64 format, NOT a PBKDF2 hash
+        Assert.Equal(expectedBase64, hash);
+        Assert.True(_sut.IsLegacyFormat(hash));
+    }
+
+    [Fact]
+    public void HashForStorage_Sha256Hex_VerifiableByPlaintextViaLegacy()
+    {
+        // Regression test for the double-hash bug:
+        // When CreateAndLoginInvalid is called with a SHA256-hex password,
+        // HashForStorage must store the legacy Base64 format so a subsequent plaintext login can verify it.
+        var passwordBytes = new byte[32];
+        for (var i = 0; i < 32; i++) passwordBytes[i] = (byte)i;
+        var hex = Convert.ToHexString(passwordBytes);
+
+        // Create account from SHA256-hex — password stored as legacy Base64
+        var storedHash = _sut.HashForStorage(Password.FromSha256Hex(hex));
+
+        // Verify — should succeed (SuccessRehashNeeded because it's legacy format)
+        var resultPreHashed = _sut.VerifyPassword(storedHash, Password.FromSha256Hex(hex));
+        Assert.Equal(PasswordVerificationResult.SuccessRehashNeeded, resultPreHashed);
+    }
+
+    [Fact]
+    public void VerifyPassword_LegacyFormat_CorrectPassword_ReturnsSuccessRehashNeeded()
+    {
+        // Arrange - legacy format stores Base64(raw bytes), client sends hex string
+        var passwordBytes = new byte[32];
+        for (var i = 0; i < 32; i++) passwordBytes[i] = (byte)i;
+        var legacyHash = Convert.ToBase64String(passwordBytes);
+        var passwordHex = Convert.ToHexString(passwordBytes);
+
+        // Act
+        var result = _sut.VerifyPassword(legacyHash, Password.FromSha256Hex(passwordHex));
+
+        // Assert
+        Assert.Equal(PasswordVerificationResult.SuccessRehashNeeded, result);
+    }
+
+    [Fact]
+    public void VerifyPassword_LegacyFormat_WrongPassword_ReturnsFailed()
+    {
+        // Arrange
+        var storedPasswordBytes = new byte[32];
+        for (var i = 0; i < 32; i++) storedPasswordBytes[i] = (byte)i;
+        var legacyHash = Convert.ToBase64String(storedPasswordBytes);
+
+        var wrongPasswordBytes = new byte[32];
+        for (var i = 0; i < 32; i++) wrongPasswordBytes[i] = (byte)(i + 1);
+        var wrongPasswordHex = Convert.ToHexString(wrongPasswordBytes);
+
+        // Act
+        var result = _sut.VerifyPassword(legacyHash, Password.FromSha256Hex(wrongPasswordHex));
+
+        // Assert
+        Assert.Equal(PasswordVerificationResult.Failed, result);
+    }
+
+    [Fact]
+    public void VerifyPassword_NewFormat_CorrectPassword_ReturnsSuccess()
+    {
+        // Arrange
+        var passwordHex = "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F";
+        var newHash = _sut.HashForStorage(Password.FromPlaintext(passwordHex));
+
+        // Act
+        var result = _sut.VerifyPassword(newHash, Password.FromPlaintext(passwordHex));
+
+        // Assert
+        Assert.Equal(PasswordVerificationResult.Success, result);
+    }
+
+    [Fact]
+    public void VerifyPassword_NewFormat_WrongPassword_ReturnsFailed()
+    {
+        // Arrange
+        var passwordHex = "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F";
+        var newHash = _sut.HashForStorage(Password.FromPlaintext(passwordHex));
+
+        var wrongPasswordHex = "0102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F20";
+
+        // Act
+        var result = _sut.VerifyPassword(newHash, Password.FromPlaintext(wrongPasswordHex));
+
+        // Assert
+        Assert.Equal(PasswordVerificationResult.Failed, result);
+    }
+
+    [Fact]
+    public void VerifyPassword_MigrationScenario_PreHashed_Works()
+    {
+        // Arrange - simulate a user with legacy password logging in with pre-hashed password
+        var passwordBytes = new byte[32];
+        for (var i = 0; i < 32; i++) passwordBytes[i] = (byte)i;
+        var legacyHash = Convert.ToBase64String(passwordBytes);
+        var passwordHex = Convert.ToHexString(passwordBytes);
+
+        // Act - first login with legacy format (pre-hashed, returns SuccessRehashNeeded)
+        var firstResult = _sut.VerifyPassword(legacyHash, Password.FromSha256Hex(passwordHex));
+
+        // Simulate rehashing with plaintext equivalent
+        var newHash = _sut.HashForStorage(Password.FromPlaintext(passwordHex));
+
+        // Second login with new format
+        var secondResult = _sut.VerifyPassword(newHash, Password.FromPlaintext(passwordHex));
+
+        // Assert
+        Assert.Equal(PasswordVerificationResult.SuccessRehashNeeded, firstResult);
+        Assert.Equal(PasswordVerificationResult.Success, secondResult);
+    }
+
+    [Fact]
+    public void VerifyPassword_LegacyFormat_Plaintext_CorrectPassword_ReturnsSuccessRehashNeeded()
+    {
+        // Arrange - legacy format stores Base64(SHA256(plaintext)), new client sends plaintext
+        var plaintext = "mypassword123";
+        var sha256Bytes = System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(plaintext));
+        var legacyHash = Convert.ToBase64String(sha256Bytes);
+
+        // Act
+        var result = _sut.VerifyPassword(legacyHash, Password.FromPlaintext(plaintext));
+
+        // Assert
+        Assert.Equal(PasswordVerificationResult.SuccessRehashNeeded, result);
+    }
+
+    [Fact]
+    public void VerifyPassword_LegacyFormat_Plaintext_WrongPassword_ReturnsFailed()
+    {
+        // Arrange
+        var plaintext = "mypassword123";
+        var sha256Bytes = System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(plaintext));
+        var legacyHash = Convert.ToBase64String(sha256Bytes);
+
+        // Act
+        var result = _sut.VerifyPassword(legacyHash, Password.FromPlaintext("wrongpassword"));
+
+        // Assert
+        Assert.Equal(PasswordVerificationResult.Failed, result);
+    }
+
+    [Fact]
+    public void VerifyPassword_MigrationScenario_Plaintext_Works()
+    {
+        // Arrange - simulate plaintext login against legacy hash, rehash, then verify again
+        var plaintext = "mypassword123";
+        var sha256Bytes = System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(plaintext));
+        var legacyHash = Convert.ToBase64String(sha256Bytes);
+
+        // Act - first login with plaintext against legacy format
+        var firstResult = _sut.VerifyPassword(legacyHash, Password.FromPlaintext(plaintext));
+
+        // Simulate rehashing with plaintext
+        var newHash = _sut.HashForStorage(Password.FromPlaintext(plaintext));
+
+        // Second login with new format
+        var secondResult = _sut.VerifyPassword(newHash, Password.FromPlaintext(plaintext));
+
+        // Assert
+        Assert.Equal(PasswordVerificationResult.SuccessRehashNeeded, firstResult);
+        Assert.Equal(PasswordVerificationResult.Success, secondResult);
+    }
+}


### PR DESCRIPTION
Replace Base64-encoded unsalted SHA256 password storage with `IPasswordHasher<T>` for improved security. SHA256 passwords are automatically rehashed on successful plaintext login, enabling rolling migration without downtime. Currently there's no rehashing as all passwords are still interpreted as SHA256 hashes, but when it's possible for plaintext passwords (via new launcher behaviour, or an auth API), the rehashing will occur using PBKDF2.

Fully backwards compatible and shouldn't cause any changes to login behaviour currently.

- Add `IPasswordService` for password hashing and verification
- Use timing-safe comparison for legacy password verification
- Configure 600,000 PBKDF2 iterations per [OWASP recommendation](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html)

#### Why would we want this?

The current password storage of SHA256 hashes is insufficient, and ideally we'd offer a secure-by-default solution. As the SHA256 hash is calculated by the AAEmu Launcher rather than the backend, it essentially becomes the password itself - if intercepted in transit, the hash can be used to log in by an attacker. The hash is also unsalted, meaning the same password has the same value in the database, allowing an attacker to easily identify identical passwords or compare to a pre-built rainbow table. There's also no work factor, so only one iteration of the hash is used, making it incredibly fast to generate compatible hashes to test passwords in a brute-force attack.

None of these issues are major for a small project that's still in development and where users are expected to make their own changes for security, but it would be nice to offer a more secure password system for future growth - and ASP.NET Core's `PasswordHasher` takes away the complexity from that by handling algorithm, work factor, and salts internally.