### PR TITLE
feat(login): Add initial Korea authentication flow

### DIFF
--- a/AAEmu.Login.IntegrationTests/AAEmu.Login.IntegrationTests.csproj
+++ b/AAEmu.Login.IntegrationTests/AAEmu.Login.IntegrationTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
     <!-- Enable Testing Platform support for xunit -->
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>

--- a/AAEmu.Login.IntegrationTests/LoginControllerIntegrationTests.cs
+++ b/AAEmu.Login.IntegrationTests/LoginControllerIntegrationTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using AAEmu.Commons.Utils.DB;
+using AAEmu.Login.Core.Authentication;
 using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.PacketHandlers.C2L;
 using AAEmu.Login.Core.Services;
@@ -43,8 +44,9 @@ public class LoginControllerIntegrationTests : IAsyncLifetime
         var connectionFactory = new Mock<IMySqlConnectionFactory>();
         connectionFactory.Setup(f => f.CreateConnection()).Returns(MySQL.CreateConnection);
         var logger = new Mock<ILogger<LoginController>>();
-        return new LoginController(gameController.Object, passwordService.Object, appConfig, connectionFactory.Object,
-            logger.Object);
+        var koreaOptions = Options.Create(new KoreaChallengeAuthOptions());
+        return new LoginController(gameController.Object, passwordService.Object, appConfig, koreaOptions,
+            connectionFactory.Object, logger.Object);
     }
 
     private static async Task InsertUser(string username, string password, bool banned = false, int banReason = 0)

--- a/AAEmu.Login.IntegrationTests/LoginControllerIntegrationTests.cs
+++ b/AAEmu.Login.IntegrationTests/LoginControllerIntegrationTests.cs
@@ -43,7 +43,8 @@ public class LoginControllerIntegrationTests : IAsyncLifetime
         var connectionFactory = new Mock<IMySqlConnectionFactory>();
         connectionFactory.Setup(f => f.CreateConnection()).Returns(MySQL.CreateConnection);
         var logger = new Mock<ILogger<LoginController>>();
-        return new LoginController(gameController.Object, passwordService.Object, appConfig, connectionFactory.Object, logger.Object);
+        return new LoginController(gameController.Object, passwordService.Object, appConfig, connectionFactory.Object,
+            logger.Object);
     }
 
     private static async Task InsertUser(string username, string password, bool banned = false, int banReason = 0)
@@ -65,10 +66,11 @@ public class LoginControllerIntegrationTests : IAsyncLifetime
     {
         var controller = CreateController(autoAccount: false);
 
-        var result = await controller.Login("no_such_user", Password.FromPlaintext("pass"), _ipAddress, TestContext.Current.CancellationToken);
+        var result = await controller.Login("no_such_user", Password.FromPlaintext("pass"), _ipAddress,
+            TestContext.Current.CancellationToken);
 
         Assert.False(result.Success);
-        Assert.Equal(LoginDeniedReason.BadResponse, result.DenialReason);
+        Assert.Equal(LoginDeniedReason.BadAccount, result.DenialReason);
     }
 
     [Fact]
@@ -76,7 +78,8 @@ public class LoginControllerIntegrationTests : IAsyncLifetime
     {
         var controller = CreateController(autoAccount: true);
 
-        var result = await controller.Login("autouser", Password.FromPlaintext("newpass"), _ipAddress, TestContext.Current.CancellationToken);
+        var result = await controller.Login("autouser", Password.FromPlaintext("newpass"), _ipAddress,
+            TestContext.Current.CancellationToken);
 
         Assert.True(result.Success);
         Assert.NotEqual(default, result.AccountId);
@@ -89,7 +92,8 @@ public class LoginControllerIntegrationTests : IAsyncLifetime
         var controller = CreateController();
 
         var result =
-            await controller.Login("alice", Password.FromPlaintext("mypassword"), _ipAddress, TestContext.Current.CancellationToken);
+            await controller.Login("alice", Password.FromPlaintext("mypassword"), _ipAddress,
+                TestContext.Current.CancellationToken);
 
         Assert.True(result.Success);
     }
@@ -100,10 +104,11 @@ public class LoginControllerIntegrationTests : IAsyncLifetime
         await InsertUser("bob", "correctpass");
         var controller = CreateController();
 
-        var result = await controller.Login("bob", Password.FromPlaintext("wrongpass"), _ipAddress, TestContext.Current.CancellationToken);
+        var result = await controller.Login("bob", Password.FromPlaintext("wrongpass"), _ipAddress,
+            TestContext.Current.CancellationToken);
 
         Assert.False(result.Success);
-        Assert.Equal(LoginDeniedReason.BadResponse, result.DenialReason);
+        Assert.Equal(LoginDeniedReason.BadAccount, result.DenialReason);
     }
 
     [Fact]
@@ -112,7 +117,8 @@ public class LoginControllerIntegrationTests : IAsyncLifetime
         await InsertUser("banned_user", "pass", banned: true, banReason: 5);
         var controller = CreateController();
 
-        var result = await controller.Login("banned_user", Password.FromPlaintext("pass"), _ipAddress, TestContext.Current.CancellationToken);
+        var result = await controller.Login("banned_user", Password.FromPlaintext("pass"), _ipAddress,
+            TestContext.Current.CancellationToken);
 
         Assert.False(result.Success);
         Assert.Equal(LoginDeniedReason.TryTradeCashTemporal, result.DenialReason);
@@ -123,8 +129,9 @@ public class LoginControllerIntegrationTests : IAsyncLifetime
     {
         await InsertUser("tracker", "pass");
         var controller = CreateController();
- 
-        var result = await controller.Login("tracker", Password.FromPlaintext("pass"), _ipAddress, TestContext.Current.CancellationToken);
+
+        var result = await controller.Login("tracker", Password.FromPlaintext("pass"), _ipAddress,
+            TestContext.Current.CancellationToken);
         Assert.True(result.Success);
 
         // Verify the DB was updated

--- a/AAEmu.Login/Core/Authentication/IArsAuthFlow.cs
+++ b/AAEmu.Login/Core/Authentication/IArsAuthFlow.cs
@@ -1,0 +1,28 @@
+using AAEmu.Login.Core.Network.Connections;
+
+namespace AAEmu.Login.Core.Authentication;
+
+/// <summary>
+/// Authentication flow that requires ARS (Automatic Response System/자동응답시스템) verification.
+/// </summary>
+/// <remarks>
+/// ARS is automated phone verification used in Korean authentication. The system calls the user's
+/// registered phone number, and they enter a code displayed on screen via IVR (Interactive Voice Response).
+/// Since Korean phone numbers are tied to real identity, this serves as identity verification.
+/// <para/>
+/// Unlike OTP and certificate flows, ARS is callback-based rather than packet-based.
+/// The external phone system calls back to the server to confirm success/failure.
+/// <para/>
+/// Returns <see cref="AuthFlowResult"/> values; <see cref="ILoginSession"/> manages the lifecycle.
+/// </remarks>
+public interface IArsAuthFlow : IAuthenticationFlow
+{
+    /// <summary>
+    /// Completes the ARS verification with the result from the external phone system callback.
+    /// </summary>
+    /// <param name="client">The login client for sending responses.</param>
+    /// <param name="success">Whether the user successfully entered the code via phone.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The result of ARS verification.</returns>
+    Task<AuthFlowResult> CompleteArsAsync(ILoginClient client, bool success, CancellationToken cancellationToken);
+}

--- a/AAEmu.Login/Core/Authentication/ICertAuthFlow.cs
+++ b/AAEmu.Login/Core/Authentication/ICertAuthFlow.cs
@@ -1,0 +1,21 @@
+using AAEmu.Login.Core.Network.Connections;
+
+namespace AAEmu.Login.Core.Authentication;
+
+/// <summary>
+/// Authentication flow that requires certificate verification.
+/// </summary>
+/// <remarks>
+/// Returns <see cref="AuthFlowResult"/> values; <see cref="ILoginSession"/> manages the lifecycle.
+/// </remarks>
+public interface ICertAuthFlow : IAuthenticationFlow
+{
+    /// <summary>
+    /// Submits the certificate number provided by the client.
+    /// </summary>
+    /// <param name="client">The login client for sending responses.</param>
+    /// <param name="certNumber">The certificate number entered by the user.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The result of certificate verification.</returns>
+    Task<AuthFlowResult> SubmitCertAsync(ILoginClient client, string certNumber, CancellationToken cancellationToken);
+}

--- a/AAEmu.Login/Core/Authentication/IChallenge2AuthFlow.cs
+++ b/AAEmu.Login/Core/Authentication/IChallenge2AuthFlow.cs
@@ -1,0 +1,17 @@
+using AAEmu.Login.Core.Network.Connections;
+
+namespace AAEmu.Login.Core.Authentication;
+
+/// <summary>
+/// Flow for V2 Korea challenge-response authentication.
+/// </summary>
+public interface IChallenge2AuthFlow : IAuthenticationFlow
+{
+    /// <summary>
+    /// Continues the V2 challenge-response flow with the client's computed response.
+    /// </summary>
+    /// <param name="client">The login client for sending responses.</param>
+    /// <param name="ch">The 8 AES-encrypted challenge uint32 values computed by the client.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<AuthFlowResult> ContinueV2Async(ILoginClient client, uint[] ch, CancellationToken cancellationToken);
+}

--- a/AAEmu.Login/Core/Authentication/IChallengeAuthFlow.cs
+++ b/AAEmu.Login/Core/Authentication/IChallengeAuthFlow.cs
@@ -1,0 +1,23 @@
+using AAEmu.Login.Core.Network.Connections;
+
+
+namespace AAEmu.Login.Core.Authentication;
+
+/// <summary>
+/// Authentication flow that uses challenge-response for password authentication.
+/// </summary>
+/// <remarks>
+/// The flow sends a challenge packet in <see cref="IAuthenticationFlow.StartAsync"/>,
+/// and the client responds with the password which is submitted via <see cref="ContinueAsync"/>.
+/// </remarks>
+public interface IChallengeAuthFlow : IAuthenticationFlow
+{
+    /// <summary>
+    /// Continues the authentication flow with the password provided by the client.
+    /// </summary>
+    /// <param name="client">The login client for sending responses.</param>
+    /// <param name="password">The password from the client's challenge response.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The result of password verification.</returns>
+    Task<AuthFlowResult> ContinueAsync(ILoginClient client, string password, CancellationToken cancellationToken);
+}

--- a/AAEmu.Login/Core/Authentication/IChallengeAuthFlow.cs
+++ b/AAEmu.Login/Core/Authentication/IChallengeAuthFlow.cs
@@ -1,23 +1,27 @@
 using AAEmu.Login.Core.Network.Connections;
 
-
 namespace AAEmu.Login.Core.Authentication;
 
 /// <summary>
-/// Authentication flow that uses challenge-response for password authentication.
+/// Authentication flow for V1 Korea challenge-response (not enabled in production).
 /// </summary>
 /// <remarks>
-/// The flow sends a challenge packet in <see cref="IAuthenticationFlow.StartAsync"/>,
-/// and the client responds with the password which is submitted via <see cref="ContinueAsync"/>.
+/// <b>NOTE:</b> V1 challenge authentication is not enabled — SHA-1 without a per-account salt is
+/// approximately 17 million times weaker than PBKDF2@600k. Implementations must always deny
+/// in <see cref="ContinueAsync"/> when called (the server never issues <c>ACChallengePacket</c>).
+/// This interface is preserved for protocol completeness only.
 /// </remarks>
 public interface IChallengeAuthFlow : IAuthenticationFlow
 {
     /// <summary>
-    /// Continues the authentication flow with the password provided by the client.
+    /// Continues the V1 challenge-response flow with the parsed packet fields.
+    /// Implementations must return <see cref="AuthFlowResult.Denied"/> immediately —
+    /// V1 is never issued so this should never be reached in production.
     /// </summary>
     /// <param name="client">The login client for sending responses.</param>
-    /// <param name="password">The password from the client's challenge response.</param>
+    /// <param name="ch">The 4 AES-encrypted challenge uint32 values from the client.</param>
+    /// <param name="pw">The 32 raw bytes of the AES-encrypted plaintext password (V1 only).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The result of password verification.</returns>
-    Task<AuthFlowResult> ContinueAsync(ILoginClient client, string password, CancellationToken cancellationToken);
+    Task<AuthFlowResult> ContinueAsync(ILoginClient client, uint[] ch, byte[] pw,
+        CancellationToken cancellationToken);
 }

--- a/AAEmu.Login/Core/Authentication/IOtpAuthFlow.cs
+++ b/AAEmu.Login/Core/Authentication/IOtpAuthFlow.cs
@@ -1,0 +1,21 @@
+using AAEmu.Login.Core.Network.Connections;
+
+namespace AAEmu.Login.Core.Authentication;
+
+/// <summary>
+/// Authentication flow that requires OTP (One-Time Password) verification.
+/// </summary>
+/// <remarks>
+/// Returns <see cref="AuthFlowResult"/> values; <see cref="ILoginSession"/> manages the lifecycle.
+/// </remarks>
+public interface IOtpAuthFlow : IAuthenticationFlow
+{
+    /// <summary>
+    /// Submits the OTP code provided by the client.
+    /// </summary>
+    /// <param name="client">The login client for sending responses.</param>
+    /// <param name="otpCode">The OTP code entered by the user.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The result of OTP verification.</returns>
+    Task<AuthFlowResult> SubmitOtpAsync(ILoginClient client, string otpCode, CancellationToken cancellationToken);
+}

--- a/AAEmu.Login/Core/Authentication/KoreaAuthFlow.cs
+++ b/AAEmu.Login/Core/Authentication/KoreaAuthFlow.cs
@@ -1,0 +1,195 @@
+using System.Net;
+using AAEmu.Login.Core.Controllers;
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.PacketHandlers.C2L;
+using AAEmu.Login.Core.Services;
+using AAEmu.Login.Models;
+using Microsoft.Extensions.Options;
+
+namespace AAEmu.Login.Core.Authentication;
+
+/// <summary>
+/// Authentication flow for Korea supporting password, OTP, certificate, and ARS verification steps.
+/// </summary>
+/// <remarks>
+/// This flow implements a state machine that can handle multiple sequential verification steps:
+/// <list type="number">
+///   <item>Password authentication (always required)</item>
+///   <item>OTP verification (if account requires it)</item>
+///   <item>Certificate verification (if account requires it)</item>
+///   <item>ARS phone verification (if account requires it)</item>
+/// </list>
+/// Each step is optional based on account configuration. The flow advances through each required step
+/// in sequence until all verifications complete.
+/// </remarks>
+public class KoreaAuthFlow(ILoginController loginController, IOptions<KoreaAuthOptions> options, string username,
+    IPAddress clientIp)
+    : IChallengeAuthFlow, IOtpAuthFlow, ICertAuthFlow, IArsAuthFlow
+{
+    private enum State
+    {
+        AwaitingPassword,
+        AwaitingOtp,
+        AwaitingCert,
+        AwaitingArs,
+        Completed
+    }
+
+    private readonly KoreaAuthOptions _options = options.Value;
+
+    private State _state = State.AwaitingPassword;
+    private AccountId _authenticatedAccountId;
+
+    // Step requirements (hardcoded false for now - no DB/controller support)
+    private bool _requiresOtp;
+    private bool _requiresCert;
+    private bool _requiresArs;
+
+    // Retry tracking
+    private int _otpAttempts;
+    private int _certAttempts;
+
+    public async Task<AuthFlowResult> StartAsync(ILoginClient client, CancellationToken cancellationToken)
+    {
+        // Challenge the client to provide the password.
+        await client.SendChallengeAsync(cancellationToken);
+
+        return new AuthFlowResult.Pending();
+    }
+
+    public async Task<AuthFlowResult> ContinueAsync(ILoginClient client, string password,
+        CancellationToken cancellationToken)
+    {
+        if (_state != State.AwaitingPassword)
+        {
+            return new AuthFlowResult.Denied(LoginDeniedReason.BadResponse);
+        }
+
+        var result = await loginController.Login(username, Password.FromSha256Hex(password), clientIp, cancellationToken);
+
+        if (!result.Success)
+        {
+            return new AuthFlowResult.Denied(result.DenialReason);
+        }
+
+        _authenticatedAccountId = result.AccountId;
+
+        // TODO: Query account requirements from database/controller
+        // For now, these are hardcoded to false
+        _requiresOtp = false;
+        _requiresCert = false;
+        _requiresArs = false;
+
+        return await AdvanceToNextStepAsync(client, cancellationToken);
+    }
+
+    public async Task<AuthFlowResult> SubmitOtpAsync(ILoginClient client, string otpCode,
+        CancellationToken cancellationToken)
+    {
+        if (_state != State.AwaitingOtp)
+        {
+            return new AuthFlowResult.Denied(LoginDeniedReason.BadResponse);
+        }
+
+        _otpAttempts++;
+
+        // TODO: Actual OTP validation (e.g., TOTP algorithm)
+        var isValid = false;
+
+        if (!isValid)
+        {
+            if (_otpAttempts >= _options.MaxOtpAttempts)
+            {
+                return new AuthFlowResult.Denied(LoginDeniedReason.BadResponse);
+            }
+
+            // Send retry packet
+            await client.SendOtpPromptAsync(_options.MaxOtpAttempts, _otpAttempts + 1, cancellationToken);
+            return new AuthFlowResult.Pending();
+        }
+
+        return await AdvanceToNextStepAsync(client, cancellationToken);
+    }
+
+    public async Task<AuthFlowResult> SubmitCertAsync(ILoginClient client, string certNumber,
+        CancellationToken cancellationToken)
+    {
+        if (_state != State.AwaitingCert)
+        {
+            return new AuthFlowResult.Denied(LoginDeniedReason.BadResponse);
+        }
+
+        _certAttempts++;
+
+        // TODO: Actual certificate validation
+        var isValid = false;
+
+        if (!isValid)
+        {
+            if (_certAttempts >= _options.MaxCertAttempts)
+            {
+                return new AuthFlowResult.Denied(LoginDeniedReason.BadResponse);
+            }
+
+            // Send retry packet
+            await client.SendCertPromptAsync(_options.MaxCertAttempts, _certAttempts + 1, cancellationToken);
+            return new AuthFlowResult.Pending();
+        }
+
+        return await AdvanceToNextStepAsync(client, cancellationToken);
+    }
+
+    public async Task<AuthFlowResult> CompleteArsAsync(ILoginClient client, bool success,
+        CancellationToken cancellationToken)
+    {
+        if (_state != State.AwaitingArs)
+        {
+            return new AuthFlowResult.Denied(LoginDeniedReason.BadResponse);
+        }
+
+        if (!success)
+        {
+            return new AuthFlowResult.Denied(LoginDeniedReason.BadResponse);
+        }
+
+        return await AdvanceToNextStepAsync(client, cancellationToken);
+    }
+
+    /// <summary>
+    /// Advances to the next required verification step, or completes authentication if all steps are done.
+    /// </summary>
+    private async Task<AuthFlowResult> AdvanceToNextStepAsync(ILoginClient client,
+        CancellationToken cancellationToken)
+    {
+        // Check each remaining step in order
+        if (_state <= State.AwaitingPassword && _requiresOtp)
+        {
+            _state = State.AwaitingOtp;
+
+            await client.SendOtpPromptAsync(0, 0, cancellationToken);
+            return new AuthFlowResult.Pending();
+        }
+
+        if (_state <= State.AwaitingOtp && _requiresCert)
+        {
+            _state = State.AwaitingCert;
+
+            await client.SendCertPromptAsync(0, 0, cancellationToken);
+            return new AuthFlowResult.Pending();
+        }
+
+        if (_state <= State.AwaitingCert && _requiresArs)
+        {
+            _state = State.AwaitingArs;
+
+            // TODO: Generate actual ARS code
+            const string ArsCode = "1234";
+            await client.SendArsPromptAsync(ArsCode, _options.ArsTimeout, cancellationToken);
+            return new AuthFlowResult.Pending();
+        }
+
+        // All steps complete
+        _state = State.Completed;
+        return new AuthFlowResult.Success(_authenticatedAccountId, username);
+    }
+}

--- a/AAEmu.Login/Core/Authentication/KoreaAuthFlow.cs
+++ b/AAEmu.Login/Core/Authentication/KoreaAuthFlow.cs
@@ -1,4 +1,6 @@
+using System.Buffers.Binary;
 using System.Net;
+using System.Security.Cryptography;
 using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.PacketHandlers.C2L;
@@ -9,7 +11,7 @@ using Microsoft.Extensions.Options;
 namespace AAEmu.Login.Core.Authentication;
 
 /// <summary>
-/// Authentication flow for Korea supporting password, OTP, certificate, and ARS verification steps.
+/// Authentication flow for Korea supporting V2 challenge-response, OTP, certificate, and ARS verification steps.
 /// </summary>
 /// <remarks>
 /// This flow implements a state machine that can handle multiple sequential verification steps:
@@ -22,13 +24,13 @@ namespace AAEmu.Login.Core.Authentication;
 /// Each step is optional based on account configuration. The flow advances through each required step
 /// in sequence until all verifications complete.
 /// </remarks>
-public class KoreaAuthFlow(ILoginController loginController, IOptions<KoreaAuthOptions> options, string username,
-    IPAddress clientIp)
-    : IChallengeAuthFlow, IOtpAuthFlow, ICertAuthFlow, IArsAuthFlow
+public class KoreaAuthFlow(ILoginController loginController, IOptions<KoreaAuthOptions> options,
+    IOptions<KoreaChallengeAuthOptions> challengeOptions, string username, IPAddress clientIp)
+    : IChallengeAuthFlow, IChallenge2AuthFlow, IOtpAuthFlow, ICertAuthFlow, IArsAuthFlow
 {
     private enum State
     {
-        AwaitingPassword,
+        AwaitingChallengeResponse,
         AwaitingOtp,
         AwaitingCert,
         AwaitingArs,
@@ -36,9 +38,14 @@ public class KoreaAuthFlow(ILoginController loginController, IOptions<KoreaAuthO
     }
 
     private readonly KoreaAuthOptions _options = options.Value;
+    private readonly KoreaChallengeAuthOptions _challengeOptions = challengeOptions.Value;
 
-    private State _state = State.AwaitingPassword;
-    private AccountId _authenticatedAccountId;
+    private State _state = State.AwaitingChallengeResponse;
+    private AccountId _accountId;
+
+    // V2 challenge state (cleared after successful verification)
+    private uint[] _v2Hc = [];
+    private ReadOnlyMemory<byte> _challengeKey;
 
     // Step requirements (hardcoded false for now - no DB/controller support)
     private bool _requiresOtp;
@@ -51,31 +58,61 @@ public class KoreaAuthFlow(ILoginController loginController, IOptions<KoreaAuthO
 
     public async Task<AuthFlowResult> StartAsync(ILoginClient client, CancellationToken cancellationToken)
     {
-        // Challenge the client to provide the password.
-        await client.SendChallengeAsync(cancellationToken);
+        if (!_challengeOptions.Enabled)
+            return new AuthFlowResult.Denied(LoginDeniedReason.LoginUnknown);
 
+        // Look up the account's Korea challenge material.
+        // No ban check here — doing so before authentication would leak whether an account exists.
+        var info = await loginController.GetKoreaAuthInfoAsync(username, cancellationToken);
+        if (info is null)
+        {
+            // Account doesn't exist, or has no korea_challenge_hash yet.
+            // User must log in via EU auth first (with KoreaChallengeAuth:Enabled=true) to seed the hash.
+            return new AuthFlowResult.Denied(LoginDeniedReason.BadAccount);
+        }
+
+        _accountId = info.AccountId;
+        _challengeKey = info.ChallengeKeyHash;
+
+        // Generate 8 cryptographically secure random uint32 challenge values
+        _v2Hc = new uint[8];
+        Span<byte> rngBytes = stackalloc byte[32];
+        RandomNumberGenerator.Fill(rngBytes);
+        for (var i = 0; i < 8; i++)
+            _v2Hc[i] = BinaryPrimitives.ReadUInt32LittleEndian(rngBytes.Slice(i * 4, 4));
+
+        await client.SendChallenge2Async(info.ChallengeRounds, info.ChallengeSalt, _v2Hc, cancellationToken);
         return new AuthFlowResult.Pending();
     }
 
-    public async Task<AuthFlowResult> ContinueAsync(ILoginClient client, string password,
+    /// <summary>
+    /// V1 challenge-response continuation — always denied.
+    /// The server never issues <c>ACChallengePacket</c>; this path should never be reached in production.
+    /// </summary>
+    public Task<AuthFlowResult> ContinueAsync(ILoginClient client, uint[] ch, byte[] pw,
         CancellationToken cancellationToken)
     {
-        if (_state != State.AwaitingPassword)
-        {
+        // V1 Korea challenge is disabled (SHA-1 without per-account salt is ~17M× weaker than PBKDF2@600k).
+        return Task.FromResult<AuthFlowResult>(new AuthFlowResult.Denied(LoginDeniedReason.BadResponse));
+    }
+
+    /// <summary>
+    /// V2 challenge-response continuation — verifies the AES-256 challenge response.
+    /// </summary>
+    public async Task<AuthFlowResult> ContinueV2Async(ILoginClient client, uint[] ch,
+        CancellationToken cancellationToken)
+    {
+        if (_state != State.AwaitingChallengeResponse)
             return new AuthFlowResult.Denied(LoginDeniedReason.BadResponse);
-        }
 
-        var result = await loginController.Login(username, Password.FromSha256Hex(password), clientIp, cancellationToken);
+        if (!KoreanChallengeVerifier.VerifyV2(_challengeKey.Span, _v2Hc, ch))
+            return new AuthFlowResult.Denied(LoginDeniedReason.BadAccount);
 
-        if (!result.Success)
-        {
-            return new AuthFlowResult.Denied(result.DenialReason);
-        }
-
-        _authenticatedAccountId = result.AccountId;
+        // Clear key material now that verification is done
+        _challengeKey = ReadOnlyMemory<byte>.Empty;
+        _v2Hc = [];
 
         // TODO: Query account requirements from database/controller
-        // For now, these are hardcoded to false
         _requiresOtp = false;
         _requiresCert = false;
         _requiresArs = false;
@@ -87,9 +124,7 @@ public class KoreaAuthFlow(ILoginController loginController, IOptions<KoreaAuthO
         CancellationToken cancellationToken)
     {
         if (_state != State.AwaitingOtp)
-        {
             return new AuthFlowResult.Denied(LoginDeniedReason.BadResponse);
-        }
 
         _otpAttempts++;
 
@@ -157,15 +192,16 @@ public class KoreaAuthFlow(ILoginController loginController, IOptions<KoreaAuthO
 
     /// <summary>
     /// Advances to the next required verification step, or completes authentication if all steps are done.
+    /// Performs the ban check immediately before issuing the final <see cref="AuthFlowResult.Success"/>
+    /// to avoid leaking account status prior to successful authentication.
     /// </summary>
     private async Task<AuthFlowResult> AdvanceToNextStepAsync(ILoginClient client,
         CancellationToken cancellationToken)
     {
         // Check each remaining step in order
-        if (_state <= State.AwaitingPassword && _requiresOtp)
+        if (_state <= State.AwaitingChallengeResponse && _requiresOtp)
         {
             _state = State.AwaitingOtp;
-
             await client.SendOtpPromptAsync(0, 0, cancellationToken);
             return new AuthFlowResult.Pending();
         }
@@ -173,7 +209,6 @@ public class KoreaAuthFlow(ILoginController loginController, IOptions<KoreaAuthO
         if (_state <= State.AwaitingOtp && _requiresCert)
         {
             _state = State.AwaitingCert;
-
             await client.SendCertPromptAsync(0, 0, cancellationToken);
             return new AuthFlowResult.Pending();
         }
@@ -181,15 +216,17 @@ public class KoreaAuthFlow(ILoginController loginController, IOptions<KoreaAuthO
         if (_state <= State.AwaitingCert && _requiresArs)
         {
             _state = State.AwaitingArs;
-
-            // TODO: Generate actual ARS code
-            const string ArsCode = "1234";
+            const string ArsCode = "1234"; // TODO: Generate actual ARS code
             await client.SendArsPromptAsync(ArsCode, _options.ArsTimeout, cancellationToken);
             return new AuthFlowResult.Pending();
         }
 
-        // All steps complete
+        // All steps complete. Check ban status before issuing success
         _state = State.Completed;
-        return new AuthFlowResult.Success(_authenticatedAccountId, username);
+        var (banned, banReason) = await loginController.CheckBanStatusAsync(_accountId, cancellationToken);
+        if (banned)
+            return new AuthFlowResult.Denied(banReason);
+
+        return new AuthFlowResult.Success(_accountId, username);
     }
 }

--- a/AAEmu.Login/Core/Authentication/KoreaAuthOptions.cs
+++ b/AAEmu.Login/Core/Authentication/KoreaAuthOptions.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace AAEmu.Login.Core.Authentication;
+
+/// <summary>
+/// Configuration options for Korean authentication flow.
+/// </summary>
+public class KoreaAuthOptions
+{
+    /// <summary>
+    /// The maximum number of OTP entry attempts before denying authentication.
+    /// </summary>
+    [Range(1, int.MaxValue)]
+    public int MaxOtpAttempts { get; set; } = 3;
+
+    /// <summary>
+    /// The maximum number of certificate entry attempts before denying authentication.
+    /// </summary>
+    [Range(1, int.MaxValue)]
+    public int MaxCertAttempts { get; set; } = 3;
+
+    /// <summary>
+    /// The timeout for ARS (phone verification).
+    /// </summary>
+    public TimeSpan ArsTimeout { get; set; } = TimeSpan.FromMinutes(3);
+}

--- a/AAEmu.Login/Core/Authentication/KoreaChallengeAuthOptions.cs
+++ b/AAEmu.Login/Core/Authentication/KoreaChallengeAuthOptions.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace AAEmu.Login.Core.Authentication;
+
+/// <summary>
+/// Configuration for Korea challenge-response authentication (V2, AES-256 with sha256_crypt key).
+/// </summary>
+/// <remarks>
+/// <para><b>Security trade-off:</b> sha256_crypt at 100,000 rounds is approximately 3× weaker than
+/// PBKDF2@310k (ASP.NET Core Identity default) for offline attacks against a stolen DB.
+/// At 300,000 rounds it reaches approximate parity. The hash is never transmitted to clients —
+/// only the salt and round count are sent in the challenge packet.</para>
+/// <para>V1 (<c>ACChallengePacket</c> / SHA-1 key) is intentionally not configurable.
+/// SHA-1 without a per-account salt is ~17 million times weaker than PBKDF2@600k.</para>
+/// </remarks>
+public class KoreaChallengeAuthOptions
+{
+    public const string ConfigurationSectionName = "KoreaChallengeAuth";
+
+    /// <summary>
+    /// Whether Korea challenge-response authentication is enabled.
+    /// When <c>false</c> (default), <c>korea_challenge_hash</c> is never written to the DB
+    /// and clients using Korea auth cannot log in.
+    /// </summary>
+    public bool Enabled { get; set; } = false;
+
+    /// <summary>
+    /// Number of sha256_crypt rounds for newly computed Korea auth challenge hashes.
+    /// Valid range: 1,000–999,999,999 (sha256_crypt spec limit).
+    /// Higher rounds increase offline-attack resistance but also increase the client's
+    /// login computation time on low-end hardware.
+    /// Rounds are stored in the hash string; existing accounts keep their original rounds
+    /// until they next log in by plaintext password.
+    /// </summary>
+    [Range(1_000, 999_999_999)]
+    public int Rounds { get; set; } = 100_000;
+}

--- a/AAEmu.Login/Core/Controllers/ILoginController.cs
+++ b/AAEmu.Login/Core/Controllers/ILoginController.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.PacketHandlers.C2L;
 using AAEmu.Login.Core.Services;
@@ -12,12 +12,7 @@ public interface ILoginController
     Task<ReconnectResult> Reconnect(GameServerId gsId, AccountId accountId, uint token);
 
     /// <summary>
-    /// Kr Method Auth
-    /// </summary>
-    Task<LoginResult> Login(string username);
-
-    /// <summary>
-    /// Eu Method Auth
+    /// Eu Method Auth.
     /// </summary>
     /// <param name="username">The username.</param>
     /// <param name="password">The password sent by the client, with its encoding kind.</param>

--- a/AAEmu.Login/Core/Controllers/ILoginController.cs
+++ b/AAEmu.Login/Core/Controllers/ILoginController.cs
@@ -19,4 +19,22 @@ public interface ILoginController
     /// <param name="ip">The client IP address for recording.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task<LoginResult> Login(string username, Password password, IPAddress ip, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Retrieves the Korea challenge-response authentication material for the given username.
+    /// Used by <see cref="AAEmu.Login.Core.Authentication.KoreaAuthFlow"/> to seed the V2 challenge.
+    /// </summary>
+    /// <returns>
+    /// The auth info if the account exists and has a <c>korea_challenge_hash</c> stored;
+    /// <c>null</c> if the account does not exist or has no hash yet
+    /// (user must log in via EU auth first to seed the hash when <c>KoreaChallengeAuth:Enabled=true</c>).
+    /// </returns>
+    Task<KoreaAuthInfo?> GetKoreaAuthInfoAsync(string username, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Checks the ban status of an account.
+    /// Called after successful challenge verification to avoid leaking account status before auth.
+    /// </summary>
+    Task<(bool Banned, LoginDeniedReason BanReason)> CheckBanStatusAsync(
+        AccountId accountId, CancellationToken cancellationToken);
 }

--- a/AAEmu.Login/Core/Controllers/LoginController.cs
+++ b/AAEmu.Login/Core/Controllers/LoginController.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Net;
 using System.Text.RegularExpressions;
+using AAEmu.Login.Core.Authentication;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.PacketHandlers.C2L;
 using AAEmu.Login.Core.Packets.L2G;
@@ -16,10 +17,12 @@ public partial class LoginController(
     IGameController gameController,
     IPasswordService passwordService,
     IOptions<AppConfiguration> appConfig,
+    IOptions<KoreaChallengeAuthOptions> koreaOptions,
     IMySqlConnectionFactory connectionFactory,
     ILogger<LoginController> logger) : ILoginController
 {
     private readonly bool _autoAccount = appConfig.Value.AutoAccount;
+    private readonly KoreaChallengeAuthOptions _koreaOptions = koreaOptions.Value;
 
     private readonly ConcurrentDictionary<GameServerId, ConcurrentDictionary<uint, AccountId>>
         _tokens = []; // gsId, [token, accountId]
@@ -55,6 +58,10 @@ public partial class LoginController(
         }
 
         var storedPassword = reader.GetString("password");
+        var storedKoreaChallengeHash = reader.IsDBNull(reader.GetOrdinal("korea_challenge_hash"))
+            ? null
+            : reader.GetString("korea_challenge_hash");
+
         var verificationResult = passwordService.VerifyPassword(storedPassword, password);
         if (verificationResult == PasswordVerificationResult.Failed)
         {
@@ -69,7 +76,7 @@ public partial class LoginController(
         }
 
         var accountId = new AccountId(reader.GetUInt32("id"));
-        var lastLogin = DateTime.UtcNow;
+        var now = DateTime.UtcNow;
 
         logger.LogInformation("{Username} connected.", username.ReplaceLineEndings(" "));
 
@@ -77,32 +84,97 @@ public partial class LoginController(
 
         #region update account
 
+        // Determine what needs rehashing, which is only possible when we have a plaintext password
+        var rehashPbkdf2 = verificationResult == PasswordVerificationResult.SuccessRehashNeeded
+                           && password.Kind == PasswordKind.Plaintext;
+        var koreaRehashNeeded = _koreaOptions.Enabled
+                                && password.Kind == PasswordKind.Plaintext
+                                && (storedKoreaChallengeHash == null
+                                    || Sha256Crypt.ParseRounds(storedKoreaChallengeHash) != _koreaOptions.Rounds);
+
         command.Parameters.Clear();
-        if (verificationResult == PasswordVerificationResult.SuccessRehashNeeded && password.Kind == PasswordKind.Plaintext)
+
+        if (rehashPbkdf2 && koreaRehashNeeded)
         {
-            var newHash = passwordService.HashForStorage(password);
             command.CommandText =
-                "UPDATE `users` SET password = @password, last_ip = @last_ip, last_login = @last_login, updated_at = @updated_at WHERE id = @id";
-            command.Parameters.AddWithValue("@password", newHash);
+                "UPDATE `users` SET password = @password, korea_challenge_hash = @koreaHash," +
+                " last_ip = @last_ip, last_login = @last_login, updated_at = @updated_at WHERE id = @id";
+            command.Parameters.AddWithValue("@password", passwordService.HashForStorage(password));
+            command.Parameters.AddWithValue("@koreaHash", passwordService.ComputeKoreaChallengeHash(password.Value, rounds: _koreaOptions.Rounds));
+        }
+        else if (rehashPbkdf2)
+        {
+            command.CommandText =
+                "UPDATE `users` SET password = @password," +
+                " last_ip = @last_ip, last_login = @last_login, updated_at = @updated_at WHERE id = @id";
+            command.Parameters.AddWithValue("@password", passwordService.HashForStorage(password));
+        }
+        else if (koreaRehashNeeded)
+        {
+            command.CommandText =
+                "UPDATE `users` SET korea_challenge_hash = @koreaHash," +
+                " last_ip = @last_ip, last_login = @last_login, updated_at = @updated_at WHERE id = @id";
+            command.Parameters.AddWithValue("@koreaHash", passwordService.ComputeKoreaChallengeHash(password.Value, rounds: _koreaOptions.Rounds));
         }
         else
         {
             command.CommandText =
                 "UPDATE `users` SET last_ip = @last_ip, last_login = @last_login, updated_at = @updated_at WHERE id = @id";
         }
+
         command.Parameters.AddWithValue("@id", accountId.Value);
-        command.Parameters.AddWithValue("@last_ip", ip);
-        command.Parameters.AddWithValue("@last_login", ((DateTimeOffset)lastLogin).ToUnixTimeSeconds());
-        command.Parameters.AddWithValue("@updated_at", ((DateTimeOffset)lastLogin).ToUnixTimeSeconds());
+        command.Parameters.AddWithValue("@last_ip", ip.ToString());
+        command.Parameters.AddWithValue("@last_login", ((DateTimeOffset)now).ToUnixTimeSeconds());
+        command.Parameters.AddWithValue("@updated_at", ((DateTimeOffset)now).ToUnixTimeSeconds());
 
         if (await command.ExecuteNonQueryAsync() != 1)
         {
             logger.LogWarning("Database update failed, error occurred while updating account login IP and time");
         }
 
-        # endregion
+        #endregion
 
         return new LoginResult(true, accountId, default);
+    }
+
+    public async Task<KoreaAuthInfo?> GetKoreaAuthInfoAsync(string username, CancellationToken cancellationToken)
+    {
+        await using var connect = connectionFactory.CreateConnection();
+        await using var command = connect.CreateCommand();
+        command.CommandText =
+            "SELECT id, korea_challenge_hash FROM users WHERE username = @username";
+        command.Parameters.AddWithValue("@username", username);
+        await using var reader = command.ExecuteReader();
+
+        if (!await reader.ReadAsync(cancellationToken))
+            return null;
+
+        var accountId = new AccountId(reader.GetUInt32("id"));
+
+        if (reader.IsDBNull(reader.GetOrdinal("korea_challenge_hash")))
+            return null;
+
+        var stored = reader.GetString("korea_challenge_hash");
+        var rawHash = new byte[32];
+        var (rounds, salt) = Sha256Crypt.Parse(stored, rawHash);
+        return new KoreaAuthInfo(accountId, rawHash.AsMemory(), salt, rounds);
+    }
+
+    public async Task<(bool Banned, LoginDeniedReason BanReason)> CheckBanStatusAsync(
+        AccountId accountId, CancellationToken cancellationToken)
+    {
+        await using var connect = connectionFactory.CreateConnection();
+        await using var command = connect.CreateCommand();
+        command.CommandText = "SELECT banned, ban_reason FROM users WHERE id = @accountId";
+        command.Parameters.AddWithValue("@accountId", accountId.Value);
+        await using var reader = command.ExecuteReader();
+
+        if (!await reader.ReadAsync(cancellationToken))
+            return (false, default);
+
+        var banned = reader.GetBoolean("banned");
+        var banReason = banned ? (LoginDeniedReason)(byte)reader.GetUInt32("ban_reason") : default;
+        return (banned, banReason);
     }
 
     private async Task<LoginResult> CreateAndLoginInvalid(string username, Password password,
@@ -114,12 +186,27 @@ public partial class LoginController(
         var passwordHash = passwordService.HashForStorage(password);
 
         await using var command = connection.CreateCommand();
-        command.CommandText =
-            "INSERT into users (username, password, email, last_ip, last_login, created_at, updated_at) VALUES (@username, @password, @email, @last_ip, @last_login, @created_at, @updated_at)";
+
+        if (_koreaOptions.Enabled && password.Kind == PasswordKind.Plaintext)
+        {
+            string koreaHash;
+            { Span<byte> rawKey = stackalloc byte[32]; koreaHash = passwordService.ComputeKoreaChallengeHash(password.Value, rawKey, rounds: _koreaOptions.Rounds); }
+            command.CommandText =
+                "INSERT into users (username, password, korea_challenge_hash, email, last_ip, last_login, created_at, updated_at)" +
+                " VALUES (@username, @password, @koreaHash, @email, @last_ip, @last_login, @created_at, @updated_at)";
+            command.Parameters.AddWithValue("@koreaHash", koreaHash);
+        }
+        else
+        {
+            command.CommandText =
+                "INSERT into users (username, password, email, last_ip, last_login, created_at, updated_at)" +
+                " VALUES (@username, @password, @email, @last_ip, @last_login, @created_at, @updated_at)";
+        }
+
         command.Parameters.AddWithValue("@username", username);
         command.Parameters.AddWithValue("@password", passwordHash);
         command.Parameters.AddWithValue("@email", "");
-        command.Parameters.AddWithValue("@last_ip", clientIp);
+        command.Parameters.AddWithValue("@last_ip", clientIp.ToString());
         command.Parameters.AddWithValue("@last_login", ((DateTimeOffset)DateTime.UtcNow).ToUnixTimeSeconds());
         command.Parameters.AddWithValue("@created_at", ((DateTimeOffset)DateTime.UtcNow).ToUnixTimeSeconds());
         command.Parameters.AddWithValue("@updated_at", ((DateTimeOffset)DateTime.UtcNow).ToUnixTimeSeconds());

--- a/AAEmu.Login/Core/Controllers/LoginController.cs
+++ b/AAEmu.Login/Core/Controllers/LoginController.cs
@@ -29,50 +29,12 @@ public partial class LoginController(
     private static partial Regex UsernameRegex();
 
     /// <summary>
-    /// Kr Method Auth
-    /// </summary>
-    public async Task<LoginResult> Login(string username)
-    {
-        await using var connect = connectionFactory.CreateConnection();
-        await using var command = connect.CreateCommand();
-        command.CommandText = "SELECT * FROM users where username=@username";
-        command.Parameters.AddWithValue("@username", username);
-        await using var reader = command.ExecuteReader();
-        if (!await reader.ReadAsync())
-        {
-            return new LoginResult(false, default, LoginDeniedReason.BadAccount);
-        }
-
-        // TODO ... validation password
-
-        var accountId = new AccountId(reader.GetUInt32("id"));
-        var lastLogin = DateTime.UtcNow;
-
-        await reader.CloseAsync();
-
-        #region update account
-
-        command.Parameters.Clear();
-        command.CommandText =
-            "UPDATE `users` SET last_ip = @last_ip, last_login = @last_login, updated_at = @updated_at WHERE id = @id";
-        command.Parameters.AddWithValue("@id", accountId.Value);
-        command.Parameters.AddWithValue("@last_ip", "");
-        command.Parameters.AddWithValue("@last_login", ((DateTimeOffset)lastLogin).ToUnixTimeSeconds());
-        command.Parameters.AddWithValue("@updated_at", ((DateTimeOffset)lastLogin).ToUnixTimeSeconds());
-
-        if (await command.ExecuteNonQueryAsync() != 1)
-        {
-            logger.LogWarning("Database update failed, error occurred while updating account login IP and time");
-        }
-
-        # endregion
-
-        return new LoginResult(true, accountId, default);
-    }
-
-    /// <summary>
     /// Eu Method Auth
     /// </summary>
+    /// <param name="username">The username.</param>
+    /// <param name="password">The password sent by the client, with its encoding kind.</param>
+    /// <param name="ip">The client IP address for recording.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     public async Task<LoginResult> Login(string username, Password password, IPAddress ip,
         CancellationToken cancellationToken)
     {
@@ -89,14 +51,14 @@ public partial class LoginController(
                 return await CreateAndLoginInvalid(username, password, ip, connect);
             }
 
-            return new LoginResult(false, default, LoginDeniedReason.BadResponse);
+            return new LoginResult(false, default, LoginDeniedReason.BadAccount);
         }
 
         var storedPassword = reader.GetString("password");
         var verificationResult = passwordService.VerifyPassword(storedPassword, password);
         if (verificationResult == PasswordVerificationResult.Failed)
         {
-            return new LoginResult(false, default, LoginDeniedReason.BadResponse);
+            return new LoginResult(false, default, LoginDeniedReason.BadAccount);
         }
 
         var banned = reader.GetBoolean("banned");
@@ -164,7 +126,7 @@ public partial class LoginController(
 
         if (await command.ExecuteNonQueryAsync() != 1)
         {
-            return new LoginResult(false, default, LoginDeniedReason.BadResponse);
+            return new LoginResult(false, default, LoginDeniedReason.LoginUnknown);
         }
 
         logger.LogDebug("Created account from invalid username login with value {Username}", username);

--- a/AAEmu.Login/Core/Network/Connections/ILoginClient.cs
+++ b/AAEmu.Login/Core/Network/Connections/ILoginClient.cs
@@ -12,7 +12,19 @@ public interface ILoginClient
     ValueTask SendAuthSuccessAsync(AccountId accountId, CancellationToken cancellationToken);
     ValueTask SendAuthDeniedAsync(LoginDeniedReason reason, CancellationToken cancellationToken);
     ValueTask SendWorldListAsync(WorldListResult worldList, CancellationToken cancellationToken);
-    ValueTask SendChallengeAsync(CancellationToken cancellationToken);
+    /// <summary>
+    /// Sends a V1 Korea challenge packet (<c>ACChallengePacket</c>).
+    /// V1 is not enabled in production — SHA-1 without a per-account salt is ~17M× weaker than PBKDF2@600k.
+    /// Preserved for protocol completeness only.
+    /// </summary>
+    ValueTask SendChallengeAsync(uint salt, uint[] hc, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Sends a V2 Korea challenge packet (<c>ACChallenge2Packet</c>).
+    /// The client uses <paramref name="round"/> and <paramref name="salt"/> to derive the AES-256 key
+    /// via sha256_crypt, then computes the 8-uint challenge response.
+    /// </summary>
+    ValueTask SendChallenge2Async(int round, string salt, uint[] hc, CancellationToken cancellationToken);
     ValueTask SendOtpPromptAsync(int maximumTries, int currentTry, CancellationToken cancellationToken);
     ValueTask SendCertPromptAsync(int maximumTries, int currentTry, CancellationToken cancellationToken);
     ValueTask SendArsPromptAsync(string sessionCode, TimeSpan timeout, CancellationToken cancellationToken);

--- a/AAEmu.Login/Core/Network/Connections/ILoginClient.cs
+++ b/AAEmu.Login/Core/Network/Connections/ILoginClient.cs
@@ -12,6 +12,10 @@ public interface ILoginClient
     ValueTask SendAuthSuccessAsync(AccountId accountId, CancellationToken cancellationToken);
     ValueTask SendAuthDeniedAsync(LoginDeniedReason reason, CancellationToken cancellationToken);
     ValueTask SendWorldListAsync(WorldListResult worldList, CancellationToken cancellationToken);
+    ValueTask SendChallengeAsync(CancellationToken cancellationToken);
+    ValueTask SendOtpPromptAsync(int maximumTries, int currentTry, CancellationToken cancellationToken);
+    ValueTask SendCertPromptAsync(int maximumTries, int currentTry, CancellationToken cancellationToken);
+    ValueTask SendArsPromptAsync(string sessionCode, TimeSpan timeout, CancellationToken cancellationToken);
     ValueTask SendWorldCookieAsync(GameServer server, CancellationToken cancellationToken);
     ValueTask SendEnterWorldDeniedAsync(byte reason, CancellationToken cancellationToken);
 }

--- a/AAEmu.Login/Core/Network/Connections/LoginClient.cs
+++ b/AAEmu.Login/Core/Network/Connections/LoginClient.cs
@@ -29,8 +29,11 @@ public sealed class LoginClient(ILoginConnection connection) : ILoginClient
     public ValueTask SendWorldListAsync(WorldListResult worldList, CancellationToken cancellationToken) =>
         connection.SendPacketAsync(new ACWorldListPacket(worldList.GameServers, worldList.Characters), cancellationToken);
 
-    public ValueTask SendChallengeAsync(CancellationToken cancellationToken) =>
-        connection.SendPacketAsync(new ACChallengePacket(), cancellationToken);
+    public ValueTask SendChallengeAsync(uint salt, uint[] hc, CancellationToken cancellationToken) =>
+        connection.SendPacketAsync(new ACChallengePacket(salt, hc), cancellationToken);
+
+    public ValueTask SendChallenge2Async(int round, string salt, uint[] hc, CancellationToken cancellationToken) =>
+        connection.SendPacketAsync(new ACChallenge2Packet(round, salt, hc), cancellationToken);
 
     public ValueTask SendOtpPromptAsync(int maximumTries, int currentTry, CancellationToken cancellationToken)
     {

--- a/AAEmu.Login/Core/Network/Connections/LoginClient.cs
+++ b/AAEmu.Login/Core/Network/Connections/LoginClient.cs
@@ -12,7 +12,14 @@ public sealed class LoginClient(ILoginConnection connection) : ILoginClient
 {
     public async ValueTask SendAuthSuccessAsync(AccountId accountId, CancellationToken cancellationToken)
     {
-        await connection.SendPacketAsync(new ACJoinResponsePacket(0, 6), cancellationToken);
+        const byte MaxCharactersPerAccount = 6; // TODO: Make configurable
+        const uint AdditionalCharactersPerServer = 0; // TODO: Make configurable
+        const bool IsPreSelectCharacterPeriod = false; // TODO: Make configurable
+
+        await connection.SendPacketAsync(
+            new ACJoinResponsePacket(JoinResponseReason.Success,
+                new AfsValue(MaxCharactersPerAccount, AdditionalCharactersPerServer, IsPreSelectCharacterPeriod)),
+            cancellationToken);
         await connection.SendPacketAsync(new ACAuthResponsePacket(accountId, 6), cancellationToken);
     }
 
@@ -21,6 +28,28 @@ public sealed class LoginClient(ILoginConnection connection) : ILoginClient
 
     public ValueTask SendWorldListAsync(WorldListResult worldList, CancellationToken cancellationToken) =>
         connection.SendPacketAsync(new ACWorldListPacket(worldList.GameServers, worldList.Characters), cancellationToken);
+
+    public ValueTask SendChallengeAsync(CancellationToken cancellationToken) =>
+        connection.SendPacketAsync(new ACChallengePacket(), cancellationToken);
+
+    public ValueTask SendOtpPromptAsync(int maximumTries, int currentTry, CancellationToken cancellationToken)
+    {
+        var packet = currentTry == 0
+            ? ACEnterOtpPacket.CreateInitialPacket()
+            : ACEnterOtpPacket.CreateFailurePacket(maximumTries, currentTry);
+        return connection.SendPacketAsync(packet, cancellationToken);
+    }
+
+    public ValueTask SendCertPromptAsync(int maximumTries, int currentTry, CancellationToken cancellationToken)
+    {
+        var packet = currentTry == 0
+            ? ACEnterPcCertPacket.CreateInitialPacket()
+            : ACEnterPcCertPacket.CreateFailurePacket(maximumTries, currentTry);
+        return connection.SendPacketAsync(packet, cancellationToken);
+    }
+
+    public ValueTask SendArsPromptAsync(string sessionCode, TimeSpan timeout, CancellationToken cancellationToken) =>
+        connection.SendPacketAsync(new ACShowArsPacket(sessionCode, timeout), cancellationToken);
 
     public ValueTask SendWorldCookieAsync(GameServer server, CancellationToken cancellationToken) =>
         connection.SendPacketAsync(new ACWorldCookiePacket(connection, server), cancellationToken);

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponse2PacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponse2PacketHandler.cs
@@ -1,20 +1,20 @@
-﻿using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.Authentication;
+using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.Packets.C2L;
-using AAEmu.Login.Core.Packets.L2C;
 
 namespace AAEmu.Login.Core.PacketHandlers.C2L;
 
 /// <summary>
-/// Handles the <see cref="CAChallengeResponse2Packet"/> which is sent by the client in response to a challenge made by
-/// the login server.
+/// Handles the <see cref="CAChallengeResponse2Packet"/> (V2 Korea challenge response).
 /// </summary>
-/// <seealso cref="ACChallenge2Packet"/>
+/// <seealso cref="AAEmu.Login.Core.Packets.L2C.ACChallenge2Packet"/>
 public class CAChallengeResponse2PacketHandler : ILoginPacketHandler<CAChallengeResponse2Packet>
 {
     public async Task Execute(CAChallengeResponse2Packet packet, ILoginSession session,
         CancellationToken cancellationToken)
     {
-        // Deny as this auth method is not supported
-        await session.Client.SendAuthDeniedAsync(LoginDeniedReason.LoginUnknown, cancellationToken);
+        await session.ContinueAuthAsync<IChallenge2AuthFlow>(
+            flow => flow.ContinueV2Async(session.Client, packet.Ch, cancellationToken),
+            cancellationToken);
     }
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponse2PacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponse2PacketHandler.cs
@@ -15,6 +15,6 @@ public class CAChallengeResponse2PacketHandler : ILoginPacketHandler<CAChallenge
         CancellationToken cancellationToken)
     {
         // Deny as this auth method is not supported
-        await session.SendPacketAsync(new ACLoginDeniedPacket(LoginDeniedReason.BadResponse), cancellationToken);
+        await session.Client.SendAuthDeniedAsync(LoginDeniedReason.LoginUnknown, cancellationToken);
     }
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponsePacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponsePacketHandler.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using AAEmu.Login.Core.Authentication;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.Packets.C2L;
@@ -6,8 +5,7 @@ using AAEmu.Login.Core.Packets.C2L;
 namespace AAEmu.Login.Core.PacketHandlers.C2L;
 
 /// <summary>
-/// Handles the <see cref="CAChallengeResponsePacket"/> which is sent by the client in response to a challenge made by
-/// the login server.
+/// Handles the <see cref="CAChallengeResponsePacket"/> (V1 Korea challenge response).
 /// </summary>
 /// <seealso cref="AAEmu.Login.Core.Packets.L2C.ACChallengePacket"/>
 public class CAChallengeResponsePacketHandler : ILoginPacketHandler<CAChallengeResponsePacket>
@@ -15,8 +13,8 @@ public class CAChallengeResponsePacketHandler : ILoginPacketHandler<CAChallengeR
     public async Task Execute(CAChallengeResponsePacket packet, ILoginSession session,
         CancellationToken cancellationToken)
     {
-        var password = Encoding.UTF8.GetString(packet.Password!);
         await session.ContinueAuthAsync<IChallengeAuthFlow>(
-            flow => flow.ContinueAsync(session.Client, password, cancellationToken), cancellationToken);
+            flow => flow.ContinueAsync(session.Client, packet.Ch, packet.Pw, cancellationToken),
+            cancellationToken);
     }
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponsePacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAChallengeResponsePacketHandler.cs
@@ -1,6 +1,7 @@
+using System.Text;
+using AAEmu.Login.Core.Authentication;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.Packets.C2L;
-using AAEmu.Login.Core.Packets.L2C;
 
 namespace AAEmu.Login.Core.PacketHandlers.C2L;
 
@@ -8,13 +9,14 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// Handles the <see cref="CAChallengeResponsePacket"/> which is sent by the client in response to a challenge made by
 /// the login server.
 /// </summary>
-/// <seealso cref="ACChallengePacket"/>
+/// <seealso cref="AAEmu.Login.Core.Packets.L2C.ACChallengePacket"/>
 public class CAChallengeResponsePacketHandler : ILoginPacketHandler<CAChallengeResponsePacket>
 {
     public async Task Execute(CAChallengeResponsePacket packet, ILoginSession session,
         CancellationToken cancellationToken)
     {
-        // Deny as this auth method is not supported
-        await session.SendPacketAsync(new ACLoginDeniedPacket(LoginDeniedReason.DuplicateLogin), cancellationToken);
+        var password = Encoding.UTF8.GetString(packet.Password!);
+        await session.ContinueAuthAsync<IChallengeAuthFlow>(
+            flow => flow.ContinueAsync(session.Client, password, cancellationToken), cancellationToken);
     }
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAOtpNumberPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAOtpNumberPacketHandler.cs
@@ -1,3 +1,4 @@
+using AAEmu.Login.Core.Authentication;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.Packets.C2L;
 
@@ -9,6 +10,9 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// </summary>
 public class CAOtpNumberPacketHandler : ILoginPacketHandler<CAOtpNumberPacket>
 {
-    public Task Execute(CAOtpNumberPacket packet, ILoginSession session, CancellationToken cancellationToken) =>
-        Task.CompletedTask;
+    public async Task Execute(CAOtpNumberPacket packet, ILoginSession session, CancellationToken cancellationToken)
+    {
+        await session.ContinueAuthAsync<IOtpAuthFlow>(
+            flow => flow.SubmitOtpAsync(session.Client, packet.OtpNumber ?? "", cancellationToken), cancellationToken);
+    }
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CAPcCertNumberPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CAPcCertNumberPacketHandler.cs
@@ -1,13 +1,18 @@
+using AAEmu.Login.Core.Authentication;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.Packets.C2L;
 
 namespace AAEmu.Login.Core.PacketHandlers.C2L;
 
 /// <summary>
-/// Handles the <see cref="CAPcCertNumberPacket"/> which is sent by the client to provide a certificate number.
+/// Handles the <see cref="CAPcCertNumberPacket"/> which is sent by the client to provide the certificate number
+/// for Korean authentication.
 /// </summary>
 public class CAPcCertNumberPacketHandler : ILoginPacketHandler<CAPcCertNumberPacket>
 {
-    public Task Execute(CAPcCertNumberPacket packet, ILoginSession session,
-        CancellationToken cancellationToken) => Task.CompletedTask;
+    public async Task Execute(CAPcCertNumberPacket packet, ILoginSession session, CancellationToken cancellationToken)
+    {
+        await session.ContinueAuthAsync<ICertAuthFlow>(
+            flow => flow.SubmitCertAsync(session.Client, packet.CertNumber ?? "", cancellationToken), cancellationToken);
+    }
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthPacketHandler.cs
@@ -9,13 +9,14 @@ namespace AAEmu.Login.Core.PacketHandlers.C2L;
 /// <summary>
 /// Handles the <see cref="CARequestAuthPacket"/> which is sent by the client to request authentication.
 /// </summary>
-public class CARequestAuthPacketHandler(ILoginController loginController, IOptions<KoreaAuthOptions> options)
+public class CARequestAuthPacketHandler(ILoginController loginController, IOptions<KoreaAuthOptions> options,
+    IOptions<KoreaChallengeAuthOptions> challengeOptions)
     : ILoginPacketHandler<CARequestAuthPacket>
 {
     public async Task Execute(CARequestAuthPacket packet, ILoginSession session,
         CancellationToken cancellationToken)
     {
-        var flow = new KoreaAuthFlow(loginController, options, packet.Account!, session.Connection.Ip);
+        var flow = new KoreaAuthFlow(loginController, options, challengeOptions, packet.Account!, session.Connection.Ip);
         await session.AuthenticateAsync(flow, cancellationToken);
     }
 }

--- a/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthPacketHandler.cs
+++ b/AAEmu.Login/Core/PacketHandlers/C2L/CARequestAuthPacketHandler.cs
@@ -2,33 +2,20 @@ using AAEmu.Login.Core.Authentication;
 using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.Packets.C2L;
+using Microsoft.Extensions.Options;
 
 namespace AAEmu.Login.Core.PacketHandlers.C2L;
 
 /// <summary>
 /// Handles the <see cref="CARequestAuthPacket"/> which is sent by the client to request authentication.
 /// </summary>
-public class CARequestAuthPacketHandler(ILoginController loginController) : ILoginPacketHandler<CARequestAuthPacket>
+public class CARequestAuthPacketHandler(ILoginController loginController, IOptions<KoreaAuthOptions> options)
+    : ILoginPacketHandler<CARequestAuthPacket>
 {
     public async Task Execute(CARequestAuthPacket packet, ILoginSession session,
         CancellationToken cancellationToken)
     {
-        var flow = new KrLoginFlow(loginController, packet.Account!);
+        var flow = new KoreaAuthFlow(loginController, options, packet.Account!, session.Connection.Ip);
         await session.AuthenticateAsync(flow, cancellationToken);
-    }
-
-    /// <summary>
-    /// Simple auth flow wrapping the Kr method (username-only login).
-    /// Will be replaced by KoreaAuthFlow with multi-step auth support.
-    /// </summary>
-    private class KrLoginFlow(ILoginController loginController, string username) : IAuthenticationFlow
-    {
-        public async Task<AuthFlowResult> StartAsync(ILoginClient client, CancellationToken cancellationToken)
-        {
-            var result = await loginController.Login(username);
-            return result.Success
-                ? new AuthFlowResult.Success(result.AccountId, username)
-                : new AuthFlowResult.Denied(result.DenialReason);
-        }
     }
 }

--- a/AAEmu.Login/Core/Packets/C2L/CAChallengeResponse2Packet.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAChallengeResponse2Packet.cs
@@ -1,20 +1,22 @@
-﻿using AAEmu.Commons.Network;
+using AAEmu.Commons.Network;
 using AAEmu.Login.Core.Network.Login;
 using AAEmu.Login.Core.Packets.L2C;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
 /// <summary>
-/// A packet sent by the client in response to a challenge issued by the server.
+/// Sent by the client in response to a V2 Korea authentication challenge (<see cref="ACChallenge2Packet"/>).
 /// </summary>
-/// <seealso cref="ACChallenge2Packet"/>
 public class CAChallengeResponse2Packet() : LoginPacket(TypeId), ILoginPacket
 {
     public new static ushort TypeId => CLOffsets.CAChallengeResponse2Packet;
-    
+
+    /// <summary>8 AES-encrypted challenge uint32 values.</summary>
+    public uint[] Ch { get; } = new uint[8];
+
     public override void Read(PacketStream stream)
     {
         for (var i = 0; i < 8; i++)
-            stream.ReadUInt32(); // hc
+            Ch[i] = stream.ReadUInt32();
     }
 }

--- a/AAEmu.Login/Core/Packets/C2L/CAChallengeResponsePacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAChallengeResponsePacket.cs
@@ -11,12 +11,13 @@ namespace AAEmu.Login.Core.Packets.C2L;
 public class CAChallengeResponsePacket() : LoginPacket(TypeId), ILoginPacket
 {
     public new static ushort TypeId => CLOffsets.CAChallengeResponsePacket;
-    
+
+    public byte[]? Password { get; private set; }
+
     public override void Read(PacketStream stream)
     {
         for (var i = 0; i < 4; i++)
             stream.ReadUInt32(); // responses
-        var password = stream.ReadBytes(); // TODO or bytes? length 32
-        var bytes = Convert.FromBase64String("jZae727K08KaOmKSgOaGzww/XVqGr/PKEgIMkjrcbJI=");
+        Password = stream.ReadBytes(); // TODO or bytes? length 32
     }
 }

--- a/AAEmu.Login/Core/Packets/C2L/CAChallengeResponsePacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAChallengeResponsePacket.cs
@@ -1,23 +1,29 @@
-﻿using AAEmu.Commons.Network;
+using AAEmu.Commons.Network;
 using AAEmu.Login.Core.Network.Login;
 using AAEmu.Login.Core.Packets.L2C;
 
 namespace AAEmu.Login.Core.Packets.C2L;
 
 /// <summary>
-/// A packet sent by the client in response to a challenge issued by the login server.
+/// Sent by the client in response to a V1 Korea authentication challenge (<see cref="ACChallengePacket"/>).
 /// </summary>
-/// <seealso cref="ACChallengePacket"/>
+/// <remarks>
+/// V1 is not enabled in production — see <see cref="ACChallengePacket"/> for details.
+/// </remarks>
 public class CAChallengeResponsePacket() : LoginPacket(TypeId), ILoginPacket
 {
     public new static ushort TypeId => CLOffsets.CAChallengeResponsePacket;
 
-    public byte[]? Password { get; private set; }
+    /// <summary>4 AES-encrypted challenge uint32 values.</summary>
+    public uint[] Ch { get; } = new uint[4];
+
+    /// <summary>32 raw bytes containing the AES-encrypted plaintext password (V1 only).</summary>
+    public byte[] Pw { get; private set; } = [];
 
     public override void Read(PacketStream stream)
     {
         for (var i = 0; i < 4; i++)
-            stream.ReadUInt32(); // responses
-        Password = stream.ReadBytes(); // TODO or bytes? length 32
+            Ch[i] = stream.ReadUInt32();
+        Pw = stream.ReadBytes(32);
     }
 }

--- a/AAEmu.Login/Core/Packets/C2L/CAOtpNumberPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAOtpNumberPacket.cs
@@ -10,8 +10,10 @@ public class CAOtpNumberPacket() : LoginPacket(TypeId), ILoginPacket
 {
     public new static ushort TypeId => CLOffsets.CAOtpNumberPacket;
 
+    public string? OtpNumber { get; private set; }
+
     public override void Read(PacketStream stream)
     {
-        var num = stream.ReadString(); // TODO but on old client length const 8
+        OtpNumber = stream.ReadString(); // TODO but on old client length const 8
     }
 }

--- a/AAEmu.Login/Core/Packets/C2L/CAPcCertNumberPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAPcCertNumberPacket.cs
@@ -9,9 +9,12 @@ namespace AAEmu.Login.Core.Packets.C2L;
 public class CAPcCertNumberPacket() : LoginPacket(TypeId), ILoginPacket
 {
     public new static ushort TypeId => CLOffsets.CAPcCertNumberPacket;
-    
+
+    public string? CertNumber { get; private set; }
+
     public override void Read(PacketStream stream)
     {
-        var num = stream.ReadString(); // TODO but on old client length const 8
+        // Nexon Simple Authentication Number? https://easyprotect.nexon.com/
+        CertNumber = stream.ReadString(); // TODO but on old client length const 8
     }
 }

--- a/AAEmu.Login/Core/Packets/L2C/ACChallenge2Packet.cs
+++ b/AAEmu.Login/Core/Packets/L2C/ACChallenge2Packet.cs
@@ -1,18 +1,22 @@
-﻿using AAEmu.Commons.Network;
+using System.Text;
+using AAEmu.Commons.Network;
 using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.L2C;
 
 /// <summary>
-/// A packet sent by the login server to the client as part of the authentication challenge process.
+/// Sent by the login server as part of the V2 Korea authentication challenge.
+/// The client uses the provided <paramref name="round"/> and <paramref name="salt"/> to derive
+/// the AES-256 key via sha256_crypt, then computes the challenge response.
 /// </summary>
-public class ACChallenge2Packet() : LoginPacket(LCOffsets.ACChallenge2Packet)
+public class ACChallenge2Packet(int round, string salt, uint[] hc) : LoginPacket(LCOffsets.ACChallenge2Packet)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(5000); // round
-        stream.Write("xnDekI2enmWuAvwL"); // salt; length 16?
-        stream.Write(new byte[32]); // hc
+        stream.Write(round);
+        stream.Write(Encoding.ASCII.GetBytes(salt), appendSize: true);
+        for (var i = 0; i < 8; i++)
+            stream.Write(i < hc.Length ? hc[i] : 0u);
 
         return stream;
     }

--- a/AAEmu.Login/Core/Packets/L2C/ACChallengePacket.cs
+++ b/AAEmu.Login/Core/Packets/L2C/ACChallengePacket.cs
@@ -1,18 +1,23 @@
-﻿using AAEmu.Commons.Network;
+using AAEmu.Commons.Network;
 using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.L2C;
 
 /// <summary>
-/// A packet sent by the login server to the client as part of the authentication challenge process.
+/// Sent by the login server as part of the V1 Korea authentication challenge.
 /// </summary>
-public class ACChallengePacket() : LoginPacket(LCOffsets.ACChallengePacket)
+/// <remarks>
+/// <b>NOTE:</b> V1 challenge authentication is not enabled — SHA-1 without a per-account salt is
+/// approximately 17 million times weaker than PBKDF2@600k. This packet type is preserved for
+/// protocol completeness only. The server never issues this packet in production.
+/// </remarks>
+public class ACChallengePacket(uint salt, uint[] hc) : LoginPacket(LCOffsets.ACChallengePacket)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write((uint)0); // salt
+        stream.Write(salt);
         for (var i = 0; i < 4; i++)
-            stream.Write((uint)0); // hc
+            stream.Write(i < hc.Length ? hc[i] : 0u);
 
         return stream;
     }

--- a/AAEmu.Login/Core/Packets/L2C/ACEnterOtpPacket.cs
+++ b/AAEmu.Login/Core/Packets/L2C/ACEnterOtpPacket.cs
@@ -6,13 +6,33 @@ namespace AAEmu.Login.Core.Packets.L2C;
 /// <summary>
 /// A packet sent by the login server to the client to prompt for OTP (One-Time Password) entry.
 /// </summary>
-public class ACEnterOtpPacket() : LoginPacket(LCOffsets.ACEnterOtpPacket)
+/// <param name="maximumTries">The maximum number of tries at entering the one-time password.</param>
+/// <param name="currentTry">The current try at entering the one-time password.</param>
+/// <remarks>
+/// If <paramref name="currentTry"/> is 0 or 1, no error message is displayed. If greater than one, the client displays
+/// the number of remaining attempts.
+/// Displayed as currentTry-1/maximumTries in the client UI.
+/// </remarks>
+public class ACEnterOtpPacket(int maximumTries = 0, int currentTry = 0) : LoginPacket(LCOffsets.ACEnterOtpPacket)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(0); // mt
-        stream.Write(0); // ct
+        stream.Write(maximumTries); // mt
+        stream.Write(currentTry); // ct
 
         return stream;
     }
+
+    /// <summary>
+    /// Creates an initial OTP entry packet with no error message.
+    /// </summary>
+    public static ACEnterOtpPacket CreateInitialPacket() => new(0, 0);
+
+    /// <summary>
+    /// Creates a failure OTP entry packet with the specified maximum tries and current try.
+    /// </summary>
+    /// <param name="maximumTries">The maximum number of tries at entering the one-time password.</param>
+    /// <param name="currentTry">The current try at entering the one-time password.</param>
+    public static ACEnterOtpPacket CreateFailurePacket(int maximumTries, int currentTry) =>
+        new(maximumTries, currentTry);
 }

--- a/AAEmu.Login/Core/Packets/L2C/ACEnterPcCertPacket.cs
+++ b/AAEmu.Login/Core/Packets/L2C/ACEnterPcCertPacket.cs
@@ -1,4 +1,4 @@
-﻿using AAEmu.Commons.Network;
+using AAEmu.Commons.Network;
 using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.L2C;
@@ -6,13 +6,33 @@ namespace AAEmu.Login.Core.Packets.L2C;
 /// <summary>
 /// A packet sent by the login server to the client to initiate the certificate process.
 /// </summary>
-public class ACEnterPcCertPacket() : LoginPacket(LCOffsets.ACEnterPcCertPacket)
+/// <param name="maximumTries">The maximum number of tries at entering the certificate number.</param>
+/// <param name="currentTry">The current try at entering the certificate number.</param>
+/// <remarks>
+/// If <paramref name="currentTry"/> is 0 or 1, no error message is displayed. If greater than one, the client displays
+/// the number of remaining attempts.
+/// Displayed as currentTry-1/maximumTries in the client UI.
+/// </remarks>
+public class ACEnterPcCertPacket(int maximumTries = 0, int currentTry = 0) : LoginPacket(LCOffsets.ACEnterPcCertPacket)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(0); // mt
-        stream.Write(0); // ct
+        stream.Write(maximumTries); // mt
+        stream.Write(currentTry); // ct
 
         return stream;
     }
+
+    /// <summary>
+    /// Creates an initial certificate entry packet with no error message.
+    /// </summary>
+    public static ACEnterPcCertPacket CreateInitialPacket() => new(0, 0);
+
+    /// <summary>
+    /// Creates a failure certificate entry packet with the specified maximum tries and current try.
+    /// </summary>
+    /// <param name="maximumTries">The maximum number of tries at entering the certificate number.</param>
+    /// <param name="currentTry">The current try at entering the certificate number.</param>
+    public static ACEnterPcCertPacket CreateFailurePacket(int maximumTries, int currentTry) =>
+        new(maximumTries, currentTry);
 }

--- a/AAEmu.Login/Core/Packets/L2C/ACJoinResponsePacket.cs
+++ b/AAEmu.Login/Core/Packets/L2C/ACJoinResponsePacket.cs
@@ -3,6 +3,42 @@ using AAEmu.Login.Core.Network.Login;
 
 namespace AAEmu.Login.Core.Packets.L2C;
 
+public enum JoinResponseReason : ushort
+{
+    Success = 0,
+    ProtocolMismatch = 1,
+    ModeMismatch = 2
+}
+
+/// <summary>
+/// An AFS (Account Feature Settings?) value.
+/// </summary>
+/// <param name="MaxCharactersPerAccount">The maximum number of characters per account.</param>
+/// <param name="AdditionalCharactersPerServer">The additional number of characters per server when using the slot increase item.</param>
+/// <param name="IsPreSelectCharacterPeriod">Whether the server is in character pre-creation mode.</param>
+public readonly record struct AfsValue(
+    byte MaxCharactersPerAccount,
+    uint AdditionalCharactersPerServer,
+    bool IsPreSelectCharacterPeriod)
+{
+    public static AfsValue FromULong(ulong afs)
+    {
+        var maxCharactersPerAccount = (byte)(afs & 0xFF);
+        var isPreSelectCharacterPeriod = (afs & 0x100) != 0;
+        var additionalSlotsPerServer = (uint)(afs >> 32);
+
+        return new AfsValue(maxCharactersPerAccount, additionalSlotsPerServer, isPreSelectCharacterPeriod);
+    }
+
+    public ulong ToULong()
+    {
+        var afs = ((ulong)AdditionalCharactersPerServer << 32)
+                  | (IsPreSelectCharacterPeriod ? 1UL << 8 : 0UL)
+                  | MaxCharactersPerAccount;
+        return afs;
+    }
+}
+
 /// <summary>
 /// A packet sent by the login server to the client in response to a successful authentication request.
 /// </summary>
@@ -10,6 +46,10 @@ namespace AAEmu.Login.Core.Packets.L2C;
 /// <param name="afs"></param>
 public class ACJoinResponsePacket(ushort reason, ulong afs) : LoginPacket(LCOffsets.ACJoinResponsePacket)
 {
+    public ACJoinResponsePacket(JoinResponseReason reason, AfsValue afs) : this((ushort)reason, afs.ToULong())
+    {
+    }
+
     public override PacketStream Write(PacketStream stream)
     {
         stream.Write(reason);

--- a/AAEmu.Login/Core/Packets/L2C/ACShowArsPacket.cs
+++ b/AAEmu.Login/Core/Packets/L2C/ACShowArsPacket.cs
@@ -4,14 +4,21 @@ using AAEmu.Login.Core.Network.Login;
 namespace AAEmu.Login.Core.Packets.L2C;
 
 /// <summary>
-/// A packet sent by the login server to the client to show ARS information.
+/// A packet sent by the login server to the client to show ARS (Automatic Response System/자동응답시스템) information.
 /// </summary>
-public class ACShowArsPacket() : LoginPacket(LCOffsets.ACShowArsPacket)
+/// <param name="number">The ARS number displayed to the user in the game client.</param>
+/// <param name="timeout">The timeout displayed next to the ARS number as remaining time.</param>
+/// <remarks>
+/// ARS is automated phone verification. The system calls your registered phone number, and you enter a code displayed
+/// on screen. Since Korean phone numbers are tied to real identity, this serves as identity verification.
+/// </remarks>
+public class ACShowArsPacket(string number, TimeSpan timeout) : LoginPacket(LCOffsets.ACShowArsPacket)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(""); // num
-        stream.Write((uint)0); // timeout
+        // "Enter the number below when you get a call"
+        stream.Write(number); // num - the text displayed to the user
+        stream.Write((uint)timeout.TotalMilliseconds); // timeout - time in milliseconds displayed next to the text as remaining time
 
         return stream;
     }

--- a/AAEmu.Login/Core/Services/IPasswordService.cs
+++ b/AAEmu.Login/Core/Services/IPasswordService.cs
@@ -55,4 +55,37 @@ public interface IPasswordService
     /// <param name="storedHash">The hash stored in the database.</param>
     /// <returns><c>true</c> if the hash is in legacy format; otherwise, <c>false</c>.</returns>
     bool IsLegacyFormat(string storedHash);
+
+    /// <summary>
+    /// Computes a sha256_crypt (<c>$5$</c>) hash for Korea challenge-response authentication (V2 only).
+    /// Writes the 32-byte raw hash (AES-256 key) into <paramref name="rawHashDestination"/>
+    /// and returns the full <c>$5$rounds=N$salt$…</c> string for DB storage.
+    /// </summary>
+    /// <param name="plaintext">The plaintext password.</param>
+    /// <param name="rawHashDestination">
+    /// Must be exactly 32 bytes. Receives the raw hash that is used as the AES-256 key
+    /// in <c>KoreanChallengeVerifier.VerifyV2</c>.
+    /// </param>
+    /// <param name="salt">
+    /// The salt to use, or <c>null</c> to generate a new random 16-character salt.
+    /// </param>
+    /// <param name="rounds">Number of stretching rounds.</param>
+    /// <returns>The full <c>$5$rounds=N$salt$…</c> encoded string for DB storage.</returns>
+    string ComputeKoreaChallengeHash(string plaintext, Span<byte> rawHashDestination,
+        string? salt = null, int rounds = 5000);
+
+    /// <summary>
+    /// Convenience overload for callers that only need the encoded string for DB storage
+    /// and have no use for the raw hash bytes.
+    /// </summary>
+    /// <inheritdoc cref="ComputeKoreaChallengeHash(string, Span{byte}, string?, int)"/>
+    string ComputeKoreaChallengeHash(string plaintext, string? salt = null, int rounds = 5000);
+
+    /// <summary>
+    /// Verifies a plaintext password against a stored <c>korea_challenge_hash</c> (constant-time).
+    /// Useful when plaintext is available without performing a full challenge-response exchange.
+    /// </summary>
+    /// <param name="stored">The <c>$5$…</c> string from the DB.</param>
+    /// <param name="plaintext">The plaintext password to verify.</param>
+    bool VerifyKoreaChallengeHash(string stored, string plaintext);
 }

--- a/AAEmu.Login/Core/Services/KoreanChallengeVerifier.cs
+++ b/AAEmu.Login/Core/Services/KoreanChallengeVerifier.cs
@@ -1,0 +1,117 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+
+namespace AAEmu.Login.Core.Services;
+
+/// <summary>
+/// Pure-static AES-based challenge-response verifier for the Korea login protocol.
+/// </summary>
+/// <remarks>
+/// The client performs the following computation (from binary analysis of x2game-dev.dll,
+/// function sub_393C51F0 / AES CBC wrapper sub_395C4F20):
+/// <code>
+/// K              = sha256_crypt(password, "$5$rounds=N$salt")  // 32-byte raw hash = AES-256 key
+/// t              = AES_CBC_decrypt(K, IV=zeros, hc_bytes)      // mode=0 in sub_395C4F20
+/// t_uint32[i]   += 1                                           // increment each DWORD
+/// ch_response[:] = AES_CBC_encrypt(K, IV=zeros, t)             // mode=1 in sub_395C4F20
+/// </code>
+/// The server recomputes <c>ch_response</c> using the stored key material and the
+/// received <c>hc</c> values, then compares with the received <c>ch</c>.
+/// </remarks>
+public static class KoreanChallengeVerifier
+{
+    /// <summary>
+    /// V1 Korea challenge verifier (AES-192, SHA-1-based key).
+    /// </summary>
+    /// <remarks>
+    /// <b>NOT ENABLED IN PRODUCTION.</b> SHA-1 without a per-account salt is approximately
+    /// 17 million times weaker than PBKDF2@600k for offline attacks. This method exists for
+    /// protocol completeness only. The server never issues <c>ACChallengePacket</c> (V1).
+    /// </remarks>
+    [Obsolete("V1 Korea challenge is disabled due to SHA-1 security weaknesses. Use V2 only.", true)]
+    internal static bool VerifyV1(ReadOnlySpan<byte> sha1Hash, uint challengeSalt,
+        ReadOnlySpan<uint> hc, ReadOnlySpan<uint> responseCh)
+    {
+        if (sha1Hash.Length != 20 || hc.Length != 4 || responseCh.Length != 4)
+            return false;
+
+        // K = SHA1(password)[0..19] || challengeSalt_bytes[0..3] → 24 bytes = AES-192
+        using var key = MemoryPool<byte>.Shared.Rent(24);
+        var keySpan = key.Memory.Span;
+
+        sha1Hash.CopyTo(keySpan[..20]);
+        BinaryPrimitives.WriteUInt32LittleEndian(keySpan.Slice(20, 4), challengeSalt);
+        return VerifyCore(keySpan[..24], hc, responseCh);
+    }
+
+    /// <summary>
+    /// Verifies a V2 Korea challenge response (AES-256, sha256_crypt-based key).
+    /// </summary>
+    /// <param name="challengeKey">32-byte raw sha256_crypt hash used as the AES-256 key.</param>
+    /// <param name="hc">8 server-generated challenge values sent in <c>ACChallenge2Packet</c>.</param>
+    /// <param name="responseCh">8 client-computed challenge response values from <c>CAChallengeResponse2Packet</c>.</param>
+    /// <returns><c>true</c> if the response is cryptographically correct.</returns>
+    public static bool VerifyV2(ReadOnlySpan<byte> challengeKey,
+        ReadOnlySpan<uint> hc, ReadOnlySpan<uint> responseCh)
+    {
+        if (challengeKey.Length != 32 || hc.Length != 8 || responseCh.Length != 8)
+            return false;
+
+        return VerifyCore(challengeKey, hc, responseCh);
+    }
+
+    private static bool VerifyCore(ReadOnlySpan<byte> key,
+        ReadOnlySpan<uint> hc, ReadOnlySpan<uint> expectedCh)
+    {
+        var blockCount = hc.Length; // 4 for V1 (16 bytes), 8 for V2 (32 bytes)
+        var byteCount = blockCount * 4;
+
+        using var tBuf = MemoryPool<byte>.Shared.Rent(byteCount);
+        var hcBytesBuf = MemoryPool<byte>.Shared.Rent(byteCount);
+        var expectedBuf = MemoryPool<byte>.Shared.Rent(byteCount);
+
+        var t = tBuf.Memory.Span[..byteCount];
+        var hcBytes = hcBytesBuf.Memory.Span[..byteCount];
+        var expectedChBytes = expectedBuf.Memory.Span[..byteCount];
+
+        // Step 1: marshal hc uints → bytes (little-endian)
+        for (var i = 0; i < blockCount; i++)
+            BinaryPrimitives.WriteUInt32LittleEndian(hcBytes.Slice(i * 4, 4), hc[i]);
+
+        // Step 2: t = AES_CBC_decrypt(K, IV=zeros, hc_bytes)
+        ApplyCbcDecryptZeroIv(key, hcBytes, t);
+
+        // Step 3: each uint32 in t += 1
+        for (var i = 0; i < blockCount; i++)
+        {
+            var val = BinaryPrimitives.ReadUInt32LittleEndian(t.Slice(i * 4, 4));
+            BinaryPrimitives.WriteUInt32LittleEndian(t.Slice(i * 4, 4), unchecked(val + 1));
+        }
+
+        // Step 4: ch_computed = AES_CBC_encrypt(K, IV=zeros, t) → reuse hcBytes buffer (hc input no longer needed)
+        ApplyCbcEncryptZeroIv(key, t, hcBytes);
+
+        // Step 5: marshal expected ch uints → bytes and compare (constant-time)
+        for (var i = 0; i < blockCount; i++)
+            BinaryPrimitives.WriteUInt32LittleEndian(expectedChBytes.Slice(i * 4, 4), expectedCh[i]);
+
+        return CryptographicOperations.FixedTimeEquals(hcBytes, expectedChBytes);
+    }
+
+    private static void ApplyCbcDecryptZeroIv(ReadOnlySpan<byte> key, ReadOnlySpan<byte> input, Span<byte> output)
+    {
+        Span<byte> iv = stackalloc byte[16];
+        using var aes = Aes.Create();
+        aes.Key = key.ToArray();
+        aes.DecryptCbc(input, iv, output, PaddingMode.None);
+    }
+
+    private static void ApplyCbcEncryptZeroIv(ReadOnlySpan<byte> key, ReadOnlySpan<byte> input, Span<byte> output)
+    {
+        Span<byte> iv = stackalloc byte[16]; // zero-initialised
+        using var aes = Aes.Create();
+        aes.SetKey(key);
+        aes.EncryptCbc(input, iv, output, PaddingMode.None);
+    }
+}

--- a/AAEmu.Login/Core/Services/PasswordService.cs
+++ b/AAEmu.Login/Core/Services/PasswordService.cs
@@ -53,6 +53,23 @@ public class PasswordService(IPasswordHasher<string> passwordHasher) : IPassword
                && bytesWritten == LegacyHashByteLength;
     }
 
+    public string ComputeKoreaChallengeHash(string plaintext, Span<byte> rawHashDestination,
+        string? salt = null, int rounds = 5000)
+    {
+        var saltStr = salt ?? Sha256Crypt.GenerateSalt();
+        Sha256Crypt.ComputeRaw(plaintext, saltStr, rounds, rawHashDestination);
+        return Sha256Crypt.FormatEncoded(rawHashDestination, saltStr, rounds);
+    }
+
+    public string ComputeKoreaChallengeHash(string plaintext, string? salt = null, int rounds = 5000)
+    {
+        Span<byte> rawKey = stackalloc byte[32];
+        return ComputeKoreaChallengeHash(plaintext, rawKey, salt, rounds);
+    }
+
+    public bool VerifyKoreaChallengeHash(string stored, string plaintext) =>
+        Sha256Crypt.Verify(plaintext, stored);
+
     private static bool VerifyLegacyPasswordFromPlaintext(string storedHash, string plaintext)
     {
         Span<byte> storedBytes = stackalloc byte[LegacyHashByteLength];

--- a/AAEmu.Login/Core/Services/Sha256Crypt.cs
+++ b/AAEmu.Login/Core/Services/Sha256Crypt.cs
@@ -1,0 +1,283 @@
+using System.Buffers;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace AAEmu.Login.Core.Services;
+
+/// <summary>
+/// Implements the Unix SHA-256 crypt (<c>$5$</c>) password hashing algorithm per Drepper's specification.
+/// </summary>
+/// <remarks>
+/// <para><b>Security note:</b> sha256_crypt at moderate rounds is weaker than PBKDF2@600k for offline attacks.
+/// At 100,000 rounds it is approximately 3× weaker than PBKDF2@310k.
+/// This hash is used internally for Korea challenge-response authentication only — the server never transmits
+/// the hash to clients; only the salt and rounds are sent. The password is therefore not recoverable from
+/// network captures, but offline dictionary attacks against a stolen DB are ~3× faster than against PBKDF2.</para>
+/// <para>Each account has a unique random salt, preventing rainbow table attacks.</para>
+/// </remarks>
+/// <seealso href="https://akkadia.org/drepper/SHA-crypt.txt"/>
+public static class Sha256Crypt
+{
+    private const string Alphabet = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+    // Byte-reordering groups for SHA-256: (i2, i1, i0, charCount)
+    // Where i2 is the high byte, i1 is the mid byte, i0 is the low byte.
+    // i2 == -1 means the high byte is zero (for the 2-byte final group).
+    private static readonly (int i2, int i1, int i0, int n)[] ByteGroups =
+    [
+        (0, 10, 20, 4), (21, 1, 11, 4), (12, 22, 2, 4), (3, 13, 23, 4),
+        (24, 4, 14, 4), (15, 25, 5, 4), (6, 16, 26, 4), (27, 7, 17, 4),
+        (18, 28, 8, 4), (9, 19, 29, 4), (-1, 31, 30, 3),
+    ];
+
+    /// <summary>
+    /// Computes the raw 32-byte SHA-256 crypt hash into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="password">The plaintext password.</param>
+    /// <param name="salt">The salt string (up to 16 chars).</param>
+    /// <param name="rounds">Number of stretching rounds (1000–999,999,999).</param>
+    /// <param name="destination">Must be exactly 32 bytes.</param>
+    public static void ComputeRaw(string password, string salt, int rounds, Span<byte> destination)
+    {
+        ArgumentOutOfRangeException.ThrowIfNotEqual(destination.Length, 32);
+
+        var pwBytes = Encoding.UTF8.GetBytes(password);
+        var saltBytes = Encoding.UTF8.GetBytes(salt);
+
+        // Step 1: digest B = SHA256(password + salt + password)
+        Span<byte> sumB = stackalloc byte[32];
+        {
+            using var sha = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+            sha.AppendData(pwBytes);
+            sha.AppendData(saltBytes);
+            sha.AppendData(pwBytes);
+            sha.GetHashAndReset(sumB);
+        }
+
+        // Step 2: digest A = SHA256(password + salt + (sumB repeated to fill pwLen) + bit-alternation)
+        Span<byte> sumA = stackalloc byte[32];
+        {
+            using var sha = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+            sha.AppendData(pwBytes);
+            sha.AppendData(saltBytes);
+
+            // Add sumB in 32-byte chunks to fill password.Length bytes
+            var rem = pwBytes.Length;
+            while (rem > 0)
+            {
+                sha.AppendData(sumB[..Math.Min(rem, 32)]);
+                rem -= 32;
+            }
+
+            // Bit-alternation: process bits of password length from LSB
+            var bits = pwBytes.Length;
+            while (bits > 0)
+            {
+                if ((bits & 1) != 0)
+                    sha.AppendData(sumB);
+                else
+                    sha.AppendData(pwBytes);
+                bits >>= 1;
+            }
+
+            sha.GetHashAndReset(sumA);
+        }
+
+        // Rent buffers for P-string and S-string
+        //var pBuf = ArrayPool<byte>.Shared.Rent(Math.Max(pwBytes.Length, 1));
+        using var pBuf = MemoryPool<byte>.Shared.Rent(Math.Max(pwBytes.Length, 1));
+        using var sBuf = MemoryPool<byte>.Shared.Rent(Math.Max(saltBytes.Length, 1));
+
+        var pString = pBuf.Memory.Span[..pwBytes.Length];
+        var sString = sBuf.Memory.Span[..saltBytes.Length];
+
+        // Step 3: P-string = SHA256(password × pwLen), expanded to pwLen bytes
+        {
+            Span<byte> sumP = stackalloc byte[32];
+            using var sha = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+            // Add the entire password once for each byte of the password
+            for (var i = 0; i < pwBytes.Length; i++)
+                sha.AppendData(pwBytes);
+            sha.GetHashAndReset(sumP);
+            for (var i = 0; i < pwBytes.Length; i++)
+                pString[i] = sumP[i % 32];
+        }
+
+        // Step 4: S-string = SHA256(salt × (16 + sumA[0])), expanded to saltLen bytes
+        {
+            Span<byte> sumS = stackalloc byte[32];
+            using var sha = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+            var saltReps = 16 + sumA[0];
+            for (var i = 0; i < saltReps; i++)
+                sha.AppendData(saltBytes);
+            sha.GetHashAndReset(sumS);
+            for (var i = 0; i < saltBytes.Length; i++)
+                sString[i] = sumS[i % 32];
+        }
+
+        // Step 5: Stretch for `rounds` iterations
+        for (var c = 0; c < rounds; c++)
+        {
+            using var sha = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+            if ((c & 1) != 0)
+                sha.AppendData(pString);
+            else
+                sha.AppendData(sumA);
+
+            if (c % 3 != 0)
+                sha.AppendData(sString);
+
+            if (c % 7 != 0)
+                sha.AppendData(pString);
+
+            if ((c & 1) != 0)
+                sha.AppendData(sumA);
+            else
+                sha.AppendData(pString);
+
+            sha.GetHashAndReset(sumA);
+        }
+
+        sumA.CopyTo(destination);
+    }
+
+    /// <summary>
+    /// Formats a pre-computed 32-byte raw hash into the <c>$5$rounds=N$salt$...</c> string.
+    /// Does not recompute the hash — use when you already have the raw bytes.
+    /// </summary>
+    public static string FormatEncoded(ReadOnlySpan<byte> rawHash, string salt, int rounds)
+    {
+        ArgumentOutOfRangeException.ThrowIfNotEqual(rawHash.Length, 32);
+
+        var sb = new StringBuilder(128);
+        sb.Append("$5$rounds=");
+        sb.Append(rounds);
+        sb.Append('$');
+        sb.Append(salt);
+        sb.Append('$');
+
+        foreach (var (i2, i1, i0, n) in ByteGroups)
+        {
+            var b2 = i2 >= 0 ? rawHash[i2] : (byte)0;
+            var b1 = rawHash[i1];
+            var b0 = rawHash[i0];
+            var w = (b2 << 16) | (b1 << 8) | b0;
+            for (var k = 0; k < n; k++)
+            {
+                sb.Append(Alphabet[w & 63]);
+                w >>= 6;
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Generates a 16-character random salt using cryptographically secure random bytes.
+    /// </summary>
+    public static string GenerateSalt()
+    {
+        const string SaltChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789./";
+        Span<char> salt = stackalloc char[16];
+        Span<byte> rng = stackalloc byte[16];
+        RandomNumberGenerator.Fill(rng);
+        for (var i = 0; i < 16; i++)
+            salt[i] = SaltChars[rng[i] % SaltChars.Length];
+        return new string(salt);
+    }
+
+    /// <summary>
+    /// Parses only the rounds value from a stored <c>$5$rounds=N$salt$hash</c> string.
+    /// Cheaper than <see cref="Parse"/> when only the round count is needed (e.g. rehash checks).
+    /// </summary>
+    public static int ParseRounds(string stored)
+    {
+        if (!stored.StartsWith("$5$"))
+            throw new FormatException("Not a SHA-256 crypt hash ($5$ prefix missing).");
+
+        var rest = stored.AsSpan(3);
+        if (!rest.StartsWith("rounds="))
+            return 5000;
+
+        var sepIdx = rest.IndexOf('$');
+        if (sepIdx < 0)
+            throw new FormatException("Malformed $5$ hash: missing '$' after rounds.");
+
+        return int.Parse(rest[7..sepIdx]);
+    }
+
+    /// <summary>
+    /// Parses a stored <c>$5$rounds=N$salt$hash</c> string and writes the 32-byte raw hash
+    /// into <paramref name="rawHashDestination"/>.
+    /// </summary>
+    /// <param name="stored">The full <c>$5$…</c> string from the database.</param>
+    /// <param name="rawHashDestination">Must be exactly 32 bytes. Receives the decoded raw hash.</param>
+    /// <returns>A tuple of (rounds, salt).</returns>
+    public static (int rounds, string salt) Parse(string stored, Span<byte> rawHashDestination)
+    {
+        ArgumentOutOfRangeException.ThrowIfNotEqual(rawHashDestination.Length, 32);
+
+        if (!stored.StartsWith("$5$"))
+            throw new FormatException("Not a SHA-256 crypt hash ($5$ prefix missing).");
+
+        var rest = stored.AsSpan(3);
+        var rounds = 5000;
+
+        if (rest.StartsWith("rounds="))
+        {
+            var sepIdx = rest.IndexOf('$');
+            if (sepIdx < 0)
+                throw new FormatException("Malformed $5$ hash: missing '$' after rounds.");
+            rounds = int.Parse(rest[7..sepIdx]);
+            rest = rest[(sepIdx + 1)..];
+        }
+
+        var saltEnd = rest.IndexOf('$');
+        if (saltEnd < 0)
+            throw new FormatException("Malformed $5$ hash: missing '$' after salt.");
+
+        var salt = new string(rest[..saltEnd]);
+        Decode(rest[(saltEnd + 1)..], rawHashDestination);
+        return (rounds, salt);
+    }
+
+    /// <summary>
+    /// Verifies a plaintext password against a stored <c>$5$</c> hash string (constant-time).
+    /// Uses <c>stackalloc byte[32]</c> internally — no heap allocation.
+    /// </summary>
+    public static bool Verify(string plaintext, string stored)
+    {
+        Span<byte> expectedRaw = stackalloc byte[32];
+        var (rounds, salt) = Parse(stored, expectedRaw);
+        Span<byte> computedRaw = stackalloc byte[32];
+        ComputeRaw(plaintext, salt, rounds, computedRaw);
+        return CryptographicOperations.FixedTimeEquals(computedRaw, expectedRaw);
+    }
+
+    /// <summary>
+    /// Decodes the 43-character base64 portion of a <c>$5$</c> hash into <paramref name="destination"/>.
+    /// </summary>
+    private static void Decode(ReadOnlySpan<char> hash, Span<byte> destination)
+    {
+        if (hash.Length != 43)
+            throw new FormatException($"Expected 43-char hash, got {hash.Length}.");
+
+        var charIdx = 0;
+
+        foreach (var (i2, i1, i0, n) in ByteGroups)
+        {
+            var w = 0;
+            for (var k = 0; k < n; k++)
+            {
+                var c = hash[charIdx++];
+                var v = Alphabet.IndexOf(c);
+                if (v < 0) throw new FormatException($"Invalid character '{c}' in SHA-256 crypt hash.");
+                w |= v << (6 * k);
+            }
+
+            if (i2 >= 0) destination[i2] = (byte)(w >> 16);
+            destination[i1] = (byte)((w >> 8) & 0xFF);
+            destination[i0] = (byte)(w & 0xFF);
+        }
+    }
+}

--- a/AAEmu.Login/Models/KoreaAuthInfo.cs
+++ b/AAEmu.Login/Models/KoreaAuthInfo.cs
@@ -1,0 +1,25 @@
+namespace AAEmu.Login.Models;
+
+/// <summary>
+/// Korea challenge-response authentication material for a specific account.
+/// Returned by <see cref="AAEmu.Login.Core.Controllers.ILoginController.GetKoreaAuthInfoAsync"/>.
+/// </summary>
+/// <param name="AccountId">The account's numeric identifier.</param>
+/// <param name="ChallengeKeyHash">
+/// The 32-byte raw sha256_crypt hash used as the AES-256 key during V2 verification.
+/// Do not transmit or log this value.
+/// </param>
+/// <param name="ChallengeSalt">
+/// The salt extracted from the stored <c>$5$</c> hash string.
+/// Sent to the client in <c>ACChallenge2Packet</c> so the client can derive the same key.
+/// </param>
+/// <param name="ChallengeRounds">
+/// The iteration count extracted from the stored <c>$5$</c> hash string.
+/// Sent to the client in <c>ACChallenge2Packet</c> so the client knows how many rounds to apply.
+/// </param>
+public record KoreaAuthInfo(
+    AccountId AccountId,
+    ReadOnlyMemory<byte> ChallengeKeyHash,
+    string ChallengeSalt,
+    int ChallengeRounds
+);

--- a/AAEmu.Login/Program.cs
+++ b/AAEmu.Login/Program.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Reflection;
 using AAEmu.Commons.IO;
+using AAEmu.Login.Core.Authentication;
 using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Internal;
 using AAEmu.Login.Core.Network.Login;
@@ -108,6 +109,10 @@ public static class Program
             .ValidateDataAnnotations();
         builder.Services.AddOptionsWithValidateOnStart<PublicNetworkConfig>()
             .BindConfiguration(PublicNetworkConfig.ConfigurationSectionName)
+            .ValidateDataAnnotations();
+
+        builder.Services.AddOptionsWithValidateOnStart<KoreaChallengeAuthOptions>()
+            .BindConfiguration(KoreaChallengeAuthOptions.ConfigurationSectionName)
             .ValidateDataAnnotations();
 
         builder.Services.AddSingleton<IMySqlConnectionFactory, MySqlConnectionFactory>();

--- a/AAEmu.UnitTests/Login/Core/Authentication/KoreaAuthFlowTests.cs
+++ b/AAEmu.UnitTests/Login/Core/Authentication/KoreaAuthFlowTests.cs
@@ -1,6 +1,8 @@
 #nullable enable
 
+using System.Buffers.Binary;
 using System.Net;
+using System.Reflection;
 using AAEmu.Login.Core.Authentication;
 using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Connections;
@@ -16,18 +18,72 @@ public class KoreaAuthFlowTests
     private readonly Mock<ILoginController> _loginController = Mock.Of<ILoginController>();
     private readonly Mock<ILoginClient> _client = Mock.Of<ILoginClient>();
 
-    private KoreaAuthFlow CreateFlow(string username, KoreaAuthOptions? options = null)
+    private KoreaAuthFlow CreateFlow(string username, KoreaAuthOptions? options = null,
+        KoreaChallengeAuthOptions? challengeOptions = null)
     {
         var opts = Options.Create(options ?? new KoreaAuthOptions());
-        return new KoreaAuthFlow(_loginController.Object, opts, username, IPAddress.Loopback);
+        var challengeOpts = Options.Create(challengeOptions ?? new KoreaChallengeAuthOptions { Enabled = true });
+        return new KoreaAuthFlow(_loginController.Object, opts, challengeOpts, username, IPAddress.Loopback);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="KoreaAuthInfo"/> with a real sha256_crypt hash for the given password.
+    /// Uses fast (1000) rounds to keep unit tests speedy.
+    /// </summary>
+    private static KoreaAuthInfo MakeKoreaAuthInfo(AccountId accountId, string password,
+        string salt = "unitsalttestABCD", int rounds = 1000)
+    {
+        var rawHash = new byte[32];
+        Sha256Crypt.ComputeRaw(password, salt, rounds, rawHash);
+        return new KoreaAuthInfo(accountId, rawHash.AsMemory(), salt, rounds);
+    }
+
+    /// <summary>
+    /// Computes the correct V2 challenge response for <paramref name="hc"/> given the raw AES-256
+    /// <paramref name="key"/>. Mirrors the client's computation for testing round-trips.
+    /// </summary>
+    private static uint[] ComputeExpectedV2Response(ReadOnlySpan<byte> key, uint[] hc)
+    {
+        using var aes = System.Security.Cryptography.Aes.Create();
+        aes.Key = key.ToArray();
+        Span<byte> iv = stackalloc byte[16]; // zero-initialised
+
+        // Step 1: marshal hc uints → bytes
+        var hcBytes = new byte[32];
+        for (var i = 0; i < 8; i++)
+            BinaryPrimitives.WriteUInt32LittleEndian(hcBytes.AsSpan(i * 4, 4), hc[i]);
+
+        // Step 2: t = AES_CBC_decrypt(key, IV=zeros, hc_bytes)
+        var t = aes.DecryptCbc(hcBytes, iv, System.Security.Cryptography.PaddingMode.None);
+
+        // Step 3: each uint32 += 1
+        for (var i = 0; i < 8; i++)
+        {
+            var val = BinaryPrimitives.ReadUInt32LittleEndian(t.AsSpan(i * 4, 4));
+            BinaryPrimitives.WriteUInt32LittleEndian(t.AsSpan(i * 4, 4), unchecked(val + 1));
+        }
+
+        // Step 4: ch = AES_CBC_encrypt(key, IV=zeros, t)
+        var encrypted = aes.EncryptCbc(t, iv, System.Security.Cryptography.PaddingMode.None);
+
+        var result = new uint[8];
+        for (var i = 0; i < 8; i++)
+            result[i] = BinaryPrimitives.ReadUInt32LittleEndian(encrypted.AsSpan(i * 4, 4));
+        return result;
     }
 
     #region StartAsync Tests
 
     [Test]
-    public async Task StartAsync_SendsChallengePacket_ReturnsPending()
+    public async Task StartAsync_WithValidKoreaHash_SendsChallenge2AndReturnsPending()
     {
         // Arrange
+        var accountId = new AccountId(42);
+        var info = MakeKoreaAuthInfo(accountId, "password");
+        _loginController
+            .GetKoreaAuthInfoAsync(Any<string>(), Any<CancellationToken>())
+            .Returns(info);
+
         var flow = CreateFlow("testuser");
 
         // Act
@@ -35,84 +91,175 @@ public class KoreaAuthFlowTests
 
         // Assert
         await Assert.That(result).IsTypeOf<AuthFlowResult.Pending>();
-        _client.SendChallengeAsync(Any<CancellationToken>()).WasCalled(Times.Once);
+        _client.SendChallenge2Async(
+            Any<int>(), Any<string>(), Any<uint[]>(), Any<CancellationToken>())
+            .WasCalled(Times.Once);
+    }
+
+    [Test]
+    public async Task StartAsync_AccountNotFound_ReturnsDenied()
+    {
+        // Arrange
+        _loginController
+            .GetKoreaAuthInfoAsync(Any<string>(), Any<CancellationToken>())
+            .Returns((KoreaAuthInfo?)null);
+
+        var flow = CreateFlow("unknownuser");
+
+        // Act
+        var result = await flow.StartAsync(_client.Object, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsTypeOf<AuthFlowResult.Denied>();
+        var denied = (AuthFlowResult.Denied)result;
+        await Assert.That(denied.Reason).IsEqualTo(LoginDeniedReason.BadAccount);
+    }
+
+    [Test]
+    public async Task StartAsync_NoKoreaChallengeHash_ReturnsDenied()
+    {
+        // Arrange — null return = account exists but no korea_challenge_hash stored
+        _loginController
+            .GetKoreaAuthInfoAsync(Any<string>(), Any<CancellationToken>())
+            .Returns((KoreaAuthInfo?)null);
+
+        var flow = CreateFlow("nokoreauser");
+
+        // Act
+        var result = await flow.StartAsync(_client.Object, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsTypeOf<AuthFlowResult.Denied>();
     }
 
     #endregion
 
-    #region ContinueAsync (Password) Tests
+    #region Continue2Async (V2 Challenge) Tests
 
     [Test]
-    public async Task ContinueAsync_SuccessfulLogin_ReturnsSuccess()
+    public async Task Continue2Async_CorrectResponse_ReturnsSuccess()
     {
         // Arrange
-        const string Username = "testuser";
-        const string password = "password123";
-        var accountId = new AccountId(456);
+        const string Password = "correctpassword";
+        var accountId = new AccountId(100);
+        var info = MakeKoreaAuthInfo(accountId, Password);
 
         _loginController
-            .Login(Any<string>(), Any<Password>(), Any<IPAddress>(), Any<CancellationToken>())
-            .Returns(new LoginResult(true, accountId, 0));
+            .GetKoreaAuthInfoAsync(Any<string>(), Any<CancellationToken>())
+            .Returns(info);
+        _loginController
+            .CheckBanStatusAsync(Any<AccountId>(), Any<CancellationToken>())
+            .Returns((false, default));
 
-        var flow = CreateFlow(Username);
+        uint[]? capturedHc = null;
+        _client.SendChallenge2Async(Any<int>(), Any<string>(), Any<uint[]>(), Any<CancellationToken>())
+            .Callback((_, _, hc, _) => capturedHc = hc);
+
+        var flow = CreateFlow("testuser");
         await flow.StartAsync(_client.Object, CancellationToken.None);
 
+        var correctCh = ComputeExpectedV2Response(info.ChallengeKeyHash.Span, capturedHc!);
+
         // Act
-        var result = await flow.ContinueAsync(_client.Object, password, CancellationToken.None);
+        var result = await flow.ContinueV2Async(_client.Object, correctCh, CancellationToken.None);
 
         // Assert
         await Assert.That(result).IsTypeOf<AuthFlowResult.Success>();
         var success = (AuthFlowResult.Success)result;
         await Assert.That(success.AccountId).IsEqualTo(accountId);
-        await Assert.That(success.Username).IsEqualTo(Username);
+        await Assert.That(success.Username).IsEqualTo("testuser");
     }
 
     [Test]
-    public async Task ContinueAsync_UserNotFound_ReturnsDenied()
+    public async Task Continue2Async_WrongResponse_ReturnsDenied()
     {
         // Arrange
-        const string Username = "unknownuser";
-        const string password = "password123";
-        const LoginDeniedReason DenialReason = LoginDeniedReason.BadAccount;
+        var accountId = new AccountId(100);
+        var info = MakeKoreaAuthInfo(accountId, "password");
 
         _loginController
-            .Login(Any<string>(), Any<Password>(), Any<IPAddress>(), Any<CancellationToken>())
-            .Returns(new LoginResult(false, default, DenialReason));
+            .GetKoreaAuthInfoAsync(Any<string>(), Any<CancellationToken>())
+            .Returns(info);
 
-        var flow = CreateFlow(Username);
+        var flow = CreateFlow("testuser");
         await flow.StartAsync(_client.Object, CancellationToken.None);
 
+        var wrongCh = new uint[8]; // all zeros — wrong response
+
         // Act
-        var result = await flow.ContinueAsync(_client.Object, password, CancellationToken.None);
+        var result = await flow.ContinueV2Async(_client.Object, wrongCh, CancellationToken.None);
 
         // Assert
         await Assert.That(result).IsTypeOf<AuthFlowResult.Denied>();
         var denied = (AuthFlowResult.Denied)result;
-        await Assert.That(denied.Reason).IsEqualTo(DenialReason);
+        await Assert.That(denied.Reason).IsEqualTo(LoginDeniedReason.BadAccount);
     }
 
     [Test]
-    public async Task ContinueAsync_WrongPassword_ReturnsDenied()
+    public async Task Continue2Async_WhenNotAwaitingChallengeResponse_ReturnsDenied()
     {
-        // Arrange
-        const string Username = "testuser";
-        const string WrongPassword = "wrongpassword";
-        const LoginDeniedReason DenialReason = LoginDeniedReason.BadAccount;
-
-        _loginController
-            .Login(Any<string>(), Any<Password>(), Any<IPAddress>(), Any<CancellationToken>())
-            .Returns(new LoginResult(false, default, DenialReason));
-
-        var flow = CreateFlow(Username);
-        await flow.StartAsync(_client.Object, CancellationToken.None);
+        // Arrange — bypass StartAsync by setting state directly
+        var flow = CreateFlow("testuser");
+        SetFlowState(flow, "Completed");
 
         // Act
-        var result = await flow.ContinueAsync(_client.Object, WrongPassword, CancellationToken.None);
+        var result = await flow.ContinueV2Async(_client.Object, new uint[8], CancellationToken.None);
 
         // Assert
         await Assert.That(result).IsTypeOf<AuthFlowResult.Denied>();
         var denied = (AuthFlowResult.Denied)result;
-        await Assert.That(denied.Reason).IsEqualTo(DenialReason);
+        await Assert.That(denied.Reason).IsEqualTo(LoginDeniedReason.BadResponse);
+    }
+
+    [Test]
+    public async Task Continue2Async_BannedAccount_ReturnsDenied()
+    {
+        // Arrange
+        const string Password = "password";
+        var accountId = new AccountId(200);
+        var info = MakeKoreaAuthInfo(accountId, Password);
+
+        _loginController
+            .GetKoreaAuthInfoAsync(Any<string>(), Any<CancellationToken>())
+            .Returns(info);
+        _loginController
+            .CheckBanStatusAsync(Any<AccountId>(), Any<CancellationToken>())
+            .Returns((true, LoginDeniedReason.BadAccount));
+
+        uint[]? capturedHc = null;
+        _client.SendChallenge2Async(Any<int>(), Any<string>(), Any<uint[]>(), Any<CancellationToken>())
+            .Callback((int _, string _, uint[] hc, CancellationToken _) => capturedHc = hc);
+
+        var flow = CreateFlow("testuser");
+        await flow.StartAsync(_client.Object, CancellationToken.None);
+
+        var correctCh = ComputeExpectedV2Response(info.ChallengeKeyHash.Span, capturedHc!);
+
+        // Act
+        var result = await flow.ContinueV2Async(_client.Object, correctCh, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsTypeOf<AuthFlowResult.Denied>();
+    }
+
+    #endregion
+
+    #region ContinueAsync (V1 — always denied) Tests
+
+    [Test]
+    public async Task ContinueAsync_V1_AlwaysReturnsDenied()
+    {
+        // Arrange
+        var flow = CreateFlow("testuser");
+
+        // Act — V1 ContinueAsync should always deny regardless of state
+        var result = await flow.ContinueAsync(_client.Object, new uint[4], new byte[32],
+            CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsTypeOf<AuthFlowResult.Denied>();
+        var denied = (AuthFlowResult.Denied)result;
+        await Assert.That(denied.Reason).IsEqualTo(LoginDeniedReason.BadResponse);
     }
 
     #endregion
@@ -122,9 +269,8 @@ public class KoreaAuthFlowTests
     [Test]
     public async Task SubmitOtpAsync_WhenNotAwaitingOtp_ReturnsDenied()
     {
-        // Arrange - flow is still in AwaitingPassword state
+        // Arrange — flow is in AwaitingChallengeResponse state (not AwaitingOtp)
         var flow = CreateFlow("testuser");
-        await flow.StartAsync(_client.Object, CancellationToken.None);
 
         // Act
         var result = await flow.SubmitOtpAsync(_client.Object, "123456", CancellationToken.None);
@@ -139,19 +285,8 @@ public class KoreaAuthFlowTests
     public async Task SubmitOtpAsync_InvalidOtp_SendsRetryPacket_ReturnsPending()
     {
         // Arrange
-        const string Username = "testuser";
-        var accountId = new AccountId(456);
         var options = new KoreaAuthOptions { MaxOtpAttempts = 3 };
-
-        _loginController
-            .Login(Any<string>(), Any<Password>(), Any<IPAddress>(), Any<CancellationToken>())
-            .Returns(new LoginResult(true, accountId, 0));
-
-        var flow = CreateFlow(Username, options);
-        await flow.StartAsync(_client.Object, CancellationToken.None);
-        await flow.ContinueAsync(_client.Object, "password", CancellationToken.None);
-
-        // Set up OTP state after password authentication
+        var flow = CreateFlow("testuser", options);
         SetFlowState(flow, "AwaitingOtp");
 
         // Act
@@ -166,25 +301,14 @@ public class KoreaAuthFlowTests
     public async Task SubmitOtpAsync_MaxAttemptsExceeded_ReturnsDenied()
     {
         // Arrange
-        const string Username = "testuser";
-        var accountId = new AccountId(456);
         var options = new KoreaAuthOptions { MaxOtpAttempts = 2 };
-
-        _loginController
-            .Login(Any<string>(), Any<Password>(), Any<IPAddress>(), Any<CancellationToken>())
-            .Returns(new LoginResult(true, accountId, 0));
-
-        var flow = CreateFlow(Username, options);
-        await flow.StartAsync(_client.Object, CancellationToken.None);
-        await flow.ContinueAsync(_client.Object, "password", CancellationToken.None);
-
-        // Set up OTP state after password authentication
+        var flow = CreateFlow("testuser", options);
         SetFlowState(flow, "AwaitingOtp");
 
         // First attempt
         await flow.SubmitOtpAsync(_client.Object, "000000", CancellationToken.None);
 
-        // Act - second attempt (max reached)
+        // Act — second attempt (max reached)
         var result = await flow.SubmitOtpAsync(_client.Object, "000000", CancellationToken.None);
 
         // Assert
@@ -200,9 +324,8 @@ public class KoreaAuthFlowTests
     [Test]
     public async Task SubmitCertAsync_WhenNotAwaitingCert_ReturnsDenied()
     {
-        // Arrange - flow is still in AwaitingPassword state
+        // Arrange — flow is in AwaitingChallengeResponse state
         var flow = CreateFlow("testuser");
-        await flow.StartAsync(_client.Object, CancellationToken.None);
 
         // Act
         var result = await flow.SubmitCertAsync(_client.Object, "12345678", CancellationToken.None);
@@ -217,19 +340,8 @@ public class KoreaAuthFlowTests
     public async Task SubmitCertAsync_InvalidCert_SendsRetryPacket_ReturnsPending()
     {
         // Arrange
-        const string Username = "testuser";
-        var accountId = new AccountId(456);
         var options = new KoreaAuthOptions { MaxCertAttempts = 3 };
-
-        _loginController
-            .Login(Any<string>(), Any<Password>(), Any<IPAddress>(), Any<CancellationToken>())
-            .Returns(new LoginResult(true, accountId, 0));
-
-        var flow = CreateFlow(Username, options);
-        await flow.StartAsync(_client.Object, CancellationToken.None);
-        await flow.ContinueAsync(_client.Object, "password", CancellationToken.None);
-
-        // Set up Cert state after password authentication
+        var flow = CreateFlow("testuser", options);
         SetFlowState(flow, "AwaitingCert");
 
         // Act
@@ -244,25 +356,14 @@ public class KoreaAuthFlowTests
     public async Task SubmitCertAsync_MaxAttemptsExceeded_ReturnsDenied()
     {
         // Arrange
-        const string Username = "testuser";
-        var accountId = new AccountId(456);
         var options = new KoreaAuthOptions { MaxCertAttempts = 2 };
-
-        _loginController
-            .Login(Any<string>(), Any<Password>(), Any<IPAddress>(), Any<CancellationToken>())
-            .Returns(new LoginResult(true, accountId, 0));
-
-        var flow = CreateFlow(Username, options);
-        await flow.StartAsync(_client.Object, CancellationToken.None);
-        await flow.ContinueAsync(_client.Object, "password", CancellationToken.None);
-
-        // Set up Cert state after password authentication
+        var flow = CreateFlow("testuser", options);
         SetFlowState(flow, "AwaitingCert");
 
         // First attempt
         await flow.SubmitCertAsync(_client.Object, "00000000", CancellationToken.None);
 
-        // Act - second attempt (max reached)
+        // Act — second attempt (max reached)
         var result = await flow.SubmitCertAsync(_client.Object, "00000000", CancellationToken.None);
 
         // Assert
@@ -278,9 +379,8 @@ public class KoreaAuthFlowTests
     [Test]
     public async Task CompleteArsAsync_WhenNotAwaitingArs_ReturnsDenied()
     {
-        // Arrange - flow is still in AwaitingPassword state
+        // Arrange — flow is in AwaitingChallengeResponse state
         var flow = CreateFlow("testuser");
-        await flow.StartAsync(_client.Object, CancellationToken.None);
 
         // Act
         var result = await flow.CompleteArsAsync(_client.Object, true, CancellationToken.None);
@@ -295,18 +395,7 @@ public class KoreaAuthFlowTests
     public async Task CompleteArsAsync_Failure_ReturnsDenied()
     {
         // Arrange
-        const string Username = "testuser";
-        var accountId = new AccountId(456);
-
-        _loginController
-            .Login(Any<string>(), Any<Password>(), Any<IPAddress>(), Any<CancellationToken>())
-            .Returns(new LoginResult(true, accountId, 0));
-
-        var flow = CreateFlow(Username);
-        await flow.StartAsync(_client.Object, CancellationToken.None);
-        await flow.ContinueAsync(_client.Object, "password", CancellationToken.None);
-
-        // Set up ARS state after password authentication
+        var flow = CreateFlow("testuser");
         SetFlowState(flow, "AwaitingArs");
 
         // Act
@@ -322,19 +411,13 @@ public class KoreaAuthFlowTests
     public async Task CompleteArsAsync_Success_ReturnsSuccess()
     {
         // Arrange
-        const string Username = "testuser";
-        var accountId = new AccountId(456);
-
-        _loginController
-            .Login(Any<string>(), Any<Password>(), Any<IPAddress>(), Any<CancellationToken>())
-            .Returns(new LoginResult(true, accountId, 0));
-
-        var flow = CreateFlow(Username);
-        await flow.StartAsync(_client.Object, CancellationToken.None);
-        await flow.ContinueAsync(_client.Object, "password", CancellationToken.None);
-
-        // Set up ARS state after password authentication
+        var accountId = new AccountId(999);
+        var flow = CreateFlow("testuser");
         SetFlowState(flow, "AwaitingArs");
+        SetAccountId(flow, accountId);
+        _loginController
+            .CheckBanStatusAsync(Any<AccountId>(), Any<CancellationToken>())
+            .Returns((false, default));
 
         // Act
         var result = await flow.CompleteArsAsync(_client.Object, true, CancellationToken.None);
@@ -343,32 +426,31 @@ public class KoreaAuthFlowTests
         await Assert.That(result).IsTypeOf<AuthFlowResult.Success>();
         var success = (AuthFlowResult.Success)result;
         await Assert.That(success.AccountId).IsEqualTo(accountId);
-        await Assert.That(success.Username).IsEqualTo(Username);
     }
 
     #endregion
 
     #region Helper Methods
 
-    /// <summary>
-    /// Sets the internal state of the flow using reflection.
-    /// </summary>
-    /// <param name="flow">The flow to modify.</param>
-    /// <param name="stateName">The state name (e.g., "AwaitingOtp", "AwaitingCert", "AwaitingArs").</param>
     private static void SetFlowState(KoreaAuthFlow flow, string stateName)
     {
         var stateField = typeof(KoreaAuthFlow).GetField("_state",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-
-        // Get the State enum type (nested private enum)
+            BindingFlags.NonPublic | BindingFlags.Instance);
         var stateType = typeof(KoreaAuthFlow).GetNestedType("State",
-            System.Reflection.BindingFlags.NonPublic);
+            BindingFlags.NonPublic);
 
         if (stateField != null && stateType != null)
         {
             var stateValue = Enum.Parse(stateType, stateName);
             stateField.SetValue(flow, stateValue);
         }
+    }
+
+    private static void SetAccountId(KoreaAuthFlow flow, AccountId accountId)
+    {
+        var field = typeof(KoreaAuthFlow).GetField("_accountId",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        field?.SetValue(flow, accountId);
     }
 
     #endregion

--- a/AAEmu.UnitTests/Login/Core/Authentication/KoreaAuthFlowTests.cs
+++ b/AAEmu.UnitTests/Login/Core/Authentication/KoreaAuthFlowTests.cs
@@ -1,0 +1,375 @@
+#nullable enable
+
+using System.Net;
+using AAEmu.Login.Core.Authentication;
+using AAEmu.Login.Core.Controllers;
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.PacketHandlers.C2L;
+using AAEmu.Login.Core.Services;
+using AAEmu.Login.Models;
+using Microsoft.Extensions.Options;
+
+namespace AAEmu.UnitTests.Login.Core.Authentication;
+
+public class KoreaAuthFlowTests
+{
+    private readonly Mock<ILoginController> _loginController = Mock.Of<ILoginController>();
+    private readonly Mock<ILoginClient> _client = Mock.Of<ILoginClient>();
+
+    private KoreaAuthFlow CreateFlow(string username, KoreaAuthOptions? options = null)
+    {
+        var opts = Options.Create(options ?? new KoreaAuthOptions());
+        return new KoreaAuthFlow(_loginController.Object, opts, username, IPAddress.Loopback);
+    }
+
+    #region StartAsync Tests
+
+    [Test]
+    public async Task StartAsync_SendsChallengePacket_ReturnsPending()
+    {
+        // Arrange
+        var flow = CreateFlow("testuser");
+
+        // Act
+        var result = await flow.StartAsync(_client.Object, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsTypeOf<AuthFlowResult.Pending>();
+        _client.SendChallengeAsync(Any<CancellationToken>()).WasCalled(Times.Once);
+    }
+
+    #endregion
+
+    #region ContinueAsync (Password) Tests
+
+    [Test]
+    public async Task ContinueAsync_SuccessfulLogin_ReturnsSuccess()
+    {
+        // Arrange
+        const string Username = "testuser";
+        const string password = "password123";
+        var accountId = new AccountId(456);
+
+        _loginController
+            .Login(Any<string>(), Any<Password>(), Any<IPAddress>(), Any<CancellationToken>())
+            .Returns(new LoginResult(true, accountId, 0));
+
+        var flow = CreateFlow(Username);
+        await flow.StartAsync(_client.Object, CancellationToken.None);
+
+        // Act
+        var result = await flow.ContinueAsync(_client.Object, password, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsTypeOf<AuthFlowResult.Success>();
+        var success = (AuthFlowResult.Success)result;
+        await Assert.That(success.AccountId).IsEqualTo(accountId);
+        await Assert.That(success.Username).IsEqualTo(Username);
+    }
+
+    [Test]
+    public async Task ContinueAsync_UserNotFound_ReturnsDenied()
+    {
+        // Arrange
+        const string Username = "unknownuser";
+        const string password = "password123";
+        const LoginDeniedReason DenialReason = LoginDeniedReason.BadAccount;
+
+        _loginController
+            .Login(Any<string>(), Any<Password>(), Any<IPAddress>(), Any<CancellationToken>())
+            .Returns(new LoginResult(false, default, DenialReason));
+
+        var flow = CreateFlow(Username);
+        await flow.StartAsync(_client.Object, CancellationToken.None);
+
+        // Act
+        var result = await flow.ContinueAsync(_client.Object, password, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsTypeOf<AuthFlowResult.Denied>();
+        var denied = (AuthFlowResult.Denied)result;
+        await Assert.That(denied.Reason).IsEqualTo(DenialReason);
+    }
+
+    [Test]
+    public async Task ContinueAsync_WrongPassword_ReturnsDenied()
+    {
+        // Arrange
+        const string Username = "testuser";
+        const string WrongPassword = "wrongpassword";
+        const LoginDeniedReason DenialReason = LoginDeniedReason.BadAccount;
+
+        _loginController
+            .Login(Any<string>(), Any<Password>(), Any<IPAddress>(), Any<CancellationToken>())
+            .Returns(new LoginResult(false, default, DenialReason));
+
+        var flow = CreateFlow(Username);
+        await flow.StartAsync(_client.Object, CancellationToken.None);
+
+        // Act
+        var result = await flow.ContinueAsync(_client.Object, WrongPassword, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsTypeOf<AuthFlowResult.Denied>();
+        var denied = (AuthFlowResult.Denied)result;
+        await Assert.That(denied.Reason).IsEqualTo(DenialReason);
+    }
+
+    #endregion
+
+    #region SubmitOtpAsync Tests
+
+    [Test]
+    public async Task SubmitOtpAsync_WhenNotAwaitingOtp_ReturnsDenied()
+    {
+        // Arrange - flow is still in AwaitingPassword state
+        var flow = CreateFlow("testuser");
+        await flow.StartAsync(_client.Object, CancellationToken.None);
+
+        // Act
+        var result = await flow.SubmitOtpAsync(_client.Object, "123456", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsTypeOf<AuthFlowResult.Denied>();
+        var denied = (AuthFlowResult.Denied)result;
+        await Assert.That(denied.Reason).IsEqualTo(LoginDeniedReason.BadResponse);
+    }
+
+    [Test]
+    public async Task SubmitOtpAsync_InvalidOtp_SendsRetryPacket_ReturnsPending()
+    {
+        // Arrange
+        const string Username = "testuser";
+        var accountId = new AccountId(456);
+        var options = new KoreaAuthOptions { MaxOtpAttempts = 3 };
+
+        _loginController
+            .Login(Any<string>(), Any<Password>(), Any<IPAddress>(), Any<CancellationToken>())
+            .Returns(new LoginResult(true, accountId, 0));
+
+        var flow = CreateFlow(Username, options);
+        await flow.StartAsync(_client.Object, CancellationToken.None);
+        await flow.ContinueAsync(_client.Object, "password", CancellationToken.None);
+
+        // Set up OTP state after password authentication
+        SetFlowState(flow, "AwaitingOtp");
+
+        // Act
+        var result = await flow.SubmitOtpAsync(_client.Object, "000000", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsTypeOf<AuthFlowResult.Pending>();
+        _client.SendOtpPromptAsync(3, 2, Any<CancellationToken>()).WasCalled(Times.Once);
+    }
+
+    [Test]
+    public async Task SubmitOtpAsync_MaxAttemptsExceeded_ReturnsDenied()
+    {
+        // Arrange
+        const string Username = "testuser";
+        var accountId = new AccountId(456);
+        var options = new KoreaAuthOptions { MaxOtpAttempts = 2 };
+
+        _loginController
+            .Login(Any<string>(), Any<Password>(), Any<IPAddress>(), Any<CancellationToken>())
+            .Returns(new LoginResult(true, accountId, 0));
+
+        var flow = CreateFlow(Username, options);
+        await flow.StartAsync(_client.Object, CancellationToken.None);
+        await flow.ContinueAsync(_client.Object, "password", CancellationToken.None);
+
+        // Set up OTP state after password authentication
+        SetFlowState(flow, "AwaitingOtp");
+
+        // First attempt
+        await flow.SubmitOtpAsync(_client.Object, "000000", CancellationToken.None);
+
+        // Act - second attempt (max reached)
+        var result = await flow.SubmitOtpAsync(_client.Object, "000000", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsTypeOf<AuthFlowResult.Denied>();
+        var denied = (AuthFlowResult.Denied)result;
+        await Assert.That(denied.Reason).IsEqualTo(LoginDeniedReason.BadResponse);
+    }
+
+    #endregion
+
+    #region SubmitCertAsync Tests
+
+    [Test]
+    public async Task SubmitCertAsync_WhenNotAwaitingCert_ReturnsDenied()
+    {
+        // Arrange - flow is still in AwaitingPassword state
+        var flow = CreateFlow("testuser");
+        await flow.StartAsync(_client.Object, CancellationToken.None);
+
+        // Act
+        var result = await flow.SubmitCertAsync(_client.Object, "12345678", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsTypeOf<AuthFlowResult.Denied>();
+        var denied = (AuthFlowResult.Denied)result;
+        await Assert.That(denied.Reason).IsEqualTo(LoginDeniedReason.BadResponse);
+    }
+
+    [Test]
+    public async Task SubmitCertAsync_InvalidCert_SendsRetryPacket_ReturnsPending()
+    {
+        // Arrange
+        const string Username = "testuser";
+        var accountId = new AccountId(456);
+        var options = new KoreaAuthOptions { MaxCertAttempts = 3 };
+
+        _loginController
+            .Login(Any<string>(), Any<Password>(), Any<IPAddress>(), Any<CancellationToken>())
+            .Returns(new LoginResult(true, accountId, 0));
+
+        var flow = CreateFlow(Username, options);
+        await flow.StartAsync(_client.Object, CancellationToken.None);
+        await flow.ContinueAsync(_client.Object, "password", CancellationToken.None);
+
+        // Set up Cert state after password authentication
+        SetFlowState(flow, "AwaitingCert");
+
+        // Act
+        var result = await flow.SubmitCertAsync(_client.Object, "00000000", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsTypeOf<AuthFlowResult.Pending>();
+        _client.SendCertPromptAsync(3, 2, Any<CancellationToken>()).WasCalled(Times.Once);
+    }
+
+    [Test]
+    public async Task SubmitCertAsync_MaxAttemptsExceeded_ReturnsDenied()
+    {
+        // Arrange
+        const string Username = "testuser";
+        var accountId = new AccountId(456);
+        var options = new KoreaAuthOptions { MaxCertAttempts = 2 };
+
+        _loginController
+            .Login(Any<string>(), Any<Password>(), Any<IPAddress>(), Any<CancellationToken>())
+            .Returns(new LoginResult(true, accountId, 0));
+
+        var flow = CreateFlow(Username, options);
+        await flow.StartAsync(_client.Object, CancellationToken.None);
+        await flow.ContinueAsync(_client.Object, "password", CancellationToken.None);
+
+        // Set up Cert state after password authentication
+        SetFlowState(flow, "AwaitingCert");
+
+        // First attempt
+        await flow.SubmitCertAsync(_client.Object, "00000000", CancellationToken.None);
+
+        // Act - second attempt (max reached)
+        var result = await flow.SubmitCertAsync(_client.Object, "00000000", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsTypeOf<AuthFlowResult.Denied>();
+        var denied = (AuthFlowResult.Denied)result;
+        await Assert.That(denied.Reason).IsEqualTo(LoginDeniedReason.BadResponse);
+    }
+
+    #endregion
+
+    #region CompleteArsAsync Tests
+
+    [Test]
+    public async Task CompleteArsAsync_WhenNotAwaitingArs_ReturnsDenied()
+    {
+        // Arrange - flow is still in AwaitingPassword state
+        var flow = CreateFlow("testuser");
+        await flow.StartAsync(_client.Object, CancellationToken.None);
+
+        // Act
+        var result = await flow.CompleteArsAsync(_client.Object, true, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsTypeOf<AuthFlowResult.Denied>();
+        var denied = (AuthFlowResult.Denied)result;
+        await Assert.That(denied.Reason).IsEqualTo(LoginDeniedReason.BadResponse);
+    }
+
+    [Test]
+    public async Task CompleteArsAsync_Failure_ReturnsDenied()
+    {
+        // Arrange
+        const string Username = "testuser";
+        var accountId = new AccountId(456);
+
+        _loginController
+            .Login(Any<string>(), Any<Password>(), Any<IPAddress>(), Any<CancellationToken>())
+            .Returns(new LoginResult(true, accountId, 0));
+
+        var flow = CreateFlow(Username);
+        await flow.StartAsync(_client.Object, CancellationToken.None);
+        await flow.ContinueAsync(_client.Object, "password", CancellationToken.None);
+
+        // Set up ARS state after password authentication
+        SetFlowState(flow, "AwaitingArs");
+
+        // Act
+        var result = await flow.CompleteArsAsync(_client.Object, false, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsTypeOf<AuthFlowResult.Denied>();
+        var denied = (AuthFlowResult.Denied)result;
+        await Assert.That(denied.Reason).IsEqualTo(LoginDeniedReason.BadResponse);
+    }
+
+    [Test]
+    public async Task CompleteArsAsync_Success_ReturnsSuccess()
+    {
+        // Arrange
+        const string Username = "testuser";
+        var accountId = new AccountId(456);
+
+        _loginController
+            .Login(Any<string>(), Any<Password>(), Any<IPAddress>(), Any<CancellationToken>())
+            .Returns(new LoginResult(true, accountId, 0));
+
+        var flow = CreateFlow(Username);
+        await flow.StartAsync(_client.Object, CancellationToken.None);
+        await flow.ContinueAsync(_client.Object, "password", CancellationToken.None);
+
+        // Set up ARS state after password authentication
+        SetFlowState(flow, "AwaitingArs");
+
+        // Act
+        var result = await flow.CompleteArsAsync(_client.Object, true, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsTypeOf<AuthFlowResult.Success>();
+        var success = (AuthFlowResult.Success)result;
+        await Assert.That(success.AccountId).IsEqualTo(accountId);
+        await Assert.That(success.Username).IsEqualTo(Username);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    /// <summary>
+    /// Sets the internal state of the flow using reflection.
+    /// </summary>
+    /// <param name="flow">The flow to modify.</param>
+    /// <param name="stateName">The state name (e.g., "AwaitingOtp", "AwaitingCert", "AwaitingArs").</param>
+    private static void SetFlowState(KoreaAuthFlow flow, string stateName)
+    {
+        var stateField = typeof(KoreaAuthFlow).GetField("_state",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        // Get the State enum type (nested private enum)
+        var stateType = typeof(KoreaAuthFlow).GetNestedType("State",
+            System.Reflection.BindingFlags.NonPublic);
+
+        if (stateField != null && stateType != null)
+        {
+            var stateValue = Enum.Parse(stateType, stateName);
+            stateField.SetValue(flow, stateValue);
+        }
+    }
+
+    #endregion
+}

--- a/AAEmu.UnitTests/Login/Core/Authentication/PasswordAuthFlowTests.cs
+++ b/AAEmu.UnitTests/Login/Core/Authentication/PasswordAuthFlowTests.cs
@@ -1,0 +1,88 @@
+#nullable enable
+
+using System.Net;
+using AAEmu.Login.Core.Authentication;
+using AAEmu.Login.Core.Controllers;
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.PacketHandlers.C2L;
+using AAEmu.Login.Core.Services;
+using AAEmu.Login.Models;
+
+namespace AAEmu.UnitTests.Login.Core.Authentication;
+
+public class PasswordAuthFlowTests
+{
+    private readonly Mock<ILoginController> _loginController = Mock.Of<ILoginController>();
+    private readonly Mock<ILoginClient> _client = Mock.Of<ILoginClient>();
+
+    [Test]
+    public async Task StartAsync_SuccessfulLogin_ReturnsSuccessWithUsername()
+    {
+        // Arrange
+        const string Username = "testuser";
+        const string TestPassword = "testpass";
+        var accountId = new AccountId(123);
+
+        _loginController
+            .Login(Any<string>(), Any<Password>(), Any<IPAddress>(), Any<CancellationToken>())
+            .Returns(new LoginResult(true, accountId, 0));
+
+        var flow = new PasswordAuthFlow(_loginController.Object, Username, Password.FromSha256Hex(TestPassword),
+            IPAddress.Loopback);
+
+        // Act
+        var result = await flow.StartAsync(_client.Object, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsTypeOf<AuthFlowResult.Success>();
+        var success = (AuthFlowResult.Success)result;
+        await Assert.That(success.AccountId).IsEqualTo(accountId);
+        await Assert.That(success.Username).IsEqualTo(Username);
+    }
+
+    [Test]
+    public async Task StartAsync_FailedLogin_ReturnsDenied()
+    {
+        // Arrange
+        const string Username = "testuser";
+        const string password = "wrongpass";
+        const LoginDeniedReason DenialReason = LoginDeniedReason.BadResponse;
+
+        _loginController
+            .Login(Any<string>(), Any<Password>(), Any<IPAddress>(), Any<CancellationToken>())
+            .Returns(new LoginResult(false, default, DenialReason));
+
+        var flow = new PasswordAuthFlow(_loginController.Object, Username, Password.FromSha256Hex(password), IPAddress.Loopback);
+
+        // Act
+        var result = await flow.StartAsync(_client.Object, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsTypeOf<AuthFlowResult.Denied>();
+        var denied = (AuthFlowResult.Denied)result;
+        await Assert.That(denied.Reason).IsEqualTo(DenialReason);
+    }
+
+    [Test]
+    public async Task StartAsync_BannedAccount_ReturnsDeniedWithBanReason()
+    {
+        // Arrange
+        const string Username = "banneduser";
+        const string password = "password";
+        const LoginDeniedReason BanReason = LoginDeniedReason.TryTradeCashTemporal;
+
+        _loginController
+            .Login(Any<string>(), Any<Password>(), Any<IPAddress>(), Any<CancellationToken>())
+            .Returns(new LoginResult(false, default, BanReason));
+
+        var flow = new PasswordAuthFlow(_loginController.Object, Username, Password.FromSha256Hex(password), IPAddress.Loopback);
+
+        // Act
+        var result = await flow.StartAsync(_client.Object, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsTypeOf<AuthFlowResult.Denied>();
+        var denied = (AuthFlowResult.Denied)result;
+        await Assert.That(denied.Reason).IsEqualTo(BanReason);
+    }
+}

--- a/AAEmu.UnitTests/Login/Core/PacketHandlers/C2L/CAOtpNumberPacketHandlerTests.cs
+++ b/AAEmu.UnitTests/Login/Core/PacketHandlers/C2L/CAOtpNumberPacketHandlerTests.cs
@@ -1,0 +1,58 @@
+#nullable enable
+
+using AAEmu.Login.Core.Authentication;
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.PacketHandlers.C2L;
+using AAEmu.Login.Core.Packets.C2L;
+
+namespace AAEmu.UnitTests.Login.Core.PacketHandlers.C2L;
+
+public class CAOtpNumberPacketHandlerTests
+{
+    private readonly Mock<ILoginSession> _session = Mock.Of<ILoginSession>();
+    private readonly Mock<ILoginClient> _client = Mock.Of<ILoginClient>();
+    private readonly CAOtpNumberPacketHandler _handler = new();
+
+    public CAOtpNumberPacketHandlerTests()
+    {
+        _session.Client.Returns(_client.Object);
+    }
+
+    [Test]
+    public async Task Execute_CallsContinueAuthAsync()
+    {
+        // Arrange
+        var packet = CreatePacket("123456");
+
+        // Act
+        await _handler.Execute(packet, _session.Object, CancellationToken.None);
+
+        // Assert
+        _session.ContinueAuthAsync(
+            Any<Func<IOtpAuthFlow, Task<AuthFlowResult>>>(),
+            Any<CancellationToken>()).WasCalled(Times.Once);
+    }
+
+    [Test]
+    public async Task Execute_NullOtpNumber_CallsContinueAuthAsync()
+    {
+        // Arrange
+        var packet = CreatePacket(null);
+
+        // Act
+        await _handler.Execute(packet, _session.Object, CancellationToken.None);
+
+        // Assert
+        _session.ContinueAuthAsync(
+            Any<Func<IOtpAuthFlow, Task<AuthFlowResult>>>(),
+            Any<CancellationToken>()).WasCalled(Times.Once);
+    }
+
+    private static CAOtpNumberPacket CreatePacket(string? otpNumber)
+    {
+        var packet = new CAOtpNumberPacket();
+        var otpProperty = typeof(CAOtpNumberPacket).GetProperty(nameof(CAOtpNumberPacket.OtpNumber));
+        otpProperty!.SetValue(packet, otpNumber);
+        return packet;
+    }
+}

--- a/AAEmu.UnitTests/Login/Core/PacketHandlers/C2L/CAPcCertNumberPacketHandlerTests.cs
+++ b/AAEmu.UnitTests/Login/Core/PacketHandlers/C2L/CAPcCertNumberPacketHandlerTests.cs
@@ -1,0 +1,58 @@
+#nullable enable
+
+using AAEmu.Login.Core.Authentication;
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.PacketHandlers.C2L;
+using AAEmu.Login.Core.Packets.C2L;
+
+namespace AAEmu.UnitTests.Login.Core.PacketHandlers.C2L;
+
+public class CAPcCertNumberPacketHandlerTests
+{
+    private readonly Mock<ILoginSession> _session = Mock.Of<ILoginSession>();
+    private readonly Mock<ILoginClient> _client = Mock.Of<ILoginClient>();
+    private readonly CAPcCertNumberPacketHandler _handler = new();
+
+    public CAPcCertNumberPacketHandlerTests()
+    {
+        _session.Client.Returns(_client.Object);
+    }
+
+    [Test]
+    public async Task Execute_CallsContinueAuthAsync()
+    {
+        // Arrange
+        var packet = CreatePacket("12345678");
+
+        // Act
+        await _handler.Execute(packet, _session.Object, CancellationToken.None);
+
+        // Assert
+        _session.ContinueAuthAsync(
+            Any<Func<ICertAuthFlow, Task<AuthFlowResult>>>(),
+            Any<CancellationToken>()).WasCalled(Times.Once);
+    }
+
+    [Test]
+    public async Task Execute_NullCertNumber_CallsContinueAuthAsync()
+    {
+        // Arrange
+        var packet = CreatePacket(null);
+
+        // Act
+        await _handler.Execute(packet, _session.Object, CancellationToken.None);
+
+        // Assert
+        _session.ContinueAuthAsync(
+            Any<Func<ICertAuthFlow, Task<AuthFlowResult>>>(),
+            Any<CancellationToken>()).WasCalled(Times.Once);
+    }
+
+    private static CAPcCertNumberPacket CreatePacket(string? certNumber)
+    {
+        var packet = new CAPcCertNumberPacket();
+        var certProperty = typeof(CAPcCertNumberPacket).GetProperty(nameof(CAPcCertNumberPacket.CertNumber));
+        certProperty!.SetValue(packet, certNumber);
+        return packet;
+    }
+}

--- a/AAEmu.UnitTests/Login/Core/PacketHandlers/C2L/CARequestAuthPacketHandlerTests.cs
+++ b/AAEmu.UnitTests/Login/Core/PacketHandlers/C2L/CARequestAuthPacketHandlerTests.cs
@@ -1,0 +1,48 @@
+#nullable enable
+
+using System.Net;
+using AAEmu.Login.Core.Authentication;
+using AAEmu.Login.Core.Controllers;
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.PacketHandlers.C2L;
+using AAEmu.Login.Core.Packets.C2L;
+using Microsoft.Extensions.Options;
+
+namespace AAEmu.UnitTests.Login.Core.PacketHandlers.C2L;
+
+public class CARequestAuthPacketHandlerTests
+{
+    private readonly Mock<ILoginController> _loginController = Mock.Of<ILoginController>();
+    private readonly Mock<ILoginSession> _session = Mock.Of<ILoginSession>();
+    private readonly Mock<ILoginConnection> _connection = Mock.Of<ILoginConnection>();
+    private readonly CARequestAuthPacketHandler _handler;
+
+    public CARequestAuthPacketHandlerTests()
+    {
+        _handler = new CARequestAuthPacketHandler(_loginController.Object, Options.Create(new KoreaAuthOptions()));
+
+        _connection.Ip.Returns(IPAddress.Loopback);
+        _session.Connection.Returns(_connection.Object);
+    }
+
+    [Test]
+    public async Task Execute_CallsAuthenticateAsync()
+    {
+        // Arrange
+        var packet = CreatePacket("testuser");
+
+        // Act
+        await _handler.Execute(packet, _session.Object, CancellationToken.None);
+
+        // Assert
+        _session.AuthenticateAsync(Any<IAuthenticationFlow>(), Any<CancellationToken>()).WasCalled(Times.Once);
+    }
+
+    private static CARequestAuthPacket CreatePacket(string username)
+    {
+        var packet = new CARequestAuthPacket();
+        var accountProperty = typeof(CARequestAuthPacket).GetProperty(nameof(CARequestAuthPacket.Account));
+        accountProperty!.SetValue(packet, username);
+        return packet;
+    }
+}

--- a/AAEmu.UnitTests/Login/Core/PacketHandlers/C2L/CARequestAuthPacketHandlerTests.cs
+++ b/AAEmu.UnitTests/Login/Core/PacketHandlers/C2L/CARequestAuthPacketHandlerTests.cs
@@ -19,7 +19,10 @@ public class CARequestAuthPacketHandlerTests
 
     public CARequestAuthPacketHandlerTests()
     {
-        _handler = new CARequestAuthPacketHandler(_loginController.Object, Options.Create(new KoreaAuthOptions()));
+        _handler = new CARequestAuthPacketHandler(
+            _loginController.Object,
+            Options.Create(new KoreaAuthOptions()),
+            Options.Create(new KoreaChallengeAuthOptions()));
 
         _connection.Ip.Returns(IPAddress.Loopback);
         _session.Connection.Returns(_connection.Object);

--- a/AAEmu.UnitTests/Login/Core/PacketHandlers/C2L/CARequestAuthTrionPacketHandlerTests.cs
+++ b/AAEmu.UnitTests/Login/Core/PacketHandlers/C2L/CARequestAuthTrionPacketHandlerTests.cs
@@ -1,0 +1,49 @@
+#nullable enable
+
+using System.Net;
+using AAEmu.Login.Core.Authentication;
+using AAEmu.Login.Core.Controllers;
+using AAEmu.Login.Core.Network.Connections;
+using AAEmu.Login.Core.PacketHandlers.C2L;
+using AAEmu.Login.Core.Packets.C2L;
+
+namespace AAEmu.UnitTests.Login.Core.PacketHandlers.C2L;
+
+public class CARequestAuthTrionPacketHandlerTests
+{
+    private readonly Mock<ILoginController> _loginController = Mock.Of<ILoginController>();
+    private readonly Mock<ILoginSession> _session = Mock.Of<ILoginSession>();
+    private readonly Mock<ILoginConnection> _connection = Mock.Of<ILoginConnection>();
+    private readonly CARequestAuthTrionPacketHandler _handler;
+
+    public CARequestAuthTrionPacketHandlerTests()
+    {
+        _handler = new CARequestAuthTrionPacketHandler(_loginController.Object);
+
+        _connection.Ip.Returns(IPAddress.Loopback);
+        _session.Connection.Returns(_connection.Object);
+    }
+
+    [Test]
+    public async Task Execute_CallsAuthenticateAsync()
+    {
+        // Arrange
+        var packet = CreatePacket("testuser", "testpass");
+
+        // Act
+        await _handler.Execute(packet, _session.Object, CancellationToken.None);
+
+        // Assert
+        _session.AuthenticateAsync(Any<IAuthenticationFlow>(), Any<CancellationToken>()).WasCalled(Times.Once);
+    }
+
+    private static CARequestAuthTrionPacket CreatePacket(string username, string password)
+    {
+        var packet = new CARequestAuthTrionPacket();
+        var usernameProperty = typeof(CARequestAuthTrionPacket).GetProperty(nameof(CARequestAuthTrionPacket.Username));
+        var passwordProperty = typeof(CARequestAuthTrionPacket).GetProperty(nameof(CARequestAuthTrionPacket.Password));
+        usernameProperty!.SetValue(packet, username);
+        passwordProperty!.SetValue(packet, password);
+        return packet;
+    }
+}

--- a/AAEmu.UnitTests/Login/Core/Services/KoreaSeedDataGeneratorTests.cs
+++ b/AAEmu.UnitTests/Login/Core/Services/KoreaSeedDataGeneratorTests.cs
@@ -1,0 +1,39 @@
+using AAEmu.Login.Core.Services;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+
+namespace AAEmu.UnitTests.Login.Core.Services;
+
+/// <summary>
+/// Not a correctness test — run manually to generate SQL seed rows for Korea auth testing.
+/// Output appears in the test runner's stdout.
+/// </summary>
+public class KoreaSeedDataGeneratorTests
+{
+    private readonly PasswordService _passwordService;
+
+    public KoreaSeedDataGeneratorTests()
+    {
+        var options = Options.Create(new PasswordHasherOptions());
+        _passwordService = new PasswordService(new PasswordHasher<string>(options));
+    }
+
+    [Test]
+    public void GenerateKoreaTestAccount()
+    {
+        const string Username = "KrTest";
+        const string TestPassword = "KrTesting";
+        const int Rounds = 100_000;
+
+        var pbkdf2Hash = _passwordService.HashForStorage(Password.FromPlaintext(TestPassword));
+        var koreaHash = _passwordService.ComputeKoreaChallengeHash(TestPassword, rounds: Rounds);
+
+        Console.WriteLine($"-- Korea test account: username={Username}, password={TestPassword}");
+        Console.WriteLine($"-- PBKDF2:             {pbkdf2Hash}");
+        Console.WriteLine($"-- korea_challenge_hash: {koreaHash}");
+        Console.WriteLine();
+        Console.WriteLine(
+            $"INSERT INTO `users` (username, password, korea_challenge_hash, email, last_ip, last_login, created_at, updated_at)" +
+            $" VALUES ('{Username}', '{pbkdf2Hash}', '{koreaHash}', '', '127.0.0.1', 0, 0, 0);");
+    }
+}

--- a/SQL/aaemu_login.sql
+++ b/SQL/aaemu_login.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS `users` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `username` varchar(32) NOT NULL,
   `password` text COMMENT 'Hashed password of the user',
+  `korea_challenge_hash` varchar(120) DEFAULT NULL COMMENT 'sha256_crypt $5$ hash used as AES-256 key for Korea challenge-response auth (V2).',
   `email` varchar(128) NOT NULL,
   `last_login` bigint unsigned NOT NULL DEFAULT '0',
   `last_ip` varchar(128) NOT NULL,

--- a/SQL/updates/2026-03-14_aaemu_login_users.sql
+++ b/SQL/updates/2026-03-14_aaemu_login_users.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `users`
+  ADD COLUMN `korea_challenge_hash` VARCHAR(120) DEFAULT NULL
+    COMMENT 'sha256_crypt $5$ hash used as AES-256 key for Korea challenge-response auth (V2).'
+    AFTER `password`;


### PR DESCRIPTION
The two-factor auth features are largely unimplemented as they require additional services, and only a scaffold currently exists.

This also removes the `Login(string username)` overload from `ILoginController` for KR auth, that would have allowed users to log in to any account via the Korea auth flow without needing to enter the correct password - just the username was needed.