### PR TITLE
fix(game): ensure NPC custom model parameters are correctly applied

### DIFF
--- a/AAEmu.Game/Core/Managers/ItemManager.cs
+++ b/AAEmu.Game/Core/Managers/ItemManager.cs
@@ -892,7 +892,7 @@ public class ItemManager(ISkillManager skillManager, IItemIdManager itemIdManage
 
             using (var command = connection.CreateCommand())
             {
-                command.CommandText = "SELECT * FROM item_body_parts";
+                command.CommandText = "SELECT * FROM item_body_parts ORDER BY id";
                 command.Prepare();
                 using (var sqliteReader = command.ExecuteReader())
                 using (var reader = new SQLiteWrapperReader(sqliteReader))

--- a/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
@@ -123,7 +123,7 @@ public class CharacterManager(
                         template.ResurrectionDistrictId = reader.GetUInt32("default_resurrection_district_id");
                         using (var command2 = connection.CreateCommand())
                         {
-                            command2.CommandText = "SELECT * FROM item_body_parts WHERE model_id=@model_id";
+                            command2.CommandText = "SELECT * FROM item_body_parts WHERE model_id=@model_id ORDER BY id";
                             command2.Parameters.AddWithValue("model_id", template.ModelId);
                             command2.Prepare();
                             using (var reader2 = new SQLiteWrapperReader(command2.ExecuteReader()))

--- a/AAEmu.Game/Core/Managers/UnitManagers/NpcManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/NpcManager.cs
@@ -147,6 +147,8 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
             template.BodyItems = templ.BodyItems;
         }
 
+        npc.ModelParams = template.ModelParams;
+
         // TODO: Check if we need to override some body parts if template.EquipBodiesId is set or not
         if (template.EquipBodiesId > 0 && EquipPackBodyParts.TryGetValue(template.EquipBodiesId, out _)) // var equipBodyPartPack))
         {
@@ -459,7 +461,7 @@ public class NpcManager(IObjectIdManager objectIdManager, IModelManager modelMan
                 }
 
                 // Pre-Load body parts
-                command.CommandText = "SELECT * FROM item_body_parts";
+                command.CommandText = "SELECT * FROM item_body_parts ORDER BY id";
                 command.Prepare();
                 using (var sqliteReader = command.ExecuteReader())
                 using (var reader = new SQLiteWrapperReader(sqliteReader))

--- a/AAEmu.Game/Core/Packets/G2C/SCUnitStatePacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCUnitStatePacket.cs
@@ -18,6 +18,7 @@ public class SCUnitStatePacket : GamePacket
     private readonly Unit _unit;
     private readonly BaseUnitType _baseUnitType;
 #pragma warning disable IDE0052 // Remove unread private members
+    // ReSharper disable once NotAccessedField.Local
     private ModelPostureType _modelPostureType;
 #pragma warning restore IDE0052 // Remove unread private members
 
@@ -36,14 +37,7 @@ public class SCUnitStatePacket : GamePacket
             case Npc npc:
                 {
                     _baseUnitType = BaseUnitType.Npc;
-                    if (npc.AnimActionId > 0)
-                    {
-                        _modelPostureType = ModelPostureType.ActorModelState;
-                    }
-                    else
-                    {
-                        _modelPostureType = ModelPostureType.None;
-                    }
+                    _modelPostureType = npc.AnimActionId > 0 ? ModelPostureType.ActorModelState : ModelPostureType.None;
 
                     break;
                 }
@@ -89,7 +83,7 @@ public class SCUnitStatePacket : GamePacket
                 stream.Write(0L);           // v?
                 break;
             case BaseUnitType.Npc:
-                stream.WriteBc(npc.ObjId);    // objId
+                stream.WriteBc(npc!.ObjId);    // objId
                 stream.Write(npc.TemplateId); // npc templateId
                 stream.Write(npc.OwnerId);    // ownerId (primarily used for target_my_npc flag)
                 stream.Write((byte)0);        // clientDriven
@@ -109,7 +103,7 @@ public class SCUnitStatePacket : GamePacket
 
                 stream.Write(house.TlId);       // tl
                 stream.Write(house.TemplateId); // house templateId
-                stream.Write((short)buildStep); // buildstep
+                stream.Write((short)buildStep); // build step
                 break;
             case BaseUnitType.Transfer:
                 var transfer = (Transfer)_unit;
@@ -270,14 +264,7 @@ public class SCUnitStatePacket : GamePacket
         }
 
         // ???, ??? and Appellation (Title)
-        if (character is not null)
-        {
-            stream.WritePisc(0, 0, character.Appellations.ActiveAppellation, 0); // pisc
-        }
-        else
-        {
-            stream.WritePisc(0, 0, 0, 0); // pisc
-        }
+        stream.WritePisc(0, 0, character is not null ? character.Appellations.ActiveAppellation : 0u, 0);
 
         // Faction and Guild
         stream.WritePisc((uint)(_unit.Faction?.Id ?? 0), (uint)(_unit.Expedition?.Id ?? 0), 0, 0); // pisc
@@ -303,7 +290,7 @@ public class SCUnitStatePacket : GamePacket
              * 0x01 - 8bit - режим боя - combat mode
              * 0x04 - 6bit - невидимость? - invisibility?
              * 0x08 - 5bit - дуэль - duel
-             * 0x40 - 2bit - gmmode, дополнительно 7 байт - gmmode, extra 7 bytes
+             * 0x40 - 2bit - gmMode, дополнительно 7 байт - gmMode, extra 7 bytes
              * 0x80 - 1bit - дополнительно - additionally - tl(ushort), tl(ushort), tl(ushort), tl(ushort)
              * 0x0100 - 16bit - дополнительно 3 байт - additional 3 bytes (bc), firstHitterTeamId(uint)
              * 0x0400 - 14bit - надпись "Отсутсвует" под именем - the inscription "Missing" under the name
@@ -355,12 +342,12 @@ public class SCUnitStatePacket : GamePacket
         {
             if (!_unit.Buffs.CheckBuff(8000011)) //TODO Wrong place
             {
-                _unit.Buffs.AddBuff(new Buff(_unit, _unit, SkillCaster.GetByType(SkillCasterType.Unit), SkillManager.Instance.GetBuffTemplate(8000011), null, System.DateTime.UtcNow));
+                _unit.Buffs.AddBuff(new Buff(_unit, _unit, SkillCaster.GetByType(SkillCasterType.Unit), SkillManager.Instance.GetBuffTemplate(8000011), null, DateTime.UtcNow));
             }
 
             if (!_unit.Buffs.CheckBuff(8000012)) //TODO Wrong place
             {
-                _unit.Buffs.AddBuff(new Buff(_unit, _unit, SkillCaster.GetByType(SkillCasterType.Unit), SkillManager.Instance.GetBuffTemplate(8000012), null, System.DateTime.UtcNow));
+                _unit.Buffs.AddBuff(new Buff(_unit, _unit, SkillCaster.GetByType(SkillCasterType.Unit), SkillManager.Instance.GetBuffTemplate(8000012), null, DateTime.UtcNow));
             }
         }
 
@@ -389,33 +376,13 @@ public class SCUnitStatePacket : GamePacket
     }
 
     #region Inventory_Equip
-    private void Inventory_Equip(PacketStream stream, Unit unit0, BaseUnitType baseUnitType)
+    private void Inventory_Equip(PacketStream stream, Unit unit, BaseUnitType baseUnitType)
     {
-        var unit = new Unit();
-        switch (baseUnitType)
+        if (unit == null)
         {
-            case BaseUnitType.Character:
-                unit = (Character)unit0;
-                break;
-            case BaseUnitType.Npc:
-                unit = (Npc)unit0;
-                break;
-            case BaseUnitType.Slave:
-                unit = (Slave)_unit;
-                break;
-            case BaseUnitType.Housing:
-                unit = (House)_unit;
-                break;
-            case BaseUnitType.Transfer:
-                unit = (Transfer)_unit;
-                break;
-            case BaseUnitType.Mate:
-                unit = (Mate)_unit;
-                break;
-            case BaseUnitType.Shipyard:
-                unit = (Shipyard)_unit;
-                break;
+            return;
         }
+        
 
         // calculate validFlags
         var index = 0;
@@ -427,11 +394,11 @@ public class SCUnitStatePacket : GamePacket
             {
                 validFlags |= 1 << index;
             }
-
             index++;
         }
         if (validFlags <= 0 && baseUnitType == BaseUnitType.Npc)
         {
+            // ReSharper disable once GrammarMistakeInComment
             unit.ModelParams.SetType(UnitCustomModelType.Skin); // additional check that the NPC has no body and no face
         }
         index = 0;

--- a/AAEmu.Game/Models/Game/Units/UnitCustomModelParams.cs
+++ b/AAEmu.Game/Models/Game/Units/UnitCustomModelParams.cs
@@ -2,7 +2,7 @@
 
 namespace AAEmu.Game.Models.Game.Units;
 
-public enum UnitCustomModelType
+public enum UnitCustomModelType: byte
 {
     None = 0,
     Hair = 1,
@@ -38,7 +38,7 @@ public class FaceModel : PacketMarshaler
     public short MovableDecalMoveX { get; set; }
     public short MovableDecalMoveY { get; set; }
 
-    public FixedDecalAsset[] FixedDecalAsset { get; }
+    private FixedDecalAsset[] FixedDecalAsset { get; }
 
     public uint DiffuseMapId { get; set; }
     public uint NormalMapId { get; set; }
@@ -127,10 +127,9 @@ public class FaceModel : PacketMarshaler
 public class UnitCustomModelParams : PacketMarshaler
 {
     private UnitCustomModelType _type;
-    public uint Id { get; private set; }
-    public uint HairColorId { get; private set; }
-    public uint SkinColorId { get; private set; }
-    public uint ModelId { get; private set; }
+    private uint HairColorId { get; set; }
+    private uint SkinColorId { get; set; }
+    private uint ModelId { get; set; }
     public FaceModel Face { get; private set; }
 
     public UnitCustomModelParams(UnitCustomModelType type = UnitCustomModelType.None)
@@ -138,15 +137,10 @@ public class UnitCustomModelParams : PacketMarshaler
         SetType(type);
     }
 
-    public UnitCustomModelParams SetId(uint id)
-    {
-        Id = id;
-        return this;
-    }
     public UnitCustomModelParams SetType(UnitCustomModelType type)
     {
         _type = type;
-        if (_type == UnitCustomModelType.Face)
+        if (_type >= UnitCustomModelType.Face)
             Face = new FaceModel();
         return this;
     }
@@ -178,18 +172,18 @@ public class UnitCustomModelParams : PacketMarshaler
     {
         SetType((UnitCustomModelType)stream.ReadByte()); // ext
 
-        if (_type == UnitCustomModelType.None)
+        if (_type <= UnitCustomModelType.None)
             return;
 
         HairColorId = stream.ReadUInt32();
 
-        if (_type == UnitCustomModelType.Hair)
+        if (_type <= UnitCustomModelType.Hair)
             return;
 
         SkinColorId = stream.ReadUInt32();
         ModelId = stream.ReadUInt32();
 
-        if (_type == UnitCustomModelType.Skin)
+        if (_type <= UnitCustomModelType.Skin)
             return;
 
         Face.Read(stream);
@@ -198,20 +192,18 @@ public class UnitCustomModelParams : PacketMarshaler
     public override PacketStream Write(PacketStream stream)
     {
         stream.Write((byte)_type); // ext
-        if (_type == UnitCustomModelType.None)
-            return stream;
 
+        if (_type < UnitCustomModelType.Hair)
+            return stream;
         stream.Write(HairColorId);
 
-        if (_type == UnitCustomModelType.Hair)
+        if (_type < UnitCustomModelType.Skin)
             return stream;
-
         stream.Write(SkinColorId);
         stream.Write(ModelId);
 
-        if (_type == UnitCustomModelType.Skin)
+        if (_type < UnitCustomModelType.Face)
             return stream;
-
         stream.Write(Face);
 
         return stream;

--- a/AAEmu.sln.DotSettings
+++ b/AAEmu.sln.DotSettings
@@ -64,6 +64,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Nuia/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=nuian/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=parentable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=pisc/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Proccess/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=procs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=qtype/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
- Assign `Unit.ModelParams` from the `Npc` template's `ModelParams` so `SCUnitState` can actually write it to the client.

- Set the underlying type of `UnitCustomModelType` to byte so it can used more easily for compares.

- Refactor `SCUnitStatePacket` to remove redundant unit casting and object allocations in `Inventory_Equip`.

- Clean up packet code by simplifying ternary expressions and fixing comment typos.

- Adjust visibility of several model parameter properties to improve encapsulation.

- Added `ORDER BY id` to `item_body_parts` queries. This ensures consistent row ordering during model parameter loading, preventing potential issues with NPC looks. This is needed because it's possible to the same slot is assigned multiple times in the database.
