### PR TITLE
feat(game): implement buff persistence system by Evenstone

### DIFF
--- a/AAEmu.Game/Core/Managers/SkillManager.cs
+++ b/AAEmu.Game/Core/Managers/SkillManager.cs
@@ -20,7 +20,7 @@ namespace AAEmu.Game.Core.Managers;
 public class SkillManager(IAnimationManager animationManager, IPlotManager plotManager) : Singleton<SkillManager>, ISkillManager
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
-    private bool _loaded = false;
+    private bool _loaded;
 
     private Dictionary<uint, SkillTemplate> _skills;
     private Dictionary<uint, DefaultSkill> _defaultSkills;
@@ -78,9 +78,7 @@ public class SkillManager(IAnimationManager animationManager, IPlotManager plotM
 
     public SkillTemplate GetSkillTemplate(uint id)
     {
-        if (_skills.TryGetValue(id, out var template))
-            return template;
-        return null;
+        return _skills.GetValueOrDefault(id);
     }
 
     public bool IsDefaultSkill(uint id)
@@ -105,12 +103,7 @@ public class SkillManager(IAnimationManager animationManager, IPlotManager plotM
 
     public BuffTemplate GetBuffTemplate(uint id)
     {
-        // if(_effects["Buff"].ContainsKey(id))
-        //     return (BuffTemplate)_effects["Buff"][id];
-        // return null;
-        if (_buffs.TryGetValue(id, out var template))
-            return template;
-        return null;
+        return _buffs.GetValueOrDefault(id);
     }
 
     public List<BuffTriggerTemplate> GetBuffTriggerTemplates(uint buffId)
@@ -126,15 +119,15 @@ public class SkillManager(IAnimationManager animationManager, IPlotManager plotM
     {
         if (_types.TryGetValue(id, out var type))
         {
-            Logger.Trace("Get Effect Template: type = {0}, id = {1}", type.Type, type.ActualId);
+            Logger.Trace($"Get Effect Template: type = {type.Type}, id = {type.ActualId}");
 
-            if (_effects.TryGetValue(type.Type, out var effect))
+            if (_effects.TryGetValue(type.Type, out _))
             {
                 return _effects[type.Type][type.ActualId];
             }
             else
             {
-                Logger.Warn("No such Effect Type[{0}] found.", type.Type);
+                Logger.Warn($"No such Effect Type[{type.Type}] found.");
                 return null;
             }
         }
@@ -143,7 +136,7 @@ public class SkillManager(IAnimationManager animationManager, IPlotManager plotM
 
     public EffectTemplate GetEffectTemplate(uint id, string type)
     {
-        Logger.Trace("Get Effect Template: type = {0}, id = {1}", type, id);
+        Logger.Trace($"Get Effect Template: type = {type}, id = {id}");
 
         if (_effects.TryGetValue(type, out var value))
         {
@@ -157,37 +150,27 @@ public class SkillManager(IAnimationManager animationManager, IPlotManager plotM
 
     public List<uint> GetBuffTags(uint buffId)
     {
-        if (_buffTags.TryGetValue(buffId, out var tags))
-            return tags;
-        return [];
+        return _buffTags.TryGetValue(buffId, out var tags) ? tags : [];
     }
 
     public List<uint> GetBuffsByTagId(uint tagId)
     {
-        if (_taggedBuffs.TryGetValue(tagId, out var id))
-            return id;
-        return null;
+        return _taggedBuffs.GetValueOrDefault(tagId);
     }
 
     public List<uint> GetSkillTags(uint skillId)
     {
-        if (_skillTags.TryGetValue(skillId, out var tags))
-            return tags;
-        return [];
+        return _skillTags.TryGetValue(skillId, out var tags) ? tags : [];
     }
 
     public List<uint> GetSkillsByTag(uint tagId)
     {
-        if (_taggedSkills.TryGetValue(tagId, out var tag))
-            return tag;
-        return [];
+        return _taggedSkills.TryGetValue(tagId, out var tag) ? tag : [];
     }
 
     public PassiveBuffTemplate GetPassiveBuffTemplate(uint id)
     {
-        if (_passiveBuffs.TryGetValue(id, out var template))
-            return template;
-        return null;
+        return _passiveBuffs.GetValueOrDefault(id);
     }
 
     public List<SkillModifier> GetModifiersByOwnerId(uint id)
@@ -199,9 +182,7 @@ public class SkillManager(IAnimationManager animationManager, IPlotManager plotM
 
     public List<CombatBuffTemplate> GetCombatBuffs(uint reqBuffId)
     {
-        if (_combatBuffs.TryGetValue(reqBuffId, out var buffs))
-            return buffs;
-        return [];
+        return _combatBuffs.TryGetValue(reqBuffId, out var buffs) ? buffs : [];
     }
 
     public List<SkillReagent> GetSkillReagentsBySkillId(uint id)
@@ -450,7 +431,7 @@ public class SkillManager(IAnimationManager animationManager, IPlotManager plotM
                 }
             }
 
-            Logger.Info("Loaded {0} skills", _skills.Count);
+            Logger.Info($"Loaded {_skills.Count} skills");
 
             using (var command = connection.CreateCommand())
             {
@@ -506,6 +487,12 @@ public class SkillManager(IAnimationManager animationManager, IPlotManager plotM
                 {
                     while (reader.Read())
                     {
+                        // These string values are read here so they can fit nicely in the init-only part of the template
+                        var skillControllerIdValue = reader.GetString("skill_controller_id", "0");
+                        var mainHandToolIdValue = reader.GetString("mainhand_tool_id", "0");
+                        var offhandToolIdValue = reader.GetString("offhand_tool_id", "0");
+                        var tickMainHandToolIdValue = reader.GetString("tick_mainhand_tool_id", "0");
+                        var tickOffHandToolIdValue = reader.GetString("tick_offhand_tool_id", "0");
                         var template = new BuffTemplate
                         {
                             Id = reader.GetUInt32("id"),
@@ -543,146 +530,145 @@ public class SkillManager(IAnimationManager animationManager, IPlotManager plotM
                             SpellImmune = reader.GetBoolean("spell_immune", true),
                             RangedImmune = reader.GetBoolean("ranged_immune", true),
                             SiegeImmune = reader.GetBoolean("siege_immune", true),
-                            ImmuneDamage = reader.GetInt32("immune_damage")
+                            ImmuneDamage = reader.GetInt32("immune_damage"),
+                            SkillControllerId =
+                                skillControllerIdValue.Contains("null") ? 0 : uint.Parse(skillControllerIdValue),
+                            ResurrectionHealth = reader.GetInt32("resurrection_health"),
+                            ResurrectionMana = reader.GetInt32("resurrection_mana"),
+                            ResurrectionPercent = reader.GetBoolean("resurrection_percent", true),
+                            LevelDuration = reader.GetInt32("level_duration"),
+                            ReflectionRatio = reader.GetInt32("reflection_ratio"),
+                            ReflectionTargetRatio = reader.GetInt32("reflection_target_ratio"),
+                            KnockbackImmune = reader.GetBoolean("knockback_immune"),
+                            ImmuneBuffTagId = reader.GetUInt32("immune_buff_tag_id", 0),
+                            AuraRelationId = reader.GetUInt32("aura_relation_id"),
+                            GroupId = reader.GetUInt32("group_id", 0),
+                            GroupRank = reader.GetInt32("group_rank"),
+                            PerUnitCreation = reader.GetBoolean("per_unit_creation"),
+                            TickAreaRadius = reader.GetFloat("tick_area_radius"),
+                            TickAreaRelationId = reader.GetUInt32("tick_area_relation_id"),
+                            RemoveOnMove = reader.GetBoolean("remove_on_move", true),
+                            UseSourceFaction = reader.GetBoolean("use_source_faction", true),
+                            FactionId = (FactionsEnum)reader.GetUInt32("faction_id", 0),
+                            Exempt = reader.GetBoolean("exempt", true),
+                            TickAreaFrontAngle = reader.GetInt32("tick_area_front_angle"),
+                            TickAreaAngle = reader.GetInt32("tick_area_angle"),
+                            Psychokinesis = reader.GetBoolean("psychokinesis", true),
+                            NoCollide = reader.GetBoolean("no_collide", true),
+                            PsychokinesisSpeed = reader.GetFloat("psychokinesis_speed"),
+                            RemoveOnDeath = reader.GetBoolean("remove_on_death", true),
+                            TickAnimId = reader.GetUInt32("tick_anim_id", 0),
+                            TickActiveWeaponId = reader.GetUInt32("tick_active_weapon_id"),
+                            ConditionalTick = reader.GetBoolean("conditional_tick", true),
+                            System = reader.GetBoolean("system", true),
+                            AuraSlaveBuffId = reader.GetUInt32("aura_slave_buff_id", 0),
+                            NonPushable = reader.GetBoolean("non_pushable", true),
+                            ActiveWeaponId = reader.GetUInt32("active_weapon_id"),
+                            MaxCharge = reader.GetInt32("max_charge"),
+                            DetectStealth = reader.GetBoolean("detect_stealth", true),
+                            RemoveOnExempt = reader.GetBoolean("remove_on_exempt", true),
+                            RemoveOnLand = reader.GetBoolean("remove_on_land", true),
+                            Gliding = reader.GetBoolean("gliding", true),
+                            GlidingRotateSpeed = reader.GetInt32("gliding_rotate_speed"),
+                            Knockdown = reader.GetBoolean("knock_down", true),
+                            TickAreaExcludeSource = reader.GetBoolean("tick_area_exclude_source", true),
+                            // TODO 
+                            /*
+                                string_instrument_start_anim_id INT,
+                                percussion_instrument_start_anim_id INT,
+                                tube_instrument_start_anim_id INT,
+                                string_instrument_tick_anim_id INT,
+                                percussion_instrument_tick_anim_id INT,
+                                tube_instrument_tick_anim_id INT,
+                                gliding_startup_time REAL,
+                                gliding_startup_speed REAL,
+                                gliding_fall_speed_slow REAL,
+                                gliding_fall_speed_normal REAL,
+                                gliding_fall_speed_fast REAL,
+                                gliding_smooth_time REAL,
+                                gliding_lift_count INT,
+                                gliding_lift_height REAL,
+                                gliding_lift_valid_time REAL,
+                                gliding_lift_duration REAL,
+                                gliding_lift_speed REAL,
+                                gliding_land_height REAL,
+                                gliding_sliding_time REAL,
+                                gliding_move_speed_slow REAL,
+                                gliding_move_speed_normal REAL,
+                                gliding_move_speed_fast REAL,
+                             */
+                            FallDamageImmune = reader.GetBoolean("fall_damage_immune", true),
+                            Kind = (BuffKind)reader.GetInt32("kind_id"),
+                            TransformBuffId = reader.GetUInt32("transform_buff_id", 0),
+                            BlankMinded = reader.GetBoolean("blank_minded", true),
+                            Fastened = reader.GetBoolean("fastened", true),
+                            SlaveApplicable = reader.GetBoolean("slave_applicable", true),
+                            Pacifist = reader.GetBoolean("pacifist", true),
+                            RemoveOnInteraction = reader.GetBoolean("remove_on_interaction", true),
+                            Crime = reader.GetBoolean("crime", true),
+                            RemoveOnUnmount = reader.GetBoolean("remove_on_unmount", true),
+                            AuraChildOnly = reader.GetBoolean("aura_child_only", true),
+                            RemoveOnMount = reader.GetBoolean("remove_on_mount", true),
+                            RemoveOnStartSkill = reader.GetBoolean("remove_on_start_skill", true),
+                            SprintMotion = reader.GetBoolean("sprint_motion", true),
+                            TelescopeRange = reader.GetFloat("telescope_range"),
+                            MainhandToolId = mainHandToolIdValue.Length > 0 ? uint.Parse(mainHandToolIdValue) : 0,
+                            OffhandToolId = offhandToolIdValue.Length > 0 ? uint.Parse(offhandToolIdValue) : 0,
+                            TickMainhandToolId = tickMainHandToolIdValue.Length > 0 ? uint.Parse(tickMainHandToolIdValue) : 0,
+                            TickOffhandToolId = tickOffHandToolIdValue.Length > 0 ? uint.Parse(tickOffHandToolIdValue) : 0,
+                            TickLevelManaCost = reader.GetFloat("tick_level_mana_cost"),
+                            WalkOnly = reader.GetBoolean("walk_only", true),
+                            CannotJump = reader.GetBoolean("cannot_jump", true),
+                            CrowdBuffId = reader.GetUInt32("crowd_buff_id", 0),
+                            CrowdRadius = reader.GetFloat("crowd_radius"),
+                            CrowdNumber = reader.GetInt32("crowd_number"),
+                            EvadeTelescope = reader.GetBoolean("evade_telescope", true),
+                            TransferTelescopeRange = reader.GetFloat("transfer_telescope_range"),
+                            RemoveOnAttackSpellDot = reader.GetBoolean("remove_on_attack_spell_dot", true),
+                            RemoveOnAttackEtcDot = reader.GetBoolean("remove_on_attack_etc_dot", true),
+                            RemoveOnAttackBuffTrigger = reader.GetBoolean("remove_on_attack_buff_trigger", true),
+                            RemoveOnAttackEtc = reader.GetBoolean("remove_on_attack_etc", true),
+                            RemoveOnAttackedSpellDot = reader.GetBoolean("remove_on_attacked_spell_dot", true),
+                            RemoveOnAttackedEtcDot = reader.GetBoolean("remove_on_attacked_etc_dot", true),
+                            RemoveOnAttackedBuffTrigger = reader.GetBoolean("remove_on_attacked_buff_trigger", true),
+                            RemoveOnAttackedEtc = reader.GetBoolean("remove_on_attacked_etc", true),
+                            RemoveOnDamageSpellDot = reader.GetBoolean("remove_on_damage_spell_dot", true),
+                            RemoveOnDamageEtcDot = reader.GetBoolean("remove_on_damage_etc_dot", true),
+                            RemoveOnDamageBuffTrigger = reader.GetBoolean("remove_on_damage_buff_trigger", true),
+                            RemoveOnDamageEtc = reader.GetBoolean("remove_on_damage_etc", true),
+                            RemoveOnDamagedSpellDot = reader.GetBoolean("remove_on_damaged_spell_dot", true),
+                            RemoveOnDamagedEtcDot = reader.GetBoolean("remove_on_damaged_etc_dot", true),
+                            RemoveOnDamagedBuffTrigger = reader.GetBoolean("remove_on_damaged_buff_trigger", true),
+                            RemoveOnDamagedEtc = reader.GetBoolean("remove_on_damaged_etc", true),
+                            OwnerOnly = reader.GetBoolean("owner_only", true),
+                            RemoveOnAutoAttack = reader.GetBoolean("remove_on_autoattack", true),
+                            SaveRuleId = (BuffSaveRuleType)reader.GetUInt32("save_rule_id"),
+                            AntiStealth = reader.GetBoolean("anti_stealth", true),
+                            Scale = reader.GetFloat("scale"),
+                            ScaleDuration = reader.GetFloat("scaleDuration"),
+                            ImmuneExceptCreator = reader.GetBoolean("immune_except_creator", true),
+                            ImmuneExceptSkillTagId = reader.GetUInt32("immune_except_skill_tag_id", 0),
+                            FindSchoolOfFishRange = reader.GetFloat("find_school_of_fish_range"),
+                            AnimActionId = reader.GetUInt32("anim_action_id", 0),
+                            DeadApplicable = reader.GetBoolean("dead_applicable", true),
+                            TickAreaUseOriginSource = reader.GetBoolean("tick_area_use_origin_source", true),
+                            RealTime = reader.GetBoolean("real_time", true),
+                            DoNotRemoveByOtherSkillController =
+                                reader.GetBoolean("do_not_remove_by_other_skill_controller", true),
+                            CooldownSkillId = reader.GetUInt32("cooldown_skill_id", 0),
+                            CooldownSkillTime = reader.GetInt32("cooldown_skill_time"),
+                            ManaBurnImmune = reader.GetBoolean("mana_burn_immune", true),
+                            FreezeShip = reader.GetBoolean("freeze_ship", true),
+                            CrowdFriendly = reader.GetBoolean("crowd_friendly", true),
+                            CrowdHostile = reader.GetBoolean("crowd_hostile", true),
                         };
-                        var value = reader.GetString("skill_controller_id", "0");
-                        template.SkillControllerId = value.Contains("null") ? 0 : uint.Parse(value);
-                        template.ResurrectionHealth = reader.GetInt32("resurrection_health");
-                        template.ResurrectionMana = reader.GetInt32("resurrection_mana");
-                        template.ResurrectionPercent = reader.GetBoolean("resurrection_percent", true);
-                        template.LevelDuration = reader.GetInt32("level_duration");
-                        template.ReflectionRatio = reader.GetInt32("reflection_ratio");
-                        template.ReflectionTargetRatio = reader.GetInt32("reflection_target_ratio");
-                        template.KnockbackImmune = reader.GetBoolean("knockback_immune");
-                        template.ImmuneBuffTagId = reader.GetUInt32("immune_buff_tag_id", 0);
-                        template.AuraRelationId = reader.GetUInt32("aura_relation_id");
-                        template.GroupId = reader.GetUInt32("group_id", 0);
-                        template.GroupRank = reader.GetInt32("group_rank");
-                        template.PerUnitCreation = reader.GetBoolean("per_unit_creation");
-                        template.TickAreaRadius = reader.GetFloat("tick_area_radius");
-                        template.TickAreaRelationId = reader.GetUInt32("tick_area_relation_id");
-                        template.RemoveOnMove = reader.GetBoolean("remove_on_move", true);
-                        template.UseSourceFaction = reader.GetBoolean("use_source_faction", true);
-                        template.FactionId = (FactionsEnum)reader.GetUInt32("faction_id", 0);
-                        template.Exempt = reader.GetBoolean("exempt", true);
-                        template.TickAreaFrontAngle = reader.GetInt32("tick_area_front_angle");
-                        template.TickAreaAngle = reader.GetInt32("tick_area_angle");
-                        template.Psychokinesis = reader.GetBoolean("psychokinesis", true);
-                        template.NoCollide = reader.GetBoolean("no_collide", true);
-                        template.PsychokinesisSpeed = reader.GetFloat("psychokinesis_speed");
-                        template.RemoveOnDeath = reader.GetBoolean("remove_on_death", true);
-                        template.TickAnimId = reader.GetUInt32("tick_anim_id", 0);
-                        template.TickActiveWeaponId = reader.GetUInt32("tick_active_weapon_id");
-                        template.ConditionalTick = reader.GetBoolean("conditional_tick", true);
-                        template.System = reader.GetBoolean("system", true);
-                        template.AuraSlaveBuffId = reader.GetUInt32("aura_slave_buff_id", 0);
-                        template.NonPushable = reader.GetBoolean("non_pushable", true);
-                        template.ActiveWeaponId = reader.GetUInt32("active_weapon_id");
-                        template.MaxCharge = reader.GetInt32("max_charge");
-                        template.DetectStealth = reader.GetBoolean("detect_stealth", true);
-                        template.RemoveOnExempt = reader.GetBoolean("remove_on_exempt", true);
-                        template.RemoveOnLand = reader.GetBoolean("remove_on_land", true);
-                        template.Gliding = reader.GetBoolean("gliding", true);
-                        template.GlidingRotateSpeed = reader.GetInt32("gliding_rotate_speed");
-                        template.Knockdown = reader.GetBoolean("knock_down", true);
-                        template.TickAreaExcludeSource = reader.GetBoolean("tick_area_exclude_source", true);
-                        // TODO 
-                        /*
-                            string_instrument_start_anim_id INT,
-                            percussion_instrument_start_anim_id INT,
-                            tube_instrument_start_anim_id INT,
-                            string_instrument_tick_anim_id INT,
-                            percussion_instrument_tick_anim_id INT,
-                            tube_instrument_tick_anim_id INT,
-                            gliding_startup_time REAL,
-                            gliding_startup_speed REAL,
-                            gliding_fall_speed_slow REAL,
-                            gliding_fall_speed_normal REAL,
-                            gliding_fall_speed_fast REAL,
-                            gliding_smooth_time REAL,
-                            gliding_lift_count INT,
-                            gliding_lift_height REAL,
-                            gliding_lift_valid_time REAL,
-                            gliding_lift_duration REAL,
-                            gliding_lift_speed REAL,
-                            gliding_land_height REAL,
-                            gliding_sliding_time REAL,
-                            gliding_move_speed_slow REAL,
-                            gliding_move_speed_normal REAL,
-                            gliding_move_speed_fast REAL,
-                         */
-                        template.FallDamageImmune = reader.GetBoolean("fall_damage_immune", true);
-                        template.Kind = (BuffKind)reader.GetInt32("kind_id");
-                        template.TransformBuffId = reader.GetUInt32("transform_buff_id", 0);
-                        template.BlankMinded = reader.GetBoolean("blank_minded", true);
-                        template.Fastened = reader.GetBoolean("fastened", true);
-                        template.SlaveApplicable = reader.GetBoolean("slave_applicable", true);
-                        template.Pacifist = reader.GetBoolean("pacifist", true);
-                        template.RemoveOnInteraction = reader.GetBoolean("remove_on_interaction", true);
-                        template.Crime = reader.GetBoolean("crime", true);
-                        template.RemoveOnUnmount = reader.GetBoolean("remove_on_unmount", true);
-                        template.AuraChildOnly = reader.GetBoolean("aura_child_only", true);
-                        template.RemoveOnMount = reader.GetBoolean("remove_on_mount", true);
-                        template.RemoveOnStartSkill = reader.GetBoolean("remove_on_start_skill", true);
-                        template.SprintMotion = reader.GetBoolean("sprint_motion", true);
-                        template.TelescopeRange = reader.GetFloat("telescope_range");
-                        value = reader.GetString("mainhand_tool_id", "0");
-                        template.MainhandToolId = value.Length > 0 ? uint.Parse(value) : 0;
-                        value = reader.GetString("offhand_tool_id", "0");
-                        template.OffhandToolId = value.Length > 0 ? uint.Parse(value) : 0;
-                        value = reader.GetString("tick_mainhand_tool_id", "0");
-                        template.TickMainhandToolId = value.Length > 0 ? uint.Parse(value) : 0;
-                        value = reader.GetString("tick_offhand_tool_id", "0");
-                        template.TickOffhandToolId = value.Length > 0 ? uint.Parse(value) : 0;
-                        template.TickLevelManaCost = reader.GetFloat("tick_level_mana_cost");
-                        template.WalkOnly = reader.GetBoolean("walk_only", true);
-                        template.CannnotJump = reader.GetBoolean("cannot_jump", true);
-                        template.CrowdBuffId = reader.GetUInt32("crowd_buff_id", 0);
-                        template.CrowdRadius = reader.GetFloat("crowd_radius");
-                        template.CrowdNumber = reader.GetInt32("crowd_number");
-                        template.EvadeTelescope = reader.GetBoolean("evade_telescope", true);
-                        template.TransferTelescopeRange = reader.GetFloat("transfer_telescope_range");
-                        template.RemoveOnAttackSpellDot = reader.GetBoolean("remove_on_attack_spell_dot", true);
-                        template.RemoveOnAttackEtcDot = reader.GetBoolean("remove_on_attack_etc_dot", true);
-                        template.RemoveOnAttackBuffTrigger = reader.GetBoolean("remove_on_attack_buff_trigger", true);
-                        template.RemoveOnAttackEtc = reader.GetBoolean("remove_on_attack_etc", true);
-                        template.RemoveOnAttackedSpellDot = reader.GetBoolean("remove_on_attacked_spell_dot", true);
-                        template.RemoveOnAttackedEtcDot = reader.GetBoolean("remove_on_attacked_etc_dot", true);
-                        template.RemoveOnAttackedBuffTrigger = reader.GetBoolean("remove_on_attacked_buff_trigger", true);
-                        template.RemoveOnAttackedEtc = reader.GetBoolean("remove_on_attacked_etc", true);
-                        template.RemoveOnDamageSpellDot = reader.GetBoolean("remove_on_damage_spell_dot", true);
-                        template.RemoveOnDamageEtcDot = reader.GetBoolean("remove_on_damage_etc_dot", true);
-                        template.RemoveOnDamageBuffTrigger = reader.GetBoolean("remove_on_damage_buff_trigger", true);
-                        template.RemoveOnDamageEtc = reader.GetBoolean("remove_on_damage_etc", true);
-                        template.RemoveOnDamagedSpellDot = reader.GetBoolean("remove_on_damaged_spell_dot", true);
-                        template.RemoveOnDamagedEtcDot = reader.GetBoolean("remove_on_damaged_etc_dot", true);
-                        template.RemoveOnDamagedBuffTrigger = reader.GetBoolean("remove_on_damaged_buff_trigger", true);
-                        template.RemoveOnDamagedEtc = reader.GetBoolean("remove_on_damaged_etc", true);
-                        template.OwnerOnly = reader.GetBoolean("owner_only", true);
-                        template.RemoveOnAutoAttack = reader.GetBoolean("remove_on_autoattack", true);
-                        template.SaveRuleId = reader.GetUInt32("save_rule_id");
-                        template.AntiStealth = reader.GetBoolean("anti_stealth", true);
-                        template.Scale = reader.GetFloat("scale");
-                        template.ScaleDuration = reader.GetFloat("scaleDuration");
-                        template.ImmuneExceptCreator = reader.GetBoolean("immune_except_creator", true);
-                        template.ImmuneExceptSkillTagId = reader.GetUInt32("immune_except_skill_tag_id", 0);
-                        template.FindSchoolOfFishRange = reader.GetFloat("find_school_of_fish_range");
-                        template.AnimActionId = reader.GetUInt32("anim_action_id", 0);
-                        template.DeadApplicable = reader.GetBoolean("dead_applicable", true);
-                        template.TickAreaUseOriginSource = reader.GetBoolean("tick_area_use_origin_source", true);
-                        template.RealTime = reader.GetBoolean("real_time", true);
-                        template.DoNotRemoveByOtherSkillController = reader.GetBoolean("do_not_remove_by_other_skill_controller", true);
-                        template.CooldownSkillId = reader.GetUInt32("cooldown_skill_id", 0);
-                        template.CooldownSkillTime = reader.GetInt32("cooldown_skill_time");
-                        template.ManaBurnImmune = reader.GetBoolean("mana_burn_immune", true);
-                        template.FreezeShip = reader.GetBoolean("freeze_ship", true);
-                        template.CrowdFriendly = reader.GetBoolean("crowd_friendly", true);
-                        template.CrowdHostile = reader.GetBoolean("crowd_hostile", true);
+
                         // _effects["Buff"].Add(template.Id, template);
                         _buffs.Add(template.Id, template);
                     }
                 }
             }
+
             using (var command = connection.CreateCommand())
             {
                 command.CommandText = "SELECT * FROM buff_effects";
@@ -1738,7 +1724,7 @@ public class SkillManager(IAnimationManager animationManager, IPlotManager plotM
                         trigger.TargetNoBuffTagId = reader.GetUInt32("target_no_buff_tag_id", 0);
                         trigger.Synergy = reader.GetBoolean("synergy", true);
 
-                        //Apparently this is possible..
+                        // Apparently this is possible.
                         if (trigger.Effect != null)
                         {
                             value.Add(trigger);
@@ -1791,7 +1777,7 @@ public class SkillManager(IAnimationManager animationManager, IPlotManager plotM
                 }
                 Logger.Info("Skill Products loaded");
 
-                OnSkillsLoaded?.Invoke(this, new EventArgs());
+                OnSkillsLoaded?.Invoke(this, EventArgs.Empty);
             }
         }
 

--- a/AAEmu.Game/Core/Network/Connections/GameConnection.cs
+++ b/AAEmu.Game/Core/Network/Connections/GameConnection.cs
@@ -21,7 +21,7 @@ public class GameConnection
     public PacketStream LastPacket { get; set; }
     public AccountPayment Payment { get; set; }
     public int PacketCount { get; set; }
-    public List<IDisposable> Subscribers { get; set; }
+    private List<IDisposable> Subscribers { get; set; }
     public GameState State { get; set; }
     public Character ActiveChar { get; set; }
     public Dictionary<uint, Character> Characters { get; set; }
@@ -186,12 +186,17 @@ public class GameConnection
         // Remove Radars
         RadarManager.Instance.UnRegister(activeChar);
 
+        // Cancel all running buff effect tasks before removing the character.
+        // The buffs themselves are saved to DB inside SaveDirectlyToDatabase() → Character.Save().
+        activeChar.Buffs?.CancelAllEffectTasks();
+
+        // Hide/Despawn the player
         activeChar.Delete();
         // Removed ReleaseId here to try and fix party/raid disconnect and reconnect issues. Replaced with saving the data
         //ObjectIdManager.Instance.ReleaseId(ActiveChar.ObjId);
 
         // Do a manual save here as it's no longer in _characters at this point
-        // TODO: might need a better option like saving this transaction for later to be used by the SaveMananger
+        // TODO: might need a better option like saving this transaction for later to be used by the SaveManager
         activeChar.SaveDirectlyToDatabase();
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSSelectCharacterPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSSelectCharacterPacket.cs
@@ -104,8 +104,9 @@ public class CSSelectCharacterPacket() : GamePacket(CSOffsets.CSSelectCharacterP
                 character.Buffs.AddBuff(new Buff(character, character, casterObj, buffTemplate, null, DateTime.UtcNow) { Passive = true });
             }
             
-            // TODO: Load persistent buffs
-
+            // Load persistent buffs from database
+            character.Buffs.LoadActiveBuffs(character);
+            
             character.UpdateGearBonuses(null, null);
             character.RestoreSavedHpMp();
 

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -2533,12 +2533,15 @@ public partial class Character : Unit, ICharacter
             Abilities?.Save(connection, transaction);
             Actability?.Save(connection, transaction);
             Appellations?.Save(connection, transaction);
+            // Save active buffs that should persist across logout (SaveRuleId > 0)
+            Buffs?.SaveActiveBuffs(connection, transaction, Id);
             Portals?.Save(connection, transaction);
             Friends?.Save(connection, transaction);
             Blocked?.Save(connection, transaction);
             Skills?.Save(connection, transaction);
             Quests?.Save(connection, transaction);
             Mates?.Save(connection, transaction);
+            
             result = true;
         }
         catch (Exception ex)

--- a/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
+++ b/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
@@ -9,156 +9,157 @@ using AAEmu.Game.Models.Game.Skills.Effects;
 using AAEmu.Game.Models.Game.Skills.Utils;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.StaticValues;
+// ReSharper disable UnusedAutoPropertyAccessor.Global
 
 namespace AAEmu.Game.Models.Game.Skills.Templates;
 
 public class BuffTemplate
 {
-    public uint Id { get; set; }
+    public uint Id { get; init; }
     public uint BuffId => Id;
-    public uint AnimStartId { get; set; }
-    public uint AnimEndId { get; set; }
-    public int Duration { get; set; }
-    public double Tick { get; set; }
-    public bool Silence { get; set; }
-    public bool Root { get; set; }
-    public bool Sleep { get; set; }
-    public bool Stun { get; set; }
-    public bool Cripled { get; set; }
-    public bool Stealth { get; set; }
-    public bool RemoveOnSourceDead { get; set; }
-    public uint LinkBuffId { get; set; }
-    public int TickManaCost { get; set; }
-    public BuffStackRule StackRule { get; set; }
-    public int InitMinCharge { get; set; }
-    public int InitMaxCharge { get; set; }
-    public int MaxStack { get; set; }
-    public uint DamageAbsorptionTypeId { get; set; }
-    public int DamageAbsorptionPerHit { get; set; }
-    public int AuraRadius { get; set; }
-    public int ManaShieldRatio { get; set; }
-    public bool FrameHold { get; set; }
-    public bool Ragdoll { get; set; }
-    public bool OneTime { get; set; }
-    public int ReflectionChance { get; set; }
-    public uint ReflectionTypeId { get; set; }
-    public uint RequireBuffId { get; set; }
-    public bool Taunt { get; set; }
-    public bool TauntWithTopAggro { get; set; }
-    public bool RemoveOnUseSkill { get; set; }
-    public bool MeleeImmune { get; set; }
-    public bool SpellImmune { get; set; }
-    public bool RangedImmune { get; set; }
-    public bool SiegeImmune { get; set; }
-    public int ImmuneDamage { get; set; }
-    public uint SkillControllerId { get; set; }
-    public int ResurrectionHealth { get; set; }
-    public int ResurrectionMana { get; set; }
-    public bool ResurrectionPercent { get; set; }
-    public int LevelDuration { get; set; }
-    public int ReflectionRatio { get; set; }
-    public int ReflectionTargetRatio { get; set; }
-    public bool KnockbackImmune { get; set; }
-    public uint ImmuneBuffTagId { get; set; }
-    public uint AuraRelationId { get; set; }
-    public uint GroupId { get; set; }
-    public int GroupRank { get; set; }
-    public bool PerUnitCreation { get; set; }
-    public float TickAreaRadius { get; set; }
-    public uint TickAreaRelationId { get; set; }
-    public bool RemoveOnMove { get; set; }
-    public bool UseSourceFaction { get; set; }
-    public FactionsEnum FactionId { get; set; }
-    public bool Exempt { get; set; }
-    public int TickAreaFrontAngle { get; set; }
-    public int TickAreaAngle { get; set; }
-    public bool Psychokinesis { get; set; }
-    public bool NoCollide { get; set; }
-    public float PsychokinesisSpeed { get; set; }
-    public bool RemoveOnDeath { get; set; }
-    public uint TickAnimId { get; set; }
-    public uint TickActiveWeaponId { get; set; }
-    public bool ConditionalTick { get; set; }
-    public bool System { get; set; }
-    public uint AuraSlaveBuffId { get; set; }
-    public bool NonPushable { get; set; }
-    public uint ActiveWeaponId { get; set; }
-    public int MaxCharge { get; set; }
-    public bool DetectStealth { get; set; }
-    public bool RemoveOnExempt { get; set; }
-    public bool RemoveOnLand { get; set; }
-    public bool Gliding { get; set; }
-    public int GlidingRotateSpeed { get; set; }
-    public bool Knockdown { get; set; }
-    public bool TickAreaExcludeSource { get; set; }
-    public bool FallDamageImmune { get; set; }
-    public BuffKind Kind { get; set; }
-    public uint TransformBuffId { get; set; }
-    public bool BlankMinded { get; set; }
-    public bool Fastened { get; set; }
-    public bool SlaveApplicable { get; set; }
-    public bool Pacifist { get; set; }
-    public bool RemoveOnInteraction { get; set; }
-    public bool Crime { get; set; }
-    public bool RemoveOnUnmount { get; set; }
-    public bool AuraChildOnly { get; set; }
-    public bool RemoveOnMount { get; set; }
-    public bool RemoveOnStartSkill { get; set; }
-    public bool SprintMotion { get; set; }
-    public float TelescopeRange { get; set; }
-    public uint MainhandToolId { get; set; }
-    public uint OffhandToolId { get; set; }
-    public uint TickMainhandToolId { get; set; }
-    public uint TickOffhandToolId { get; set; }
-    public float TickLevelManaCost { get; set; }
-    public bool WalkOnly { get; set; }
-    public bool CannnotJump { get; set; }
-    public uint CrowdBuffId { get; set; }
-    public float CrowdRadius { get; set; }
-    public int CrowdNumber { get; set; }
-    public bool EvadeTelescope { get; set; }
-    public float TransferTelescopeRange { get; set; }
-    public bool RemoveOnAttackSpellDot { get; set; }
-    public bool RemoveOnAttackEtcDot { get; set; }
-    public bool RemoveOnAttackBuffTrigger { get; set; }
-    public bool RemoveOnAttackEtc { get; set; }
-    public bool RemoveOnAttackedSpellDot { get; set; }
-    public bool RemoveOnAttackedEtcDot { get; set; }
-    public bool RemoveOnAttackedBuffTrigger { get; set; }
-    public bool RemoveOnAttackedEtc { get; set; }
-    public bool RemoveOnDamageSpellDot { get; set; }
-    public bool RemoveOnDamageEtcDot { get; set; }
-    public bool RemoveOnDamageBuffTrigger { get; set; }
-    public bool RemoveOnDamageEtc { get; set; }
-    public bool RemoveOnDamagedSpellDot { get; set; }
-    public bool RemoveOnDamagedEtcDot { get; set; }
-    public bool RemoveOnDamagedBuffTrigger { get; set; }
-    public bool RemoveOnDamagedEtc { get; set; }
-    public bool OwnerOnly { get; set; }
-    public bool RemoveOnAutoAttack { get; set; }
-    public uint SaveRuleId { get; set; }
-    public bool AntiStealth { get; set; }
-    public float Scale { get; set; }
-    public float ScaleDuration { get; set; }
-    public bool ImmuneExceptCreator { get; set; }
-    public uint ImmuneExceptSkillTagId { get; set; }
-    public float FindSchoolOfFishRange { get; set; }
-    public uint AnimActionId { get; set; }
-    public bool DeadApplicable { get; set; }
-    public bool TickAreaUseOriginSource { get; set; }
-    public bool RealTime { get; set; }
-    public bool DoNotRemoveByOtherSkillController { get; set; }
-    public uint CooldownSkillId { get; set; }
-    public int CooldownSkillTime { get; set; }
-    public bool ManaBurnImmune { get; set; }
-    public bool FreezeShip { get; set; }
-    public bool CrowdFriendly { get; set; }
-    public bool CrowdHostile { get; set; }
+    public uint AnimStartId { get; init; }
+    public uint AnimEndId { get; init; }
+    public int Duration { get; init; }
+    public double Tick { get; init; }
+    public bool Silence { get; init; }
+    public bool Root { get; init; }
+    public bool Sleep { get; init; }
+    public bool Stun { get; init; }
+    public bool Cripled { get; init; }
+    public bool Stealth { get; init; }
+    public bool RemoveOnSourceDead { get; init; }
+    public uint LinkBuffId { get; init; }
+    public int TickManaCost { get; init; }
+    public BuffStackRule StackRule { get; init; }
+    public int InitMinCharge { get; init; }
+    public int InitMaxCharge { get; init; }
+    public int MaxStack { get; init; }
+    public uint DamageAbsorptionTypeId { get; init; }
+    public int DamageAbsorptionPerHit { get; init; }
+    public int AuraRadius { get; init; }
+    public int ManaShieldRatio { get; init; }
+    public bool FrameHold { get; init; }
+    public bool Ragdoll { get; init; }
+    public bool OneTime { get; init; }
+    public int ReflectionChance { get; init; }
+    public uint ReflectionTypeId { get; init; }
+    public uint RequireBuffId { get; init; }
+    public bool Taunt { get; init; }
+    public bool TauntWithTopAggro { get; init; }
+    public bool RemoveOnUseSkill { get; init; }
+    public bool MeleeImmune { get; init; }
+    public bool SpellImmune { get; init; }
+    public bool RangedImmune { get; init; }
+    public bool SiegeImmune { get; init; }
+    public int ImmuneDamage { get; init; }
+    public uint SkillControllerId { get; init; }
+    public int ResurrectionHealth { get; init; }
+    public int ResurrectionMana { get; init; }
+    public bool ResurrectionPercent { get; init; }
+    public int LevelDuration { get; init; }
+    public int ReflectionRatio { get; init; }
+    public int ReflectionTargetRatio { get; init; }
+    public bool KnockbackImmune { get; init; }
+    public uint ImmuneBuffTagId { get; init; }
+    public uint AuraRelationId { get; init; }
+    public uint GroupId { get; init; }
+    public int GroupRank { get; init; }
+    public bool PerUnitCreation { get; init; }
+    public float TickAreaRadius { get; init; }
+    public uint TickAreaRelationId { get; init; }
+    public bool RemoveOnMove { get; init; }
+    public bool UseSourceFaction { get; init; }
+    public FactionsEnum FactionId { get; init; }
+    public bool Exempt { get; init; }
+    public int TickAreaFrontAngle { get; init; }
+    public int TickAreaAngle { get; init; }
+    public bool Psychokinesis { get; init; }
+    public bool NoCollide { get; init; }
+    public float PsychokinesisSpeed { get; init; }
+    public bool RemoveOnDeath { get; init; }
+    public uint TickAnimId { get; init; }
+    public uint TickActiveWeaponId { get; init; }
+    public bool ConditionalTick { get; init; }
+    public bool System { get; init; }
+    public uint AuraSlaveBuffId { get; init; }
+    public bool NonPushable { get; init; }
+    public uint ActiveWeaponId { get; init; }
+    public int MaxCharge { get; init; }
+    public bool DetectStealth { get; init; }
+    public bool RemoveOnExempt { get; init; }
+    public bool RemoveOnLand { get; init; }
+    public bool Gliding { get; init; }
+    public int GlidingRotateSpeed { get; init; }
+    public bool Knockdown { get; init; }
+    public bool TickAreaExcludeSource { get; init; }
+    public bool FallDamageImmune { get; init; }
+    public BuffKind Kind { get; init; }
+    public uint TransformBuffId { get; init; }
+    public bool BlankMinded { get; init; }
+    public bool Fastened { get; init; }
+    public bool SlaveApplicable { get; init; }
+    public bool Pacifist { get; init; }
+    public bool RemoveOnInteraction { get; init; }
+    public bool Crime { get; init; }
+    public bool RemoveOnUnmount { get; init; }
+    public bool AuraChildOnly { get; init; }
+    public bool RemoveOnMount { get; init; }
+    public bool RemoveOnStartSkill { get; init; }
+    public bool SprintMotion { get; init; }
+    public float TelescopeRange { get; init; }
+    public uint MainhandToolId { get; init; }
+    public uint OffhandToolId { get; init; }
+    public uint TickMainhandToolId { get; init; }
+    public uint TickOffhandToolId { get; init; }
+    public float TickLevelManaCost { get; init; }
+    public bool WalkOnly { get; init; }
+    public bool CannotJump { get; init; }
+    public uint CrowdBuffId { get; init; }
+    public float CrowdRadius { get; init; }
+    public int CrowdNumber { get; init; }
+    public bool EvadeTelescope { get; init; }
+    public float TransferTelescopeRange { get; init; }
+    public bool RemoveOnAttackSpellDot { get; init; }
+    public bool RemoveOnAttackEtcDot { get; init; }
+    public bool RemoveOnAttackBuffTrigger { get; init; }
+    public bool RemoveOnAttackEtc { get; init; }
+    public bool RemoveOnAttackedSpellDot { get; init; }
+    public bool RemoveOnAttackedEtcDot { get; init; }
+    public bool RemoveOnAttackedBuffTrigger { get; init; }
+    public bool RemoveOnAttackedEtc { get; init; }
+    public bool RemoveOnDamageSpellDot { get; init; }
+    public bool RemoveOnDamageEtcDot { get; init; }
+    public bool RemoveOnDamageBuffTrigger { get; init; }
+    public bool RemoveOnDamageEtc { get; init; }
+    public bool RemoveOnDamagedSpellDot { get; init; }
+    public bool RemoveOnDamagedEtcDot { get; init; }
+    public bool RemoveOnDamagedBuffTrigger { get; init; }
+    public bool RemoveOnDamagedEtc { get; init; }
+    public bool OwnerOnly { get; init; }
+    public bool RemoveOnAutoAttack { get; init; }
+    public BuffSaveRuleType SaveRuleId { get; init; }
+    public bool AntiStealth { get; init; }
+    public float Scale { get; init; }
+    public float ScaleDuration { get; init; }
+    public bool ImmuneExceptCreator { get; init; }
+    public uint ImmuneExceptSkillTagId { get; init; }
+    public float FindSchoolOfFishRange { get; init; }
+    public uint AnimActionId { get; init; }
+    public bool DeadApplicable { get; init; }
+    public bool TickAreaUseOriginSource { get; init; }
+    public bool RealTime { get; init; }
+    public bool DoNotRemoveByOtherSkillController { get; init; }
+    public uint CooldownSkillId { get; init; }
+    public int CooldownSkillTime { get; init; }
+    public bool ManaBurnImmune { get; init; }
+    public bool FreezeShip { get; init; }
+    public bool CrowdFriendly { get; init; }
+    public bool CrowdHostile { get; init; }
     public bool OnActionTime => Tick > 0;
 
-    public List<TickEffect> TickEffects { get; set; } = [];
-    public List<BonusTemplate> Bonuses { get; set; } = [];
-    public List<DynamicBonusTemplate> DynamicBonuses { get; set; } = [];
+    public List<TickEffect> TickEffects { get; } = [];
+    public List<BonusTemplate> Bonuses { get; } = [];
+    public List<DynamicBonusTemplate> DynamicBonuses { get; } = [];
 
     public void Apply(BaseUnit caster, SkillCaster casterObj, BaseUnit target, SkillCastTarget targetObj,
         CastAction castObj, EffectSource source, SkillObject skillObject, DateTime time,
@@ -201,7 +202,7 @@ public class BuffTemplate
                 abLevel = (uint)source.Skill.Template.AbilityLevel;
             }
         }
-        target.Buffs.AddBuff(new Buff(target, caster, casterObj, this, source?.Skill, time) { AbLevel = abLevel });
+        target.Buffs.AddBuff(new Buff(target, caster, casterObj, this, source.Skill, time) { AbLevel = abLevel });
     }
 
     public void Start(BaseUnit caster, BaseUnit owner, Buff buff)
@@ -265,7 +266,7 @@ public class BuffTemplate
         }
     }
 
-    public void DoAreaTick(BaseUnit caster, BaseUnit owner, Buff buff)
+    private void DoAreaTick(BaseUnit caster, BaseUnit owner, Buff buff)
     {
         var units = WorldManager.GetAround<Unit>(owner, TickAreaRadius);
 

--- a/AAEmu.Game/Models/Game/Units/Buffs.cs
+++ b/AAEmu.Game/Models/Game/Units/Buffs.cs
@@ -8,11 +8,18 @@ using AAEmu.Game.Models.Game.Skills.Buffs;
 using AAEmu.Game.Models.Game.Skills.Static;
 using AAEmu.Game.Models.Game.Skills.Templates;
 using AAEmu.Game.Models.StaticValues;
+using AAEmu.Commons.Utils.DB;
+using MySql.Data.MySqlClient;
+using NLog;
 
 namespace AAEmu.Game.Models.Game.Units;
 
 public class Buffs : IBuffs
 {
+    // ReSharper disable once InconsistentNaming
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+    private const int MinimumBuffDurationToSave = 60000;
+
     // ReSharper disable once ChangeFieldTypeToSystemThreadingLock
     private readonly object _lock = new();
     private uint _nextIndex;
@@ -374,7 +381,7 @@ public class Buffs : IBuffs
             {
                 case BuffStackRule.Refresh:
                     foreach (var e in new List<Buff>(_effects))
-                        if (e != null && e.InUse && e.Template.BuffId == buff.Template.BuffId)
+                        if (e is { InUse: true } && e.Template.BuffId == buff.Template.BuffId)
                             if (buff.GetTimeLeft() < e.GetTimeLeft())
                                 return;
                             else
@@ -382,7 +389,7 @@ public class Buffs : IBuffs
                     break;
                 case BuffStackRule.ChargeRefresh:
                     foreach (var e in new List<Buff>(_effects))
-                        if (e != null && e.InUse && e.Template.BuffId == buff.Template.BuffId)
+                        if (e is { InUse: true } && e.Template.BuffId == buff.Template.BuffId)
                             if (buff.Charge < e.Charge)
                                 return;
                             else
@@ -391,7 +398,7 @@ public class Buffs : IBuffs
                 default:
                     if (buff.Template.MaxStack > 0 && GetBuffCountById(buff.Template.BuffId) >= buff.Template.MaxStack)
                         foreach (var e in new List<Buff>(_effects))
-                            if (e != null && e.InUse && e.Template.BuffId == buff.Template.BuffId)
+                            if (e is { InUse: true } && e.Template.BuffId == buff.Template.BuffId)
                                 if (e.GetTimeLeft() < buff.GetTimeLeft())
                                     last = e;
                     break;
@@ -408,12 +415,12 @@ public class Buffs : IBuffs
 
                 if (buff.Template.BuffId > 0)
                 {
-                    var bufft = SkillManager.Instance.GetBuffTemplate(buff.Template.BuffId);
+                    var buffTemplate = SkillManager.Instance.GetBuffTemplate(buff.Template.BuffId);
                     owner.SkillModifiersCache.AddModifiers(buff.Template.BuffId);
                     owner.BuffModifiersCache.AddModifiers(buff.Template.BuffId);
                     owner.CombatBuffs.AddCombatBuffs(buff.Template.BuffId);
 
-                    if (owner is Character character && character.IsRiding && (bufft.Stun || bufft.Sleep || bufft.Root))
+                    if (owner is Character { IsRiding: true } character && (buffTemplate.Stun || buffTemplate.Sleep || buffTemplate.Root))
                     {
                         var mateList = character.ParentWorld.MateManager.GetActiveMates(character.Id);
                         foreach (var mate in mateList)
@@ -423,7 +430,7 @@ public class Buffs : IBuffs
                         }
                     }
 
-                    if (bufft.Stun || bufft.Silence || bufft.Sleep)
+                    if (buffTemplate.Stun || buffTemplate.Silence || buffTemplate.Sleep)
                         owner.InterruptSkills();
                 }
 
@@ -441,7 +448,7 @@ public class Buffs : IBuffs
                 if (buffIds.Contains((uint)TagsEnum.NoFight) || buffIds.Contains((uint)TagsEnum.Returning))
                 {
                     // Unit entered a "safe zone"
-                    if (owner is Npc npc && npc.Ai != null)
+                    if (owner is Npc { Ai: not null } npc)
                     {
                         npc.ClearAllAggro();
                     }
@@ -732,8 +739,6 @@ public class Buffs : IBuffs
                     effect.Exit();
                 else if (template.RemoveOnUseSkill && on == BuffRemoveOn.UseSkill)
                     effect.Exit();
-                else
-                    continue;
             }
         }
     }
@@ -807,4 +812,280 @@ public class Buffs : IBuffs
 
         return effects.Any(predicate);
     }
+
+    #region Buff Persistence
+    /// <summary>
+    /// Determines whether a buff should be saved to the database on logout.
+    /// </summary>
+    private static bool ShouldPersistBuff(Buff buff)
+    {
+        if (buff == null)
+            return false;
+
+        // Only save buffs with SaveRuleId > 0
+        if (buff.Template.SaveRuleId == BuffSaveRuleType.DontSave)
+            return false;
+
+        // Passive buffs are restored via the skill system
+        if (buff.Passive)
+            return false;
+
+        // Permanent buffs (Duration=0) are race/template buffs
+        if (buff.Duration <= 0)
+            return false;
+
+        // Don't save already expired buffs
+        if (buff.GetTimeLeft() <= 0)
+            return false;
+
+        // Don't save buffs in Finishing/Finished state
+        if (buff.State == EffectState.Finishing || buff.State == EffectState.Finished)
+            return false;
+
+        // --- SaveRule differentiation ---
+
+        // Rule 2: Premium/Crafting (Cash-Shop, Mastery, Proficiency) → always save
+        // Rule 3: Special (Inn/Sleep, Battlefield, Cosmetics) → always save
+        if (buff.Template.SaveRuleId >= BuffSaveRuleType.CharacterPersistent)
+            return true;
+
+        // Rule 1: Standard buffs — only save beneficial buffs with ≥60s duration.
+        // Filters out short combat debuffs (stuns, bleeds, knockdowns).
+        if (buff.Template.SaveRuleId == BuffSaveRuleType.Normal)
+        {
+            // Don't save debuffs (combat effects should not persist through logout)
+            if (buff.Template.Kind == BuffKind.Bad)
+                return false;
+
+            // Very short buffs (< 60s) are combat abilities, not consumables
+            if (buff.Duration < MinimumBuffDurationToSave)
+                return false;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Saves all persistable active buffs to the database.
+    /// Called during Character.Save().
+    /// </summary>
+    public void SaveActiveBuffs(MySqlConnection connection, MySqlTransaction transaction, uint characterId)
+    {
+        try
+        {
+            // Delete previously saved buffs
+            using (var deleteCmd = connection.CreateCommand())
+            {
+                deleteCmd.Connection = connection;
+                deleteCmd.Transaction = transaction;
+                deleteCmd.CommandText = "DELETE FROM `character_active_buffs` WHERE `character_id` = @characterId";
+                deleteCmd.Parameters.AddWithValue("@characterId", characterId);
+                deleteCmd.ExecuteNonQuery();
+            }
+
+            // Snapshot active buffs
+            Buff[] effects;
+            lock (_lock)
+            {
+                effects = _effects.ToArray();
+            }
+
+            var savedCount = 0;
+            foreach (var buff in effects)
+            {
+                if (!ShouldPersistBuff(buff))
+                    continue;
+
+                var timeLeft = (int)buff.GetTimeLeft();
+                if (timeLeft <= 0)
+                    continue;
+
+                using var cmd = connection.CreateCommand();
+                cmd.Connection = connection;
+                cmd.Transaction = transaction;
+                cmd.CommandText =
+                    "INSERT INTO `character_active_buffs` " +
+                    "(`character_id`, `buff_id`, `caster_id`, `skill_id`, `ab_level`, " +
+                    " `duration`, `time_left`, `charge`, `stack_count`, `real_time`, `saved_at`) " +
+                    "VALUES (@characterId, @buffId, @casterId, @skillId, @abLevel, " +
+                    "        @duration, @timeLeft, @charge, @stackCount, @realTime, @savedAt) " +
+                    "ON DUPLICATE KEY UPDATE " +
+                    "`caster_id`=@casterId, `skill_id`=@skillId, `ab_level`=@abLevel, " +
+                    "`duration`=@duration, `time_left`=@timeLeft, `charge`=@charge, " +
+                    "`stack_count`=@stackCount, `real_time`=@realTime, `saved_at`=@savedAt";
+
+                cmd.Parameters.AddWithValue("@characterId", characterId);
+                cmd.Parameters.AddWithValue("@buffId", buff.Template.Id);
+                cmd.Parameters.AddWithValue("@casterId", buff.Caster?.Id ?? characterId);
+                cmd.Parameters.AddWithValue("@skillId", buff.Skill?.Template?.Id ?? 0u);
+                cmd.Parameters.AddWithValue("@abLevel", buff.AbLevel);
+                cmd.Parameters.AddWithValue("@duration", buff.Duration);
+                cmd.Parameters.AddWithValue("@timeLeft", timeLeft);
+                cmd.Parameters.AddWithValue("@charge", buff.Charge);
+                cmd.Parameters.AddWithValue("@stackCount", 1);
+                cmd.Parameters.AddWithValue("@realTime", buff.Template.RealTime ? 1 : 0);
+                cmd.Parameters.AddWithValue("@savedAt", DateTime.UtcNow);
+                cmd.ExecuteNonQuery();
+                savedCount++;
+            }
+
+            if (savedCount > 0)
+                Logger.Info($"Saved {savedCount} active buff(s) for character {characterId}");
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, $"Failed to save active buffs for character {characterId}");
+        }
+    }
+
+    /// <summary>
+    /// Loads saved buffs from the database and reapplies them to the character.
+    /// RealTime buffs: offline time is subtracted.
+    /// GameTime buffs: timer was paused, full remaining time is restored.
+    /// </summary>
+    public void LoadActiveBuffs(Character character)
+    {
+        try
+        {
+            var restoredCount = 0;
+
+            using var connection = MySQL.CreateConnection();
+            using (var cmd = connection.CreateCommand())
+            {
+                cmd.CommandText =
+                    "SELECT * FROM `character_active_buffs` WHERE `character_id` = @characterId";
+                cmd.Parameters.AddWithValue("@characterId", character.Id);
+
+                using var reader = cmd.ExecuteReader();
+                var buffRows = new List<(uint buffId, uint casterId, uint skillId,
+                    uint abLevel, int duration, int timeLeft, int charge,
+                    bool realTime, DateTime savedAt)>();
+
+                while (reader.Read())
+                {
+                    buffRows.Add((
+                        buffId:   reader.GetUInt32("buff_id"),
+                        casterId: reader.GetUInt32("caster_id"),
+                        skillId:  reader.GetUInt32("skill_id"),
+                        abLevel:  reader.GetUInt32("ab_level"),
+                        duration: reader.GetInt32("duration"),
+                        timeLeft: reader.GetInt32("time_left"),
+                        charge:   reader.GetInt32("charge"),
+                        realTime: reader.GetBoolean("real_time"),
+                        savedAt:  reader.GetDateTime("saved_at")
+                    ));
+                }
+
+                reader.Close();
+
+                foreach (var row in buffRows)
+                {
+                    var buffTemplate = SkillManager.Instance.GetBuffTemplate(row.buffId);
+                    if (buffTemplate == null)
+                    {
+                        Logger.Warn($"LoadActiveBuffs: BuffTemplate {row.buffId} not found, skipping");
+                        continue;
+                    }
+
+                    // Calculate remaining time
+                    int remainingMs;
+                    if (row.realTime)
+                    {
+                        // RealTime: subtract offline time
+                        var offlineMs = (int)(DateTime.UtcNow - row.savedAt).TotalMilliseconds;
+                        remainingMs = row.timeLeft - offlineMs;
+
+                        if (remainingMs <= 0)
+                        {
+                            Logger.Debug($"LoadActiveBuffs: RealTime buff {row.buffId} expired offline");
+                            continue;
+                        }
+                    }
+                    else
+                    {
+                        // GameTime: timer was paused → restore full remaining time
+                        remainingMs = row.timeLeft;
+                    }
+
+                    if (remainingMs <= 0)
+                        continue;
+
+                    // Check if buff is already active (e.g. from passive skills)
+                    if (CheckBuff(row.buffId))
+                    {
+                        Logger.Debug($"LoadActiveBuffs: Buff {row.buffId} already active, skipping");
+                        continue;
+                    }
+
+                    // Create and apply the buff
+                    var casterObj = new SkillCasterUnit(character.ObjId);
+                    var buff = new Buff(character, character, casterObj,
+                        buffTemplate, null, DateTime.UtcNow)
+                    {
+                        AbLevel  = row.abLevel,
+                        Duration = remainingMs,
+                        Charge   = row.charge > 0 ? row.charge : buffTemplate.InitMinCharge
+                    };
+
+                    AddBuff(buff, forcedDuration: remainingMs);
+                    restoredCount++;
+
+                    Logger.Debug($"LoadActiveBuffs: Restored buff {row.buffId} ({remainingMs}ms) for char {character.Id}");
+                }
+            }
+
+            // Delete saved buffs — they are now active again
+            using (var deleteCmd = connection.CreateCommand())
+            {
+                deleteCmd.CommandText =
+                    "DELETE FROM `character_active_buffs` WHERE `character_id` = @characterId";
+                deleteCmd.Parameters.AddWithValue("@characterId", character.Id);
+                deleteCmd.ExecuteNonQuery();
+            }
+
+            if (restoredCount > 0)
+                Logger.Info($"Restored {restoredCount} buff(s) for character {character.Id} ({character.Name})");
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, $"Failed to load active buffs for character {character.Id}");
+        }
+    }
+
+    /// <summary>
+    /// Cancels all running buff timers (DispelTasks) without triggering the normal
+    /// dispel/exit flow. Called during logout.
+    /// </summary>
+    public void CancelAllEffectTasks()
+    {
+        Buff[] effects;
+        lock (_lock)
+        {
+            effects = _effects.ToArray();
+        }
+
+        foreach (var buff in effects)
+        {
+            if (buff == null)
+                continue;
+
+            try
+            {
+                TaskManager.Instance.RemoveTasks(task =>
+                {
+                    if (task is AAEmu.Game.Models.Tasks.Skills.DispelTask dt
+                        && dt.Effect.Target is Buff b)
+                        return b == buff;
+                    return false;
+                });
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn(ex, $"Error cancelling tasks for buff {buff.Template?.Id}");
+            }
+        }
+    }
+    #endregion
 }

--- a/AAEmu.Game/Models/Game/Units/IBuffs.cs
+++ b/AAEmu.Game/Models/Game/Units/IBuffs.cs
@@ -1,6 +1,8 @@
 ﻿using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Skills.Buffs;
 using AAEmu.Game.Models.Game.Skills.Templates;
+using AAEmu.Game.Models.Game.Char;
+using MySql.Data.MySqlClient;
 
 namespace AAEmu.Game.Models.Game.Units;
 
@@ -33,4 +35,8 @@ public interface IBuffs
     void RemoveStealth();
     void SetOwner(BaseUnit owner);
     void TriggerRemoveOn(BuffRemoveOn on, uint value = 0);
+    // Buff Persistence
+    void SaveActiveBuffs(MySqlConnection connection, MySqlTransaction transaction, uint characterId);
+    void LoadActiveBuffs(Character character);
+    void CancelAllEffectTasks();
 }

--- a/AAEmu.Game/Models/StaticValues/BuffSaveRuleType.cs
+++ b/AAEmu.Game/Models/StaticValues/BuffSaveRuleType.cs
@@ -1,0 +1,23 @@
+﻿namespace AAEmu.Game.Models.StaticValues;
+
+// This is probably just a byte, but we're reading it as a uint so ...
+
+public enum BuffSaveRuleType : uint
+{
+    /// <summary>
+    /// Not persistable (combat, food, potions, scrolls), Only save if `Kind=Good` AND `Duration ≥ 60s`
+    /// </summary>
+    DontSave = 0,
+    /// <summary>
+    /// Standard buffs
+    /// </summary>
+    Normal = 1,
+    /// <summary>
+    /// Premium/Crafting (Cash-Shop, Mastery 24h, Proficiency 30min)
+    /// </summary>
+    CharacterPersistent = 2,
+    /// <summary>
+    /// Special (Inn/Sleep, Battlefield, Cosmetics, Mount skins)
+    /// </summary>
+    Special = 3,
+}

--- a/AAEmu.Game/Models/Tasks/Doodads/DoodadFuncFinalTask.cs
+++ b/AAEmu.Game/Models/Tasks/Doodads/DoodadFuncFinalTask.cs
@@ -49,7 +49,7 @@ public class DoodadFuncFinalTask : DoodadFuncTask
 
             var world = WorldManager.Instance.GetWorld(_owner.Transform.InstanceId);
             //_owner.Spawner.DecreaseCount(_owner);
-            _owner.Spawner.Position.WorldId = world.Id;
+            _owner.Spawner.Position.WorldId = world?.Id ?? WorldManager.DefaultInstanceId;
             _owner.Spawner.Spawn(0);
         }
         else

--- a/AAEmu.sln.DotSettings
+++ b/AAEmu.sln.DotSettings
@@ -16,6 +16,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Auroria/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=beautyshop/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=childable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Cripled/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ctype/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Cutdown/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Cutdowning/@EntryIndexedValue">True</s:Boolean>
@@ -53,6 +54,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=induns/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=kyrios/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=lootpack/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Mainhand/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Mana/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=mdps/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=medicalingredient/@EntryIndexedValue">True</s:Boolean>

--- a/SQL/updates/2026-03-21_aaemu_game_character_active_buffs.sql
+++ b/SQL/updates/2026-03-21_aaemu_game_character_active_buffs.sql
@@ -1,0 +1,23 @@
+-- ============================================================================
+-- Buff Persistence System — MySQL Migration
+-- ============================================================================
+-- Run this on your `aaemu_game` database before starting the server.
+-- This table stores active buffs when a player logs out so they can be
+-- restored on the next login.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS `character_active_buffs` (
+  `character_id`  INT UNSIGNED NOT NULL COMMENT 'Character who owns this buff',
+  `buff_id`       INT UNSIGNED NOT NULL COMMENT 'BuffTemplate.Id from game data',
+  `caster_id`     INT UNSIGNED NOT NULL COMMENT 'Character who originally cast this buff',
+  `skill_id`      INT UNSIGNED NOT NULL DEFAULT 0 COMMENT 'Source skill template ID (0 if none)',
+  `ab_level`      INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'Ability level for bonus scaling',
+  `duration`      INT NOT NULL COMMENT 'Total duration in milliseconds',
+  `time_left`     INT NOT NULL COMMENT 'Remaining time in milliseconds at save',
+  `charge`        INT NOT NULL DEFAULT 0 COMMENT 'Current charge count',
+  `stack_count`   INT NOT NULL DEFAULT 1 COMMENT 'Number of stacks',
+  `real_time`     TINYINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '1=timer ticks offline, 0=timer paused offline',
+  `saved_at`      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'UTC timestamp when buff was saved',
+  PRIMARY KEY (`character_id`, `buff_id`),
+  INDEX `idx_character_id` (`character_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Stores active buffs across player sessions';


### PR DESCRIPTION
Co-authored-by: Evenstone

- Save active buffs to the database on character logout and restore them upon login.
- Introduce `BuffSaveRuleType` enum to better visualize the types of save rules.
- Control persistence logic for buffs, filtering for long-duration consumables and premium effects while excluding short-term combat debuffs.
- Refactor `BuffTemplate` and `SkillManager` to use modern C# features, including `init`-only properties and string interpolation.
- Handle "RealTime" buffs by calculating offline time elapsed during the restoration process.
- Ensure all buff-related tasks are cancelled on disconnect to prevent stale state.
