### PR TITLE
fix(test): allow 4-digit codes starting with zero in ArsService tests

### DIFF
--- a/AAEmu.UnitTests/Login/Core/Services/TwoFactor/ArsServiceTests.cs
+++ b/AAEmu.UnitTests/Login/Core/Services/TwoFactor/ArsServiceTests.cs
@@ -1,4 +1,4 @@
-using AAEmu.Login.Core.Services.TwoFactor;
+﻿using AAEmu.Login.Core.Services.TwoFactor;
 using AAEmu.Login.Models;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
@@ -22,7 +22,7 @@ public class ArsServiceTests
 
         await Assert.That(session.SessionCode.Length).IsEqualTo(4);
         await Assert.That(int.TryParse(session.SessionCode, out var code)).IsTrue();
-        await Assert.That(code).IsGreaterThanOrEqualTo(1000);
+        await Assert.That(code).IsGreaterThanOrEqualTo(0);
         await Assert.That(code).IsLessThanOrEqualTo(9999);
     }
 


### PR DESCRIPTION
The session code validation in ArsServiceTests previously required the parsed integer to be at least 1000, which caused test failures for 4-digit codes that began with leading zeros (e.g., "0123").
