### PR TITLE
fix: resolve character ghosting on disconnect (fixes #1395)

### DIFF
--- a/AAEmu.Game/Core/Managers/World/WorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/WorldManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Numerics;
 using System.Xml;
@@ -986,13 +986,14 @@ public class WorldManager(
         if (obj?.Region == null)
             return;
 
-        var neighbors = obj.Region.GetNeighbors();
-        obj.Region?.RemoveObject(obj);
+        var region = obj.Region;
+        var neighbors = region.GetNeighbors();
+        region.RemoveObject(obj);
 
-        if (neighbors == null)
-            return;
-
-        if (neighbors.Length > 0)
+        // Must match AddToCharacters: visibility is updated for this region and all neighbors.
+        // Previously only neighbors were notified, so players in the same region cell never got removal packets.
+        region.RemoveFromCharacters(obj);
+        if (neighbors != null && neighbors.Length > 0)
             foreach (var neighbor in neighbors)
                 neighbor?.RemoveFromCharacters(obj);
 

--- a/AAEmu.Game/Models/Game/World/Region.cs
+++ b/AAEmu.Game/Models/Game/World/Region.cs
@@ -1,4 +1,4 @@
-﻿using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.DoodadObj;
@@ -223,6 +223,14 @@ public class Region(WorldInstance worldInstance, int x, int y, uint zoneKey)
             {
                 character1.CurrentTarget = null;
                 character1.SendPacket(new SCTargetChangedPacket(character1.ObjId, 0));
+            }
+
+            // Also remove this character from visibility of nearby players.
+            // Without this, other players keep a stale local copy ("ghost target")
+            // when the character disconnects or leaves the world.
+            foreach (var characterInRegion in GetList(new List<Character>(), character1.ObjId))
+            {
+                obj.RemoveVisibleObject(characterInRegion);
             }
         }
         // Special handling for non-player objects (NPCs, vehicles, doodads, etc.)

--- a/AAEmu.Game/Models/Game/World/Region.cs
+++ b/AAEmu.Game/Models/Game/World/Region.cs
@@ -229,9 +229,8 @@ public class Region(WorldInstance worldInstance, int x, int y, uint zoneKey)
             // Without this, other players keep a stale local copy ("ghost target")
             // when the character disconnects or leaves the world.
             foreach (var characterInRegion in GetList(new List<Character>(), character1.ObjId))
-            {
                 obj.RemoveVisibleObject(characterInRegion);
-            }
+
         }
         // Special handling for non-player objects (NPCs, vehicles, doodads, etc.)
         else


### PR DESCRIPTION
## Description
Fixed a bug where characters remained visible to other players after disconnecting (ghost targets).

## Changes
- Modified `Region.RemoveFromCharacters()` to ensure `SCUnitsRemovedPacket` is sent to all nearby players when a character despawns.

Fixes #1395