### PR TITLE
Marine mechanics 2

### DIFF
--- a/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
+++ b/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
@@ -252,6 +252,7 @@ public class PhysicsManager
                                 BoatPhysicsTick(slave, physicsTotalDelta);
                                 // Check if we collided
                                 CheckLandCollisions(slave, physicsTotalDelta);
+                                slave.DoFloorCollisionDamage(physicsTotalDelta);
                                 // Update Controls
                                 boat.ApplyForceAndTorque(slave, physicsTotalDelta);
                                 SendUpdatedMovementData(slave, slave.RigidBody, physicsTotalDelta);

--- a/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
+++ b/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
@@ -620,42 +620,38 @@ public class PhysicsManager
         var cliffY = slave.RigidBody.Position.Z + dirZ * cliffDist * probeSign;
         var cliffFloor = slave.ParentWorld.GetHeight(cliffX, cliffY);
         // Prevent underwater terrain ("sea floor") from being treated as a wall:
-        // only trigger cliff collision when the sampled point is at/above water surface.
+        // only run cliff-barrier logic when the probe sample is at/above water; otherwise fall through to beaching.
         const float CliffAboveWaterMargin = 0.20f;
-        if (cliffFloor <= slave.CachedWaterSurface + CliffAboveWaterMargin)
+        if (cliffFloor > slave.CachedWaterSurface + CliffAboveWaterMargin)
         {
-            // Not a shoreline wall; continue with normal beaching logic.
-            goto AfterCliffCheck;
-        }
-
-        var dh = cliffFloor - slave.CachedFloorLevel;
-        var slopeFrac = dh / MathF.Max(0.01f, cliffDist);
-        if (slopeFrac > CliffSlopeFracThreshold)
-        {
-            // Collision: remove the component of horizontal velocity pushing into the cliff.
-            var v = slave.RigidBody.Velocity;
-            var vAlong = v.X * dirX + v.Z * dirZ;
-            var pushingIntoBarrier = useSternProbe ? (vAlong < 0f) : (vAlong > 0f);
-            if (pushingIntoBarrier)
+            var dh = cliffFloor - slave.CachedFloorLevel;
+            var slopeFrac = dh / MathF.Max(0.01f, cliffDist);
+            if (slopeFrac > CliffSlopeFracThreshold)
             {
-                // Stop the "poke": ShipController will otherwise re-apply forward/back velocity next tick from slave.Speed.
-                slave.Speed = 0f;
-                var newVX = v.X - vAlong * dirX;
-                var newVZ = v.Z - vAlong * dirZ;
-                slave.RigidBody.Velocity = new JVector(newVX * 0.85f, 0f, newVZ * 0.85f);
-                slave.RigidBody.AngularVelocity *= 0.85f;
+                // Collision: remove the component of horizontal velocity pushing into the cliff.
+                var v = slave.RigidBody.Velocity;
+                var vAlong = v.X * dirX + v.Z * dirZ;
+                var pushingIntoBarrier = useSternProbe ? (vAlong < 0f) : (vAlong > 0f);
+                if (pushingIntoBarrier)
+                {
+                    // Stop the "poke": ShipController will otherwise re-apply forward/back velocity next tick from slave.Speed.
+                    slave.Speed = 0f;
+                    var newVX = v.X - vAlong * dirX;
+                    var newVZ = v.Z - vAlong * dirZ;
+                    slave.RigidBody.Velocity = new JVector(newVX * 0.85f, 0f, newVZ * 0.85f);
+                    slave.RigidBody.AngularVelocity *= 0.85f;
+                }
+
+                // Push out of the barrier so we don't clip into wall textures.
+                // Single small push opposite to the barrier-facing direction (no loops -> no jitter).
+                var pushDirSign = useSternProbe ? 1f : -1f;
+                var dt = Math.Max(0.0001f, (float)deltaTime.TotalSeconds);
+                var pushStep = MathF.Min(0.50f, MathF.Max(0.08f, MathF.Abs(vAlong) * dt * 1.10f));
+                slave.RigidBody.Position += new JVector(dirX * pushStep * pushDirSign, 0f, dirZ * pushStep * pushDirSign);
+
+                return;
             }
-
-            // Push out of the barrier so we don't clip into wall textures.
-            // Single small push opposite to the barrier-facing direction (no loops -> no jitter).
-            var pushDirSign = useSternProbe ? 1f : -1f;
-            var dt = Math.Max(0.0001f, (float)deltaTime.TotalSeconds);
-            var pushStep = MathF.Min(0.50f, MathF.Max(0.08f, MathF.Abs(vAlong) * dt * 1.10f));
-            slave.RigidBody.Position += new JVector(dirX * pushStep * pushDirSign, 0f, dirZ * pushStep * pushDirSign);
-
-            return;
         }
-AfterCliffCheck: ;
 
         // Latch ground contact with enter/exit hysteresis to avoid rapid toggling (visual jitter).
         const float ShoreEnterHyst = 0.35f;

--- a/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
+++ b/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
@@ -509,14 +509,17 @@ public class PhysicsManager
             // Smooth sampled heights to avoid geo noise causing visual pitch jitter.
             const float pitchFloorSmoothResponse = 8.0f;
             var floorA = 1f - MathF.Exp(-pitchFloorSmoothResponse * dt);
-            if (slave.GroundPitchFrontFloorSmoothed == 0f)
+            if (!slave.GroundPitchFloorSmoothingSeeded)
+            {
                 slave.GroundPitchFrontFloorSmoothed = frontH;
-            else
-                slave.GroundPitchFrontFloorSmoothed += (frontH - slave.GroundPitchFrontFloorSmoothed) * floorA;
-            if (slave.GroundPitchBackFloorSmoothed == 0f)
                 slave.GroundPitchBackFloorSmoothed = backH;
+                slave.GroundPitchFloorSmoothingSeeded = true;
+            }
             else
+            {
+                slave.GroundPitchFrontFloorSmoothed += (frontH - slave.GroundPitchFrontFloorSmoothed) * floorA;
                 slave.GroundPitchBackFloorSmoothed += (backH - slave.GroundPitchBackFloorSmoothed) * floorA;
+            }
 
             var slopeRad = MathF.Atan2(slave.GroundPitchFrontFloorSmoothed - slave.GroundPitchBackFloorSmoothed, groundPitchProbeDistance * 2f);
             targetGroundPitch = Math.Clamp(slopeRad, -groundPitchMaxDeg.DegToRad(), groundPitchMaxDeg.DegToRad());
@@ -525,6 +528,9 @@ public class PhysicsManager
             if (slave.GroundedByStern)
                 targetGroundPitch = -targetGroundPitch;
         }
+        else
+            slave.GroundPitchFloorSmoothingSeeded = false;
+
         var pitchA = 1f - MathF.Exp(-groundPitchResponse * dt);
         slave.GroundPitchAngle += (targetGroundPitch - slave.GroundPitchAngle) * pitchA;
 
@@ -660,8 +666,11 @@ AfterCliffCheck: ;
         {
             var dt = Math.Max(0.0001f, (float)deltaTime.TotalSeconds);
             var a = 1f - MathF.Exp(-FloorSmoothResponse * dt);
-            if (!slave.GroundContactLatched && slave.GroundContactFloorSmoothed == 0f)
+            if (!slave.GroundContactLatched && !slave.GroundContactFloorSmoothingSeeded)
+            {
                 slave.GroundContactFloorSmoothed = contactFloor;
+                slave.GroundContactFloorSmoothingSeeded = true;
+            }
             else
                 slave.GroundContactFloorSmoothed += (contactFloor - slave.GroundContactFloorSmoothed) * a;
         }

--- a/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
+++ b/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
@@ -582,6 +582,8 @@ public class PhysicsManager
         if (slave.ShipController?.ShipModel is null)
             return;
 
+        var dt = Math.Max(0.0001f, (float)deltaTime.TotalSeconds);
+
         // Terrain contact is evaluated at a probe point in front of bow / behind stern (not hull center).
         // Requested tuning: probe is placed at 2x hull length from center.
         var boatBottom = slave.RigidBody.Position.Y;
@@ -645,7 +647,6 @@ public class PhysicsManager
                 // Push out of the barrier so we don't clip into wall textures.
                 // Single small push opposite to the barrier-facing direction (no loops -> no jitter).
                 var pushDirSign = useSternProbe ? 1f : -1f;
-                var dt = Math.Max(0.0001f, (float)deltaTime.TotalSeconds);
                 var pushStep = MathF.Min(0.50f, MathF.Max(0.08f, MathF.Abs(vAlong) * dt * 1.10f));
                 slave.RigidBody.Position += new JVector(dirX * pushStep * pushDirSign, 0f, dirZ * pushStep * pushDirSign);
 
@@ -660,7 +661,6 @@ public class PhysicsManager
         // Smooth contact floor itself (geo height noise + probe jitter).
         const float FloorSmoothResponse = 10.0f;
         {
-            var dt = Math.Max(0.0001f, (float)deltaTime.TotalSeconds);
             var a = 1f - MathF.Exp(-FloorSmoothResponse * dt);
             if (!slave.GroundContactLatched && !slave.GroundContactFloorSmoothingSeeded)
             {
@@ -722,7 +722,6 @@ public class PhysicsManager
         var maxUpStepPerTick = slave.GroundContactLatchedTime < 0.30f ? 0.04f : 0.07f;
         if (penetration > PenetrationEpsilon)
         {
-            var dt = Math.Max(0.0001f, (float)deltaTime.TotalSeconds);
             var a = 1f - MathF.Exp(-PenetrationResponse * dt);
             var step = MathF.Min(penetration * a, maxUpStepPerTick);
             slave.RigidBody.Position += new JVector(0, step, 0); // lift toward terrain smoothly

--- a/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
+++ b/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
@@ -484,7 +484,50 @@ public class PhysicsManager
         var targetBank = Math.Clamp(-yawRate * 0.9f, -maxBankRad, maxBankRad) * speedFactor;
         var a = 1f - MathF.Exp(-bankResponse * dt);
         slave.BankAngle += (targetBank - slave.BankAngle) * a;
-        var bankedRpy = (rpy.Item1, rpy.Item2 + slave.BankAngle, rpy.Item3);
+
+        // Visual-only pitch on shoal/ground: align nose/stern to local terrain slope.
+        // This does not affect rigidbody Y/physics, only replicated rotation.
+        const float groundPitchMaxDeg = 8.0f;
+        const float groundPitchProbeDistance = 6.0f;
+        const float groundPitchResponse = 2.0f; // smoother to avoid pitch jitter
+        var targetGroundPitch = 0f;
+        if (slave.CachedFloorLevel > slave.CachedWaterSurface || slave.GroundContactLatched)
+        {
+            var yaw = rpy.Item1 + 1.57f; // bow heading in world X/Y plane
+            var cosYaw = MathF.Cos(yaw);
+            var sinYaw = MathF.Sin(yaw);
+            var cx = rigidBody.Position.X;
+            var cy = rigidBody.Position.Z;
+            var frontX = cx + cosYaw * groundPitchProbeDistance;
+            var frontY = cy + sinYaw * groundPitchProbeDistance;
+            var backX = cx - cosYaw * groundPitchProbeDistance;
+            var backY = cy - sinYaw * groundPitchProbeDistance;
+            var frontH = slave.ParentWorld.GetHeight(frontX, frontY);
+            var backH = slave.ParentWorld.GetHeight(backX, backY);
+
+            // Smooth sampled heights to avoid geo noise causing visual pitch jitter.
+            const float pitchFloorSmoothResponse = 8.0f;
+            var floorA = 1f - MathF.Exp(-pitchFloorSmoothResponse * dt);
+            if (slave.GroundPitchFrontFloorSmoothed == 0f)
+                slave.GroundPitchFrontFloorSmoothed = frontH;
+            else
+                slave.GroundPitchFrontFloorSmoothed += (frontH - slave.GroundPitchFrontFloorSmoothed) * floorA;
+            if (slave.GroundPitchBackFloorSmoothed == 0f)
+                slave.GroundPitchBackFloorSmoothed = backH;
+            else
+                slave.GroundPitchBackFloorSmoothed += (backH - slave.GroundPitchBackFloorSmoothed) * floorA;
+
+            var slopeRad = MathF.Atan2(slave.GroundPitchFrontFloorSmoothed - slave.GroundPitchBackFloorSmoothed, groundPitchProbeDistance * 2f);
+            targetGroundPitch = Math.Clamp(slopeRad, -groundPitchMaxDeg.DegToRad(), groundPitchMaxDeg.DegToRad());
+
+            // When beaching in reverse (stern on ground), invert pitch so the stern rises (not the bow).
+            if (slave.GroundedByStern)
+                targetGroundPitch = -targetGroundPitch;
+        }
+        var pitchA = 1f - MathF.Exp(-groundPitchResponse * dt);
+        slave.GroundPitchAngle += (targetGroundPitch - slave.GroundPitchAngle) * pitchA;
+
+        var bankedRpy = (rpy.Item1, rpy.Item2 + slave.BankAngle, rpy.Item3 + slave.GroundPitchAngle);
 
         // Insert new Rotation data into MoveType
         var (rotZ, rotY, rotX) = MathUtil.GetSlaveRotationFromDegrees(bankedRpy.Item1, bankedRpy.Item2, bankedRpy.Item3);
@@ -513,7 +556,7 @@ public class PhysicsManager
         slave.Transform.Local.SetRotation(
             slave.Transform.Local.Rotation.X,
             slave.Transform.Local.Rotation.Y + slave.BankAngle,
-            slave.Transform.Local.Rotation.Z);
+            slave.Transform.Local.Rotation.Z + slave.GroundPitchAngle);
 
         // Send the packet
         slave.BroadcastPacket(new SCOneUnitMovementPacket(slave.ObjId, moveType), false);
@@ -532,21 +575,168 @@ public class PhysicsManager
         if (slave.ShipController?.ShipModel is null)
             return;
 
+        // Terrain contact is evaluated at a probe point in front of bow / behind stern (not hull center).
+        // Requested tuning: probe is placed at 2x hull length from center.
         var boatBottom = slave.RigidBody.Position.Y;
-        //Logger.Debug($"Slave: {slave.Name}, floor: {floor:F1}, boatBottom: {boatBottom:F1}, boxSize: {boxSize}");
 
-        if (slave.CachedWaterSurface >= slave.CachedFloorLevel)
+        var rpy = PhysicsUtil.GetYawPitchRollFromMatrix(JMatrix.CreateFromQuaternion(slave.RigidBody.Orientation));
+        var heading = rpy.Item1 + 1.57f;
+        var dirX = MathF.Cos(heading);
+        var dirZ = MathF.Sin(heading);
+
+        var vX = slave.RigidBody.Velocity.X;
+        var vZ = slave.RigidBody.Velocity.Z;
+        var along = vX * dirX + vZ * dirZ; // >0 forward, <0 backward
+        var movingBackward = along < -0.05f || (MathF.Abs(along) <= 0.05f && slave.ThrottleRequest < 0);
+
+        const float BowProbeMul = 1.5f;
+        const float SternProbeMul = 1.5f;
+        // IMPORTANT: once we latched ground contact, keep the same hull-end selection stable.
+        // Otherwise, releasing reverse at standstill can flip the probe from stern->bow,
+        // making contactFloor drop and causing GroundContactLatched + visual pitch to flicker.
+        var useSternProbe = slave.GroundContactLatched ? slave.GroundedByStern : movingBackward;
+        var probeMul = useSternProbe ? SternProbeMul : BowProbeMul;
+        var probeDist = MathF.Max(1.0f, slave.ShipController.ShipModel.MassBoxSizeX * probeMul * slave.Scale);
+        var probeSign = useSternProbe ? -1f : 1f; // stern / bow
+        var probeX = slave.RigidBody.Position.X + dirX * probeDist * probeSign;
+        var probeY = slave.RigidBody.Position.Z + dirZ * probeDist * probeSign;
+        var contactFloor = slave.ParentWorld.GetHeight(probeX, probeY);
+
+        // Simple "cliff collision" rule:
+        // look ahead/behind at 2x hull length; if slope is steeper than 45% treat as a barrier.
+        // "Wall / cliff" detection probe distance (independent from beach contact probe).
+        const float CliffProbeMul = 1.45f;
+        // ~30 degrees slope threshold (rounded): 57%
+        const float CliffSlopeFracThreshold = 0.57f;
+        var cliffDist = MathF.Max(1.0f, slave.ShipController.ShipModel.MassBoxSizeX * CliffProbeMul * slave.Scale);
+        var cliffX = slave.RigidBody.Position.X + dirX * cliffDist * probeSign;
+        var cliffY = slave.RigidBody.Position.Z + dirZ * cliffDist * probeSign;
+        var cliffFloor = slave.ParentWorld.GetHeight(cliffX, cliffY);
+        // Prevent underwater terrain ("sea floor") from being treated as a wall:
+        // only trigger cliff collision when the sampled point is at/above water surface.
+        const float CliffAboveWaterMargin = 0.20f;
+        if (cliffFloor <= slave.CachedWaterSurface + CliffAboveWaterMargin)
         {
-            return;
+            // Not a shoreline wall; continue with normal beaching logic.
+            goto AfterCliffCheck;
         }
 
-        var penetration = slave.CachedFloorLevel - boatBottom;
-        slave.RigidBody.Position += new JVector(0, penetration, 0); // Move the boat upwards to put the center level with the floor
+        var dh = cliffFloor - slave.CachedFloorLevel;
+        var slopeFrac = dh / MathF.Max(0.01f, cliffDist);
+        if (slopeFrac > CliffSlopeFracThreshold)
+        {
+            // Collision: remove the component of horizontal velocity pushing into the cliff.
+            var v = slave.RigidBody.Velocity;
+            var vAlong = v.X * dirX + v.Z * dirZ;
+            var pushingIntoBarrier = useSternProbe ? (vAlong < 0f) : (vAlong > 0f);
+            if (pushingIntoBarrier)
+            {
+                // Stop the "poke": ShipController will otherwise re-apply forward/back velocity next tick from slave.Speed.
+                slave.Speed = 0f;
+                var newVX = v.X - vAlong * dirX;
+                var newVZ = v.Z - vAlong * dirZ;
+                slave.RigidBody.Velocity = new JVector(newVX * 0.85f, 0f, newVZ * 0.85f);
+                slave.RigidBody.AngularVelocity *= 0.85f;
+            }
+
+            // Push out of the barrier so we don't clip into wall textures.
+            // Single small push opposite to the barrier-facing direction (no loops -> no jitter).
+            var pushDirSign = useSternProbe ? 1f : -1f;
+            var dt = Math.Max(0.0001f, (float)deltaTime.TotalSeconds);
+            var pushStep = MathF.Min(0.50f, MathF.Max(0.08f, MathF.Abs(vAlong) * dt * 1.10f));
+            slave.RigidBody.Position += new JVector(dirX * pushStep * pushDirSign, 0f, dirZ * pushStep * pushDirSign);
+
+            return;
+        }
+AfterCliffCheck: ;
+
+        // Latch ground contact with enter/exit hysteresis to avoid rapid toggling (visual jitter).
+        const float ShoreEnterHyst = 0.35f;
+        const float ShoreExitHyst = 0.10f;
+
+        // Smooth contact floor itself (geo height noise + probe jitter).
+        const float FloorSmoothResponse = 10.0f;
+        {
+            var dt = Math.Max(0.0001f, (float)deltaTime.TotalSeconds);
+            var a = 1f - MathF.Exp(-FloorSmoothResponse * dt);
+            if (!slave.GroundContactLatched && slave.GroundContactFloorSmoothed == 0f)
+                slave.GroundContactFloorSmoothed = contactFloor;
+            else
+                slave.GroundContactFloorSmoothed += (contactFloor - slave.GroundContactFloorSmoothed) * a;
+        }
+        var floorSmoothed = slave.GroundContactFloorSmoothed;
+
+        // Pre-shore band: damp vertical bobbing right before latch triggers.
+        // This targets the last few "bumps" while approaching the shoreline.
+        const float PreShoreBand = 0.25f;
+        var enterDelta = (slave.CachedWaterSurface + ShoreEnterHyst) - floorSmoothed; // >=0 means "still water side"
+        if (!slave.GroundContactLatched && enterDelta >= 0f && enterDelta <= PreShoreBand)
+        {
+            var v = slave.RigidBody.Velocity;
+            // Fade Y velocity to zero as we approach latch point.
+            var t = 1f - (enterDelta / PreShoreBand); // 0..1
+            var damp = 1f - 0.85f * t;
+            slave.RigidBody.Velocity = new JVector(v.X, v.Y * damp, v.Z);
+        }
+
+        if (!slave.GroundContactLatched)
+        {
+            if (slave.CachedWaterSurface + ShoreEnterHyst >= floorSmoothed)
+                return;
+            slave.GroundContactLatched = true;
+            slave.GroundContactLatchedTime = 0f;
+        }
+        else
+        {
+            // Release latch only when we are clearly back on water side.
+            if (slave.CachedWaterSurface + ShoreExitHyst >= floorSmoothed)
+            {
+                slave.GroundContactLatched = false;
+                slave.GroundContactLatchedTime = 0f;
+                return;
+            }
+        }
+
+        // Remove vertical bobbing near shoreline / on ground contact.
+        // This targets the remaining "bumpy" height jerks right before beaching.
+        {
+            var v = slave.RigidBody.Velocity;
+            if (MathF.Abs(v.Y) > 0.01f)
+                slave.RigidBody.Velocity = new JVector(v.X, 0f, v.Z);
+        }
+        slave.GroundContactLatchedTime += Math.Max(0f, (float)deltaTime.TotalSeconds);
+
+        var penetration = floorSmoothed - boatBottom;
+        if (penetration <= 0.0f)
+            return;
+
+        // Smooth/clamp the vertical correction to prevent shaking on small height changes.
+        const float PenetrationEpsilon = 0.02f;
+        const float PenetrationResponse = 4.5f; // even smoother vertical correction
+        var maxUpStepPerTick = slave.GroundContactLatchedTime < 0.30f ? 0.04f : 0.07f;
+        if (penetration > PenetrationEpsilon)
+        {
+            var dt = Math.Max(0.0001f, (float)deltaTime.TotalSeconds);
+            var a = 1f - MathF.Exp(-PenetrationResponse * dt);
+            var step = MathF.Min(penetration * a, maxUpStepPerTick);
+            slave.RigidBody.Position += new JVector(0, step, 0); // lift toward terrain smoothly
+
+            // Kill vertical bounce when we manually resolve penetration (prevents small height jerks).
+            var v = slave.RigidBody.Velocity;
+            if (MathF.Abs(v.Y) > 0.01f)
+                slave.RigidBody.Velocity = new JVector(v.X, 0f, v.Z);
+        }
         var collisionForce = _physWorld.Gravity * -1f;
         slave.RigidBody.AddForce(collisionForce);
 
-        // Gradually reduce speed
-        var collisionDamping = 0.9f;
+        // Gradually reduce speed.
+        // Keep much more momentum for valid escape direction; otherwise the ship can get stuck jittering.
+        var escapeThrottleSign = slave.GroundedByStern ? 1 : -1;
+        var isEscapeThrottle = slave.ThrottleRequest != 0 && Math.Sign(slave.ThrottleRequest) == escapeThrottleSign;
+        // Less aggressive damping on initial shoreline contact to preserve inertia.
+        // Only apply strong damping once penetration is clearly "on land".
+        var deepContact = penetration > 0.25f;
+        var collisionDamping = isEscapeThrottle ? 0.99f : (deepContact ? 0.88f : 0.95f);
         slave.RigidBody.Velocity *= collisionDamping;
         slave.RigidBody.AngularVelocity *= collisionDamping;
 

--- a/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
+++ b/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
@@ -252,7 +252,7 @@ public class PhysicsManager
                                 BoatPhysicsTick(slave, physicsTotalDelta);
                                 // Check if we collided
                                 CheckLandCollisions(slave, physicsTotalDelta);
-                                slave.DoFloorCollisionDamage(physicsTotalDelta);
+                                slave.TickBeachedHullDamage(physicsTotalDelta);
                                 // Update Controls
                                 boat.ApplyForceAndTorque(slave, physicsTotalDelta);
                                 SendUpdatedMovementData(slave, slave.RigidBody, physicsTotalDelta);

--- a/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
+++ b/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models;
 using AAEmu.Game.Models.Game.DoodadObj.Static;
+using AAEmu.Game.Models.Game.Slaves;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.Units.Movements;
 using AAEmu.Game.Models.Game.World;
@@ -461,7 +462,17 @@ public class PhysicsManager
 
         // Visual-only bank (ship leans into turns). Applied to replicated rotation, not physics.
         // Coordinate mapping is legacy: GetSlaveRotationFromDegrees reorders axes, so injecting into rpy.Item2 affects client-side roll.
-        const float maxBankDeg = 8.0f;
+        var maxBankDeg = slave.Template.SlaveKind switch
+        {
+            SlaveKind.BigSailingShip => 10.0f,
+            SlaveKind.SmallSailingShip => 10.0f,
+            SlaveKind.Speedboat => 8.0f,
+            SlaveKind.Fishboat => 8.0f,
+            SlaveKind.MerchantShip => 8.0f,
+            SlaveKind.Leviathan => 8.0f,
+            SlaveKind.Boat => 8.0f,
+            _ => 0f
+        };
         const float bankResponse = 7.5f; // higher = snappier
         var dt = Math.Max(0.0001f, (float)deltaTime.TotalSeconds);
         var maxBankRad = maxBankDeg.DegToRad();

--- a/AAEmu.Game/Models/Game/Units/Slave.cs
+++ b/AAEmu.Game/Models/Game/Units/Slave.cs
@@ -719,12 +719,7 @@ public class Slave : Unit
         }
     }
 
-    /// <summary>Immediate hull damage (percent of <see cref="MaxHp"/> when <paramref name="isPercent"/>).</summary>
-    public void DoFloorCollisionDamage(int damage, bool isPercent = true, KillReason killReason = KillReason.Damage)
-    {
-        ApplyFloorCollisionDamageImmediate(damage, isPercent, killReason);
-    }
-
+    /// <summary>Immediate hull damage from floor/collision (percent of <see cref="MaxHp"/> when <paramref name="isPercent"/>).</summary>
     private void ApplyFloorCollisionDamageImmediate(int damage, bool isPercent = true, KillReason killReason = KillReason.Damage)
     {
         if (isPercent)

--- a/AAEmu.Game/Models/Game/Units/Slave.cs
+++ b/AAEmu.Game/Models/Game/Units/Slave.cs
@@ -55,6 +55,8 @@ public class Slave : Unit
     public sbyte Steering { get; set; }
     public float SteeringSmoothed { get; set; }
     public float RotSpeed { get; set; }
+    /// <summary>Smoothed 0.9..1 multiplier: forward speed loss while turning (see <see cref="ShipController"/>).</summary>
+    public float TurnSpeedVelocityMul { get; set; } = 1f;
     /// <summary>Visual-only bank angle (radians) applied to ship movement replication.</summary>
     public float BankAngle { get; set; }
     public short RotationZ { get; set; }

--- a/AAEmu.Game/Models/Game/Units/Slave.cs
+++ b/AAEmu.Game/Models/Game/Units/Slave.cs
@@ -84,7 +84,7 @@ public class Slave : Unit
     public bool GroundContactFloorSmoothingSeeded { get; set; }
     /// <summary>Time (seconds) since ground contact was latched.</summary>
     public float GroundContactLatchedTime { get; set; }
-    /// <summary>Seconds accumulated toward periodic hull damage while beached (see <see cref="DoFloorCollisionDamage(System.TimeSpan)"/>).</summary>
+    /// <summary>Seconds accumulated toward periodic hull damage while beached (see <see cref="TickBeachedHullDamage(System.TimeSpan)"/>).</summary>
     public float ShoreGroundDamageSecondsAccumulator { get; set; }
     public short RotationZ { get; set; }
     public float RotationDegrees { get; set; }
@@ -694,9 +694,9 @@ public class Slave : Unit
     }
 
     /// <summary>
-    /// While <see cref="GroundContactLatched"/> (beached on shore), applies hull damage once per second.
+    /// While <see cref="GroundContactLatched"/> (beached on shore), advances time toward hull damage dealt once per second.
     /// </summary>
-    public void DoFloorCollisionDamage(TimeSpan deltaTime)
+    public void TickBeachedHullDamage(TimeSpan deltaTime)
     {
         if (!GroundContactLatched)
         {

--- a/AAEmu.Game/Models/Game/Units/Slave.cs
+++ b/AAEmu.Game/Models/Game/Units/Slave.cs
@@ -636,7 +636,7 @@ public class Slave : Unit
     }
 
     [UnitAttribute(UnitAttribute.TurnSpeed)]
-    public virtual float TurnSpeed { get => (float)CalculateWithBonuses(0, UnitAttribute.TurnSpeed); }
+    public virtual float TurnSpeed { get => (float)CalculateWithBonuses(100f, UnitAttribute.TurnSpeed) / 100f; }
 
     #endregion
 

--- a/AAEmu.Game/Models/Game/Units/Slave.cs
+++ b/AAEmu.Game/Models/Game/Units/Slave.cs
@@ -735,8 +735,7 @@ public class Slave : Unit
         if (dealt <= 0)
             return;
 
-        var envTargetId = Summoner?.ObjId ?? ObjId;
-        BroadcastPacket(new SCEnvDamagePacket(EnvSource.Falling, envTargetId, (uint)dealt), true);
+        BroadcastPacket(new SCEnvDamagePacket(EnvSource.Collision, ObjId, (uint)dealt), true);
     }
 
     public override void PostUpdateCurrentHp(BaseUnit attacker, int oldHpValue, int newHpValue, KillReason killReason = KillReason.Damage)

--- a/AAEmu.Game/Models/Game/Units/Slave.cs
+++ b/AAEmu.Game/Models/Game/Units/Slave.cs
@@ -59,6 +59,26 @@ public class Slave : Unit
     public float TurnSpeedVelocityMul { get; set; } = 1f;
     /// <summary>Visual-only bank angle (radians) applied to ship movement replication.</summary>
     public float BankAngle { get; set; }
+    /// <summary>Visual-only ground pitch angle (radians) for ships beached on terrain.</summary>
+    public float GroundPitchAngle { get; set; }
+    /// <summary>Grounded contact side hint: true when grounding happened while moving backward (stern-side).</summary>
+    public bool GroundedByStern { get; set; }
+    /// <summary>Grounded state from previous physics tick (used to detect water->ground transition).</summary>
+    public bool GroundedLastTick { get; set; }
+    /// <summary>How long ship stays grounded with near-zero speed while player keeps throttle input.</summary>
+    public float GroundStuckTime { get; set; }
+    /// <summary>Smoothed 0..1 assist strength used to help unstuck from shoal.</summary>
+    public float GroundEscapeAssist { get; set; }
+    /// <summary>Latched "ground contact" state to avoid shoreline jitter.</summary>
+    public bool GroundContactLatched { get; set; }
+    /// <summary>Smoothed terrain height at the active hull probe point.</summary>
+    public float GroundContactFloorSmoothed { get; set; }
+    /// <summary>Smoothed terrain height sampled in front of the hull (for visual pitch).</summary>
+    public float GroundPitchFrontFloorSmoothed { get; set; }
+    /// <summary>Smoothed terrain height sampled behind the hull (for visual pitch).</summary>
+    public float GroundPitchBackFloorSmoothed { get; set; }
+    /// <summary>Time (seconds) since ground contact was latched.</summary>
+    public float GroundContactLatchedTime { get; set; }
     public short RotationZ { get; set; }
     public float RotationDegrees { get; set; }
     public sbyte AttachPointId { get; init; } = -1;

--- a/AAEmu.Game/Models/Game/Units/Slave.cs
+++ b/AAEmu.Game/Models/Game/Units/Slave.cs
@@ -79,6 +79,8 @@ public class Slave : Unit
     public float GroundPitchBackFloorSmoothed { get; set; }
     /// <summary>Time (seconds) since ground contact was latched.</summary>
     public float GroundContactLatchedTime { get; set; }
+    /// <summary>Seconds accumulated toward periodic hull damage while beached (see <see cref="DoFloorCollisionDamage(System.TimeSpan)"/>).</summary>
+    public float ShoreGroundDamageSecondsAccumulator { get; set; }
     public short RotationZ { get; set; }
     public float RotationDegrees { get; set; }
     public sbyte AttachPointId { get; init; } = -1;
@@ -687,18 +689,41 @@ public class Slave : Unit
     }
 
     /// <summary>
-    /// Damage handler used by BoatPhysics
+    /// While <see cref="GroundContactLatched"/> (beached on shore), applies hull damage once per second.
     /// </summary>
-    /// <param name="damage"></param>
-    /// <param name="isPercent"></param>
-    /// <param name="killReason"></param>
+    public void DoFloorCollisionDamage(TimeSpan deltaTime)
+    {
+        if (!GroundContactLatched)
+        {
+            ShoreGroundDamageSecondsAccumulator = 0f;
+            return;
+        }
+
+        const float IntervalSec = 1f;
+        const int PercentPerTick = 1;
+
+        var dt = (float)deltaTime.TotalSeconds;
+        if (dt <= 0f)
+            return;
+
+        ShoreGroundDamageSecondsAccumulator += dt;
+        while (ShoreGroundDamageSecondsAccumulator >= IntervalSec)
+        {
+            ShoreGroundDamageSecondsAccumulator -= IntervalSec;
+            ApplyFloorCollisionDamageImmediate(PercentPerTick, isPercent: true);
+        }
+    }
+
+    /// <summary>Immediate hull damage (percent of <see cref="MaxHp"/> when <paramref name="isPercent"/>).</summary>
     public void DoFloorCollisionDamage(int damage, bool isPercent = true, KillReason killReason = KillReason.Damage)
     {
-        // If % based, calculate its damage
+        ApplyFloorCollisionDamageImmediate(damage, isPercent, killReason);
+    }
+
+    private void ApplyFloorCollisionDamageImmediate(int damage, bool isPercent = true, KillReason killReason = KillReason.Damage)
+    {
         if (isPercent)
-        {
             damage = MaxHp * damage / 100;
-        }
 
         ReduceCurrentHp(this, damage, killReason);
     }

--- a/AAEmu.Game/Models/Game/Units/Slave.cs
+++ b/AAEmu.Game/Models/Game/Units/Slave.cs
@@ -13,6 +13,7 @@ using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Items.Actions;
 using AAEmu.Game.Models.Game.Skills.Effects;
 using AAEmu.Game.Models.Game.Slaves;
+using AAEmu.Game.Models.Game.Static;
 using AAEmu.Game.Models.Game.Units.Static;
 using AAEmu.Game.Models.StaticValues;
 using AAEmu.Game.Physics;
@@ -725,7 +726,17 @@ public class Slave : Unit
         if (isPercent)
             damage = MaxHp * damage / 100;
 
+        if (damage <= 0)
+            return;
+
+        var oldHp = Hp;
         ReduceCurrentHp(this, damage, killReason);
+        var dealt = oldHp - Hp;
+        if (dealt <= 0)
+            return;
+
+        var envTargetId = Summoner?.ObjId ?? ObjId;
+        BroadcastPacket(new SCEnvDamagePacket(EnvSource.Falling, envTargetId, (uint)dealt), true);
     }
 
     public override void PostUpdateCurrentHp(BaseUnit attacker, int oldHpValue, int newHpValue, KillReason killReason = KillReason.Damage)

--- a/AAEmu.Game/Models/Game/Units/Slave.cs
+++ b/AAEmu.Game/Models/Game/Units/Slave.cs
@@ -78,6 +78,10 @@ public class Slave : Unit
     public float GroundPitchFrontFloorSmoothed { get; set; }
     /// <summary>Smoothed terrain height sampled behind the hull (for visual pitch).</summary>
     public float GroundPitchBackFloorSmoothed { get; set; }
+    /// <summary>True after first pitch floor samples; cleared when leaving shoal/latched-ground pitch path.</summary>
+    public bool GroundPitchFloorSmoothingSeeded { get; set; }
+    /// <summary>True after first contact-floor sample while not latched (unrelated to height being zero).</summary>
+    public bool GroundContactFloorSmoothingSeeded { get; set; }
     /// <summary>Time (seconds) since ground contact was latched.</summary>
     public float GroundContactLatchedTime { get; set; }
     /// <summary>Seconds accumulated toward periodic hull damage while beached (see <see cref="DoFloorCollisionDamage(System.TimeSpan)"/>).</summary>

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -59,13 +59,13 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
     /// </summary>
     private static float GetSteerMaxDegFixed(SlaveKind kind) => kind switch
     {
-        SlaveKind.Boat => 8.7f,                // лодки
-        SlaveKind.SmallSailingShip => 5.2f,    // малыепарусник
-        SlaveKind.BigSailingShip => 4.7f,      // большиепарусник
-        SlaveKind.Fishboat => 6.7f,            // рыбацкие корабли
-        SlaveKind.Speedboat => 11.7f,          // катер
-        SlaveKind.MerchantShip => 5.7f,        // шхуна
-        _ => 6.2f
+        SlaveKind.Boat => 4.35f,               // лодки
+        SlaveKind.SmallSailingShip => 2.6f,    // малыепарусник
+        SlaveKind.BigSailingShip => 2.35f,     // большиепарусник
+        SlaveKind.Fishboat => 3.35f,           // рыбацкие корабли
+        SlaveKind.Speedboat => 5.85f,          // катер
+        SlaveKind.MerchantShip => 2.85f,       // шхуна
+        _ => 3.1f
     };
 
     /// <summary>Horizontal wind when no river flow and clock wind is off/unavailable (game X,Y).</summary>
@@ -382,14 +382,19 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         var isMovingBackward = slave.Speed < -ReverseSteerEpsilon || (MathF.Abs(slave.Speed) <= ReverseSteerEpsilon && slave.LastMoveDirSign < 0);
         var effectiveSteeringNorm = isMovingBackward ? -steeringNorm : steeringNorm;
 
-        // Per-kind turn rate (normal cap), used both for clamping and for non-linear "approach-to-cap" behavior.
-        var kindSteerDeg = GetSteerMaxDegFixed(slave.Template.SlaveKind);
+        // Per-kind turn rate with TurnSpeed multiplier from the common bonus system
+        // (same idea as MoveSpeedMul: base value + buff modifiers).
+        var baseKindSteerDeg = GetSteerMaxDegFixed(slave.Template.SlaveKind);
+        var turnSpeedBonusMul = MathF.Max(0.05f, slave.TurnSpeed);
+        var kindSteerDeg = baseKindSteerDeg * turnSpeedBonusMul;
         var steerMaxDegNormal = Math.Max(0.05f, kindSteerDeg);
         var steerMaxDegHard = Math.Max(0.05f, kindSteerDeg * 2f);
         var steerMaxNormal = (steerMaxDegNormal * turnFactor).DegToRad();
 
         // Calculate rotation speed
-        var turnSpeed = slave.TurnSpeed == 0 ? 10f : slave.TurnSpeed * (float)deltaTime.TotalSeconds * MathF.PI;
+        // TurnSpeed is now a multiplier (1.0, 1.3, ...). Keep steering response at the previous "stat-scale"
+        // baseline so counter-steer and turn build-up remain responsive.
+        var turnSpeed = 100f * turnSpeedBonusMul * (float)deltaTime.TotalSeconds * MathF.PI;
         var rotDelta = effectiveSteeringNorm * (turnSpeed / 100f) * (shipModel.TurnAccel / 360f) * SteeringResponsivenessMul * turnFactor;
         if (slave.RotSpeed != 0f && effectiveSteeringNorm != 0f && Math.Sign(slave.RotSpeed) != Math.Sign(effectiveSteeringNorm))
             rotDelta *= CounterSteerResponsivenessMul;
@@ -412,15 +417,7 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
 
         slave.RotSpeed += rotDelta;
 
-        // Max turn rate (fixed by ship kind).
-        //
-        // DB-based steer cap is intentionally disabled because ship_models.steer_vel is not in valid units.
-        // If needed later, restore this block and remove GetSteerMaxDegFixed usage:
-        // var steerMaxDeg = shipModel.SteerVel >= MinSteerVelAsDegPerSec
-        //     ? Math.Min(shipModel.SteerVel, MaxSteerDegPerSec)
-        //     : Math.Min(shipModel.Velocity * 2f, MaxSteerDegPerSec);
-        // Normal (design) max turn rate is per-ship-kind; hard cap is 2x of that value.
-        // This avoids ships constantly saturating at the "cap" during normal steering.
+        // Max turn rate (fixed by ship kind). Hard cap is 2x of normal.
         var steerMaxHard = (steerMaxDegHard * turnFactor).DegToRad();
         slave.RotSpeed = Math.Clamp(slave.RotSpeed, -steerMaxHard, steerMaxHard);
 

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -38,9 +38,6 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
     /// <summary>When rudder fights current yaw rate — faster decay; same-direction turn rate unchanged.</summary>
     private const float CounterSteerResponsivenessMul = 1.35f;
 
-    /// <summary>Max yaw rate (degrees/s). Legacy code used (velocity×2)°/s — often ~25°/s on large ships.</summary>
-    private const float MaxSteerDegPerSec = 5.2f;
-
     /// <summary>ship_models.steer_vel is often a small coefficient (~1), not °/s — only trust it above this.</summary>
     private const float MinSteerVelAsDegPerSec = 8f;
 
@@ -56,17 +53,19 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
     /// <summary>Higher = snappier convergence of <see cref="Slave.TurnSpeedVelocityMul"/> toward the turn target.</summary>
     private const float TurnSpeedVelocityMulResponse = 5.5f;
 
-    /// <summary>Added to the computed max yaw rate (°/s) after ship_models cap; per <see cref="SlaveKind"/> tuning.</summary>
-    private static float GetSteerMaxDegOffset(SlaveKind kind) => kind switch
+    /// <summary>
+    /// Fixed max yaw rate (degrees/s) by <see cref="SlaveKind"/>.
+    /// NOTE: We intentionally do NOT use ship_models.steer_vel because values in DB are not in valid units.
+    /// </summary>
+    private static float GetSteerMaxDegFixed(SlaveKind kind) => kind switch
     {
-        SlaveKind.BigSailingShip => -1f,
-        SlaveKind.SmallSailingShip => -0.5f,
-        SlaveKind.Speedboat => 2f,
-        SlaveKind.Fishboat => -0.5f,
-        SlaveKind.MerchantShip => 0f,
-        SlaveKind.Leviathan => 0f,
-        SlaveKind.Boat => 0f,
-        _ => 0f
+        SlaveKind.Boat => 8.7f,                // лодки
+        SlaveKind.SmallSailingShip => 5.7f,    // малыепарусник
+        SlaveKind.BigSailingShip => 4.7f,      // большиепарусник
+        SlaveKind.Fishboat => 6.7f,            // рыбацкие корабли
+        SlaveKind.Speedboat => 10.7f,          // катер
+        SlaveKind.MerchantShip => 6.7f,        // шхуна
+        _ => 6.7f
     };
 
     /// <summary>Horizontal wind when no river flow and clock wind is off/unavailable (game X,Y).</summary>
@@ -374,11 +373,15 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
             rotDelta *= CounterSteerResponsivenessMul;
         slave.RotSpeed += rotDelta;
 
-        // Max turn rate: prefer velocity×2°/s (legacy). steer_vel in DB is often ~1 (wrong units) — only use as °/s when plausible.
-        var steerMaxDeg = shipModel.SteerVel >= MinSteerVelAsDegPerSec
-            ? Math.Min(shipModel.SteerVel, MaxSteerDegPerSec)
-            : Math.Min(shipModel.Velocity * 2f, MaxSteerDegPerSec);
-        steerMaxDeg = Math.Max(0.05f, steerMaxDeg + GetSteerMaxDegOffset(slave.Template.SlaveKind));
+        // Max turn rate (fixed by ship kind).
+        //
+        // DB-based steer cap is intentionally disabled because ship_models.steer_vel is not in valid units.
+        // If needed later, restore this block and remove GetSteerMaxDegFixed usage:
+        // var steerMaxDeg = shipModel.SteerVel >= MinSteerVelAsDegPerSec
+        //     ? Math.Min(shipModel.SteerVel, MaxSteerDegPerSec)
+        //     : Math.Min(shipModel.Velocity * 2f, MaxSteerDegPerSec);
+        var kindSteerDeg = GetSteerMaxDegFixed(slave.Template.SlaveKind);
+        var steerMaxDeg = Math.Max(0.05f, kindSteerDeg * 2f);
         var steerMax = (steerMaxDeg * turnFactor).DegToRad();
         slave.RotSpeed = Math.Clamp(slave.RotSpeed, -steerMax, steerMax);
 

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -422,11 +422,19 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         slave.RotSpeed = Math.Clamp(slave.RotSpeed, -steerMaxHard, steerMaxHard);
 
         // While steering, keep yaw rate within the normal per-kind limit.
-        // (Hard cap still protects from spikes / edge cases.)
+        // When cap decreases (e.g. sails raised), converge smoothly instead of a one-frame snap.
+        // Hard cap above still protects against spikes.
         if (slave.Steering != 0)
         {
             var steerMaxNormalRad = (steerMaxDegNormal * turnFactor).DegToRad();
-            slave.RotSpeed = Math.Clamp(slave.RotSpeed, -steerMaxNormalRad, steerMaxNormalRad);
+            var rotAbs = MathF.Abs(slave.RotSpeed);
+            if (rotAbs > steerMaxNormalRad)
+            {
+                const float turnCapResponse = 8.0f;
+                var capA = 1f - MathF.Exp(-turnCapResponse * MathF.Max(0f, dtSec));
+                var target = MathF.Sign(slave.RotSpeed) * steerMaxNormalRad;
+                slave.RotSpeed += (target - slave.RotSpeed) * capA;
+            }
         }
 
         var steerMax = (steerMaxDegNormal * turnFactor).DegToRad();

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -63,9 +63,9 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         SlaveKind.SmallSailingShip => 5.2f,    // малыепарусник
         SlaveKind.BigSailingShip => 4.7f,      // большиепарусник
         SlaveKind.Fishboat => 6.7f,            // рыбацкие корабли
-        SlaveKind.Speedboat => 10.7f,          // катер
-        SlaveKind.MerchantShip => 6.2f,        // шхуна
-        _ => 6.7f
+        SlaveKind.Speedboat => 11.7f,          // катер
+        SlaveKind.MerchantShip => 5.7f,        // шхуна
+        _ => 6.2f
     };
 
     /// <summary>Horizontal wind when no river flow and clock wind is off/unavailable (game X,Y).</summary>

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -381,9 +381,24 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         //     ? Math.Min(shipModel.SteerVel, MaxSteerDegPerSec)
         //     : Math.Min(shipModel.Velocity * 2f, MaxSteerDegPerSec);
         var kindSteerDeg = GetSteerMaxDegFixed(slave.Template.SlaveKind);
-        var steerMaxDeg = Math.Max(0.05f, kindSteerDeg * 2f);
-        var steerMax = (steerMaxDeg * turnFactor).DegToRad();
-        slave.RotSpeed = Math.Clamp(slave.RotSpeed, -steerMax, steerMax);
+
+        // Normal (design) max turn rate is per-ship-kind; hard cap is 2x of that value.
+        // This avoids ships constantly saturating at the "cap" during normal steering.
+        var steerMaxDegNormal = Math.Max(0.05f, kindSteerDeg);
+        var steerMaxDegHard = Math.Max(0.05f, kindSteerDeg * 2f);
+
+        var steerMaxHard = (steerMaxDegHard * turnFactor).DegToRad();
+        slave.RotSpeed = Math.Clamp(slave.RotSpeed, -steerMaxHard, steerMaxHard);
+
+        // While steering, keep yaw rate within the normal per-kind limit.
+        // (Hard cap still protects from spikes / edge cases.)
+        if (slave.Steering != 0)
+        {
+            var steerMaxNormal = (steerMaxDegNormal * turnFactor).DegToRad();
+            slave.RotSpeed = Math.Clamp(slave.RotSpeed, -steerMaxNormal, steerMaxNormal);
+        }
+
+        var steerMax = (steerMaxDegNormal * turnFactor).DegToRad();
 
         // Up to TurnSpeedSlowdownFrac slower at full yaw rate; smooth return on straight course (forward and reverse).
         var steerMaxSafe = Math.Max(steerMax, 1e-5f);

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -315,21 +315,37 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         var rpy = PhysicsUtil.GetYawPitchRollFromMatrix(JMatrix.CreateFromQuaternion(rigidBody.Orientation));
         var slaveRotRad = rpy.Item1 + 1.57f; // bow heading in physics XZ; reused for wind + velocity
 
+        // Clamp speed between min and max Velocity (wind: ±15% of max speed when within ±15° of with/against wind)
+        var windMul = GetWindSpeedMul(slave, slaveRotRad);
+        var maxForward = shipModel.Velocity * slave.MoveSpeedMul / 2f * windMul;
+        var maxBackward = -shipModel.ReverseVelocity * slave.MoveSpeedMul / 2f * windMul;
+
         // Use data reverse_accel for braking; scale up when fighting current motion (feels less sluggish than forward-only Accel).
         var linearAccel = shipModel.Accel;
-        if (throttleNorm != 0f && slave.Speed != 0f && Math.Sign(slave.Speed) != Math.Sign(throttleNorm))
+        var isOpposingThrottle = throttleNorm != 0f && slave.Speed != 0f && Math.Sign(slave.Speed) != Math.Sign(throttleNorm);
+        if (isOpposingThrottle)
         {
             var reverseCap = shipModel.ReverseAccel > 0f ? shipModel.ReverseAccel : shipModel.Accel;
             linearAccel = Math.Max(shipModel.Accel, reverseCap) * OpposingThrottleAccelMul * OpposingThrottleBrakeTuneMul;
         }
 
+        // Non-linear approach to max speed: accelerate strongly at low speed, taper off near the cap.
+        // Applies only when accelerating in the current movement direction (not when braking/opposing throttle).
+        if (throttleNorm != 0f && !isOpposingThrottle)
+        {
+            var capAbs = throttleNorm > 0f ? maxForward : -maxBackward;
+            if (capAbs > 1e-4f)
+            {
+                var n = Math.Clamp(MathF.Abs(slave.Speed) / capAbs, 0f, 1f);
+                const float approachPow = 2.0f; // higher = stronger slowdown near cap
+                var approachMul = 1f - MathF.Pow(n, approachPow);
+                approachMul = Math.Clamp(approachMul, 0.10f, 1f);
+                linearAccel *= approachMul;
+            }
+        }
+
         // Calculate speed
         slave.Speed += throttleNorm * (linearAccel * dtSec) / 2f;
-
-        // Clamp speed between min and max Velocity (wind: ±15% of max speed when within ±15° of with/against wind)
-        var windMul = GetWindSpeedMul(slave, slaveRotRad);
-        var maxForward = shipModel.Velocity * slave.MoveSpeedMul / 2f * windMul;
-        var maxBackward = -shipModel.ReverseVelocity * slave.MoveSpeedMul / 2f * windMul;
 
         // When wind bonus disappears (especially Official "hard cutoff"), max speed can drop instantly.
         // Hard-clamping causes a visible speed snap. Instead, smoothly converge back to the new cap unless

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -50,6 +50,12 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
     /// <summary>Speed (in current ship speed units) at which turning reaches 100%.</summary>
     private const float TurnFullFactorAtSpeed = 2.5f;
 
+    /// <summary>Max forward/back speed multiplier removed at full yaw rate (linear in |ω|/ω_max).</summary>
+    private const float TurnSpeedSlowdownFrac = 0.1f;
+
+    /// <summary>Higher = snappier convergence of <see cref="Slave.TurnSpeedVelocityMul"/> toward the turn target.</summary>
+    private const float TurnSpeedVelocityMulResponse = 5.5f;
+
     /// <summary>Added to the computed max yaw rate (°/s) after ship_models cap; per <see cref="SlaveKind"/> tuning.</summary>
     private static float GetSteerMaxDegOffset(SlaveKind kind) => kind switch
     {
@@ -292,6 +298,7 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
             slave.Steering = 0;
             slave.ThrottleSmoothed = 0f;
             slave.SteeringSmoothed = 0f;
+            slave.TurnSpeedVelocityMul = 1f;
         }
 
         // Minimum crawl speed when starting in that direction only. Do not apply while still moving
@@ -375,6 +382,13 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         var steerMax = (steerMaxDeg * turnFactor).DegToRad();
         slave.RotSpeed = Math.Clamp(slave.RotSpeed, -steerMax, steerMax);
 
+        // Up to TurnSpeedSlowdownFrac slower at full yaw rate; smooth return on straight course (forward and reverse).
+        var steerMaxSafe = Math.Max(steerMax, 1e-5f);
+        var turnRateNorm = Math.Clamp(MathF.Abs(slave.RotSpeed) / steerMaxSafe, 0f, 1f);
+        var targetTurnVelMul = 1f - TurnSpeedSlowdownFrac * turnRateNorm;
+        var turnMulA = 1f - MathF.Exp(-TurnSpeedVelocityMulResponse * MathF.Max(0f, dtSec));
+        slave.TurnSpeedVelocityMul += (targetTurnVelMul - slave.TurnSpeedVelocityMul) * turnMulA;
+
         // Slow down turning if no steering active
         const float AngularDamping = 0.975f; // Damping of angular velocity
         if (slave.Steering == 0)
@@ -420,7 +434,7 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
                 slave.Speed = 0f;
         }
 
-        var forceThrottle = slave.Speed * slave.MoveSpeedMul / 4f; // Not sure if correct, but it feels correct
+        var forceThrottle = slave.Speed * slave.MoveSpeedMul / 4f * slave.TurnSpeedVelocityMul; // Not sure if correct, but it feels correct
 
         // Apply directional force
         rigidBody.Velocity = new JVector(forceThrottle * MathF.Cos(slaveRotRad), 0.0f, forceThrottle * MathF.Sin(slaveRotRad));

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -60,11 +60,11 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
     private static float GetSteerMaxDegFixed(SlaveKind kind) => kind switch
     {
         SlaveKind.Boat => 8.7f,                // лодки
-        SlaveKind.SmallSailingShip => 5.7f,    // малыепарусник
+        SlaveKind.SmallSailingShip => 5.2f,    // малыепарусник
         SlaveKind.BigSailingShip => 4.7f,      // большиепарусник
         SlaveKind.Fishboat => 6.7f,            // рыбацкие корабли
         SlaveKind.Speedboat => 10.7f,          // катер
-        SlaveKind.MerchantShip => 6.7f,        // шхуна
+        SlaveKind.MerchantShip => 6.2f,        // шхуна
         _ => 6.7f
     };
 
@@ -366,11 +366,34 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         var isMovingBackward = slave.Speed < -ReverseSteerEpsilon || (MathF.Abs(slave.Speed) <= ReverseSteerEpsilon && slave.LastMoveDirSign < 0);
         var effectiveSteeringNorm = isMovingBackward ? -steeringNorm : steeringNorm;
 
+        // Per-kind turn rate (normal cap), used both for clamping and for non-linear "approach-to-cap" behavior.
+        var kindSteerDeg = GetSteerMaxDegFixed(slave.Template.SlaveKind);
+        var steerMaxDegNormal = Math.Max(0.05f, kindSteerDeg);
+        var steerMaxDegHard = Math.Max(0.05f, kindSteerDeg * 2f);
+        var steerMaxNormal = (steerMaxDegNormal * turnFactor).DegToRad();
+
         // Calculate rotation speed
         var turnSpeed = slave.TurnSpeed == 0 ? 10f : slave.TurnSpeed * (float)deltaTime.TotalSeconds * MathF.PI;
         var rotDelta = effectiveSteeringNorm * (turnSpeed / 100f) * (shipModel.TurnAccel / 360f) * SteeringResponsivenessMul * turnFactor;
         if (slave.RotSpeed != 0f && effectiveSteeringNorm != 0f && Math.Sign(slave.RotSpeed) != Math.Sign(effectiveSteeringNorm))
             rotDelta *= CounterSteerResponsivenessMul;
+
+        // Non-linear approach: turning accelerates normally at low yaw rates, but slows down as we approach the cap.
+        // This prevents the turn rate from building linearly all the way up to the limit.
+        if (effectiveSteeringNorm != 0f && steerMaxNormal > 1e-6f)
+        {
+            var sameDir = slave.RotSpeed == 0f || Math.Sign(slave.RotSpeed) == Math.Sign(rotDelta);
+            if (sameDir)
+            {
+                var n = Math.Clamp(MathF.Abs(slave.RotSpeed) / steerMaxNormal, 0f, 1f);
+                const float approachPow = 2.0f; // higher = stronger slowdown near cap
+                var approachMul = 1f - MathF.Pow(n, approachPow);
+                // keep some authority even near cap, otherwise the last bit can feel "stuck"
+                approachMul = Math.Clamp(approachMul, 0.10f, 1f);
+                rotDelta *= approachMul;
+            }
+        }
+
         slave.RotSpeed += rotDelta;
 
         // Max turn rate (fixed by ship kind).
@@ -380,13 +403,8 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         // var steerMaxDeg = shipModel.SteerVel >= MinSteerVelAsDegPerSec
         //     ? Math.Min(shipModel.SteerVel, MaxSteerDegPerSec)
         //     : Math.Min(shipModel.Velocity * 2f, MaxSteerDegPerSec);
-        var kindSteerDeg = GetSteerMaxDegFixed(slave.Template.SlaveKind);
-
         // Normal (design) max turn rate is per-ship-kind; hard cap is 2x of that value.
         // This avoids ships constantly saturating at the "cap" during normal steering.
-        var steerMaxDegNormal = Math.Max(0.05f, kindSteerDeg);
-        var steerMaxDegHard = Math.Max(0.05f, kindSteerDeg * 2f);
-
         var steerMaxHard = (steerMaxDegHard * turnFactor).DegToRad();
         slave.RotSpeed = Math.Clamp(slave.RotSpeed, -steerMaxHard, steerMaxHard);
 
@@ -394,8 +412,8 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         // (Hard cap still protects from spikes / edge cases.)
         if (slave.Steering != 0)
         {
-            var steerMaxNormal = (steerMaxDegNormal * turnFactor).DegToRad();
-            slave.RotSpeed = Math.Clamp(slave.RotSpeed, -steerMaxNormal, steerMaxNormal);
+            var steerMaxNormalRad = (steerMaxDegNormal * turnFactor).DegToRad();
+            slave.RotSpeed = Math.Clamp(slave.RotSpeed, -steerMaxNormalRad, steerMaxNormalRad);
         }
 
         var steerMax = (steerMaxDegNormal * turnFactor).DegToRad();

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -59,12 +59,12 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
     /// </summary>
     private static float GetSteerMaxDegFixed(SlaveKind kind) => kind switch
     {
-        SlaveKind.Boat => 4.35f,               // лодки
-        SlaveKind.SmallSailingShip => 2.6f,    // малыепарусник
-        SlaveKind.BigSailingShip => 2.35f,     // большиепарусник
-        SlaveKind.Fishboat => 3.35f,           // рыбацкие корабли
-        SlaveKind.Speedboat => 5.85f,          // катер
-        SlaveKind.MerchantShip => 2.85f,       // шхуна
+        SlaveKind.Boat => 4.35f,
+        SlaveKind.SmallSailingShip => 2.6f,
+        SlaveKind.BigSailingShip => 2.35f,
+        SlaveKind.Fishboat => 3.35f,
+        SlaveKind.Speedboat => 5.85f,
+        SlaveKind.MerchantShip => 2.85f,
         _ => 3.1f
     };
 

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -290,27 +290,117 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         if (shipModel is null)
             return;
 
-        // If not in water, disable input for ships
-        if (slave.CachedFloorLevel > slave.CachedWaterSurface)
+        var dtSec = (float)deltaTime.TotalSeconds;
+
+        // If not in water (grounded), keep limited control to let ships get unstuck,
+        // while still strongly discouraging driving deeper inland.
+        //
+        // Use the latched ground contact from PhysicsManager to avoid shoreline jitter causing
+        // abrupt control/velocity changes ("jerks") when transitioning water<->land.
+        var isGrounded = (slave.CachedFloorLevel > slave.CachedWaterSurface) || slave.GroundContactLatched;
+
+        // Still compute movement direction for stern/bow logic.
+        var rpy0 = PhysicsUtil.GetYawPitchRollFromMatrix(JMatrix.CreateFromQuaternion(rigidBody.Orientation));
+        var heading0 = rpy0.Item1 + 1.57f;
+        var dirX0 = MathF.Cos(heading0);
+        var dirZ0 = MathF.Sin(heading0);
+        var along0 = rigidBody.Velocity.X * dirX0 + rigidBody.Velocity.Z * dirZ0;
+        var movingBackward0 = along0 < -0.05f || (MathF.Abs(along0) <= 0.05f && slave.ThrottleRequest < 0);
+        var isEscapeInputOnGround = false;
+        var escapeThrottleSignOnGround = 0;
+
+        if (isGrounded)
         {
-            slave.Throttle = 0;
-            slave.Steering = 0;
-            slave.ThrottleSmoothed = 0f;
-            slave.SteeringSmoothed = 0f;
+            // Latch grounding side only when entering ground state.
+            // Recomputing it every tick from current speed causes escape direction to flip mid-maneuver.
+            if (!slave.GroundedLastTick)
+                slave.GroundedByStern = movingBackward0;
+            var groundedByStern = slave.GroundedByStern;
+
+            var escapeThrottleSign = groundedByStern ? 1 : -1; // forward to escape stern-grounding, reverse to escape bow-grounding
+            escapeThrottleSignOnGround = escapeThrottleSign;
+            isEscapeInputOnGround = slave.ThrottleRequest != 0 && Math.Sign(slave.ThrottleRequest) == escapeThrottleSign;
+            var isTryingMoveDeeper = slave.ThrottleRequest != 0 && !isEscapeInputOnGround;
+            var isStuckOnGround = MathF.Abs(slave.Speed) < 0.08f && slave.ThrottleRequest != 0;
+
+            if (isStuckOnGround)
+                slave.GroundStuckTime += dtSec;
+            else
+                slave.GroundStuckTime = 0f;
+
+            // Hard-stop "digging into shore": when stern is the leading edge and player keeps reverse,
+            // do not allow building/keeping significant backward speed on land.
+            if (groundedByStern && slave.ThrottleRequest < 0 && isTryingMoveDeeper)
+            {
+                // Kill the "run-on" distance: clamp backward speed and add extra damping.
+                slave.Speed = Math.Max(slave.Speed, -0.15f);
+                slave.Speed *= 0.75f;
+            }
+
+            // If player keeps trying the "escape direction" but ship stays almost still, gradually assist.
+            var assistTarget = isEscapeInputOnGround && slave.GroundStuckTime > 1.2f ? 1f : 0f;
+            var assistA = 1f - MathF.Exp(-4.0f * MathF.Max(0f, dtSec));
+            slave.GroundEscapeAssist += (assistTarget - slave.GroundEscapeAssist) * assistA;
+
+            // Base asymmetric throttle on ground differs by contact side.
+            var groundThrottleForwardMul = groundedByStern ? 0.78f : 0.10f;
+            var groundThrottleReverseMul = groundedByStern ? 0.02f : 0.85f;
+
+            // Boost only the "escape" direction while stuck; suppress direction that digs deeper inland.
+            if (isEscapeInputOnGround)
+            {
+                var escapeBoost = 1f + 0.35f * slave.GroundEscapeAssist;
+                if (escapeThrottleSign > 0)
+                    groundThrottleForwardMul = MathF.Min(1f, groundThrottleForwardMul * escapeBoost);
+                else
+                    groundThrottleReverseMul = MathF.Min(1f, groundThrottleReverseMul * escapeBoost);
+            }
+            else if (isTryingMoveDeeper)
+            {
+                if (slave.ThrottleRequest > 0)
+                    groundThrottleForwardMul *= 0.55f;
+                else
+                    groundThrottleReverseMul *= 0.20f;
+            }
+
+            var groundedThrottleInputMul = slave.ThrottleRequest >= 0 ? groundThrottleForwardMul : groundThrottleReverseMul;
+            slave.Throttle = (sbyte)Math.Clamp((int)Math.Round(slave.ThrottleRequest * groundedThrottleInputMul), -128, 127);
+            // Avoid sbyte quantization dead-zone: keep tiny non-zero throttle while player gives
+            // valid escape input, otherwise speed can oscillate 0.1 -> 0.0 repeatedly.
+            if (isEscapeInputOnGround && slave.Throttle == 0 && Math.Abs(slave.ThrottleRequest) >= 8)
+                slave.Throttle = (sbyte)(escapeThrottleSign * 8);
+            slave.ThrottleSmoothed = slave.Throttle;
+
+            // Keep responsive steering on ground; add a bit extra during escape assist.
+            var groundSteerInputMul = groundedByStern ? 0.9f : 0.8f;
+            groundSteerInputMul = MathF.Min(1f, groundSteerInputMul + 0.15f * slave.GroundEscapeAssist);
+            slave.Steering = (sbyte)Math.Clamp((int)Math.Round(slave.SteeringRequest * groundSteerInputMul), -128, 127);
+            slave.SteeringSmoothed = slave.Steering;
+
             slave.TurnSpeedVelocityMul = 1f;
         }
+        else
+        {
+            slave.GroundedByStern = false;
+            slave.GroundStuckTime = 0f;
+            slave.GroundEscapeAssist = 0f;
+        }
+        slave.GroundedLastTick = isGrounded;
 
         // Minimum crawl speed when starting in that direction only. Do not apply while still moving
         // the other way — otherwise forward+reverse snaps Speed to ±1 and the ship stops instantly.
-        if (slave is { Throttle: > 0, Speed: < 1f } && slave.Speed >= 0f)
-            slave.Speed = 1f;
+        // Do not force crawl while grounded, otherwise ships can "slide-drive" on land at low speed.
+        if (!isGrounded)
+        {
+            if (slave is { Throttle: > 0, Speed: < 1f } && slave.Speed >= 0f)
+                slave.Speed = 1f;
 
-        if (slave is { Throttle: < 0, Speed: > -1f } && slave.Speed <= 0f)
-            slave.Speed = -1f;
+            if (slave is { Throttle: < 0, Speed: > -1f } && slave.Speed <= 0f)
+                slave.Speed = -1f;
+        }
 
         var throttleNorm = slave.Throttle * 0.00787401575f; // sbyte -> float
         var steeringNorm = slave.Steering * 0.00787401575f; // sbyte -> float
-        var dtSec = (float)deltaTime.TotalSeconds;
 
         var rpy = PhysicsUtil.GetYawPitchRollFromMatrix(JMatrix.CreateFromQuaternion(rigidBody.Orientation));
         var slaveRotRad = rpy.Item1 + 1.57f; // bow heading in physics XZ; reused for wind + velocity
@@ -346,6 +436,17 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
 
         // Calculate speed
         slave.Speed += throttleNorm * (linearAccel * dtSec) / 2f;
+
+        // Anti-stall nudge: when grounded and escape input is held, avoid jitter around zero.
+        if (isGrounded && isEscapeInputOnGround && slave.GroundStuckTime > 0.35f)
+        {
+            const float targetEscapeSpeed = 1.6f;
+            var escapeA = 1f - MathF.Exp(-(6.0f + 2.0f * slave.GroundEscapeAssist) * MathF.Max(0f, dtSec));
+            var target = escapeThrottleSignOnGround * targetEscapeSpeed;
+            slave.Speed += (target - slave.Speed) * escapeA;
+        }
+
+
 
         // When wind bonus disappears (especially Official "hard cutoff"), max speed can drop instantly.
         // Hard-clamping causes a visible speed snap. Instead, smoothly converge back to the new cap unless
@@ -454,11 +555,15 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         }
 
         // If not in water, seriously slow down the velocity
-        const float FloorCollisionSpeedMultiplier = 0.975f;
-        if (slave.CachedFloorLevel > slave.CachedWaterSurface)
+        const float FloorCollisionSpeedMultiplier = 0.96f;
+        if (isGrounded)
         {
-            slave.Speed *= FloorCollisionSpeedMultiplier;
-            slave.RigidBody.Velocity *= FloorCollisionSpeedMultiplier;
+            // While applying escape throttle, preserve more momentum to avoid "stuck in place" feel.
+            var groundDamping = isEscapeInputOnGround
+                ? 0.97f + 0.01f * slave.GroundEscapeAssist
+                : FloorCollisionSpeedMultiplier;
+            slave.Speed *= groundDamping;
+            slave.RigidBody.Velocity *= groundDamping;
         }
 
         // this needs to be fixed : ships need to apply a static drag, and slowly ship away at the speed instead of doing it like this
@@ -479,15 +584,20 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
             var dragMul = coastDragMinMul + (coastDragMaxMul - coastDragMinMul) * lowSpeedCurve;
             var effectiveDrag = drag * dragMul;
 
+            // Ground friction/braking: when beached we need to avoid long inland drift.
+            if (isGrounded)
+                effectiveDrag *= 1.35f;
+
             // Hard cap so "let go of throttle" never brakes harder than intended,
             // even if ship_models.water_resistance is high for some templates.
-            const float maxCoastDragPerSecond = 0.22f;
+            var maxCoastDragPerSecond = isGrounded ? 0.26f : 0.22f;
             effectiveDrag = MathF.Min(effectiveDrag, maxCoastDragPerSecond);
 
             var decay = MathF.Exp(-effectiveDrag * dt);
             slave.Speed *= decay;
 
-            if (MathF.Abs(slave.Speed) < 0.002f)
+            var stopEpsilon = isGrounded ? 0.04f : 0.002f;
+            if (MathF.Abs(slave.Speed) < stopEpsilon)
                 slave.Speed = 0f;
         }
 

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -50,6 +50,19 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
     /// <summary>Speed (in current ship speed units) at which turning reaches 100%.</summary>
     private const float TurnFullFactorAtSpeed = 2.5f;
 
+    /// <summary>Added to the computed max yaw rate (°/s) after ship_models cap; per <see cref="SlaveKind"/> tuning.</summary>
+    private static float GetSteerMaxDegOffset(SlaveKind kind) => kind switch
+    {
+        SlaveKind.BigSailingShip => -1f,
+        SlaveKind.SmallSailingShip => -0.5f,
+        SlaveKind.Speedboat => 2f,
+        SlaveKind.Fishboat => -0.5f,
+        SlaveKind.MerchantShip => 0f,
+        SlaveKind.Leviathan => 0f,
+        SlaveKind.Boat => 0f,
+        _ => 0f
+    };
+
     /// <summary>Horizontal wind when no river flow and clock wind is off/unavailable (game X,Y).</summary>
     private const float DefaultWindDirX = 0f;
     private const float DefaultWindDirY = 1f;
@@ -203,6 +216,9 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
 
         if (model == WorldConfig.WindModelType.Official)
         {
+            if (slave.Template.SlaveKind is not (SlaveKind.SmallSailingShip or SlaveKind.BigSailingShip or SlaveKind.Fishboat))
+                return 1f;
+
             // Retail-like: +15% within ±15° of the N↔S axis, both directions (no "against wind" penalty).
             var cosCone = MathF.Cos(WindConeHalfAngleDeg * MathF.PI / 180f);
             var dotAbs = MathF.Abs(dotBow);
@@ -355,6 +371,7 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         var steerMaxDeg = shipModel.SteerVel >= MinSteerVelAsDegPerSec
             ? Math.Min(shipModel.SteerVel, MaxSteerDegPerSec)
             : Math.Min(shipModel.Velocity * 2f, MaxSteerDegPerSec);
+        steerMaxDeg = Math.Max(0.05f, steerMaxDeg + GetSteerMaxDegOffset(slave.Template.SlaveKind));
         var steerMax = (steerMaxDeg * turnFactor).DegToRad();
         slave.RotSpeed = Math.Clamp(slave.RotSpeed, -steerMax, steerMax);
 

--- a/SQL/patches/compact/2026-03-25-fix-schooners-slave-kind.sql
+++ b/SQL/patches/compact/2026-03-25-fix-schooners-slave-kind.sql
@@ -1,0 +1,10 @@
+-- Fix: correct SlaveKind for merchant schooners.
+-- Previously these ship templates were using the SmallSailingShip class (slave_kind_id = 2),
+-- which made their handling/physics match small sailing ships instead of the intended class.
+--
+-- This patch sets slave_kind_id = 10 for the schooner templates by their template ids.
+
+UPDATE `slaves`
+SET `slave_kind_id` = 10
+WHERE `id` IN (75, 80);
+


### PR DESCRIPTION
PR description (marine-mechanics → develop)
Summary
Improved ship handling with non-linear acceleration near max speed and non-linear yaw acceleration near the turn-rate cap.
Introduced fixed per-SlaveKind yaw-rate limits (DB ship_models.steer_vel intentionally disabled) plus a 2× hard safety cap.
Added a smoothed forward-speed reduction while turning to make steering feel more consistent.
Made visual-only bank/lean depend on SlaveKind (replication only, not physics).
Fixed merchant schooner classification with a data patch.
Changes
Turn-rate caps
Stop using ship_models.steer_vel as a cap source (DB values are not in reliable units).
Apply per-SlaveKind “normal” caps + 2× hard cap to protect against spikes/edge cases.
Non-linear approach to caps
Speed: taper acceleration as current speed approaches the directional max (only when accelerating, not when braking/opposing throttle).
Yaw: taper yaw acceleration as yaw rate approaches the per-kind cap while keeping a minimum authority near the limit.
Turning slowdown
New Slave.TurnSpeedVelocityMul: smoothly approaches a target multiplier based on normalized yaw rate (up to ~10% loss at full yaw rate), and recovers smoothly when going straight.
Wind model scope
“Official” wind bonus applies only to sail-type ships (small/big sailing ships and fishboat); other ship kinds return 1f.
Visual bank per kind
Different max bank angles per SlaveKind; non-ship kinds default to 0.
Data fix
SQL patch sets merchant schooner templates to the correct SlaveKind (slave_kind_id = 10, template IDs: 75, 80).
Files changed
AAEmu.Game/Physics/ShipController.cs: turn caps, non-linear tapers, turn slowdown, wind scope.
AAEmu.Game/Core/Managers/World/PhysicsManager.cs: per-kind visual bank.
AAEmu.Game/Models/Game/Units/Slave.cs: add TurnSpeedVelocityMul.
SQL/patches/compact/2026-03-25-fix-schooners-slave-kind.sql: schooner SlaveKind fix.
Test plan
Spawn and drive multiple ship kinds (small/big sailing, fishboat, speedboat, merchant/schooner, boat) and verify:
yaw rate ramps smoothly and stays within the per-kind cap (no constant “hard clamp” feel),
acceleration tapers near max speed,
turning reduces effective thrust slightly and recovers smoothly when steering is released,
“Official” wind affects only sail ships,
merchant schooner behaves as merchant class after applying the SQL patch.
Notes / Risks
Since DB steer_vel is disabled, tuning is now primarily per SlaveKind. If per-model tuning is needed later, DB units must be standardized before re-enabling it.