### PR TITLE
Full Ship physics implementation

### DIFF
--- a/AAEmu.Game/Core/Managers/SlaveManager.cs
+++ b/AAEmu.Game/Core/Managers/SlaveManager.cs
@@ -41,7 +41,7 @@ public class SlaveManager(WorldInstance parentWorldInstance)
         lock (_slaveListLock)
         {
             var slaves = World.GetAllSlaves();
-            return slaves.FirstOrDefault(slave => slave.Summoner?.ObjId == objId);
+            return slaves.FirstOrDefault(slave => slave.Summoner?.ObjId == objId && !slave.IsDead);
         }
     }
 

--- a/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
+++ b/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
@@ -294,9 +294,10 @@ public class PhysicsManager
                         {
                             ShipTuningDebug.TickShip(slave);
                         }
-                        catch
+                        catch (Exception ex)
                         {
-                            // Debug-only; must never affect physics loop.
+                            // Debug-only; must never affect physics loop — log for diagnostics only.
+                            Logger.Debug(ex, $"ShipTuningDebug.TickShip failed for {slave.Name} ({slave.ObjId})");
                         }
                     }
 

--- a/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
+++ b/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
@@ -9,6 +9,7 @@ using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.Units.Movements;
 using AAEmu.Game.Models.Game.World;
 using AAEmu.Game.Physics;
+using AAEmu.Game.Physics.Debug;
 using AAEmu.Game.Physics.Forces;
 using AAEmu.Game.Physics.HeightMaps;
 using AAEmu.Game.Physics.Util;
@@ -291,7 +292,7 @@ public class PhysicsManager
                     {
                         try
                         {
-                            AAEmu.Game.Physics.Debug.ShipTuningDebug.TickShip(slave);
+                            ShipTuningDebug.TickShip(slave);
                         }
                         catch
                         {

--- a/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
+++ b/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
@@ -247,7 +247,8 @@ public class PhysicsManager
                                 }
                             }
 
-                            if (_shipControllers.ContainsKey(slave.Id))
+                            // Single dictionary lookup: ShipController matches _shipControllers[slave.Id] (set together in AddShip).
+                            if (_shipControllers.TryGetValue(slave.Id, out _))
                             {
                                 // Create floor/surface cache
                                 slave.CreateWaterAndLandSurfaceCache();
@@ -270,8 +271,7 @@ public class PhysicsManager
                     {
                         try
                         {
-                            if (_shipControllers.TryGetValue(slave.Id, out var boat))
-                                boat.ApplyForceAndTorque(slave, physicsTotalDelta);
+                            slave.ShipController?.ApplyForceAndTorque(slave, physicsTotalDelta);
                         }
                         catch (Exception slaveException)
                         {

--- a/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
+++ b/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
@@ -422,6 +422,8 @@ public class PhysicsManager
         _buoyancy.Remove(rigidBody);
         slave.RigidBody = null;
 
+        ShipTuningDebug.DespawnAll(slave.Id);
+
         Logger.Debug($"RemoveShip {slave.Name} <- {SimulationWorld.Template.Name}");
     }
 

--- a/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
+++ b/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
@@ -4,6 +4,7 @@ using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models;
 using AAEmu.Game.Models.Game.DoodadObj.Static;
 using AAEmu.Game.Models.Game.Slaves;
+using AAEmu.Game.Models.Game.Models;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.Units.Movements;
 using AAEmu.Game.Models.Game.World;
@@ -50,6 +51,8 @@ public class PhysicsManager
     /// List of Ship controllers (slaveId, controller)
     /// </summary>
     private readonly Dictionary<uint, ShipController> _shipControllers = new();
+    private readonly ShipShoreInteraction _shipShore = new();
+    private readonly ShipShipInteraction _shipShip = new();
 
     private readonly ConcurrentQueue<Action> _pendingActions = new();
     // ReSharper disable once ChangeFieldTypeToSystemThreadingLock
@@ -200,6 +203,7 @@ public class PhysicsManager
 
                     // 4. Sync positions and broadcast outside lock
                     // body, velocity, isMoving
+                    var shipsThisTick = new List<Slave>();
                     foreach (var (body, _, _) in snapshot)
                     {
                         /*
@@ -242,7 +246,7 @@ public class PhysicsManager
                                 }
                             }
 
-                            if (_shipControllers.TryGetValue(slave.Id, out var boat))
+                            if (_shipControllers.ContainsKey(slave.Id))
                             {
                                 // Create floor/surface cache
                                 slave.CreateWaterAndLandSurfaceCache();
@@ -250,17 +254,47 @@ public class PhysicsManager
                                 SyncTransformWithRigidBody(slave);
                                 // Do physics tick
                                 BoatPhysicsTick(slave, physicsTotalDelta);
-                                // Check if we collided
-                                CheckLandCollisions(slave, physicsTotalDelta);
-                                slave.TickBeachedHullDamage(physicsTotalDelta);
-                                // Update Controls
-                                boat.ApplyForceAndTorque(slave, physicsTotalDelta);
-                                SendUpdatedMovementData(slave, slave.RigidBody, physicsTotalDelta);
+                                _shipShore.ResolveTerrainContacts(slave, physicsTotalDelta, _physWorld);
+                                shipsThisTick.Add(slave);
                             }
                         }
                         catch (Exception slaveException)
                         {
                             // Put a separate catch here to catch individual errors without it breaking all the physics in this world 
+                            Logger.Error($"PhysicsThread Error on Slave {slave.Id} {slave.Name} ({slave.ObjId}): {slaveException.Message}\n{slaveException.StackTrace}");
+                        }
+                    }
+
+                    foreach (var slave in shipsThisTick)
+                    {
+                        try
+                        {
+                            if (_shipControllers.TryGetValue(slave.Id, out var boat))
+                                boat.ApplyForceAndTorque(slave, physicsTotalDelta);
+                        }
+                        catch (Exception slaveException)
+                        {
+                            Logger.Error($"PhysicsThread Error on Slave {slave.Id} {slave.Name} ({slave.ObjId}): {slaveException.Message}\n{slaveException.StackTrace}");
+                        }
+                    }
+
+                    try
+                    {
+                        _shipShip.ResolveAllPairs(shipsThisTick, physicsTotalDelta);
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Error($"PhysicsThread ship-ship resolve: {e.Message}\n{e.StackTrace}");
+                    }
+
+                    foreach (var slave in shipsThisTick)
+                    {
+                        try
+                        {
+                            SendUpdatedMovementData(slave, slave.RigidBody, physicsTotalDelta);
+                        }
+                        catch (Exception slaveException)
+                        {
                             Logger.Error($"PhysicsThread Error on Slave {slave.Id} {slave.Name} ({slave.ObjId}): {slaveException.Message}\n{slaveException.StackTrace}");
                         }
                     }
@@ -349,6 +383,9 @@ public class PhysicsManager
         // so ensure the initial server-side Transform matches the physics spawn position.
         SyncTransformWithRigidBody(slave);
         slave.Transform.FinalizeTransform();
+        ctrl.Replication.Reset();
+        slave.WavePitchPhase = 0f;
+        slave.ShipHullCollisionDamageCooldownByOtherShipId.Clear();
 
         EnqueueAddBody(slave.RigidBody);
         _buoyancy.AddForRectangularParallelepiped(slave.RigidBody, 3);
@@ -384,46 +421,7 @@ public class PhysicsManager
         var shipModel = slave.ShipController?.ShipModel;
         if (shipModel == null) return;
 
-        // Calculate submerged depth and buoyancy force
-        var submergedDepth = Math.Max(0, slave.CachedWaterSurface - slave.RigidBody.Position.Y);
-        var isOnWater = submergedDepth > 0;
-        var isOnLand = !isOnWater && submergedDepth <= 0;
-
-        if (isOnLand)
-        {
-            // Apply ground friction and stop the ship
-            const float GroundFriction = 0.4f; // Sand: around 0.4
-            var frictionForce = new JVector(-slave.RigidBody.Velocity.X * GroundFriction, 0, -slave.RigidBody.Velocity.Z * GroundFriction);
-            slave.RigidBody.AddForce(frictionForce);
-
-            // Gradually reduce speed
-            const float CollisionDamping = 0.5f;
-            slave.RigidBody.Velocity *= CollisionDamping;
-            slave.RigidBody.AngularVelocity *= CollisionDamping;
-
-            // Stop the ship and apply roll
-            if (slave.RigidBody.Velocity.Length() < 0.01f)
-            {
-                slave.RigidBody.Velocity = JVector.Zero;
-                slave.RigidBody.AngularVelocity = JVector.Zero;
-
-                // Apply roll to the ship
-                var rollAngle = GetRollAngle(JMatrix.CreateFromQuaternion(slave.RigidBody.Orientation));
-                if (Math.Abs(rollAngle) < 0.1f)
-                {
-                    var correctionTorque = new JVector(0, 0, -rollAngle * slave.RigidBody.Mass * 0.1f);
-                    slave.RigidBody.AddForce(correctionTorque);
-                }
-
-                // Disable control
-                slave.ThrottleRequest = 0;
-                slave.SteeringRequest = 0;
-                slave.Throttle = 0;
-                slave.Steering = 0;
-                slave.ThrottleSmoothed = 0f;
-                slave.SteeringSmoothed = 0f;
-            }
-        }
+        _shipShore.ApplyOnLandPhysics(slave, deltaTime);
 
         // Check if the ship has a driver
         var hasDriver = slave.AttachedCharacters.ContainsKey(AttachPointKind.Driver);
@@ -449,6 +447,107 @@ public class PhysicsManager
     }
 
     /// <summary>
+    /// Waterline length = max(X,Y), beam = min(X,Y), height = Z, mass from <c>ship_models</c> (same convention as bank).
+    /// </summary>
+    private static bool TryGetShipMassBoxWaterlineExtents(ShipModelV1 model, float scale,
+        out float length, out float beam, out float height, out float mass)
+    {
+        if (model == null)
+        {
+            length = beam = height = mass = 0f;
+            return false;
+        }
+
+        var s = MathF.Max(scale, 0.01f);
+        var hx = model.MassBoxSizeX * s;
+        var hy = model.MassBoxSizeY * s;
+        length = MathF.Max(MathF.Max(hx, hy), 0.25f);
+        beam = MathF.Max(MathF.Min(hx, hy), 0.25f);
+        height = MathF.Max(model.MassBoxSizeZ * s, 0.15f);
+        mass = MathF.Max(model.Mass, 10f);
+        return true;
+    }
+
+    /// <summary>
+    /// Visual wave pitch amplitude (rad) and angular frequency from hull length/mass; matches bank reference scale.
+    /// Longer/heavier → smaller amp, slightly slower cycle; short/light dinghies stay closer to legacy ±3° / 0.06 Hz.
+    /// </summary>
+    private static void GetVisualWavePitchModelFactors(ShipModelV1 model, float scale, out float maxAmpRad, out float omega)
+    {
+        const float baseDeg = 3f;
+        const float baseHz = 0.06f;
+        if (!TryGetShipMassBoxWaterlineExtents(model, scale, out var length, out _, out _, out var mass))
+        {
+            maxAmpRad = baseDeg.DegToRad();
+            omega = 2f * MathF.PI * baseHz;
+            return;
+        }
+
+        const float refLength = 14f;
+        const float refMass = 85000f;
+
+        var lenRatio = Math.Clamp(refLength / length, 0.35f, 2.5f);
+        var massRatio = Math.Clamp(MathF.Sqrt(refMass / mass), 0.45f, 2.2f);
+        var ampMul = MathF.Pow(lenRatio, 0.38f) * MathF.Pow(massRatio, 0.28f);
+        var maxDeg = Math.Clamp(baseDeg * ampMul, 1.1f, 5.5f);
+        maxAmpRad = maxDeg.DegToRad();
+
+        var freqMul = MathF.Pow(Math.Clamp(length / refLength, 0.5f, 2.2f), -0.18f);
+        var hz = Math.Clamp(baseHz * freqMul, 0.042f, 0.078f);
+        omega = 2f * MathF.PI * hz;
+    }
+
+    /// <summary>
+    /// Visual-only pitch oscillation on open water, summed with shore différent. Does not affect rigid body.
+    /// </summary>
+    private static float ComputeVisualWavePitchOnWater(Slave slave, RigidBody rigidBody, float dt)
+    {
+        var grounded = slave.CachedFloorLevel > slave.CachedWaterSurface || slave.GroundContactLatched;
+        if (grounded)
+            return 0f;
+
+        var submerged = MathF.Max(0f, slave.CachedWaterSurface - rigidBody.Position.Y);
+        const float submergedForFullAmp = 0.32f;
+        var depthMul = Math.Clamp(submerged / submergedForFullAmp, 0f, 1f);
+        if (depthMul <= 0f)
+            return 0f;
+
+        GetVisualWavePitchModelFactors(slave.ShipController?.ShipModel, slave.Scale, out var maxAmpRad, out var omega);
+        slave.WavePitchPhase += omega * dt;
+        // keep phase bounded
+        if (slave.WavePitchPhase > MathF.PI * 4000f)
+            slave.WavePitchPhase -= MathF.PI * 4000f;
+
+        var phaseOff = (slave.ObjId & 511) * 0.211f;
+        return MathF.Sin(slave.WavePitchPhase + phaseOff) * maxAmpRad * depthMul;
+    }
+
+    /// <summary>
+    /// Max visual bank (degrees) for turn lean from <c>ship_models</c> mass box and mass.
+    /// Horizontal footprint: <c>mass_box_size_x/y</c> are both in-plane; length = max(X,Y), beam = min(X,Y); height = Z.
+    /// Reference constants coarsely fitted to former per-<see cref="SlaveKind"/> caps using averages from <c>compact.sqlite3</c>.
+    /// </summary>
+    private static float ComputeVisualMaxBankDegFromShipModel(ShipModelV1 model, float scale)
+    {
+        if (!TryGetShipMassBoxWaterlineExtents(model, scale, out var length, out var beam, out var height, out var mass))
+            return 8f;
+
+        const float refLength = 14f;
+        const float refBeam = 1.5f;
+        const float refHeight = 16f;
+        const float refMass = 85000f;
+        const float baseDeg = 9f;
+
+        var lengthFactor = MathF.Pow(Math.Clamp(length / refLength, 0.35f, 2.8f), 0.22f);
+        var beamFactor = MathF.Pow(Math.Clamp(refBeam / beam, 0.65f, 1.6f), 0.28f);
+        var massFactor = MathF.Pow(Math.Clamp(refMass / mass, 0.2f, 4f), 0.18f);
+        var heightFactor = MathF.Pow(Math.Clamp(refHeight / height, 0.5f, 2f), 0.12f);
+
+        var deg = baseDeg * lengthFactor * beamFactor * massFactor * heightFactor;
+        return Math.Clamp(deg, 5f, 14f);
+    }
+
+    /// <summary>
     /// Update ship's movement data and broadcasts it 
     /// </summary>
     /// <param name="slave"></param>
@@ -463,17 +562,7 @@ public class PhysicsManager
 
         // Visual-only bank (ship leans into turns). Applied to replicated rotation, not physics.
         // Coordinate mapping is legacy: GetSlaveRotationFromDegrees reorders axes, so injecting into rpy.Item2 affects client-side roll.
-        var maxBankDeg = slave.Template.SlaveKind switch
-        {
-            SlaveKind.BigSailingShip => 10.0f,
-            SlaveKind.SmallSailingShip => 10.0f,
-            SlaveKind.Speedboat => 8.0f,
-            SlaveKind.Fishboat => 8.0f,
-            SlaveKind.MerchantShip => 8.0f,
-            SlaveKind.Leviathan => 8.0f,
-            SlaveKind.Boat => 8.0f,
-            _ => 0f
-        };
+        var maxBankDeg = ComputeVisualMaxBankDegFromShipModel(slave.ShipController?.ShipModel, slave.Scale);
         const float bankResponse = 7.5f; // higher = snappier
         var dt = Math.Max(0.0001f, (float)deltaTime.TotalSeconds);
         var maxBankRad = maxBankDeg.DegToRad();
@@ -486,73 +575,77 @@ public class PhysicsManager
         var a = 1f - MathF.Exp(-bankResponse * dt);
         slave.BankAngle += (targetBank - slave.BankAngle) * a;
 
-        // Visual-only pitch on shoal/ground: align nose/stern to local terrain slope.
-        // This does not affect rigidbody Y/physics, only replicated rotation.
-        const float groundPitchMaxDeg = 8.0f;
-        const float groundPitchProbeDistance = 6.0f;
-        const float groundPitchResponse = 2.0f; // smoother to avoid pitch jitter
-        var targetGroundPitch = 0f;
-        if (slave.CachedFloorLevel > slave.CachedWaterSurface || slave.GroundContactLatched)
+        _shipShore.UpdateVisualGroundPitch(slave, rigidBody, deltaTime);
+
+        var wavePitchRad = ComputeVisualWavePitchOnWater(slave, rigidBody, dt);
+
+        // Replication smoothing for clients only; rigid body and transform stay physics-accurate below.
+        // Horizontal (phys X,Z → packet X,Y) uses snappier lambdas; vertical / trim softer; bank softer still (turn lean jitter).
+        const float repLambdaHorizFree = 22f;
+        const float repLambdaHorizContact = 11f;
+        const float repLambdaVertFree = 8f;
+        const float repLambdaVertContact = 4f;
+        const float repLambdaBankFree = 4f;
+        const float repLambdaBankContact = 2f;
+        var rep = slave.ShipController!.Replication;
+        var repLambdaH = rep.ContactHoldTicks > 0 ? repLambdaHorizContact : repLambdaHorizFree;
+        var repLambdaV = rep.ContactHoldTicks > 0 ? repLambdaVertContact : repLambdaVertFree;
+        var repLambdaB = rep.ContactHoldTicks > 0 ? repLambdaBankContact : repLambdaBankFree;
+        var repAlphaH = 1f - MathF.Exp(-repLambdaH * dt);
+        var repAlphaV = 1f - MathF.Exp(-repLambdaV * dt);
+        var repAlphaB = 1f - MathF.Exp(-repLambdaB * dt);
+
+        var tgtX = rigidBody.Position.X;
+        var tgtY = rigidBody.Position.Z;
+        var tgtZ = rigidBody.Position.Y;
+        var tgtVx = rigidBody.Velocity.X;
+        var tgtVy = rigidBody.Velocity.Z;
+        var tgtVz = rigidBody.Velocity.Y;
+
+        if (!rep.Seeded)
         {
-            var yaw = rpy.Item1 + 1.57f; // bow heading in world X/Y plane
-            var cosYaw = MathF.Cos(yaw);
-            var sinYaw = MathF.Sin(yaw);
-            var cx = rigidBody.Position.X;
-            var cy = rigidBody.Position.Z;
-            var frontX = cx + cosYaw * groundPitchProbeDistance;
-            var frontY = cy + sinYaw * groundPitchProbeDistance;
-            var backX = cx - cosYaw * groundPitchProbeDistance;
-            var backY = cy - sinYaw * groundPitchProbeDistance;
-            var frontH = slave.ParentWorld.GetHeight(frontX, frontY);
-            var backH = slave.ParentWorld.GetHeight(backX, backY);
-
-            // Smooth sampled heights to avoid geo noise causing visual pitch jitter.
-            const float pitchFloorSmoothResponse = 8.0f;
-            var floorA = 1f - MathF.Exp(-pitchFloorSmoothResponse * dt);
-            if (!slave.GroundPitchFloorSmoothingSeeded)
-            {
-                slave.GroundPitchFrontFloorSmoothed = frontH;
-                slave.GroundPitchBackFloorSmoothed = backH;
-                slave.GroundPitchFloorSmoothingSeeded = true;
-            }
-            else
-            {
-                slave.GroundPitchFrontFloorSmoothed += (frontH - slave.GroundPitchFrontFloorSmoothed) * floorA;
-                slave.GroundPitchBackFloorSmoothed += (backH - slave.GroundPitchBackFloorSmoothed) * floorA;
-            }
-
-            var slopeRad = MathF.Atan2(slave.GroundPitchFrontFloorSmoothed - slave.GroundPitchBackFloorSmoothed, groundPitchProbeDistance * 2f);
-            targetGroundPitch = Math.Clamp(slopeRad, -groundPitchMaxDeg.DegToRad(), groundPitchMaxDeg.DegToRad());
-
-            // When beaching in reverse (stern on ground), invert pitch so the stern rises (not the bow).
-            if (slave.GroundedByStern)
-                targetGroundPitch = -targetGroundPitch;
+            rep.PosX = tgtX;
+            rep.PosY = tgtY;
+            rep.PosZ = tgtZ;
+            rep.VelPx = tgtVx;
+            rep.VelPy = tgtVy;
+            rep.VelPz = tgtVz;
+            rep.BankSmoothed = slave.BankAngle;
+            rep.GroundPitchSmoothed = slave.GroundPitchAngle;
+            rep.Seeded = true;
         }
         else
-            slave.GroundPitchFloorSmoothingSeeded = false;
+        {
+            rep.PosX += (tgtX - rep.PosX) * repAlphaH;
+            rep.PosY += (tgtY - rep.PosY) * repAlphaH;
+            rep.PosZ += (tgtZ - rep.PosZ) * repAlphaV;
+            rep.VelPx += (tgtVx - rep.VelPx) * repAlphaH;
+            rep.VelPy += (tgtVy - rep.VelPy) * repAlphaH;
+            rep.VelPz += (tgtVz - rep.VelPz) * repAlphaV;
+            rep.BankSmoothed += (slave.BankAngle - rep.BankSmoothed) * repAlphaB;
+            rep.GroundPitchSmoothed += (slave.GroundPitchAngle - rep.GroundPitchSmoothed) * repAlphaV;
+        }
 
-        var pitchA = 1f - MathF.Exp(-groundPitchResponse * dt);
-        slave.GroundPitchAngle += (targetGroundPitch - slave.GroundPitchAngle) * pitchA;
+        var bankedRpy = (rpy.Item1, rpy.Item2 + rep.BankSmoothed, rpy.Item3 + rep.GroundPitchSmoothed + wavePitchRad);
 
-        var bankedRpy = (rpy.Item1, rpy.Item2 + slave.BankAngle, rpy.Item3 + slave.GroundPitchAngle);
-
-        // Insert new Rotation data into MoveType
+        // Physics yaw + euler; bank uses softer λ than vertical/trim.
         var (rotZ, rotY, rotX) = MathUtil.GetSlaveRotationFromDegrees(bankedRpy.Item1, bankedRpy.Item2, bankedRpy.Item3);
         moveType.RotationX = rotX;
         moveType.RotationY = rotY;
         moveType.RotationZ = rotZ;
 
-        // Fill in the Velocity Data into the MoveType.
-        // moveType.Velocity = new Vector3(rigidBody.Velocity.X, rigidBody.Velocity.Z, rigidBody.Velocity.Y);
+        moveType.X = rep.PosX;
+        moveType.Y = rep.PosY;
+        moveType.Z = rep.PosZ;
+
         moveType.AngVelX = rigidBody.AngularVelocity.X;
         moveType.AngVelY = rigidBody.AngularVelocity.Z;
         moveType.AngVelZ = rigidBody.AngularVelocity.Y;
 
-        // Seems display the correct speed this way, but what happens if you go over the bounds ?
-        var velMultiplier = 2048; // 1024;
-        moveType.VelX = (short)(rigidBody.Velocity.X * velMultiplier);
-        moveType.VelY = (short)(rigidBody.Velocity.Z * velMultiplier);
-        moveType.VelZ = (short)(rigidBody.Velocity.Y * velMultiplier);
+        const int velMultiplier = 2048;
+        moveType.VelX = (short)(rep.VelPx * velMultiplier);
+        moveType.VelY = (short)(rep.VelPy * velMultiplier);
+        moveType.VelZ = (short)(rep.VelPz * velMultiplier);
 
         // Do not allow the body to flip
         //slave.RigidBody.Orientation = JMatrix.CreateFromYawPitchRoll(rpy.Item1, 0, 0); // TODO: Fix me with proper physics
@@ -562,190 +655,17 @@ public class PhysicsManager
         slave.Transform.Local.ApplyFromQuaternion(rigidBody.Orientation);
         slave.Transform.Local.SetRotation(
             slave.Transform.Local.Rotation.X,
-            slave.Transform.Local.Rotation.Y + slave.BankAngle,
-            slave.Transform.Local.Rotation.Z + slave.GroundPitchAngle);
+            slave.Transform.Local.Rotation.Y + rep.BankSmoothed,
+            slave.Transform.Local.Rotation.Z + rep.GroundPitchSmoothed + wavePitchRad);
 
         // Send the packet
         slave.BroadcastPacket(new SCOneUnitMovementPacket(slave.ObjId, moveType), false);
 
         // Update all to main Slave and it's children
         slave.Transform.FinalizeTransform();
-    }
 
-    /// <summary>
-    /// Apply land collision between the ship and the expected terrain
-    /// </summary>
-    /// <param name="slave"></param>
-    /// <param name="deltaTime"></param>
-    private void CheckLandCollisions(Slave slave, TimeSpan deltaTime)
-    {
-        if (slave.ShipController?.ShipModel is null)
-            return;
-
-        var dt = Math.Max(0.0001f, (float)deltaTime.TotalSeconds);
-
-        // Terrain contact is evaluated at a probe point in front of bow / behind stern (not hull center).
-        // Requested tuning: probe is placed at 2x hull length from center.
-        var boatBottom = slave.RigidBody.Position.Y;
-
-        var rpy = PhysicsUtil.GetYawPitchRollFromMatrix(JMatrix.CreateFromQuaternion(slave.RigidBody.Orientation));
-        var heading = rpy.Item1 + 1.57f;
-        var dirX = MathF.Cos(heading);
-        var dirZ = MathF.Sin(heading);
-
-        var vX = slave.RigidBody.Velocity.X;
-        var vZ = slave.RigidBody.Velocity.Z;
-        var along = vX * dirX + vZ * dirZ; // >0 forward, <0 backward
-        var movingBackward = along < -0.05f || (MathF.Abs(along) <= 0.05f && slave.ThrottleRequest < 0);
-
-        const float BowProbeMul = 1.5f;
-        const float SternProbeMul = 1.5f;
-        // IMPORTANT: once we latched ground contact, keep the same hull-end selection stable.
-        // Otherwise, releasing reverse at standstill can flip the probe from stern->bow,
-        // making contactFloor drop and causing GroundContactLatched + visual pitch to flicker.
-        var useSternProbe = slave.GroundContactLatched ? slave.GroundedByStern : movingBackward;
-        var probeMul = useSternProbe ? SternProbeMul : BowProbeMul;
-        var probeDist = MathF.Max(1.0f, slave.ShipController.ShipModel.MassBoxSizeX * probeMul * slave.Scale);
-        var probeSign = useSternProbe ? -1f : 1f; // stern / bow
-        var probeX = slave.RigidBody.Position.X + dirX * probeDist * probeSign;
-        var probeY = slave.RigidBody.Position.Z + dirZ * probeDist * probeSign;
-        var contactFloor = slave.ParentWorld.GetHeight(probeX, probeY);
-
-        // Simple "cliff collision" rule:
-        // look ahead/behind at 2x hull length; if slope is steeper than 45% treat as a barrier.
-        // "Wall / cliff" detection probe distance (independent from beach contact probe).
-        const float CliffProbeMul = 1.45f;
-        // ~30 degrees slope threshold (rounded): 57%
-        const float CliffSlopeFracThreshold = 0.57f;
-        var cliffDist = MathF.Max(1.0f, slave.ShipController.ShipModel.MassBoxSizeX * CliffProbeMul * slave.Scale);
-        var cliffX = slave.RigidBody.Position.X + dirX * cliffDist * probeSign;
-        var cliffY = slave.RigidBody.Position.Z + dirZ * cliffDist * probeSign;
-        var cliffFloor = slave.ParentWorld.GetHeight(cliffX, cliffY);
-        // Prevent underwater terrain ("sea floor") from being treated as a wall:
-        // only run cliff-barrier logic when the probe sample is at/above water; otherwise fall through to beaching.
-        const float CliffAboveWaterMargin = 0.20f;
-        if (cliffFloor > slave.CachedWaterSurface + CliffAboveWaterMargin)
-        {
-            var dh = cliffFloor - slave.CachedFloorLevel;
-            var slopeFrac = dh / MathF.Max(0.01f, cliffDist);
-            if (slopeFrac > CliffSlopeFracThreshold)
-            {
-                // Collision: remove the component of horizontal velocity pushing into the cliff.
-                var v = slave.RigidBody.Velocity;
-                var vAlong = v.X * dirX + v.Z * dirZ;
-                var pushingIntoBarrier = useSternProbe ? (vAlong < 0f) : (vAlong > 0f);
-                if (pushingIntoBarrier)
-                {
-                    // Stop the "poke": ShipController will otherwise re-apply forward/back velocity next tick from slave.Speed.
-                    slave.Speed = 0f;
-                    var newVX = v.X - vAlong * dirX;
-                    var newVZ = v.Z - vAlong * dirZ;
-                    slave.RigidBody.Velocity = new JVector(newVX * 0.85f, 0f, newVZ * 0.85f);
-                    slave.RigidBody.AngularVelocity *= 0.85f;
-                }
-
-                // Push out of the barrier so we don't clip into wall textures.
-                // Single small push opposite to the barrier-facing direction (no loops -> no jitter).
-                var pushDirSign = useSternProbe ? 1f : -1f;
-                var pushStep = MathF.Min(0.50f, MathF.Max(0.08f, MathF.Abs(vAlong) * dt * 1.10f));
-                slave.RigidBody.Position += new JVector(dirX * pushStep * pushDirSign, 0f, dirZ * pushStep * pushDirSign);
-
-                return;
-            }
-        }
-
-        // Latch ground contact with enter/exit hysteresis to avoid rapid toggling (visual jitter).
-        const float ShoreEnterHyst = 0.35f;
-        const float ShoreExitHyst = 0.10f;
-
-        // Smooth contact floor itself (geo height noise + probe jitter).
-        const float FloorSmoothResponse = 10.0f;
-        {
-            var a = 1f - MathF.Exp(-FloorSmoothResponse * dt);
-            if (!slave.GroundContactLatched && !slave.GroundContactFloorSmoothingSeeded)
-            {
-                slave.GroundContactFloorSmoothed = contactFloor;
-                slave.GroundContactFloorSmoothingSeeded = true;
-            }
-            else
-                slave.GroundContactFloorSmoothed += (contactFloor - slave.GroundContactFloorSmoothed) * a;
-        }
-        var floorSmoothed = slave.GroundContactFloorSmoothed;
-
-        // Pre-shore band: damp vertical bobbing right before latch triggers.
-        // This targets the last few "bumps" while approaching the shoreline.
-        const float PreShoreBand = 0.25f;
-        var enterDelta = (slave.CachedWaterSurface + ShoreEnterHyst) - floorSmoothed; // >=0 means "still water side"
-        if (!slave.GroundContactLatched && enterDelta >= 0f && enterDelta <= PreShoreBand)
-        {
-            var v = slave.RigidBody.Velocity;
-            // Fade Y velocity to zero as we approach latch point.
-            var t = 1f - (enterDelta / PreShoreBand); // 0..1
-            var damp = 1f - 0.85f * t;
-            slave.RigidBody.Velocity = new JVector(v.X, v.Y * damp, v.Z);
-        }
-
-        if (!slave.GroundContactLatched)
-        {
-            if (slave.CachedWaterSurface + ShoreEnterHyst >= floorSmoothed)
-                return;
-            slave.GroundContactLatched = true;
-            slave.GroundContactLatchedTime = 0f;
-        }
-        else
-        {
-            // Release latch only when we are clearly back on water side.
-            if (slave.CachedWaterSurface + ShoreExitHyst >= floorSmoothed)
-            {
-                slave.GroundContactLatched = false;
-                slave.GroundContactLatchedTime = 0f;
-                return;
-            }
-        }
-
-        // Remove vertical bobbing near shoreline / on ground contact.
-        // This targets the remaining "bumpy" height jerks right before beaching.
-        {
-            var v = slave.RigidBody.Velocity;
-            if (MathF.Abs(v.Y) > 0.01f)
-                slave.RigidBody.Velocity = new JVector(v.X, 0f, v.Z);
-        }
-        slave.GroundContactLatchedTime += Math.Max(0f, (float)deltaTime.TotalSeconds);
-
-        var penetration = floorSmoothed - boatBottom;
-        if (penetration <= 0.0f)
-            return;
-
-        // Smooth/clamp the vertical correction to prevent shaking on small height changes.
-        const float PenetrationEpsilon = 0.02f;
-        const float PenetrationResponse = 4.5f; // even smoother vertical correction
-        var maxUpStepPerTick = slave.GroundContactLatchedTime < 0.30f ? 0.04f : 0.07f;
-        if (penetration > PenetrationEpsilon)
-        {
-            var a = 1f - MathF.Exp(-PenetrationResponse * dt);
-            var step = MathF.Min(penetration * a, maxUpStepPerTick);
-            slave.RigidBody.Position += new JVector(0, step, 0); // lift toward terrain smoothly
-
-            // Kill vertical bounce when we manually resolve penetration (prevents small height jerks).
-            var v = slave.RigidBody.Velocity;
-            if (MathF.Abs(v.Y) > 0.01f)
-                slave.RigidBody.Velocity = new JVector(v.X, 0f, v.Z);
-        }
-        var collisionForce = _physWorld.Gravity * -1f;
-        slave.RigidBody.AddForce(collisionForce);
-
-        // Gradually reduce speed.
-        // Keep much more momentum for valid escape direction; otherwise the ship can get stuck jittering.
-        var escapeThrottleSign = slave.GroundedByStern ? 1 : -1;
-        var isEscapeThrottle = slave.ThrottleRequest != 0 && Math.Sign(slave.ThrottleRequest) == escapeThrottleSign;
-        // Less aggressive damping on initial shoreline contact to preserve inertia.
-        // Only apply strong damping once penetration is clearly "on land".
-        var deepContact = penetration > 0.25f;
-        var collisionDamping = isEscapeThrottle ? 0.99f : (deepContact ? 0.88f : 0.95f);
-        slave.RigidBody.Velocity *= collisionDamping;
-        slave.RigidBody.AngularVelocity *= collisionDamping;
-
-        // Logger.Debug($"Land Collision detected. Boat adjusted position: {slave.RigidBody.Position}, boat penetration depth: {penetration}");
+        if (rep.ContactHoldTicks > 0)
+            rep.ContactHoldTicks--;
     }
 
     /// <summary>

--- a/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
+++ b/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
@@ -408,21 +408,46 @@ public class PhysicsManager
     }
 
     /// <summary>
-    /// Removes a ship from the physics engine
+    /// Removes a ship from the physics engine.
+    /// Jitter2 <see cref="Jitter2.World"/> is not thread-safe: all <c>_physWorld</c> / <c>_buoyancy</c> mutations
+    /// run on the physics thread (same queue as <see cref="_pendingActions"/>, processed before <c>Step</c>).
     /// </summary>
     /// <param name="slave"></param>
     public void RemoveShip(Slave slave)
     {
-        if (slave.RigidBody == null) return;
+        if (slave.RigidBody == null)
+            return;
 
         var rigidBody = slave.RigidBody;
-        rigidBody.SetActivationState(false);
-        EnqueueRemoveBody(rigidBody);
-        _physWorld.Remove(rigidBody);
-        _buoyancy.Remove(rigidBody);
-        slave.RigidBody = null;
+        var slaveId = slave.Id;
+        var slaveRef = slave;
 
-        ShipTuningDebug.DespawnAll(slave.Id);
+        void RemoveFromPhysicsThread()
+        {
+            // Second queued removal (same body): first lambda already nulled RigidBody.
+            if (slaveRef.RigidBody != rigidBody)
+                return;
+
+            rigidBody.SetActivationState(false);
+            _physWorld.Remove(rigidBody);
+            _buoyancy.Remove(rigidBody);
+            _bodies.Remove(rigidBody);
+            _shipControllers.Remove(slaveId, out _);
+
+            ShipTuningDebug.DespawnAll(slaveId);
+
+            slaveRef.RigidBody = null;
+            slaveRef.ShipController = null;
+        }
+
+        if (!ThreadRunning)
+        {
+            RemoveFromPhysicsThread();
+        }
+        else
+        {
+            _pendingActions.Enqueue(RemoveFromPhysicsThread);
+        }
 
         Logger.Debug($"RemoveShip {slave.Name} <- {SimulationWorld.Template.Name}");
     }

--- a/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
+++ b/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
@@ -291,6 +291,18 @@ public class PhysicsManager
                     {
                         try
                         {
+                            AAEmu.Game.Physics.Debug.ShipTuningDebug.TickShip(slave);
+                        }
+                        catch
+                        {
+                            // Debug-only; must never affect physics loop.
+                        }
+                    }
+
+                    foreach (var slave in shipsThisTick)
+                    {
+                        try
+                        {
                             SendUpdatedMovementData(slave, slave.RigidBody, physicsTotalDelta);
                         }
                         catch (Exception slaveException)

--- a/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
+++ b/AAEmu.Game/Core/Managers/World/PhysicsManager.cs
@@ -383,7 +383,7 @@ public class PhysicsManager
         var rot = JQuaternion.CreateRotationY(slave.Transform.World.Rotation.Z);
         //                                     Width                   Length                  Height
         // var dimensions = new JVector(shipModel.MassBoxSizeX, shipModel.MassBoxSizeY, shipModel.MassBoxSizeZ);
-        var ctrl = new ShipController(_physWorld, shipModel, waterLevel: DefaultWaterLevel);
+        var ctrl = new ShipController(_physWorld, shipModel);
 
         ctrl.Build(initialPosition: pos, initialOrientation: rot);
 

--- a/AAEmu.Game/Core/Packets/C2G/CSLootOpenBagPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSLootOpenBagPacket.cs
@@ -1,7 +1,9 @@
 using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.Tasks.Doodads;
 using System.Linq;
 
 namespace AAEmu.Game.Core.Packets.C2G;
@@ -31,7 +33,7 @@ public class CSLootOpenBagPacket() : GamePacket(CSOffsets.CSLootOpenBagPacket, 1
             doodad.Use(Connection.ActiveChar, 0);
             // For one-shot loot doodads (ship debris), remove object when it transitions out of loot-capable funcs.
             if (!IsFuncDrivenLootDoodad(doodad))
-                doodad.Delete();
+                TaskManager.Instance.Schedule(new DoodadDeleteTask(doodad));
             return true;
         }
 

--- a/AAEmu.Game/Core/Packets/C2G/CSLootOpenBagPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSLootOpenBagPacket.cs
@@ -1,5 +1,8 @@
-﻿using AAEmu.Commons.Network;
+using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.Game.DoodadObj;
+using AAEmu.Game.Models.Game.Units;
+using System.Linq;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
@@ -13,7 +16,30 @@ public class CSLootOpenBagPacket() : GamePacket(CSOffsets.CSLootOpenBagPacket, 1
 
         var lootOwner = Connection.ActiveChar.ParentWorld.GetBaseUnit(objId);
         var object2 = Connection.ActiveChar.ParentWorld.GetBaseUnit(obj2Id);
-        
+
+        bool IsFuncDrivenLootDoodad(Doodad d) =>
+            // Doodads with these funcs are looted by calling doodad.Use(...) instead of LootingContainer.OpenBag().
+            d.CurrentFuncs.Any(func => Doodad.IsFuncDrivenLootFunc(func.FuncType));
+
+        bool TryHandleFuncDrivenLoot(BaseUnit target)
+        {
+            if (target is not Doodad doodad)
+                return false;
+            if (doodad.LootingContainer.Items.Count > 0 || !IsFuncDrivenLootDoodad(doodad))
+                return false;
+
+            doodad.Use(Connection.ActiveChar, 0);
+            // For one-shot loot doodads (ship debris), remove object when it transitions out of loot-capable funcs.
+            if (!IsFuncDrivenLootDoodad(doodad))
+                doodad.Delete();
+            return true;
+        }
+
+        // Some lootable doodads (e.g. ship debris) are implemented via DoodadFuncLootItem/LootPack
+        // and do not use LootingContainer.Items; route loot-open to doodad.Use().
+        if (TryHandleFuncDrivenLoot(lootOwner) || TryHandleFuncDrivenLoot(object2))
+            return;
+
         lootOwner?.LootingContainer.OpenBag(Connection.ActiveChar, object2, lootAll);
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCEnvDamagePacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCEnvDamagePacket.cs
@@ -1,10 +1,20 @@
+using System.Numerics;
+
 using AAEmu.Commons.Network;
+using AAEmu.Commons.Utils;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Models.Game.Static;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCEnvDamagePacket(EnvSource source, uint target, uint amount, uint gimmickId = 0)
+public class SCEnvDamagePacket(
+    EnvSource source,
+    uint target,
+    uint amount,
+    uint gimmickId = 0,
+    Vector3 position = new Vector3(),
+    float collisionImpact = 0,
+    byte p = 0)
     : GamePacket(SCOffsets.SCEnvDamagePacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
@@ -14,6 +24,14 @@ public class SCEnvDamagePacket(EnvSource source, uint target, uint amount, uint 
         stream.Write(amount);
         if (source == EnvSource.Gimmick)
             stream.Write(gimmickId);
+        if (source == EnvSource.Collision)
+        {
+            stream.Write(Helpers.ConvertLongX(position.X));
+            stream.Write(Helpers.ConvertLongY(position.Y));
+            stream.Write(position.Z);
+            stream.Write(collisionImpact);
+            stream.Write(p);
+        }
         return stream;
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCEnvDamagePacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCEnvDamagePacket.cs
@@ -1,20 +1,10 @@
-using System.Numerics;
-
 using AAEmu.Commons.Network;
-using AAEmu.Commons.Utils;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Models.Game.Static;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCEnvDamagePacket(
-    EnvSource source,
-    uint target,
-    uint amount,
-    uint gimmickId = 0,
-    Vector3 position = new Vector3(),
-    float collisionImpact = 0,
-    byte p = 0)
+public class SCEnvDamagePacket(EnvSource source, uint target, uint amount, uint gimmickId = 0)
     : GamePacket(SCOffsets.SCEnvDamagePacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
@@ -24,14 +14,6 @@ public class SCEnvDamagePacket(
         stream.Write(amount);
         if (source == EnvSource.Gimmick)
             stream.Write(gimmickId);
-        if (source == EnvSource.Collision)
-        {
-            stream.Write(Helpers.ConvertLongX(position.X));
-            stream.Write(Helpers.ConvertLongY(position.Y));
-            stream.Write(position.Z);
-            stream.Write(collisionImpact);
-            stream.Write(p);
-        }
         return stream;
     }
 }

--- a/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
@@ -579,6 +579,11 @@ public class Doodad : BaseUnit
                 Logger.Trace($"DoFunc Finished execution withOut ToNextPhase = {ToNextPhase}: TemplateId {TemplateId}, Using phase {FuncGroupId} with SkillId {skillId}");
             }
 
+            // DoodadFuncLootItem sets ToNextPhase=false when loot fails (or early chance miss). Multi-item func groups
+            // list several LootItem rows for one phase; return false so Use()'s foreach continues to the next func.
+            if (func.FuncType == "DoodadFuncLootItem")
+                return false;
+
             return true;
         }
 

--- a/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
@@ -881,8 +881,13 @@ public class Doodad : BaseUnit
     /// </summary>
     public override void Delete()
     {
-        base.Delete();
+        if (_deleted)
+            return;
+
+        // Mark as deleted early to avoid re-entry/races (e.g. concurrent packet handlers).
         _deleted = true;
+
+        base.Delete();
         var triggersToRemove = new List<AreaTrigger>(AttachAreaTriggers);
         foreach (var areaTrigger in triggersToRemove)
         {

--- a/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
@@ -1,4 +1,4 @@
-﻿using AAEmu.Commons.Network;
+using AAEmu.Commons.Network;
 using AAEmu.Commons.Utils.DB;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.Id;
@@ -69,6 +69,16 @@ namespace AAEmu.Game.Models.Game.DoodadObj;
 
 public class Doodad : BaseUnit
 {
+    public static readonly HashSet<string> FuncDrivenLootFuncTypes =
+    [
+        "DoodadFuncLootItem",
+        "DoodadFuncLootPack",
+        "DoodadFuncRecoverItem",
+        "DoodadFuncCutdowning"
+    ];
+
+    public static bool IsFuncDrivenLootFunc(string funcType) => FuncDrivenLootFuncTypes.Contains(funcType);
+
     private float _scale;
     private int _data;
     private uint _funcGroupId;
@@ -846,7 +856,9 @@ public class Doodad : BaseUnit
         }
 
         stream.Write(Scale); //The size of the object
-        stream.Write(false); // hasLootItem
+        // Mark doodad as lootable for client UI (gear icon) when its current phase has any loot/recover interaction func.
+        var hasLootItem = CurrentFuncs.Any(func => IsFuncDrivenLootFunc(func.FuncType));
+        stream.Write(hasLootItem); // hasLootItem
         stream.Write(FuncGroupId); // doodad_func_group_id
         stream.Write(OwnerId); // characterId (Database relative)
         stream.Write(UccId);

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncLootItem.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncLootItem.cs
@@ -1,4 +1,4 @@
-﻿using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.DoodadObj.Templates;
 using AAEmu.Game.Models.Game.Items;
@@ -63,6 +63,7 @@ public class DoodadFuncLootItem : DoodadFuncTemplate
         if (res == false)
             character.SendErrorMessage(ErrorMessageType.BagInvalidItem);
 
-        owner.ToNextPhase = true;
+        // Move to next phase only when loot was actually granted.
+        owner.ToNextPhase = res;
     }
 }

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncRecoverItem.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncRecoverItem.cs
@@ -1,4 +1,4 @@
-﻿using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.DoodadObj.Templates;

--- a/AAEmu.Game/Models/Game/Units/Slave.cs
+++ b/AAEmu.Game/Models/Game/Units/Slave.cs
@@ -19,7 +19,6 @@ using AAEmu.Game.Models.Game.Units.Static;
 using AAEmu.Game.Models.StaticValues;
 using AAEmu.Game.Physics;
 using Jitter2.Dynamics;
-using Jitter2.LinearMath;
 
 using MySql.Data.MySqlClient;
 
@@ -104,12 +103,6 @@ public class Slave : Unit
     public Vector3 CachedWaterFlow { get; set; }
     public float CachedWaterSurface { get; set; }
     public float CachedFloorLevel { get; set; }
-
-    /// <summary>Last ground contact point from ship shore probe (game coords X,Y with Z up). Used for collision env-damage position.</summary>
-    public Vector3 CachedGroundCollisionPos { get; set; }
-
-    /// <summary>Last shore penetration depth (m) at the probe point; used as collisionImpact for env-damage.</summary>
-    public float CachedGroundCollisionImpact { get; set; }
 
     public Slave()
     {
@@ -731,17 +724,6 @@ public class Slave : Unit
         }
     }
 
-    // Client-visible collision-damage subtype (last byte in SCEnvDamagePacket when EnvSource.Collision).
-    // TODO: Needs refinement — exact client mapping for these values is currently unknown in this codebase.
-    //       Values below are placeholders for iterative client testing (effects/UI behavior may differ).
-    private static class CollisionEnvDamageSubtype
-    {
-        public const byte Alt1 = 1; 
-        public const byte Alt2 = 2;
-        public const byte Ground = 3;
-        public const byte ShipShip = 4;
-    }
-
     /// <summary>Immediate hull damage from floor/collision (percent of <see cref="MaxHp"/> when <paramref name="isPercent"/>).</summary>
     private void ApplyFloorCollisionDamageImmediate(int damage, bool isPercent = true, KillReason killReason = KillReason.Damage)
     {
@@ -757,13 +739,13 @@ public class Slave : Unit
         if (dealt <= 0)
             return;
 
-        var collisionPos = CachedGroundCollisionPos != default ? CachedGroundCollisionPos : Transform.World.Position;
-        var collisionImpactValue = CachedGroundCollisionImpact;
-        BroadcastPacket(new SCEnvDamagePacket(EnvSource.Collision, ObjId, (uint)dealt, position: collisionPos, collisionImpact: collisionImpactValue, p: CollisionEnvDamageSubtype.Ground), true);
+        var driver = AttachedCharacters.GetValueOrDefault(AttachPointKind.Driver);
+        if (driver != null)
+            driver.SendPacket(new SCEnvDamagePacket(EnvSource.Falling, driver.ObjId, (uint)dealt));
     }
 
     /// <summary>Hull damage from ship–ship collision (<paramref name="damagePercent"/> of <see cref="MaxHp"/>).</summary>
-    internal void ApplyShipHullCollisionDamage(Slave attacker, int damagePercent, float collisionImpactMps = 0f)
+    internal void ApplyShipHullCollisionDamage(Slave attacker, int damagePercent)
     {
         if (damagePercent <= 0 || Hp <= 0)
             return;
@@ -778,42 +760,9 @@ public class Slave : Unit
         if (dealt <= 0)
             return;
 
-        var a = GetShipMassBoxCenterGamePosition();
-        var b = attacker?.GetShipMassBoxCenterGamePosition() ?? attacker?.Transform.World.Position ?? a;
-        var collisionPos = (a + b) * 0.5f;
-        BroadcastPacket(new SCEnvDamagePacket(EnvSource.Collision, ObjId, (uint)dealt, position: collisionPos, collisionImpact: collisionImpactMps, p: CollisionEnvDamageSubtype.ShipShip), true);
-    }
-
-    private Vector3 GetShipMassBoxCenterGamePosition()
-    {
-        var rb = RigidBody;
-        var model = ShipController?.ShipModel;
-        if (rb is null || model is null)
-            return Transform.World.Position;
-
-        var scale = MathF.Max(0.01f, Scale);
-        var centerZ = ShipController.ShipMassBoxDefaults.GetCenterZ(model.MassCenterZ, model.MassBoxSizeZ);
-        var local = new JVector(model.MassCenterX * scale, centerZ * scale, model.MassCenterY * scale);
-        var w = RotateVectorByQuaternion(local, rb.Orientation);
-        var centerPhys = rb.Position + w;
-
-        // Game coords: (X,Y,Z) == (phys X, phys Z, phys Y)
-        return new Vector3(centerPhys.X, centerPhys.Z, centerPhys.Y);
-    }
-
-    private static JVector RotateVectorByQuaternion(JVector v, JQuaternion q)
-    {
-        var qx = q.X;
-        var qy = q.Y;
-        var qz = q.Z;
-        var qw = q.W;
-        var tx = 2f * (qy * v.Z - qz * v.Y);
-        var ty = 2f * (qz * v.X - qx * v.Z);
-        var tz = 2f * (qx * v.Y - qy * v.X);
-        return new JVector(
-            v.X + qw * tx + (qy * tz - qz * ty),
-            v.Y + qw * ty + (qz * tx - qx * tz),
-            v.Z + qw * tz + (qx * ty - qy * tx));
+        var driver = AttachedCharacters.GetValueOrDefault(AttachPointKind.Driver);
+        if (driver != null)
+            driver.SendPacket(new SCEnvDamagePacket(EnvSource.Falling, driver.ObjId, (uint)dealt));
     }
 
     public override void PostUpdateCurrentHp(BaseUnit attacker, int oldHpValue, int newHpValue, KillReason killReason = KillReason.Damage)

--- a/AAEmu.Game/Models/Game/Units/Slave.cs
+++ b/AAEmu.Game/Models/Game/Units/Slave.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Numerics;
 using AAEmu.Commons.Utils.DB;
 using AAEmu.Game.Core.Managers;
@@ -80,12 +81,16 @@ public class Slave : Unit
     public float GroundPitchBackFloorSmoothed { get; set; }
     /// <summary>True after first pitch floor samples; cleared when leaving shoal/latched-ground pitch path.</summary>
     public bool GroundPitchFloorSmoothingSeeded { get; set; }
+    /// <summary>Phase (rad) for visual wave pitch on water; not replicated as state, only drives local sine.</summary>
+    public float WavePitchPhase { get; set; }
     /// <summary>True after first contact-floor sample while not latched (unrelated to height being zero).</summary>
     public bool GroundContactFloorSmoothingSeeded { get; set; }
     /// <summary>Time (seconds) since ground contact was latched.</summary>
     public float GroundContactLatchedTime { get; set; }
     /// <summary>Seconds accumulated toward periodic hull damage while beached (see <see cref="TickBeachedHullDamage(System.TimeSpan)"/>).</summary>
     public float ShoreGroundDamageSecondsAccumulator { get; set; }
+    /// <summary>Per other-ship cooldown (seconds) for hull-collision %HP (see <see cref="Physics.ShipShipInteraction"/>).</summary>
+    public Dictionary<uint, float> ShipHullCollisionDamageCooldownByOtherShipId { get; } = new();
     public short RotationZ { get; set; }
     public float RotationDegrees { get; set; }
     public sbyte AttachPointId { get; init; } = -1;
@@ -734,7 +739,30 @@ public class Slave : Unit
         if (dealt <= 0)
             return;
 
-        BroadcastPacket(new SCEnvDamagePacket(EnvSource.Collision, ObjId, (uint)dealt), true);
+        var driver = AttachedCharacters.GetValueOrDefault(AttachPointKind.Driver);
+        if (driver != null)
+            driver.SendPacket(new SCEnvDamagePacket(EnvSource.Falling, driver.ObjId, (uint)dealt));
+    }
+
+    /// <summary>Hull damage from ship–ship collision (<paramref name="damagePercent"/> of <see cref="MaxHp"/>).</summary>
+    internal void ApplyShipHullCollisionDamage(Slave attacker, int damagePercent)
+    {
+        if (damagePercent <= 0 || Hp <= 0)
+            return;
+
+        var damage = MaxHp * damagePercent / 100;
+        if (damage <= 0)
+            return;
+
+        var oldHp = Hp;
+        ReduceCurrentHp(attacker, damage, KillReason.Damage);
+        var dealt = oldHp - Hp;
+        if (dealt <= 0)
+            return;
+
+        var driver = AttachedCharacters.GetValueOrDefault(AttachPointKind.Driver);
+        if (driver != null)
+            driver.SendPacket(new SCEnvDamagePacket(EnvSource.Falling, driver.ObjId, (uint)dealt));
     }
 
     public override void PostUpdateCurrentHp(BaseUnit attacker, int oldHpValue, int newHpValue, KillReason killReason = KillReason.Damage)
@@ -760,8 +788,21 @@ public class Slave : Unit
         MarkSummoningItemAsDestroyed();
 
         Summoner?.SendPacket(new SCMySlavePacket(ObjId, TlId, Name, TemplateId, Hp, MaxHp, Transform.World.Position.X, Transform.World.Position.Y, Transform.World.Position.Z));
-        Summoner?.SendPacket(new SCSlaveRemovedPacket(ObjId, TlId));
+        Summoner?.BroadcastPacket(new SCSlaveRemovedPacket(Summoner.ObjId, TlId), true);
         ClearAllAggro();
+
+        // Unbind all passengers
+        foreach (var character in AttachedCharacters.Values.ToList())
+            ParentWorld.SlaveManager.UnbindSlave(character, TlId, AttachUnitReason.None);
+
+        // Remove from physics simulation (ships only)
+        if (Template.IsABoat())
+            WorldManager.Instance.GetWorld(Transform.InstanceId)?.Physics.RemoveShip(this);
+
+        // Schedule full cleanup via slave.Delete() → Hide() + DetachAll() + RemoveObject()
+        // This keeps the slave visible and selectable during the death animation
+        Despawn = DateTime.UtcNow.AddSeconds(Spawner?.DespawnTime ?? 20);
+        ParentWorld.SpawnManager.AddDespawn(this);
     }
 
     /// <summary>

--- a/AAEmu.Game/Models/Game/Units/Slave.cs
+++ b/AAEmu.Game/Models/Game/Units/Slave.cs
@@ -739,9 +739,7 @@ public class Slave : Unit
         if (dealt <= 0)
             return;
 
-        var driver = AttachedCharacters.GetValueOrDefault(AttachPointKind.Driver);
-        if (driver != null)
-            driver.SendPacket(new SCEnvDamagePacket(EnvSource.Falling, driver.ObjId, (uint)dealt));
+        BroadcastPacket(new SCEnvDamagePacket(EnvSource.Collision, ObjId, (uint)dealt), true);
     }
 
     /// <summary>Hull damage from ship–ship collision (<paramref name="damagePercent"/> of <see cref="MaxHp"/>).</summary>
@@ -760,9 +758,7 @@ public class Slave : Unit
         if (dealt <= 0)
             return;
 
-        var driver = AttachedCharacters.GetValueOrDefault(AttachPointKind.Driver);
-        if (driver != null)
-            driver.SendPacket(new SCEnvDamagePacket(EnvSource.Falling, driver.ObjId, (uint)dealt));
+        BroadcastPacket(new SCEnvDamagePacket(EnvSource.Collision, ObjId, (uint)dealt), true);
     }
 
     public override void PostUpdateCurrentHp(BaseUnit attacker, int oldHpValue, int newHpValue, KillReason killReason = KillReason.Damage)

--- a/AAEmu.Game/Models/Game/Units/Slave.cs
+++ b/AAEmu.Game/Models/Game/Units/Slave.cs
@@ -19,6 +19,7 @@ using AAEmu.Game.Models.Game.Units.Static;
 using AAEmu.Game.Models.StaticValues;
 using AAEmu.Game.Physics;
 using Jitter2.Dynamics;
+using Jitter2.LinearMath;
 
 using MySql.Data.MySqlClient;
 
@@ -103,6 +104,12 @@ public class Slave : Unit
     public Vector3 CachedWaterFlow { get; set; }
     public float CachedWaterSurface { get; set; }
     public float CachedFloorLevel { get; set; }
+
+    /// <summary>Last ground contact point from ship shore probe (game coords X,Y with Z up). Used for collision env-damage position.</summary>
+    public Vector3 CachedGroundCollisionPos { get; set; }
+
+    /// <summary>Last shore penetration depth (m) at the probe point; used as collisionImpact for env-damage.</summary>
+    public float CachedGroundCollisionImpact { get; set; }
 
     public Slave()
     {
@@ -724,6 +731,17 @@ public class Slave : Unit
         }
     }
 
+    // Client-visible collision-damage subtype (last byte in SCEnvDamagePacket when EnvSource.Collision).
+    // TODO: Needs refinement — exact client mapping for these values is currently unknown in this codebase.
+    //       Values below are placeholders for iterative client testing (effects/UI behavior may differ).
+    private static class CollisionEnvDamageSubtype
+    {
+        public const byte Alt1 = 1; 
+        public const byte Alt2 = 2;
+        public const byte Ground = 3;
+        public const byte ShipShip = 4;
+    }
+
     /// <summary>Immediate hull damage from floor/collision (percent of <see cref="MaxHp"/> when <paramref name="isPercent"/>).</summary>
     private void ApplyFloorCollisionDamageImmediate(int damage, bool isPercent = true, KillReason killReason = KillReason.Damage)
     {
@@ -739,13 +757,13 @@ public class Slave : Unit
         if (dealt <= 0)
             return;
 
-        var driver = AttachedCharacters.GetValueOrDefault(AttachPointKind.Driver);
-        if (driver != null)
-            driver.SendPacket(new SCEnvDamagePacket(EnvSource.Falling, driver.ObjId, (uint)dealt));
+        var collisionPos = CachedGroundCollisionPos != default ? CachedGroundCollisionPos : Transform.World.Position;
+        var collisionImpactValue = CachedGroundCollisionImpact;
+        BroadcastPacket(new SCEnvDamagePacket(EnvSource.Collision, ObjId, (uint)dealt, position: collisionPos, collisionImpact: collisionImpactValue, p: CollisionEnvDamageSubtype.Ground), true);
     }
 
     /// <summary>Hull damage from ship–ship collision (<paramref name="damagePercent"/> of <see cref="MaxHp"/>).</summary>
-    internal void ApplyShipHullCollisionDamage(Slave attacker, int damagePercent)
+    internal void ApplyShipHullCollisionDamage(Slave attacker, int damagePercent, float collisionImpactMps = 0f)
     {
         if (damagePercent <= 0 || Hp <= 0)
             return;
@@ -760,9 +778,42 @@ public class Slave : Unit
         if (dealt <= 0)
             return;
 
-        var driver = AttachedCharacters.GetValueOrDefault(AttachPointKind.Driver);
-        if (driver != null)
-            driver.SendPacket(new SCEnvDamagePacket(EnvSource.Falling, driver.ObjId, (uint)dealt));
+        var a = GetShipMassBoxCenterGamePosition();
+        var b = attacker?.GetShipMassBoxCenterGamePosition() ?? attacker?.Transform.World.Position ?? a;
+        var collisionPos = (a + b) * 0.5f;
+        BroadcastPacket(new SCEnvDamagePacket(EnvSource.Collision, ObjId, (uint)dealt, position: collisionPos, collisionImpact: collisionImpactMps, p: CollisionEnvDamageSubtype.ShipShip), true);
+    }
+
+    private Vector3 GetShipMassBoxCenterGamePosition()
+    {
+        var rb = RigidBody;
+        var model = ShipController?.ShipModel;
+        if (rb is null || model is null)
+            return Transform.World.Position;
+
+        var scale = MathF.Max(0.01f, Scale);
+        var centerZ = ShipController.ShipMassBoxDefaults.GetCenterZ(model.MassCenterZ, model.MassBoxSizeZ);
+        var local = new JVector(model.MassCenterX * scale, centerZ * scale, model.MassCenterY * scale);
+        var w = RotateVectorByQuaternion(local, rb.Orientation);
+        var centerPhys = rb.Position + w;
+
+        // Game coords: (X,Y,Z) == (phys X, phys Z, phys Y)
+        return new Vector3(centerPhys.X, centerPhys.Z, centerPhys.Y);
+    }
+
+    private static JVector RotateVectorByQuaternion(JVector v, JQuaternion q)
+    {
+        var qx = q.X;
+        var qy = q.Y;
+        var qz = q.Z;
+        var qw = q.W;
+        var tx = 2f * (qy * v.Z - qz * v.Y);
+        var ty = 2f * (qz * v.X - qx * v.Z);
+        var tz = 2f * (qx * v.Y - qy * v.X);
+        return new JVector(
+            v.X + qw * tx + (qy * tz - qz * ty),
+            v.Y + qw * ty + (qz * tx - qx * tz),
+            v.Z + qw * tz + (qx * ty - qy * tx));
     }
 
     public override void PostUpdateCurrentHp(BaseUnit attacker, int oldHpValue, int newHpValue, KillReason killReason = KillReason.Damage)

--- a/AAEmu.Game/Models/Tasks/Doodads/DoodadDeleteTask.cs
+++ b/AAEmu.Game/Models/Tasks/Doodads/DoodadDeleteTask.cs
@@ -1,0 +1,14 @@
+#nullable enable
+
+using AAEmu.Game.Models.Game.DoodadObj;
+
+namespace AAEmu.Game.Models.Tasks.Doodads;
+
+public sealed class DoodadDeleteTask(Doodad owner) : Task
+{
+    public override void Execute()
+    {
+        owner?.Delete();
+    }
+}
+

--- a/AAEmu.Game/Physics/Debug/ShipTuningDebug.cs
+++ b/AAEmu.Game/Physics/Debug/ShipTuningDebug.cs
@@ -1,0 +1,1061 @@
+#nullable enable
+
+using System.Collections.Concurrent;
+using System.Numerics;
+
+using AAEmu.Game.Core.Managers.UnitManagers;
+using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.DoodadObj.Static;
+using AAEmu.Game.Models.Game.Gimmicks;
+using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.Game.World.Transform;
+
+using Jitter2.Dynamics;
+using Jitter2.LinearMath;
+
+namespace AAEmu.Game.Physics.Debug;
+
+/// <summary>
+/// EN: Dev-only ship physics tuning & debug: ship↔ship, ship↔shore, plus ShipController tuning.
+/// RU: Dev-only тюнинг и дебаг корабельной физики: ship↔ship, ship↔shore, а также тюнинг ShipController.
+/// </summary>
+public static class ShipTuningDebug
+{
+    /// <summary>
+    /// EN: Master switch (use Hot Reload; no GM commands).
+    /// RU: Главный переключатель (через Hot Reload; без GM команд).
+    /// </summary>
+    public static bool Enabled = true;
+
+    /// <summary>
+    /// EN: Minimum effective access level to receive chat debug messages.
+    /// RU: Минимальный effective access level для получения debug-сообщений в чат.
+    /// </summary>
+    public static int MinAccessLevel = 80;
+
+    /// <summary>
+    /// EN: Throttle detailed messages (ms) per ship.
+    /// RU: Троттлинг подробных сообщений (мс) на корабль.
+    /// </summary>
+    public static int ThrottleMsPerShip = 3000;
+
+    /// <summary>
+    /// EN: Corner markers template id (table <c>gimmicks</c>). Hot Reload: edit this return value.
+    /// RU: TemplateId маркеров углов (таблица <c>gimmicks</c>). Hot Reload: меняй return в этом методе.
+    /// </summary>
+    public static uint CornerMarkerTemplateId => GetCornerMarkerTemplateId();
+    private static uint GetCornerMarkerTemplateId() => 65; // toy.flare
+
+    /// <summary>
+    /// EN: Shore markers template id (table <c>gimmicks</c>). Hot Reload: edit this return value.
+    /// RU: TemplateId маркеров берега (таблица <c>gimmicks</c>). Hot Reload: меняй return в этом методе.
+    /// </summary>
+    public static uint ShoreMarkerTemplateId => GetShoreMarkerTemplateId();
+    private static uint GetShoreMarkerTemplateId() => 28;
+
+    /// <summary>
+    /// EN: Axis marker template id for +Length (local +Z of the physics box).
+    /// RU: TemplateId осевого маркера для +Length (локальная +Z физического бокса).
+    /// </summary>
+    public static uint AxisLengthMarkerTemplateId => GetAxisLengthMarkerTemplateId();
+    private static uint GetAxisLengthMarkerTemplateId() => 16; // firecracker_green
+
+    /// <summary>
+    /// EN: Axis marker template id for +Beam (local +X of the physics box).
+    /// RU: TemplateId осевого маркера для +Beam (локальная +X физического бокса).
+    /// </summary>
+    public static uint AxisBeamMarkerTemplateId => GetAxisBeamMarkerTemplateId();
+    private static uint GetAxisBeamMarkerTemplateId() => 18; // firecracker_blue (assumed adjacent id)
+
+    /// <summary>
+    /// EN: Axis marker template id for +Up (local +Y of the physics box).
+    /// RU: TemplateId осевого маркера для +Up (локальная +Y физического бокса).
+    /// </summary>
+    public static uint AxisUpMarkerTemplateId => GetAxisUpMarkerTemplateId();
+    private static uint GetAxisUpMarkerTemplateId() => 28; // fallback: visible marker
+
+    /// <summary>
+    /// EN: Marker scale.
+    /// RU: Масштаб маркеров.
+    /// </summary>
+    public static float MarkerScale = 0.35f;
+
+    /// <summary>
+    /// EN: If true, draw markers only for ships with a driver.
+    /// RU: Если true — рисовать маркеры только для кораблей с водителем.
+    /// </summary>
+    public static bool DrawOnlyWhenDriven = false;
+
+    /// <summary>
+    /// EN: Enable ship↔shore debug (markers + latch messages + tuning override in ShipShoreInteraction).
+    /// RU: Включить ship↔shore дебаг (маркеры + сообщения latch + подмена тюнинга в ShipShoreInteraction).
+    /// </summary>
+    public static bool ShoreEnabled = true;
+
+    /// <summary>
+    /// EN: Show two extra axis markers: +Length (local +Z of the physics box) and +Beam (local +X of the physics box).
+    /// RU: Показывать 2 дополнительных маркера осей: +Length (локальная +Z физ. бокса) и +Beam (локальная +X физ. бокса).
+    /// </summary>
+    public static bool AxisMarkersEnabled = true;
+
+    /// <summary>
+    /// EN: Extra distance (meters) beyond half-extent for axis markers.
+    /// RU: Доп. расстояние (метры) за пределы half-extent для осевых маркеров.
+    /// </summary>
+    public static float AxisMarkerExtraMeters = 1.25f;
+
+    /// <summary>
+    /// EN: Mass-box tuning (center/size overrides). Useful when the hull OBB is too low/high vs the visible hull.
+    /// RU: Тюнинг mass-box (переопределения центра/размера). Полезно, когда OBB корпуса слишком низко/высоко относительно модели.
+    /// </summary>
+    public static class HullBoxTuning
+    {
+        /// <summary>
+        /// EN: Additive vertical offset to MassCenterZ (meters). Positive lifts the box up.
+        /// RU: Аддитивный вертикальный сдвиг к MassCenterZ (метры). Положительное значение поднимает бокс вверх.
+        /// </summary>
+        public static float CenterZAddMeters = 0f;
+
+        /// <summary>
+        /// EN: Additive vertical offset to MassCenterZ as a fraction of MassBoxSizeZ. Example: 0.30 lifts the box by 30% of its height.
+        /// RU: Аддитивный вертикальный сдвиг к MassCenterZ как доля MassBoxSizeZ. Например: 0.30 поднимает бокс на 30% его высоты.
+        /// </summary>
+        public static float CenterZAddFracOfSizeZ = 0.30f;
+
+        /// <summary>
+        /// EN: Multiply MassBoxSizeZ (height). 1 = no change.
+        /// RU: Множитель MassBoxSizeZ (высота). 1 = без изменений.
+        /// </summary>
+        public static float SizeZMul = 1f;
+
+        /// <summary>
+        /// EN: Additive adjustment to MassBoxSizeZ (meters). Applied after SizeZMul.
+        /// RU: Аддитивная поправка к MassBoxSizeZ (метры). Применяется после SizeZMul.
+        /// </summary>
+        public static float SizeZAddMeters = 0f;
+
+        internal static float GetCenterZ(float baseCenterZ, float baseSizeZ) =>
+            baseCenterZ + baseSizeZ * CenterZAddFracOfSizeZ + CenterZAddMeters;
+
+        internal static float GetSizeZ(float baseSizeZ)
+        {
+            var z = baseSizeZ * SizeZMul + SizeZAddMeters;
+            return MathF.Max(0.01f, z);
+        }
+    }
+
+    /// <summary>
+    /// EN: Ship↔ship SAT/response tuning (runtime fields for Hot Reload).
+    /// RU: Тюнинг ship↔ship SAT/реакции (runtime-поля для Hot Reload).
+    /// </summary>
+    public static class ShipShipTuning
+    {
+        /// <summary>
+        /// EN: Half-length multiplier for SAT overlap test only (keep near 1).
+        /// RU: Множитель полу-длины только для SAT-детекта (держать близко к 1).
+        /// </summary>
+        public static float HullDetectInflateLength = 1.025f;
+
+        /// <summary>
+        /// EN: Half-beam multiplier for SAT overlap test only.
+        /// RU: Множитель полу-ширины только для SAT-детекта.
+        /// </summary>
+        public static float HullDetectInflateBeam = 1.015f;
+
+        /// <summary>
+        /// EN: Extra tightening of beam in SAT only (reduces early side contact from oversized mass box).
+        /// RU: Доп. ужатие ширины только в SAT (убирает ранний боковой контакт из-за широкого mass box).
+        /// </summary>
+        public static float BeamDetectTightenMul = 0.78f;
+
+        /// <summary>
+        /// EN: Ignore overlap response below this penetration depth (meters).
+        /// RU: Игнорировать реакцию, если penetration меньше этого (метры).
+        /// </summary>
+        public static float MinPenetrationToAct = 0.055f;
+
+        /// <summary>
+        /// EN: Ignore periodic hull-damage below this penetration depth (meters).
+        /// RU: Не наносить периодический урон корпусу, если penetration меньше этого (метры).
+        /// </summary>
+        public static float MinPenetrationToDamage = MinPenetrationToAct * 1.15f;
+
+        /// <summary>
+        /// EN: Ramp tangential slip damping over this depth range past MinPenetrationToAct (meters).
+        /// RU: Наращивать демпф тангенциального скольжения на этом диапазоне глубины сверх MinPenetrationToAct (метры).
+        /// </summary>
+        public static float TangentialRampDepthMeters = 0.22f;
+
+        /// <summary>
+        /// EN: Multiplier on positional separation push once overlap exists.
+        /// RU: Множитель раздвижения (push) после обнаружения overlap.
+        /// </summary>
+        public static float SeparationPushMultiplier = 1.22f;
+
+        /// <summary>
+        /// EN: Extra separation slack added to computed overlap (meters).
+        /// RU: Доп. зазор к раздвижению сверх overlap (метры).
+        /// </summary>
+        public static float SeparationSlackMeters = 0.020f;
+
+        /// <summary>
+        /// EN: Fraction of relative closing speed along normal to remove (1 = full stop along normal).
+        /// RU: Доля гашения относительной скорости вдоль нормали (1 = полностью убрать вдоль нормали).
+        /// </summary>
+        public static float ClosingSpeedDamp = 1f;
+
+        /// <summary>
+        /// EN: Tangential slip damping factor while overlapping (0..1).
+        /// RU: Коэффициент демпфа тангенциального скольжения при overlap (0..1).
+        /// </summary>
+        public static float TangentialSlipDamp = 0.86f;
+
+        /// <summary>
+        /// EN: Minimum vertical overlap (meters) to consider ships colliding.
+        /// RU: Минимальный вертикальный overlap (метры) чтобы считать столкновение.
+        /// </summary>
+        public static float MinVerticalOverlap = 0.12f;
+
+        /// <summary>
+        /// EN: Outer resolve passes per tick (CPU vs stability).
+        /// RU: Внешние проходы резолва за тик (CPU vs стабильность).
+        /// </summary>
+        public static int ResolvePasses = 2;
+
+        /// <summary>
+        /// EN: Max depenetration iterations per pair per pass.
+        /// RU: Макс. итераций раздвижения на пару за проход.
+        /// </summary>
+        public static int MaxPairIterations = 12;
+
+        /// <summary>
+        /// EN: Penetration depth where “deep penetration” push boost starts (meters).
+        /// RU: Глубина penetration, с которой начинается усиление push (метры).
+        /// </summary>
+        public static float DeepPenetrationStart = 0.12f;
+
+        /// <summary>
+        /// EN: Boost factor applied as penetration exceeds DeepPenetrationStart.
+        /// RU: Коэффициент усиления push при penetration больше DeepPenetrationStart.
+        /// </summary>
+        public static float DeepPenetrationBoost = 0.72f;
+
+        /// <summary>
+        /// EN: Floor on half-separation distance (meters).
+        /// RU: Минимальная полу-дистанция раздвижения (метры).
+        /// </summary>
+        public static float MinHalfSeparationMeters = 0.02f;
+
+        /// <summary>
+        /// EN: Stop iterating if computed separation is below this (meters) to avoid micro-jitter.
+        /// RU: Остановить итерации, если раздвижение меньше этого (метры), чтобы убрать микродрожь.
+        /// </summary>
+        public static float MinLinearSeparationToApplyMeters = 0.018f;
+
+        /// <summary>
+        /// EN: Cosine threshold for “nose cone” classification.
+        /// RU: Порог косинуса для классификации “удар в нос”.
+        /// </summary>
+        public static float NoseContactCosThreshold = 0.65f;
+
+        /// <summary>
+        /// EN: Min interval between hull-collision damage ticks per other ship (seconds).
+        /// RU: Минимальный интервал тиков урона от столкновения корпусом на конкретный другой корабль (сек).
+        /// </summary>
+        public static float HullCollisionDamageCooldownSec = 1.5f;
+
+        /// <summary>
+        /// EN: Relative speed threshold (m/s) where damage uses min % (non-nose).
+        /// RU: Порог относительной скорости (м/с), ниже которого урон минимальный (не-носовые удары).
+        /// </summary>
+        public static float HullDamageLowSpeedThresholdMps = 2f;
+
+        /// <summary>
+        /// EN: Relative speed (m/s) where damage reaches max % (linear between thresholds).
+        /// RU: Относительная скорость (м/с), при которой урон достигает максимума (линейно между порогами).
+        /// </summary>
+        public static float HullDamageInterpMaxMps = 10f;
+
+        /// <summary>
+        /// EN: Min % hull damage per tick.
+        /// RU: Минимальный % урона корпуса за тик.
+        /// </summary>
+        public static int HullDamageSpeedScaledMinPercent = 1;
+
+        /// <summary>
+        /// EN: Max % hull damage per tick.
+        /// RU: Максимальный % урона корпуса за тик.
+        /// </summary>
+        public static int HullDamageSpeedScaledMaxPercent = 10;
+    }
+
+    /// <summary>
+    /// EN: Ship↔shore tuning mirrors ShipShoreInteraction constants (runtime fields for Hot Reload).
+    /// RU: Тюнинг ship↔shore зеркалит константы ShipShoreInteraction (runtime-поля для Hot Reload).
+    /// </summary>
+    public static class ShoreTuning
+    {
+        /// <summary>
+        /// EN: Ground friction multiplier on dry ground.
+        /// RU: Трение на суше.
+        /// </summary>
+        public static float GroundFriction = 0.4f;
+
+        /// <summary>
+        /// EN: Velocity/angular damping on dry ground.
+        /// RU: Демпф скорости/угловой скорости на суше.
+        /// </summary>
+        public static float DryGroundCollisionDamping = 0.5f;
+
+        /// <summary>
+        /// EN: Roll correction dead-zone (radians).
+        /// RU: Мёртвая зона коррекции roll (радианы).
+        /// </summary>
+        public static float DryGroundRollDeadZoneRad = 0.1f;
+
+        /// <summary>
+        /// EN: Roll correction torque factor (tuning).
+        /// RU: Коэффициент коррекции roll (тюнинг).
+        /// </summary>
+        public static float DryGroundRollTorqueMul = 0.1f;
+
+        /// <summary>
+        /// EN: Bow probe distance multiplier vs MassBoxSizeY (hull length).
+        /// RU: Множитель дистанции носовой пробы от MassBoxSizeY (длина корпуса).
+        /// </summary>
+        public static float BowProbeMul = 1.5f;
+
+        /// <summary>
+        /// EN: Stern probe distance multiplier vs MassBoxSizeY (hull length).
+        /// RU: Множитель дистанции кормовой пробы от MassBoxSizeY (длина корпуса).
+        /// </summary>
+        public static float SternProbeMul = 1.5f;
+
+        /// <summary>
+        /// EN: Cliff probe distance multiplier vs MassBoxSizeY (hull length).
+        /// RU: Множитель дистанции пробы “обрыва/стены” от MassBoxSizeY (длина корпуса).
+        /// </summary>
+        public static float CliffProbeMul = 1.45f;
+
+        /// <summary>
+        /// EN: Cliff slope threshold (Δh / dist).
+        /// RU: Порог “крутизны” (Δh / dist).
+        /// </summary>
+        public static float CliffSlopeFracThreshold = 0.57f;
+
+        /// <summary>
+        /// EN: Cliff must be above water by this margin (meters).
+        /// RU: “Обрыв” считается только если выше воды на этот запас (метры).
+        /// </summary>
+        public static float CliffAboveWaterMargin = 0.20f;
+
+        /// <summary>
+        /// EN: Shore latch enter hysteresis (meters).
+        /// RU: Гистерезис входа в latch (метры).
+        /// </summary>
+        public static float ShoreEnterHyst = 0.35f;
+
+        /// <summary>
+        /// EN: Shore latch exit hysteresis (meters).
+        /// RU: Гистерезис выхода из latch (метры).
+        /// </summary>
+        public static float ShoreExitHyst = 0.10f;
+
+        /// <summary>
+        /// EN: Floor height smoothing response (lambda).
+        /// RU: Сглаживание высоты пола (lambda).
+        /// </summary>
+        public static float FloorSmoothResponse = 10.0f;
+
+        /// <summary>
+        /// EN: Pre-shore damping band (meters).
+        /// RU: Полоса “перед берегом” для демпфа (метры).
+        /// </summary>
+        public static float PreShoreBand = 0.25f;
+
+        /// <summary>
+        /// EN: Penetration epsilon (meters).
+        /// RU: Эпсилон penetration (метры).
+        /// </summary>
+        public static float PenetrationEpsilon = 0.02f;
+
+        /// <summary>
+        /// EN: Penetration response (lambda).
+        /// RU: Скорость реакции на penetration (lambda).
+        /// </summary>
+        public static float PenetrationResponse = 4.5f;
+
+        /// <summary>
+        /// EN: Max up-step early after latching (m/tick).
+        /// RU: Макс. подъём на раннем этапе latch (м/тик).
+        /// </summary>
+        public static float MaxUpStepEarly = 0.04f;
+
+        /// <summary>
+        /// EN: Max up-step later while latched (m/tick).
+        /// RU: Макс. подъём после стабилизации latch (м/тик).
+        /// </summary>
+        public static float MaxUpStepLate = 0.07f;
+
+        /// <summary>
+        /// EN: Visual ground pitch max (degrees).
+        /// RU: Макс. визуальный ground pitch (градусы).
+        /// </summary>
+        public static float VisualGroundPitchMaxDeg = 8.0f;
+
+        /// <summary>
+        /// EN: Visual ground pitch probe distance (meters).
+        /// RU: Дистанция проб для визуального pitch (метры).
+        /// </summary>
+        public static float VisualGroundPitchProbeDistance = 6.0f;
+
+        /// <summary>
+        /// EN: Visual ground pitch response (lambda).
+        /// RU: Скорость реакции визуального pitch (lambda).
+        /// </summary>
+        public static float VisualGroundPitchResponse = 2.0f;
+
+        /// <summary>
+        /// EN: Visual pitch floor smoothing response (lambda).
+        /// RU: Сглаживание высот для визуального pitch (lambda).
+        /// </summary>
+        public static float VisualPitchFloorSmoothResponse = 8.0f;
+    }
+
+    /// <summary>
+    /// EN: ShipController tuning (runtime fields for Hot Reload).
+    /// RU: Тюнинг ShipController (runtime-поля для Hot Reload).
+    /// </summary>
+    public static class ShipControllerTuning
+    {
+        /// <summary>
+        /// EN: Extra acceleration multiplier when throttle opposes current motion.
+        /// RU: Доп. множитель ускорения, когда газ против текущего движения.
+        /// </summary>
+        public static float OpposingThrottleAccelMul = 1.75f;
+
+        /// <summary>
+        /// EN: Extra braking factor for opposing throttle (multiplies reverse/brake behavior).
+        /// RU: Доп. торможение при противоположном газе.
+        /// </summary>
+        public static float OpposingThrottleBrakeTuneMul = 1.2f;
+
+        /// <summary>
+        /// EN: Steering responsiveness multiplier.
+        /// RU: Множитель отзывчивости руля.
+        /// </summary>
+        public static float SteeringResponsivenessMul = 1.45f;
+
+        /// <summary>
+        /// EN: Counter-steer responsiveness multiplier.
+        /// RU: Множитель отзывчивости контрруления.
+        /// </summary>
+        public static float CounterSteerResponsivenessMul = 1.35f;
+
+        /// <summary>
+        /// EN: Minimum turning factor at zero speed.
+        /// RU: Минимальный фактор поворота на нулевой скорости.
+        /// </summary>
+        public static float MinTurnFactorAtZeroSpeed = 0.5f;
+
+        /// <summary>
+        /// EN: Speed at which turning reaches 100% (ship speed units).
+        /// RU: Скорость, при которой поворот достигает 100% (в игровых единицах скорости).
+        /// </summary>
+        public static float TurnFullFactorAtSpeed = 2.5f;
+
+        /// <summary>
+        /// EN: Fraction of speed removed at max yaw rate.
+        /// RU: Доля снижения скорости на максимальной скорости поворота.
+        /// </summary>
+        public static float TurnSpeedSlowdownFrac = 0.1f;
+
+        /// <summary>
+        /// EN: Response for TurnSpeedVelocityMul smoothing (lambda).
+        /// RU: Скорость сглаживания TurnSpeedVelocityMul (lambda).
+        /// </summary>
+        public static float TurnSpeedVelocityMulResponse = 5.5f;
+
+        /// <summary>
+        /// EN: Minimum submergence to start upright stabilization (meters).
+        /// RU: Минимальное погружение для выравнивания корпуса (метры).
+        /// </summary>
+        public static float UprightStabilizeMinSubmergedMeters = 0.04f;
+
+        /// <summary>
+        /// EN: Max upright correction angular speed (rad/s).
+        /// RU: Макс. скорость выравнивания (рад/с).
+        /// </summary>
+        public static float UprightStabilizeMaxRadPerSec = 2.25f;
+
+        /// <summary>
+        /// EN: Dead-zone for upright correction (radians).
+        /// RU: Мёртвая зона выравнивания (радианы).
+        /// </summary>
+        public static float UprightStabilizeAngleDeadZoneRad = 0.004f;
+
+        /// <summary>
+        /// EN: Wind cone half-angle (degrees).
+        /// RU: Полуугол конуса ветра (градусы).
+        /// </summary>
+        public static float WindConeHalfAngleDeg = 15f;
+
+        /// <summary>
+        /// EN: Max speed multiplier with wind.
+        /// RU: Макс. множитель скорости по ветру.
+        /// </summary>
+        public static float WindWithMaxMul = 1.15f;
+
+        /// <summary>
+        /// EN: Max speed multiplier against wind.
+        /// RU: Макс. множитель скорости против ветра.
+        /// </summary>
+        public static float WindAgainstMaxMul = 0.85f;
+    }
+
+    private static readonly ConcurrentDictionary<uint, long> _lastDetailMsgAtMs = new();
+    private static readonly ConcurrentDictionary<uint, long> _lastAxesMsgAtMs = new();
+    private static readonly ConcurrentDictionary<uint, long> _lastShorePenMsgAtMs = new();
+
+    private static readonly ConcurrentDictionary<uint, MarkerSet> _shipCornerMarkers = new();
+    private static readonly ConcurrentDictionary<uint, MarkerSet> _shipAxisLenMarkers = new();
+    private static readonly ConcurrentDictionary<uint, MarkerSet> _shipAxisBeamMarkers = new();
+    private static readonly ConcurrentDictionary<uint, MarkerSet> _shipAxisUpMarkers = new();
+    private static readonly ConcurrentDictionary<uint, MarkerSet> _shoreMarkers = new();
+
+    // ship↔ship contact latch based on ResolvePair events
+    private static readonly ConcurrentDictionary<uint, long> _shipContactUntilMs = new();
+    private static readonly ConcurrentDictionary<uint, bool> _shipContactLatched = new();
+
+    private sealed class MarkerSet
+    {
+        public readonly GimmickSpawner[] Spawners;
+        public readonly Gimmick?[] Markers;
+        public uint ZoneId;
+        public uint TemplateId;
+
+        public MarkerSet(int count)
+        {
+            Spawners = new GimmickSpawner[count];
+            Markers = new Gimmick?[count];
+        }
+    }
+
+    /// <summary>
+    /// EN: Per-ship debug tick. Updates corner markers and ship↔ship latch messages.
+    /// RU: Дебаг-тик на корабль. Обновляет углы бокса и latch-сообщения ship↔ship.
+    /// </summary>
+    public static void TickShip(Slave ship)
+    {
+        if (ship is null)
+            return;
+
+        if (!Enabled)
+        {
+            DespawnAll(ship.Id);
+            return;
+        }
+
+        if (DrawOnlyWhenDriven && TryGetDriver(ship) is null)
+        {
+            DespawnAll(ship.Id);
+            return;
+        }
+
+        UpdateShipCornerMarkers(ship);
+        UpdateShipAxisMarkers(ship);
+        UpdateShipContactLatch(ship);
+    }
+
+    private static void UpdateShipAxisMarkers(Slave ship)
+    {
+        if (!AxisMarkersEnabled)
+        {
+            DespawnMarkers(_shipAxisLenMarkers, ship.Id);
+            DespawnMarkers(_shipAxisBeamMarkers, ship.Id);
+            DespawnMarkers(_shipAxisUpMarkers, ship.Id);
+            return;
+        }
+
+        var lenTemplateId = AxisLengthMarkerTemplateId;
+        var beamTemplateId = AxisBeamMarkerTemplateId;
+        var upTemplateId = AxisUpMarkerTemplateId;
+        if ((lenTemplateId == 0 && beamTemplateId == 0 && upTemplateId == 0) || ship.ParentWorld is null)
+        {
+            DespawnMarkers(_shipAxisLenMarkers, ship.Id);
+            DespawnMarkers(_shipAxisBeamMarkers, ship.Id);
+            DespawnMarkers(_shipAxisUpMarkers, ship.Id);
+            return;
+        }
+
+        var rb = ship.RigidBody;
+        var model = ship.ShipController?.ShipModel;
+        if (rb is null || model is null)
+        {
+            DespawnMarkers(_shipAxisLenMarkers, ship.Id);
+            DespawnMarkers(_shipAxisBeamMarkers, ship.Id);
+            DespawnMarkers(_shipAxisUpMarkers, ship.Id);
+            return;
+        }
+
+        var zoneId = ship.Transform.ZoneId;
+        MarkerSet? setLen = null;
+        if (lenTemplateId != 0)
+        {
+            setLen = _shipAxisLenMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(1));
+            if (setLen.ZoneId != zoneId || setLen.TemplateId != lenTemplateId)
+            {
+                DespawnMarkers(_shipAxisLenMarkers, ship.Id);
+                setLen = _shipAxisLenMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(1));
+                setLen.ZoneId = zoneId;
+                setLen.TemplateId = lenTemplateId;
+            }
+        }
+        else
+        {
+            DespawnMarkers(_shipAxisLenMarkers, ship.Id);
+        }
+
+        MarkerSet? setBeam = null;
+        if (beamTemplateId != 0)
+        {
+            setBeam = _shipAxisBeamMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(1));
+            if (setBeam.ZoneId != zoneId || setBeam.TemplateId != beamTemplateId)
+            {
+                DespawnMarkers(_shipAxisBeamMarkers, ship.Id);
+                setBeam = _shipAxisBeamMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(1));
+                setBeam.ZoneId = zoneId;
+                setBeam.TemplateId = beamTemplateId;
+            }
+        }
+        else
+        {
+            DespawnMarkers(_shipAxisBeamMarkers, ship.Id);
+        }
+
+        MarkerSet? setUp = null;
+        if (upTemplateId != 0)
+        {
+            setUp = _shipAxisUpMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(1));
+            if (setUp.ZoneId != zoneId || setUp.TemplateId != upTemplateId)
+            {
+                DespawnMarkers(_shipAxisUpMarkers, ship.Id);
+                setUp = _shipAxisUpMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(1));
+                setUp.ZoneId = zoneId;
+                setUp.TemplateId = upTemplateId;
+            }
+        }
+        else
+        {
+            DespawnMarkers(_shipAxisUpMarkers, ship.Id);
+        }
+
+        // Same basis as UpdateShipCornerMarkers (ShipController.Build mapping).
+        var scale = MathF.Max(0.01f, ship.Scale);
+        var hx = model.MassBoxSizeX * scale * 0.5f;
+        var hy = HullBoxTuning.GetSizeZ(model.MassBoxSizeZ) * scale * 0.5f;
+        var hz = model.MassBoxSizeY * scale * 0.5f;
+
+        // Use the already-synced Transform rotation (derived from physics via SyncTransformWithRigidBody)
+        // to avoid left/right inversion from phys<->game basis reflections.
+        var rotGame = GetTransformRotationMatrix(ship.Transform.Local.Rotation);
+
+        var posGame0 = PhysToGame(rb.Position);
+        var offsetLocalPhys = new JVector(
+            model.MassCenterX * scale,
+            HullBoxTuning.GetCenterZ(model.MassCenterZ, model.MassBoxSizeZ) * scale,
+            model.MassCenterY * scale);
+        var offsetLocalGame = PhysVecToGame(offsetLocalPhys);
+        var centerGame = posGame0 + Vector3.TransformNormal(offsetLocalGame, rotGame);
+
+        var extra = MathF.Max(0f, AxisMarkerExtraMeters);
+
+        // +Length marker: local +Z of the physics box (uses MassBoxSizeY via ShipController.Build third parameter).
+        var localLenGame = PhysVecToGame(new JVector(0f, 0f, hz + extra));
+        var posLen = centerGame + Vector3.TransformNormal(localLenGame, rotGame);
+
+        // +Beam marker: local +X of the physics box (uses MassBoxSizeX via ShipController.Build first parameter).
+        var localBeamGame = PhysVecToGame(new JVector(hx + extra, 0f, 0f));
+        var posBeam = centerGame + Vector3.TransformNormal(localBeamGame, rotGame);
+
+        // +Up marker: local +Y of the physics box (uses MassBoxSizeZ via ShipController.Build second parameter).
+        var localUpGame = PhysVecToGame(new JVector(0f, hy + extra, 0f));
+        var posUp = centerGame + Vector3.TransformNormal(localUpGame, rotGame);
+
+        // Compute vertical extent of the OBB in world (game Z is up).
+        var minZ = float.PositiveInfinity;
+        var maxZ = float.NegativeInfinity;
+        Span<JVector> localCornersPhys =
+        [
+            new JVector(+hx, +hy, +hz),
+            new JVector(+hx, +hy, -hz),
+            new JVector(+hx, -hy, +hz),
+            new JVector(+hx, -hy, -hz),
+            new JVector(-hx, +hy, +hz),
+            new JVector(-hx, +hy, -hz),
+            new JVector(-hx, -hy, +hz),
+            new JVector(-hx, -hy, -hz),
+        ];
+        for (var i = 0; i < 8; i++)
+        {
+            var cGame = PhysVecToGame(localCornersPhys[i]);
+            var w = centerGame + Vector3.TransformNormal(cGame, rotGame);
+            if (w.Z < minZ) minZ = w.Z;
+            if (w.Z > maxZ) maxZ = w.Z;
+        }
+
+        if (setLen != null)
+            UpdateMarker(ship.ParentWorld, setLen, 0, lenTemplateId, zoneId, posLen);
+        if (setBeam != null)
+            UpdateMarker(ship.ParentWorld, setBeam, 0, beamTemplateId, zoneId, posBeam);
+        if (setUp != null)
+            UpdateMarker(ship.ParentWorld, setUp, 0, upTemplateId, zoneId, posUp);
+
+        // One short line to the driver's chat (sizes + centers).
+        var driver = TryGetDriver(ship);
+        if (driver is null || !CanReceive(driver))
+            return;
+
+        var nowMs = Environment.TickCount64;
+        var throttle = Math.Max(250, ThrottleMsPerShip);
+        var last = _lastAxesMsgAtMs.GetOrAdd(ship.Id, 0);
+        if (nowMs - last < throttle)
+            return;
+        _lastAxesMsgAtMs[ship.Id] = nowMs;
+
+        var waterZ = ship.CachedWaterSurface;
+        driver.SendDebugMessage(
+            $"[ShipBox] ship={ship.ObjId} sizeXYZ=({model.MassBoxSizeX:F2},{model.MassBoxSizeY:F2},{model.MassBoxSizeZ:F2}) centerXYZ=({model.MassCenterX:F2},{model.MassCenterY:F2},{model.MassCenterZ:F2}) z=[{minZ:F2}..{maxZ:F2}] waterZ={waterZ:F2}");
+    }
+
+    private static void UpdateShipContactLatch(Slave ship)
+    {
+        var nowMs = Environment.TickCount64;
+        var hasContact = _shipContactUntilMs.TryGetValue(ship.Id, out var untilMs) && untilMs > nowMs;
+        if (!hasContact)
+            _shipContactUntilMs.TryRemove(ship.Id, out _);
+
+        var prev = _shipContactLatched.TryGetValue(ship.Id, out var v) && v;
+        if (prev == hasContact)
+            return;
+
+        _shipContactLatched[ship.Id] = hasContact;
+        var driver = TryGetDriver(ship);
+        if (driver is null || !CanReceive(driver))
+            return;
+
+        driver.SendDebugMessage(hasContact
+            ? "[ShipShip] Hull contact started"
+            : "[ShipShip] Hull contact ended");
+    }
+
+    private static void UpdateShipCornerMarkers(Slave ship)
+    {
+        var templateId = CornerMarkerTemplateId;
+        if (templateId == 0 || ship.ParentWorld is null)
+        {
+            DespawnMarkers(_shipCornerMarkers, ship.Id);
+            return;
+        }
+
+        var rb = ship.RigidBody;
+        var model = ship.ShipController?.ShipModel;
+        if (rb is null || model is null)
+        {
+            DespawnMarkers(_shipCornerMarkers, ship.Id);
+            return;
+        }
+
+        var zoneId = ship.Transform.ZoneId;
+        var set = _shipCornerMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(8));
+        if (set.ZoneId != zoneId || set.TemplateId != templateId)
+        {
+            DespawnMarkers(_shipCornerMarkers, ship.Id);
+            set = _shipCornerMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(8));
+            set.ZoneId = zoneId;
+            set.TemplateId = templateId;
+        }
+
+        // REAL physics box corners, but expressed in GAME coordinates with the same quaternion component mapping
+        // used by PhysicsManager.SyncTransformWithRigidBody (rotation.X, rotation.Z, rotation.Y, rotation.W).
+        //
+        // Reason: a pure axis permutation (phys -> game) is an odd permutation (changes handedness),
+        // so "rotate in phys then permute" can appear to flip left/right in game space.
+        // Computing directly in game space with the mapped quaternion keeps turn direction consistent.
+        //
+        // ShipController.Build():
+        // - BoxShape(MassBoxSizeX, MassBoxSizeZ, MassBoxSizeY)
+        // - TransformedShape offset = (MassCenterX, MassCenterZ, MassCenterY)
+        var scale = MathF.Max(0.01f, ship.Scale);
+        var hx = model.MassBoxSizeX * scale * 0.5f;
+        var hy = HullBoxTuning.GetSizeZ(model.MassBoxSizeZ) * scale * 0.5f;
+        var hz = model.MassBoxSizeY * scale * 0.5f;
+
+        // See UpdateShipAxisMarkers comment above.
+        var rotGame = GetTransformRotationMatrix(ship.Transform.Local.Rotation);
+
+        var posGame0 = PhysToGame(rb.Position);
+        var offsetLocalPhys = new JVector(
+            model.MassCenterX * scale,
+            HullBoxTuning.GetCenterZ(model.MassCenterZ, model.MassBoxSizeZ) * scale,
+            model.MassCenterY * scale);
+        var offsetLocalGame = PhysVecToGame(offsetLocalPhys);
+        var centerGame = posGame0 + Vector3.TransformNormal(offsetLocalGame, rotGame);
+
+        Span<Vector3> localCornersGame =
+        [
+            PhysVecToGame(new JVector(+hx, +hy, +hz)),
+            PhysVecToGame(new JVector(+hx, +hy, -hz)),
+            PhysVecToGame(new JVector(+hx, -hy, +hz)),
+            PhysVecToGame(new JVector(+hx, -hy, -hz)),
+            PhysVecToGame(new JVector(-hx, +hy, +hz)),
+            PhysVecToGame(new JVector(-hx, +hy, -hz)),
+            PhysVecToGame(new JVector(-hx, -hy, +hz)),
+            PhysVecToGame(new JVector(-hx, -hy, -hz)),
+        ];
+
+        for (var i = 0; i < 8; i++)
+        {
+            var posGame = centerGame + Vector3.TransformNormal(localCornersGame[i], rotGame);
+            UpdateMarker(ship.ParentWorld, set, i, templateId, zoneId, posGame);
+        }
+    }
+
+    /// <summary>
+    /// EN: Called from ship↔ship resolver when overlap response happened.
+    /// RU: Вызывается из ship↔ship резолвера при наличии overlap/реакции.
+    /// </summary>
+    public static void OnResolvedShipPair(Slave a, Slave b, float penetrationMeters, float nx, float nz, float impactSpeedMps)
+    {
+        if (!Enabled)
+            return;
+
+        // Extend "contact active" window; TickShip will emit start/end messages.
+        var nowMs = Environment.TickCount64;
+        const int holdMs = 800;
+        _shipContactUntilMs[a.Id] = nowMs + holdMs;
+        _shipContactUntilMs[b.Id] = nowMs + holdMs;
+
+        SendShipShipDetail(a, b, penetrationMeters, nx, nz, impactSpeedMps);
+        SendShipShipDetail(b, a, penetrationMeters, -nx, -nz, impactSpeedMps);
+    }
+
+    private static void SendShipShipDetail(Slave self, Slave other, float pen, float nx, float nz, float impactSpeedMps)
+    {
+        var driver = TryGetDriver(self);
+        if (driver is null || !CanReceive(driver))
+            return;
+
+        var nowMs = Environment.TickCount64;
+        if (ThrottleMsPerShip > 0)
+        {
+            var last = _lastDetailMsgAtMs.GetOrAdd(self.Id, 0);
+            if (nowMs - last < ThrottleMsPerShip)
+                return;
+            _lastDetailMsgAtMs[self.Id] = nowMs;
+        }
+
+        driver.SendDebugMessage(
+            $"[ShipShip] ship={self.ObjId} pair={other.ObjId} pen={pen:F3}m v={impactSpeedMps:F2}m/s n=({nx:F2},{nz:F2})");
+    }
+
+    /// <summary>
+    /// EN: Called when shore latch flips. Sends chat messages "collided with ground" / "back in water".
+    /// RU: Вызывается при смене shore latch. Пишет в чат "collided with ground" / "back in water".
+    /// </summary>
+    public static void OnShoreLatchChanged(Slave ship, bool latched)
+    {
+        if (!Enabled || !ShoreEnabled)
+            return;
+
+        var driver = TryGetDriver(ship);
+        if (driver is null || !CanReceive(driver))
+            return;
+
+        driver.SendDebugMessage(latched
+            ? "[ShipShore] Ship collided with ground"
+            : "[ShipShore] Ship is back in water");
+    }
+
+    /// <summary>
+    /// EN: Feed shore probe/contact points for marker visualization.
+    /// RU: Передать точки shore-проб/контакта для визуализации маркерами.
+    /// </summary>
+    public static void OnShoreProbe(
+        Slave ship,
+        float probeX, float probeY, float floorZ,
+        float cliffX, float cliffY, float cliffZ,
+        float boatCenterX, float boatCenterY, float boatBottomZ,
+        float waterSurfaceZ,
+        float penetrationMeters)
+    {
+        if (ship is null)
+            return;
+
+        if (!Enabled || !ShoreEnabled)
+            return;
+
+        var templateId = ShoreMarkerTemplateId;
+        if (templateId == 0 || ship.ParentWorld is null || ship.Transform is null)
+        {
+            DespawnMarkers(_shoreMarkers, ship.Id);
+            return;
+        }
+
+        var zoneId = ship.Transform.ZoneId;
+        var set = _shoreMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(4));
+        if (set.ZoneId != zoneId || set.TemplateId != templateId)
+        {
+            DespawnMarkers(_shoreMarkers, ship.Id);
+            set = _shoreMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(4));
+            set.ZoneId = zoneId;
+            set.TemplateId = templateId;
+        }
+
+        UpdateMarker(ship.ParentWorld, set, 0, templateId, zoneId, new Vector3(probeX, probeY, floorZ));
+        UpdateMarker(ship.ParentWorld, set, 1, templateId, zoneId, new Vector3(cliffX, cliffY, cliffZ));
+        UpdateMarker(ship.ParentWorld, set, 2, templateId, zoneId, new Vector3(boatCenterX, boatCenterY, boatBottomZ));
+        UpdateMarker(ship.ParentWorld, set, 3, templateId, zoneId, new Vector3(probeX, probeY, waterSurfaceZ));
+
+        // Optional detail line while penetrating
+        if (penetrationMeters > 0.0f)
+        {
+            var driver = TryGetDriver(ship);
+            if (driver != null && CanReceive(driver))
+            {
+                var nowMs = Environment.TickCount64;
+                if (ThrottleMsPerShip > 0)
+                {
+                    var last = _lastShorePenMsgAtMs.GetOrAdd(ship.Id, 0);
+                    if (nowMs - last < ThrottleMsPerShip)
+                        return;
+                    _lastShorePenMsgAtMs[ship.Id] = nowMs;
+                }
+
+                driver.SendDebugMessage($"[ShipShore] ship={ship.ObjId} pen={penetrationMeters:F3}m");
+            }
+        }
+    }
+
+    private static void UpdateMarker(AAEmu.Game.Models.Game.World.WorldInstance world, MarkerSet set, int idx, uint templateId, uint zoneId, Vector3 pos)
+    {
+        var g = set.Markers[idx];
+        if (g is null || g.ParentWorld != world)
+        {
+            var spawner = new GimmickSpawner(world)
+            {
+                UnitId = templateId,
+                RespawnTime = 0,
+                Scale = MarkerScale,
+                Position = new WorldSpawnPosition
+                {
+                    ZoneId = zoneId,
+                    X = pos.X,
+                    Y = pos.Y,
+                    Z = pos.Z,
+                    Roll = 0f,
+                    Pitch = 0f,
+                    Yaw = 0f
+                }
+            };
+
+            var spawned = spawner.Spawn(0);
+            if (spawned is null)
+                return;
+
+            spawned.SetScale(MarkerScale);
+            set.Spawners[idx] = spawner;
+            set.Markers[idx] = spawned;
+            g = spawned;
+        }
+
+        g.Transform.Local.SetPosition(pos.X, pos.Y, pos.Z);
+        g.Transform.FinalizeTransform();
+        g.Vel = Vector3.Zero;
+        g.Time = (uint)(DateTime.UtcNow - DateTime.UtcNow.Date).TotalMilliseconds;
+        g.BroadcastPacket(new SCGimmickMovementPacket(g), false);
+    }
+
+    private static void DespawnAll(uint shipId)
+    {
+        DespawnMarkers(_shipCornerMarkers, shipId);
+        DespawnMarkers(_shipAxisLenMarkers, shipId);
+        DespawnMarkers(_shipAxisBeamMarkers, shipId);
+        DespawnMarkers(_shipAxisUpMarkers, shipId);
+        DespawnMarkers(_shoreMarkers, shipId);
+        _shipContactUntilMs.TryRemove(shipId, out _);
+        _shipContactLatched.TryRemove(shipId, out _);
+        _lastDetailMsgAtMs.TryRemove(shipId, out _);
+        _lastAxesMsgAtMs.TryRemove(shipId, out _);
+        _lastShorePenMsgAtMs.TryRemove(shipId, out _);
+    }
+
+    private static void DespawnMarkers(ConcurrentDictionary<uint, MarkerSet> dict, uint shipId)
+    {
+        if (!dict.TryRemove(shipId, out var set))
+            return;
+        for (var i = 0; i < set.Markers.Length; i++)
+        {
+            try
+            {
+                var g = set.Markers[i];
+                var sp = set.Spawners[i];
+                if (g is null || sp is null)
+                    continue;
+                sp.Despawn(g);
+            }
+            catch
+            {
+                // best-effort
+            }
+        }
+    }
+
+    private static Character? TryGetDriver(Slave s)
+    {
+        return s.AttachedCharacters.TryGetValue(AttachPointKind.Driver, out var driver) ? driver : null;
+    }
+
+    private static bool CanReceive(Character c)
+    {
+        return CharacterManager.Instance.GetEffectiveAccessLevel(c) >= MinAccessLevel;
+    }
+
+    private static JVector Rotate(JVector v, JQuaternion q)
+    {
+        var qx = q.X;
+        var qy = q.Y;
+        var qz = q.Z;
+        var qw = q.W;
+        var tx = 2f * (qy * v.Z - qz * v.Y);
+        var ty = 2f * (qz * v.X - qx * v.Z);
+        var tz = 2f * (qx * v.Y - qy * v.X);
+        return new JVector(
+            v.X + qw * tx + (qy * tz - qz * ty),
+            v.Y + qw * ty + (qz * tx - qx * tz),
+            v.Z + qw * tz + (qx * ty - qy * tx));
+    }
+
+    private static Vector3 PhysToGame(JVector phys)
+    {
+        // Game coords: (X,Y,Z) == (phys X, phys Z, phys Y)
+        return new Vector3(phys.X, phys.Z, phys.Y);
+    }
+
+    private static Vector3 PhysVecToGame(JVector v)
+    {
+        // Same axis mapping as PhysToGame but for a vector (no translation).
+        return new Vector3(v.X, v.Z, v.Y);
+    }
+
+    private static Matrix4x4 GetTransformRotationMatrix(Vector3 rpy)
+    {
+        // Use the project's own Euler->Quaternion conversion.
+        // PositionAndRotation stores Euler as (roll=X, pitch=Y, yaw=Z) in radians,
+        // with yaw around +Z (up). This matches how Transform is intended to behave.
+        var q = Quaternion.Normalize(PositionAndRotation.ToQuaternion(rpy));
+        return Matrix4x4.CreateFromQuaternion(q);
+    }
+}
+

--- a/AAEmu.Game/Physics/Debug/ShipTuningDebug.cs
+++ b/AAEmu.Game/Physics/Debug/ShipTuningDebug.cs
@@ -26,6 +26,20 @@ namespace AAEmu.Game.Physics.Debug;
 /// </summary>
 public static class ShipTuningDebug
 {
+    private const int MinChatThrottleIntervalMsFloor = 250;
+    private const int ShipPairContactHoldMs = 800;
+    private const int MassBoxCornerCount = 8;
+
+    private static class ChatTags
+    {
+        public const string ShipSpeed = "[ShipSpeed]";
+        public const string ShipBox = "[ShipBox]";
+        public const string ShipShip = "[ShipShip]";
+        public const string ShipShore = "[ShipShore]";
+    }
+
+    #region Public debug switches
+
     /// <summary>
     /// EN: Master switch for gimmick markers and for per-tick debug (corners, axes, speed/box chat in <see cref="TickShip"/>). Callback chat (ship↔ship detail, shore latch/penetration) uses the separate flags below and may still run when this is false.
     /// RU: Главный выключатель маркеров и тика <see cref="TickShip"/> (углы, оси, чат скорости/бокса). Чат из колбэков (детали ship↔shore, берег) — отдельные флаги ниже; часть может работать при false.
@@ -152,6 +166,10 @@ public static class ShipTuningDebug
     public static bool ShorePenetrationChatEnabled => GetShorePenetrationChatEnabled();
     private static bool GetShorePenetrationChatEnabled() => false;
 
+    #endregion
+
+    #region Throttle & marker state
+
     private static readonly ConcurrentDictionary<uint, long> _lastDetailMsgAtMs = new();
     private static readonly ConcurrentDictionary<uint, long> _lastAxesMsgAtMs = new();
     private static readonly ConcurrentDictionary<uint, long> _lastShorePenMsgAtMs = new();
@@ -166,6 +184,10 @@ public static class ShipTuningDebug
     // ship↔ship contact latch based on ResolvePair events
     private static readonly ConcurrentDictionary<uint, long> _shipContactUntilMs = new();
     private static readonly ConcurrentDictionary<uint, bool> _shipContactLatched = new();
+
+    #endregion
+
+    #region Mass-box geometry (game space)
 
     private sealed class MarkerSet
     {
@@ -225,7 +247,7 @@ public static class ShipTuningDebug
         FillMassBoxLocalCornersGame(g.Hx, g.Hy, g.Hz, cornerScratch);
         minZ = float.PositiveInfinity;
         maxZ = float.NegativeInfinity;
-        for (var i = 0; i < 8; i++)
+        for (var i = 0; i < MassBoxCornerCount; i++)
         {
             var w = g.CenterGame + Vector3.TransformNormal(cornerScratch[i], g.RotGame);
             if (w.Z < minZ) minZ = w.Z;
@@ -239,6 +261,56 @@ public static class ShipTuningDebug
         DespawnMarkers(_shipAxisBeamMarkers, shipId);
         DespawnMarkers(_shipAxisUpMarkers, shipId);
     }
+
+    #endregion
+
+    #region Marker & chat helpers
+
+    /// <summary>
+    /// One gimmick per ship for an axis; despawn when <paramref name="templateId"/> is 0.
+    /// </summary>
+    private static MarkerSet? EnsureSingleAxisMarkerSet(
+        ConcurrentDictionary<uint, MarkerSet> dict,
+        uint shipId,
+        uint zoneId,
+        uint templateId)
+    {
+        if (templateId == 0)
+        {
+            DespawnMarkers(dict, shipId);
+            return null;
+        }
+
+        var set = dict.GetOrAdd(shipId, _ => new MarkerSet(1));
+        if (set.ZoneId != zoneId || set.TemplateId != templateId)
+        {
+            DespawnMarkers(dict, shipId);
+            set = dict.GetOrAdd(shipId, _ => new MarkerSet(1));
+            set.ZoneId = zoneId;
+            set.TemplateId = templateId;
+        }
+
+        return set;
+    }
+
+    /// <returns><see langword="false"/> if this ship is still inside the throttle window.</returns>
+    private static bool TryConsumeDebugChatThrottle(ConcurrentDictionary<uint, long> lastByShip, uint shipId, int intervalMs)
+    {
+        if (intervalMs <= 0)
+            return true;
+
+        var nowMs = Environment.TickCount64;
+        var last = lastByShip.GetOrAdd(shipId, 0);
+        if (nowMs - last < intervalMs)
+            return false;
+
+        lastByShip[shipId] = nowMs;
+        return true;
+    }
+
+    #endregion
+
+    #region Per-tick & markers
 
     /// <summary>
     /// EN: Per-ship debug tick. Updates corner markers and ship↔ship latch messages.
@@ -276,12 +348,9 @@ public static class ShipTuningDebug
         if (driver is null || !CanReceive(driver))
             return;
 
-        var nowMs = Environment.TickCount64;
-        var throttle = Math.Max(250, ThrottleMsPerShip);
-        var last = _lastSpeedMsgAtMs.GetOrAdd(ship.Id, 0);
-        if (nowMs - last < throttle)
+        var intervalMs = Math.Max(MinChatThrottleIntervalMsFloor, ThrottleMsPerShip);
+        if (!TryConsumeDebugChatThrottle(_lastSpeedMsgAtMs, ship.Id, intervalMs))
             return;
-        _lastSpeedMsgAtMs[ship.Id] = nowMs;
 
         var isGrounded = (ship.CachedFloorLevel > ship.CachedWaterSurface) || ship.GroundContactLatched;
         var escapeThrottleSign = ship.GroundedByStern ? 1 : -1;
@@ -290,7 +359,7 @@ public static class ShipTuningDebug
         var cap = ShipController.ShipMotionDefaults.GroundEscapeMaxSpeedAbs;
 
         driver.SendDebugMessage(
-            $"[ShipSpeed] ship={ship.ObjId} v={ship.Speed:F2} grounded={isGrounded} latched={ship.GroundContactLatched} byStern={ship.GroundedByStern} thrReq={ship.ThrottleRequest} escape={isEscapeInputOnGround} escapeCap={cap:F2}");
+            $"{ChatTags.ShipSpeed} ship={ship.ObjId} v={ship.Speed:F2} grounded={isGrounded} latched={ship.GroundContactLatched} byStern={ship.GroundedByStern} thrReq={ship.ThrottleRequest} escape={isEscapeInputOnGround} escapeCap={cap:F2}");
     }
 
     private static void UpdateShipAxisMarkers(Slave ship)
@@ -318,56 +387,9 @@ public static class ShipTuningDebug
         }
 
         var zoneId = ship.Transform.ZoneId;
-        MarkerSet? setLen = null;
-        if (lenTemplateId != 0)
-        {
-            setLen = _shipAxisLenMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(1));
-            if (setLen.ZoneId != zoneId || setLen.TemplateId != lenTemplateId)
-            {
-                DespawnMarkers(_shipAxisLenMarkers, ship.Id);
-                setLen = _shipAxisLenMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(1));
-                setLen.ZoneId = zoneId;
-                setLen.TemplateId = lenTemplateId;
-            }
-        }
-        else
-        {
-            DespawnMarkers(_shipAxisLenMarkers, ship.Id);
-        }
-
-        MarkerSet? setBeam = null;
-        if (beamTemplateId != 0)
-        {
-            setBeam = _shipAxisBeamMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(1));
-            if (setBeam.ZoneId != zoneId || setBeam.TemplateId != beamTemplateId)
-            {
-                DespawnMarkers(_shipAxisBeamMarkers, ship.Id);
-                setBeam = _shipAxisBeamMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(1));
-                setBeam.ZoneId = zoneId;
-                setBeam.TemplateId = beamTemplateId;
-            }
-        }
-        else
-        {
-            DespawnMarkers(_shipAxisBeamMarkers, ship.Id);
-        }
-
-        MarkerSet? setUp = null;
-        if (upTemplateId != 0)
-        {
-            setUp = _shipAxisUpMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(1));
-            if (setUp.ZoneId != zoneId || setUp.TemplateId != upTemplateId)
-            {
-                DespawnMarkers(_shipAxisUpMarkers, ship.Id);
-                setUp = _shipAxisUpMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(1));
-                setUp.ZoneId = zoneId;
-                setUp.TemplateId = upTemplateId;
-            }
-        }
-        else
-        {
-            DespawnMarkers(_shipAxisUpMarkers, ship.Id);
-        }
+        var setLen = EnsureSingleAxisMarkerSet(_shipAxisLenMarkers, ship.Id, zoneId, lenTemplateId);
+        var setBeam = EnsureSingleAxisMarkerSet(_shipAxisBeamMarkers, ship.Id, zoneId, beamTemplateId);
+        var setUp = EnsureSingleAxisMarkerSet(_shipAxisUpMarkers, ship.Id, zoneId, upTemplateId);
 
         var extra = MathF.Max(0f, AxisMarkerExtraMeters);
         var hzE = geo.Hz + extra;
@@ -379,7 +401,7 @@ public static class ShipTuningDebug
         var posBeam = geo.CenterGame + Vector3.TransformNormal(PhysVecToGame(new JVector(hxE, 0f, 0f)), geo.RotGame);
         var posUp = geo.CenterGame + Vector3.TransformNormal(PhysVecToGame(new JVector(0f, hyE, 0f)), geo.RotGame);
 
-        Span<Vector3> cornerScratch = stackalloc Vector3[8];
+        Span<Vector3> cornerScratch = stackalloc Vector3[MassBoxCornerCount];
         GetMassBoxWorldVerticalExtent(in geo, cornerScratch, out var minZ, out var maxZ);
 
         if (setLen != null)
@@ -394,16 +416,13 @@ public static class ShipTuningDebug
         if (driver is null || !CanReceive(driver) || !ShipBoxChatEnabled)
             return;
 
-        var nowMs = Environment.TickCount64;
-        var throttle = Math.Max(250, ThrottleMsPerShip);
-        var last = _lastAxesMsgAtMs.GetOrAdd(ship.Id, 0);
-        if (nowMs - last < throttle)
+        var intervalMs = Math.Max(MinChatThrottleIntervalMsFloor, ThrottleMsPerShip);
+        if (!TryConsumeDebugChatThrottle(_lastAxesMsgAtMs, ship.Id, intervalMs))
             return;
-        _lastAxesMsgAtMs[ship.Id] = nowMs;
 
         var waterZ = ship.CachedWaterSurface;
         driver.SendDebugMessage(
-            $"[ShipBox] ship={ship.ObjId} sizeXYZ=({model.MassBoxSizeX:F2},{model.MassBoxSizeY:F2},{model.MassBoxSizeZ:F2}) centerXYZ=({model.MassCenterX:F2},{model.MassCenterY:F2},{model.MassCenterZ:F2}) z=[{minZ:F2}..{maxZ:F2}] waterZ={waterZ:F2}");
+            $"{ChatTags.ShipBox} ship={ship.ObjId} sizeXYZ=({model.MassBoxSizeX:F2},{model.MassBoxSizeY:F2},{model.MassBoxSizeZ:F2}) centerXYZ=({model.MassCenterX:F2},{model.MassCenterY:F2},{model.MassCenterZ:F2}) z=[{minZ:F2}..{maxZ:F2}] waterZ={waterZ:F2}");
     }
 
     private static void UpdateShipContactLatch(Slave ship)
@@ -426,8 +445,8 @@ public static class ShipTuningDebug
             return;
 
         driver.SendDebugMessage(hasContact
-            ? "[ShipShip] Hull contact started"
-            : "[ShipShip] Hull contact ended");
+            ? $"{ChatTags.ShipShip} Hull contact started"
+            : $"{ChatTags.ShipShip} Hull contact ended");
     }
 
     private static void UpdateShipCornerMarkers(Slave ship)
@@ -446,23 +465,27 @@ public static class ShipTuningDebug
         }
 
         var zoneId = ship.Transform!.ZoneId;
-        var set = _shipCornerMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(8));
+        var set = _shipCornerMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(MassBoxCornerCount));
         if (set.ZoneId != zoneId || set.TemplateId != templateId)
         {
             DespawnMarkers(_shipCornerMarkers, ship.Id);
-            set = _shipCornerMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(8));
+            set = _shipCornerMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(MassBoxCornerCount));
             set.ZoneId = zoneId;
             set.TemplateId = templateId;
         }
 
-        Span<Vector3> localCorners = stackalloc Vector3[8];
+        Span<Vector3> localCorners = stackalloc Vector3[MassBoxCornerCount];
         FillMassBoxLocalCornersGame(geo.Hx, geo.Hy, geo.Hz, localCorners);
-        for (var i = 0; i < 8; i++)
+        for (var i = 0; i < MassBoxCornerCount; i++)
         {
             var posGame = geo.CenterGame + Vector3.TransformNormal(localCorners[i], geo.RotGame);
             UpdateMarker(ship.ParentWorld, set, i, templateId, zoneId, posGame);
         }
     }
+
+    #endregion
+
+    #region Ship↔ship & shore callbacks
 
     /// <summary>
     /// EN: Called from ship↔ship resolver when overlap response happened.
@@ -470,15 +493,15 @@ public static class ShipTuningDebug
     /// </summary>
     public static void OnResolvedShipPair(Slave a, Slave b, float penetrationMeters, float nx, float nz, float impactSpeedMps)
     {
-        var anyShipShipDebug = Enabled || ShipShipContactLatchChatEnabled || ShipShipResolveDetailChatEnabled;
-        if (!anyShipShipDebug)
+        var shipPairDebugActive = Enabled || ShipShipContactLatchChatEnabled || ShipShipResolveDetailChatEnabled;
+        if (!shipPairDebugActive)
             return;
 
         // Extend "contact active" window; TickShip will emit start/end messages when Enabled.
         var nowMs = Environment.TickCount64;
-        const int holdMs = 800;
-        _shipContactUntilMs[a.Id] = nowMs + holdMs;
-        _shipContactUntilMs[b.Id] = nowMs + holdMs;
+        var holdUntil = nowMs + ShipPairContactHoldMs;
+        _shipContactUntilMs[a.Id] = holdUntil;
+        _shipContactUntilMs[b.Id] = holdUntil;
 
         if (!ShipShipResolveDetailChatEnabled)
             return;
@@ -493,17 +516,11 @@ public static class ShipTuningDebug
         if (driver is null || !CanReceive(driver))
             return;
 
-        var nowMs = Environment.TickCount64;
-        if (ThrottleMsPerShip > 0)
-        {
-            var last = _lastDetailMsgAtMs.GetOrAdd(self.Id, 0);
-            if (nowMs - last < ThrottleMsPerShip)
-                return;
-            _lastDetailMsgAtMs[self.Id] = nowMs;
-        }
+        if (!TryConsumeDebugChatThrottle(_lastDetailMsgAtMs, self.Id, ThrottleMsPerShip))
+            return;
 
         driver.SendDebugMessage(
-            $"[ShipShip] ship={self.ObjId} pair={other.ObjId} pen={pen:F3}m v={impactSpeedMps:F2}m/s n=({nx:F2},{nz:F2})");
+            $"{ChatTags.ShipShip} ship={self.ObjId} pair={other.ObjId} pen={pen:F3}m v={impactSpeedMps:F2}m/s n=({nx:F2},{nz:F2})");
     }
 
     /// <summary>
@@ -520,8 +537,8 @@ public static class ShipTuningDebug
             return;
 
         driver.SendDebugMessage(latched
-            ? "[ShipShore] Ship collided with ground"
-            : "[ShipShore] Ship is back in water");
+            ? $"{ChatTags.ShipShore} Ship collided with ground"
+            : $"{ChatTags.ShipShore} Ship is back in water");
     }
 
     /// <summary>
@@ -572,17 +589,15 @@ public static class ShipTuningDebug
         if (driver is null || !CanReceive(driver))
             return;
 
-        var nowMs = Environment.TickCount64;
-        if (ThrottleMsPerShip > 0)
-        {
-            var last = _lastShorePenMsgAtMs.GetOrAdd(ship.Id, 0);
-            if (nowMs - last < ThrottleMsPerShip)
-                return;
-            _lastShorePenMsgAtMs[ship.Id] = nowMs;
-        }
+        if (!TryConsumeDebugChatThrottle(_lastShorePenMsgAtMs, ship.Id, ThrottleMsPerShip))
+            return;
 
-        driver.SendDebugMessage($"[ShipShore] ship={ship.ObjId} pen={penetrationMeters:F3}m");
+        driver.SendDebugMessage($"{ChatTags.ShipShore} ship={ship.ObjId} pen={penetrationMeters:F3}m");
     }
+
+    #endregion
+
+    #region Marker spawn & lifecycle
 
     private static void UpdateMarker(AAEmu.Game.Models.Game.World.WorldInstance world, MarkerSet set, int idx, uint templateId, uint zoneId, Vector3 pos)
     {
@@ -659,6 +674,10 @@ public static class ShipTuningDebug
         }
     }
 
+    #endregion
+
+    #region Driver & coordinates
+
     private static Character? TryGetDriver(Slave s)
     {
         return s.AttachedCharacters.TryGetValue(AttachPointKind.Driver, out var driver) ? driver : null;
@@ -689,5 +708,7 @@ public static class ShipTuningDebug
         var q = Quaternion.Normalize(PositionAndRotation.ToQuaternion(rpy));
         return Matrix4x4.CreateFromQuaternion(q);
     }
+
+    #endregion
 }
 

--- a/AAEmu.Game/Physics/Debug/ShipTuningDebug.cs
+++ b/AAEmu.Game/Physics/Debug/ShipTuningDebug.cs
@@ -19,8 +19,8 @@ using Jitter2.LinearMath;
 namespace AAEmu.Game.Physics.Debug;
 
 /// <summary>
-/// EN: Dev-only ship physics debug: gimmick markers (mass box, axes, shore probes) and chat lines. Physics tuning lives in <see cref="ShipController.PhysicsDefaults"/>, <see cref="ShipController.ShipMassBoxDefaults"/>, interaction defaults classes — not here.
-/// RU: Только дебаг корабельной физики: маркеры-гиммики (бокс, оси, берег) и строки в чат. Тюнинг физики — в <see cref="ShipController.PhysicsDefaults"/>, <see cref="ShipController.ShipMassBoxDefaults"/> и дефолтах взаимодействий, не в этом классе.
+/// EN: Dev-only ship physics debug: gimmick markers (mass box, axes, shore probes) and chat lines. Physics tuning lives in <see cref="ShipController.ShipMotionDefaults"/>, <see cref="ShipController.ShipMassBoxDefaults"/>, <see cref="ShipShipInteraction.ShipHullPairDefaults"/>, <see cref="ShipShoreInteraction.ShorePhysicsDefaults"/> — not here.
+/// RU: Только дебаг корабельной физики: маркеры-гиммики (бокс, оси, берег) и строки в чат. Тюнинг физики — в <see cref="ShipController.ShipMotionDefaults"/>, <see cref="ShipController.ShipMassBoxDefaults"/>, <see cref="ShipShipInteraction.ShipHullPairDefaults"/>, <see cref="ShipShoreInteraction.ShorePhysicsDefaults"/>, не в этом классе.
 /// EN: Marker template ids come from table <c>gimmicks</c> — see <see cref="CornerMarkerTemplateId"/>, <see cref="ShoreMarkerTemplateId"/>, axis ids; set id to <c>0</c> or use <see cref="Enabled"/> / <see cref="AxisMarkersEnabled"/> to hide visuals.
 /// RU: Id шаблонов маркеров — таблица <c>gimmicks</c> (углы, берег, оси); <c>0</c> или флаги <see cref="Enabled"/> / <see cref="AxisMarkersEnabled"/> отключают визуал.
 /// </summary>
@@ -228,7 +228,7 @@ public static class ShipTuningDebug
         var escapeThrottleSign = ship.GroundedByStern ? 1 : -1;
         var isEscapeInputOnGround = isGrounded && ship.ThrottleRequest != 0 && Math.Sign(ship.ThrottleRequest) == escapeThrottleSign;
 
-        var cap = ShipController.PhysicsDefaults.GroundEscapeMaxSpeedAbs;
+        var cap = ShipController.ShipMotionDefaults.GroundEscapeMaxSpeedAbs;
 
         driver.SendDebugMessage(
             $"[ShipSpeed] ship={ship.ObjId} v={ship.Speed:F2} grounded={isGrounded} latched={ship.GroundContactLatched} byStern={ship.GroundedByStern} thrReq={ship.ThrottleRequest} escape={isEscapeInputOnGround} escapeCap={cap:F2}");
@@ -694,21 +694,6 @@ public static class ShipTuningDebug
     private static bool CanReceive(Character c)
     {
         return CharacterManager.Instance.GetEffectiveAccessLevel(c) >= MinAccessLevel;
-    }
-
-    private static JVector Rotate(JVector v, JQuaternion q)
-    {
-        var qx = q.X;
-        var qy = q.Y;
-        var qz = q.Z;
-        var qw = q.W;
-        var tx = 2f * (qy * v.Z - qz * v.Y);
-        var ty = 2f * (qz * v.X - qx * v.Z);
-        var tz = 2f * (qx * v.Y - qy * v.X);
-        return new JVector(
-            v.X + qw * tx + (qy * tz - qz * ty),
-            v.Y + qw * ty + (qz * tx - qx * tz),
-            v.Z + qw * tz + (qx * ty - qy * tx));
     }
 
     private static Vector3 PhysToGame(JVector phys)

--- a/AAEmu.Game/Physics/Debug/ShipTuningDebug.cs
+++ b/AAEmu.Game/Physics/Debug/ShipTuningDebug.cs
@@ -26,19 +26,36 @@ public static class ShipTuningDebug
     /// EN: Master switch (use Hot Reload; no GM commands).
     /// RU: Главный переключатель (через Hot Reload; без GM команд).
     /// </summary>
-    public static bool Enabled = true;
+    public static bool Enabled => GetEnabled();
+    private static bool GetEnabled() => true;
 
     /// <summary>
     /// EN: Minimum effective access level to receive chat debug messages.
     /// RU: Минимальный effective access level для получения debug-сообщений в чат.
     /// </summary>
-    public static int MinAccessLevel = 80;
+    public static int MinAccessLevel => GetMinAccessLevel();
+    private static int GetMinAccessLevel() => 80;
 
     /// <summary>
     /// EN: Throttle detailed messages (ms) per ship.
     /// RU: Троттлинг подробных сообщений (мс) на корабль.
     /// </summary>
-    public static int ThrottleMsPerShip = 3000;
+    public static int ThrottleMsPerShip => GetThrottleMsPerShip();
+    private static int GetThrottleMsPerShip() => 3000;
+
+    /// <summary>
+    /// EN: Enable/disable `[ShipBox]` chat line (markers still draw).
+    /// RU: Включить/выключить строку `[ShipBox]` в чате (маркеры остаются).
+    /// </summary>
+    public static bool ShipBoxChatEnabled => GetShipBoxChatEnabled();
+    private static bool GetShipBoxChatEnabled() => false;
+
+    /// <summary>
+    /// EN: Enable/disable `[ShipSpeed]` chat line (escape/ground diagnostics).
+    /// RU: Включить/выключить строку `[ShipSpeed]` в чате (диагностика скорости/мели).
+    /// </summary>
+    public static bool ShipSpeedChatEnabled => GetShipSpeedChatEnabled();
+    private static bool GetShipSpeedChatEnabled() => true;
 
     /// <summary>
     /// EN: Corner markers template id (table <c>gimmicks</c>). Hot Reload: edit this return value.
@@ -79,31 +96,36 @@ public static class ShipTuningDebug
     /// EN: Marker scale.
     /// RU: Масштаб маркеров.
     /// </summary>
-    public static float MarkerScale = 0.35f;
+    public static float MarkerScale => GetMarkerScale();
+    private static float GetMarkerScale() => 0.35f;
 
     /// <summary>
     /// EN: If true, draw markers only for ships with a driver.
     /// RU: Если true — рисовать маркеры только для кораблей с водителем.
     /// </summary>
-    public static bool DrawOnlyWhenDriven = false;
+    public static bool DrawOnlyWhenDriven => GetDrawOnlyWhenDriven();
+    private static bool GetDrawOnlyWhenDriven() => false;
 
     /// <summary>
     /// EN: Enable ship↔shore debug (markers + latch messages + tuning override in ShipShoreInteraction).
     /// RU: Включить ship↔shore дебаг (маркеры + сообщения latch + подмена тюнинга в ShipShoreInteraction).
     /// </summary>
-    public static bool ShoreEnabled = true;
+    public static bool ShoreEnabled => GetShoreEnabled();
+    private static bool GetShoreEnabled() => true;
 
     /// <summary>
     /// EN: Show two extra axis markers: +Length (local +Z of the physics box) and +Beam (local +X of the physics box).
     /// RU: Показывать 2 дополнительных маркера осей: +Length (локальная +Z физ. бокса) и +Beam (локальная +X физ. бокса).
     /// </summary>
-    public static bool AxisMarkersEnabled = true;
+    public static bool AxisMarkersEnabled => GetAxisMarkersEnabled();
+    private static bool GetAxisMarkersEnabled() => true;
 
     /// <summary>
     /// EN: Extra distance (meters) beyond half-extent for axis markers.
     /// RU: Доп. расстояние (метры) за пределы half-extent для осевых маркеров.
     /// </summary>
-    public static float AxisMarkerExtraMeters = 1.25f;
+    public static float AxisMarkerExtraMeters => GetAxisMarkerExtraMeters();
+    private static float GetAxisMarkerExtraMeters() => 1.25f;
 
     /// <summary>
     /// EN: Mass-box tuning (center/size overrides). Useful when the hull OBB is too low/high vs the visible hull.
@@ -115,25 +137,29 @@ public static class ShipTuningDebug
         /// EN: Additive vertical offset to MassCenterZ (meters). Positive lifts the box up.
         /// RU: Аддитивный вертикальный сдвиг к MassCenterZ (метры). Положительное значение поднимает бокс вверх.
         /// </summary>
-        public static float CenterZAddMeters = 0f;
+        public static float CenterZAddMeters => GetCenterZAddMeters();
+        private static float GetCenterZAddMeters() => 0f;
 
         /// <summary>
         /// EN: Additive vertical offset to MassCenterZ as a fraction of MassBoxSizeZ. Example: 0.30 lifts the box by 30% of its height.
         /// RU: Аддитивный вертикальный сдвиг к MassCenterZ как доля MassBoxSizeZ. Например: 0.30 поднимает бокс на 30% его высоты.
         /// </summary>
-        public static float CenterZAddFracOfSizeZ = 0.30f;
+        public static float CenterZAddFracOfSizeZ => GetCenterZAddFracOfSizeZ();
+        private static float GetCenterZAddFracOfSizeZ() => 0.0f;
 
         /// <summary>
         /// EN: Multiply MassBoxSizeZ (height). 1 = no change.
         /// RU: Множитель MassBoxSizeZ (высота). 1 = без изменений.
         /// </summary>
-        public static float SizeZMul = 1f;
+        public static float SizeZMul => GetSizeZMul();
+        private static float GetSizeZMul() => 1f;
 
         /// <summary>
         /// EN: Additive adjustment to MassBoxSizeZ (meters). Applied after SizeZMul.
         /// RU: Аддитивная поправка к MassBoxSizeZ (метры). Применяется после SizeZMul.
         /// </summary>
-        public static float SizeZAddMeters = 0f;
+        public static float SizeZAddMeters => GetSizeZAddMeters();
+        private static float GetSizeZAddMeters() => 0f;
 
         internal static float GetCenterZ(float baseCenterZ, float baseSizeZ) =>
             baseCenterZ + baseSizeZ * CenterZAddFracOfSizeZ + CenterZAddMeters;
@@ -155,139 +181,162 @@ public static class ShipTuningDebug
         /// EN: Half-length multiplier for SAT overlap test only (keep near 1).
         /// RU: Множитель полу-длины только для SAT-детекта (держать близко к 1).
         /// </summary>
-        public static float HullDetectInflateLength = 1.025f;
+        public static float HullDetectInflateLength => GetHullDetectInflateLength();
+        private static float GetHullDetectInflateLength() => 1.025f;
 
         /// <summary>
         /// EN: Half-beam multiplier for SAT overlap test only.
         /// RU: Множитель полу-ширины только для SAT-детекта.
         /// </summary>
-        public static float HullDetectInflateBeam = 1.015f;
+        public static float HullDetectInflateBeam => GetHullDetectInflateBeam();
+        private static float GetHullDetectInflateBeam() => 1.015f;
 
         /// <summary>
         /// EN: Extra tightening of beam in SAT only (reduces early side contact from oversized mass box).
         /// RU: Доп. ужатие ширины только в SAT (убирает ранний боковой контакт из-за широкого mass box).
         /// </summary>
-        public static float BeamDetectTightenMul = 0.78f;
+        public static float BeamDetectTightenMul => GetBeamDetectTightenMul();
+        private static float GetBeamDetectTightenMul() => 0.78f;
 
         /// <summary>
         /// EN: Ignore overlap response below this penetration depth (meters).
         /// RU: Игнорировать реакцию, если penetration меньше этого (метры).
         /// </summary>
-        public static float MinPenetrationToAct = 0.055f;
+        public static float MinPenetrationToAct => GetMinPenetrationToAct();
+        private static float GetMinPenetrationToAct() => 0.055f;
 
         /// <summary>
         /// EN: Ignore periodic hull-damage below this penetration depth (meters).
         /// RU: Не наносить периодический урон корпусу, если penetration меньше этого (метры).
         /// </summary>
-        public static float MinPenetrationToDamage = MinPenetrationToAct * 1.15f;
+        public static float MinPenetrationToDamage => GetMinPenetrationToDamage();
+        private static float GetMinPenetrationToDamage() => MinPenetrationToAct * 1.15f;
 
         /// <summary>
         /// EN: Ramp tangential slip damping over this depth range past MinPenetrationToAct (meters).
         /// RU: Наращивать демпф тангенциального скольжения на этом диапазоне глубины сверх MinPenetrationToAct (метры).
         /// </summary>
-        public static float TangentialRampDepthMeters = 0.22f;
+        public static float TangentialRampDepthMeters => GetTangentialRampDepthMeters();
+        private static float GetTangentialRampDepthMeters() => 0.22f;
 
         /// <summary>
         /// EN: Multiplier on positional separation push once overlap exists.
         /// RU: Множитель раздвижения (push) после обнаружения overlap.
         /// </summary>
-        public static float SeparationPushMultiplier = 1.22f;
+        public static float SeparationPushMultiplier => GetSeparationPushMultiplier();
+        private static float GetSeparationPushMultiplier() => 1.22f;
 
         /// <summary>
         /// EN: Extra separation slack added to computed overlap (meters).
         /// RU: Доп. зазор к раздвижению сверх overlap (метры).
         /// </summary>
-        public static float SeparationSlackMeters = 0.020f;
+        public static float SeparationSlackMeters => GetSeparationSlackMeters();
+        private static float GetSeparationSlackMeters() => 0.020f;
 
         /// <summary>
         /// EN: Fraction of relative closing speed along normal to remove (1 = full stop along normal).
         /// RU: Доля гашения относительной скорости вдоль нормали (1 = полностью убрать вдоль нормали).
         /// </summary>
-        public static float ClosingSpeedDamp = 1f;
+        public static float ClosingSpeedDamp => GetClosingSpeedDamp();
+        private static float GetClosingSpeedDamp() => 1f;
 
         /// <summary>
         /// EN: Tangential slip damping factor while overlapping (0..1).
         /// RU: Коэффициент демпфа тангенциального скольжения при overlap (0..1).
         /// </summary>
-        public static float TangentialSlipDamp = 0.86f;
+        public static float TangentialSlipDamp => GetTangentialSlipDamp();
+        private static float GetTangentialSlipDamp() => 0.86f;
 
         /// <summary>
         /// EN: Minimum vertical overlap (meters) to consider ships colliding.
         /// RU: Минимальный вертикальный overlap (метры) чтобы считать столкновение.
         /// </summary>
-        public static float MinVerticalOverlap = 0.12f;
+        public static float MinVerticalOverlap => GetMinVerticalOverlap();
+        private static float GetMinVerticalOverlap() => 0.12f;
 
         /// <summary>
         /// EN: Outer resolve passes per tick (CPU vs stability).
         /// RU: Внешние проходы резолва за тик (CPU vs стабильность).
         /// </summary>
-        public static int ResolvePasses = 2;
+        public static int ResolvePasses => GetResolvePasses();
+        private static int GetResolvePasses() => 2;
 
         /// <summary>
         /// EN: Max depenetration iterations per pair per pass.
         /// RU: Макс. итераций раздвижения на пару за проход.
         /// </summary>
-        public static int MaxPairIterations = 12;
+        public static int MaxPairIterations => GetMaxPairIterations();
+        private static int GetMaxPairIterations() => 12;
 
         /// <summary>
         /// EN: Penetration depth where “deep penetration” push boost starts (meters).
         /// RU: Глубина penetration, с которой начинается усиление push (метры).
         /// </summary>
-        public static float DeepPenetrationStart = 0.12f;
+        public static float DeepPenetrationStart => GetDeepPenetrationStart();
+        private static float GetDeepPenetrationStart() => 0.12f;
 
         /// <summary>
         /// EN: Boost factor applied as penetration exceeds DeepPenetrationStart.
         /// RU: Коэффициент усиления push при penetration больше DeepPenetrationStart.
         /// </summary>
-        public static float DeepPenetrationBoost = 0.72f;
+        public static float DeepPenetrationBoost => GetDeepPenetrationBoost();
+        private static float GetDeepPenetrationBoost() => 0.72f;
 
         /// <summary>
         /// EN: Floor on half-separation distance (meters).
         /// RU: Минимальная полу-дистанция раздвижения (метры).
         /// </summary>
-        public static float MinHalfSeparationMeters = 0.02f;
+        public static float MinHalfSeparationMeters => GetMinHalfSeparationMeters();
+        private static float GetMinHalfSeparationMeters() => 0.02f;
 
         /// <summary>
         /// EN: Stop iterating if computed separation is below this (meters) to avoid micro-jitter.
         /// RU: Остановить итерации, если раздвижение меньше этого (метры), чтобы убрать микродрожь.
         /// </summary>
-        public static float MinLinearSeparationToApplyMeters = 0.018f;
+        public static float MinLinearSeparationToApplyMeters => GetMinLinearSeparationToApplyMeters();
+        private static float GetMinLinearSeparationToApplyMeters() => 0.018f;
 
         /// <summary>
         /// EN: Cosine threshold for “nose cone” classification.
         /// RU: Порог косинуса для классификации “удар в нос”.
         /// </summary>
-        public static float NoseContactCosThreshold = 0.65f;
+        public static float NoseContactCosThreshold => GetNoseContactCosThreshold();
+        private static float GetNoseContactCosThreshold() => 0.65f;
 
         /// <summary>
         /// EN: Min interval between hull-collision damage ticks per other ship (seconds).
         /// RU: Минимальный интервал тиков урона от столкновения корпусом на конкретный другой корабль (сек).
         /// </summary>
-        public static float HullCollisionDamageCooldownSec = 1.5f;
+        public static float HullCollisionDamageCooldownSec => GetHullCollisionDamageCooldownSec();
+        private static float GetHullCollisionDamageCooldownSec() => 1.5f;
 
         /// <summary>
         /// EN: Relative speed threshold (m/s) where damage uses min % (non-nose).
         /// RU: Порог относительной скорости (м/с), ниже которого урон минимальный (не-носовые удары).
         /// </summary>
-        public static float HullDamageLowSpeedThresholdMps = 2f;
+        public static float HullDamageLowSpeedThresholdMps => GetHullDamageLowSpeedThresholdMps();
+        private static float GetHullDamageLowSpeedThresholdMps() => 2f;
 
         /// <summary>
         /// EN: Relative speed (m/s) where damage reaches max % (linear between thresholds).
         /// RU: Относительная скорость (м/с), при которой урон достигает максимума (линейно между порогами).
         /// </summary>
-        public static float HullDamageInterpMaxMps = 10f;
+        public static float HullDamageInterpMaxMps => GetHullDamageInterpMaxMps();
+        private static float GetHullDamageInterpMaxMps() => 10f;
 
         /// <summary>
         /// EN: Min % hull damage per tick.
         /// RU: Минимальный % урона корпуса за тик.
         /// </summary>
-        public static int HullDamageSpeedScaledMinPercent = 1;
+        public static int HullDamageSpeedScaledMinPercent => GetHullDamageSpeedScaledMinPercent();
+        private static int GetHullDamageSpeedScaledMinPercent() => 1;
 
         /// <summary>
         /// EN: Max % hull damage per tick.
         /// RU: Максимальный % урона корпуса за тик.
         /// </summary>
-        public static int HullDamageSpeedScaledMaxPercent = 10;
+        public static int HullDamageSpeedScaledMaxPercent => GetHullDamageSpeedScaledMaxPercent();
+        private static int GetHullDamageSpeedScaledMaxPercent() => 10;
     }
 
     /// <summary>
@@ -297,130 +346,178 @@ public static class ShipTuningDebug
     public static class ShoreTuning
     {
         /// <summary>
+        /// EN: Effective "boat bottom" offset as a fraction of MassBoxSizeZ (height).
+        /// EN: boatBottomY = rigidBodyY - MassBoxSizeZ*scale*frac. ~0.5 = keel near half-box below COM (matches legacy fallback).
+        /// EN: Values &lt; ~0.4 lift the effective bottom (less penetration, more air gap); &gt; ~0.55 can over-embed.
+        /// RU: Смещение "дна" как доля MassBoxSizeZ (высота).
+        /// RU: boatBottomY = rigidBodyY - MassBoxSizeZ*scale*frac. ~0.5 — киль около половины высоты под COM (как legacy 0.5).
+        /// RU: Меньше ~0.4 — «дно» выше, меньше penetration и больше визуальный зазор; больше ~0.55 — риск глубокого вдавливания.
+        /// </summary>
+        public static float BoatBottomOffsetFracOfSizeZ => GetBoatBottomOffsetFracOfSizeZ();
+        private static float GetBoatBottomOffsetFracOfSizeZ() => 0f;
+
+        /// <summary>
         /// EN: Ground friction multiplier on dry ground.
         /// RU: Трение на суше.
         /// </summary>
-        public static float GroundFriction = 0.4f;
+        public static float GroundFriction => GetGroundFriction();
+        private static float GetGroundFriction() => 0.1f;
 
         /// <summary>
         /// EN: Velocity/angular damping on dry ground.
         /// RU: Демпф скорости/угловой скорости на суше.
         /// </summary>
-        public static float DryGroundCollisionDamping = 0.5f;
+        public static float DryGroundCollisionDamping => GetDryGroundCollisionDamping();
+        private static float GetDryGroundCollisionDamping() => 1f;
 
         /// <summary>
         /// EN: Roll correction dead-zone (radians).
         /// RU: Мёртвая зона коррекции roll (радианы).
         /// </summary>
-        public static float DryGroundRollDeadZoneRad = 0.1f;
+        public static float DryGroundRollDeadZoneRad => GetDryGroundRollDeadZoneRad();
+        private static float GetDryGroundRollDeadZoneRad() => 0.1f;
 
         /// <summary>
         /// EN: Roll correction torque factor (tuning).
         /// RU: Коэффициент коррекции roll (тюнинг).
         /// </summary>
-        public static float DryGroundRollTorqueMul = 0.1f;
+        public static float DryGroundRollTorqueMul => GetDryGroundRollTorqueMul();
+        private static float GetDryGroundRollTorqueMul() => 0.1f;
 
         /// <summary>
         /// EN: Bow probe distance multiplier vs MassBoxSizeY (hull length).
         /// RU: Множитель дистанции носовой пробы от MassBoxSizeY (длина корпуса).
         /// </summary>
-        public static float BowProbeMul = 1.5f;
+        public static float BowProbeMul => GetBowProbeMul();
+        private static float GetBowProbeMul() => 1.5f;
 
         /// <summary>
         /// EN: Stern probe distance multiplier vs MassBoxSizeY (hull length).
         /// RU: Множитель дистанции кормовой пробы от MassBoxSizeY (длина корпуса).
         /// </summary>
-        public static float SternProbeMul = 1.5f;
+        public static float SternProbeMul => GetSternProbeMul();
+        private static float GetSternProbeMul() => 1.5f;
 
         /// <summary>
         /// EN: Cliff probe distance multiplier vs MassBoxSizeY (hull length).
         /// RU: Множитель дистанции пробы “обрыва/стены” от MassBoxSizeY (длина корпуса).
         /// </summary>
-        public static float CliffProbeMul = 1.45f;
+        public static float CliffProbeMul => GetCliffProbeMul();
+        private static float GetCliffProbeMul() => 0f;
+
+        /// <summary>
+        /// EN: Wall/cliff look-ahead distance as a fraction of half-length (added beyond the box edge).
+        /// EN: 0 = probe exactly at bow/stern box edge; 0.2 = +20% of half-length further.
+        /// RU: Дистанция look-ahead для “стены/обрыва” как доля half-length (прибавляется за край бокса).
+        /// RU: 0 = проба ровно на кромке бокса нос/корма; 0.2 = +20% half-length дальше.
+        /// </summary>
+        public static float CliffProbeLookAheadMulOfHalfLength => GetCliffProbeLookAheadMulOfHalfLength();
+        private static float GetCliffProbeLookAheadMulOfHalfLength() => 0.00f;
+
+        /// <summary>
+        /// EN: Minimum look-ahead (meters) added beyond the box edge for wall/cliff probe.
+        /// RU: Минимальный look-ahead (метры) за край бокса для пробы “стены/обрыва”.
+        /// </summary>
+        public static float CliffProbeMinLookAheadMeters => GetCliffProbeMinLookAheadMeters();
+        private static float GetCliffProbeMinLookAheadMeters() => 0.25f;
 
         /// <summary>
         /// EN: Cliff slope threshold (Δh / dist).
         /// RU: Порог “крутизны” (Δh / dist).
         /// </summary>
-        public static float CliffSlopeFracThreshold = 0.57f;
+        public static float CliffSlopeFracThreshold => GetCliffSlopeFracThreshold();
+        private static float GetCliffSlopeFracThreshold() => 0.70f;
 
         /// <summary>
         /// EN: Cliff must be above water by this margin (meters).
         /// RU: “Обрыв” считается только если выше воды на этот запас (метры).
         /// </summary>
-        public static float CliffAboveWaterMargin = 0.20f;
+        public static float CliffAboveWaterMargin => GetCliffAboveWaterMargin();
+        private static float GetCliffAboveWaterMargin() => 0.30f;
 
         /// <summary>
         /// EN: Shore latch enter hysteresis (meters).
         /// RU: Гистерезис входа в latch (метры).
         /// </summary>
-        public static float ShoreEnterHyst = 0.35f;
+        public static float ShoreEnterHyst => GetShoreEnterHyst();
+        private static float GetShoreEnterHyst() => 0.5f;
 
         /// <summary>
         /// EN: Shore latch exit hysteresis (meters).
         /// RU: Гистерезис выхода из latch (метры).
         /// </summary>
-        public static float ShoreExitHyst = 0.10f;
+        public static float ShoreExitHyst => GetShoreExitHyst();
+        private static float GetShoreExitHyst() => 0.35f;
 
         /// <summary>
         /// EN: Floor height smoothing response (lambda).
         /// RU: Сглаживание высоты пола (lambda).
         /// </summary>
-        public static float FloorSmoothResponse = 10.0f;
+        public static float FloorSmoothResponse => GetFloorSmoothResponse();
+        private static float GetFloorSmoothResponse() => 16.0f;
 
         /// <summary>
         /// EN: Pre-shore damping band (meters).
         /// RU: Полоса “перед берегом” для демпфа (метры).
         /// </summary>
-        public static float PreShoreBand = 0.25f;
+        public static float PreShoreBand => GetPreShoreBand();
+        private static float GetPreShoreBand() => 0.5f;
 
         /// <summary>
         /// EN: Penetration epsilon (meters).
         /// RU: Эпсилон penetration (метры).
         /// </summary>
-        public static float PenetrationEpsilon = 0.02f;
+        public static float PenetrationEpsilon => GetPenetrationEpsilon();
+        private static float GetPenetrationEpsilon() => 0.04f;
 
         /// <summary>
         /// EN: Penetration response (lambda).
         /// RU: Скорость реакции на penetration (lambda).
         /// </summary>
-        public static float PenetrationResponse = 4.5f;
+        public static float PenetrationResponse => GetPenetrationResponse();
+        private static float GetPenetrationResponse() => 4.5f;
 
         /// <summary>
         /// EN: Max up-step early after latching (m/tick).
         /// RU: Макс. подъём на раннем этапе latch (м/тик).
         /// </summary>
-        public static float MaxUpStepEarly = 0.04f;
+        public static float MaxUpStepEarly => GetMaxUpStepEarly();
+        private static float GetMaxUpStepEarly() => 0.04f;
 
         /// <summary>
         /// EN: Max up-step later while latched (m/tick).
         /// RU: Макс. подъём после стабилизации latch (м/тик).
         /// </summary>
-        public static float MaxUpStepLate = 0.07f;
+        public static float MaxUpStepLate => GetMaxUpStepLate();
+        private static float GetMaxUpStepLate() => 0.07f;
 
         /// <summary>
         /// EN: Visual ground pitch max (degrees).
         /// RU: Макс. визуальный ground pitch (градусы).
         /// </summary>
-        public static float VisualGroundPitchMaxDeg = 8.0f;
+        public static float VisualGroundPitchMaxDeg => GetVisualGroundPitchMaxDeg();
+        private static float GetVisualGroundPitchMaxDeg() => 8.0f;
 
         /// <summary>
         /// EN: Visual ground pitch probe distance (meters).
         /// RU: Дистанция проб для визуального pitch (метры).
         /// </summary>
-        public static float VisualGroundPitchProbeDistance = 6.0f;
+        public static float VisualGroundPitchProbeDistance => GetVisualGroundPitchProbeDistance();
+        private static float GetVisualGroundPitchProbeDistance() => 6.0f;
 
         /// <summary>
         /// EN: Visual ground pitch response (lambda).
         /// RU: Скорость реакции визуального pitch (lambda).
         /// </summary>
-        public static float VisualGroundPitchResponse = 2.0f;
+        public static float VisualGroundPitchResponse => GetVisualGroundPitchResponse();
+        private static float GetVisualGroundPitchResponse() => 2.0f;
 
         /// <summary>
         /// EN: Visual pitch floor smoothing response (lambda).
         /// RU: Сглаживание высот для визуального pitch (lambda).
         /// </summary>
-        public static float VisualPitchFloorSmoothResponse = 8.0f;
+        public static float VisualPitchFloorSmoothResponse => GetVisualPitchFloorSmoothResponse();
+        private static float GetVisualPitchFloorSmoothResponse() => 8.0f;
     }
 
     /// <summary>
@@ -430,93 +527,129 @@ public static class ShipTuningDebug
     public static class ShipControllerTuning
     {
         /// <summary>
+        /// EN: Max allowed speed (abs) while grounded AND using the correct "escape" throttle direction.
+        /// RU: Максимальная скорость (по модулю) на мели при правильном газе "на выезд".
+        /// </summary>
+        public static float GroundEscapeMaxSpeedAbs => GetGroundEscapeMaxSpeedAbs();
+        private static float GetGroundEscapeMaxSpeedAbs() => 1.5f;
+
+        /// <summary>
+        /// EN: On shoal ground, max reverse speed as percent of max reverse on water (same ship/wind basis). 100 = same as water cap.
+        /// RU: На мели: макс. задняя скорость в процентах от макс. задней на воде (та же база корабля/ветра). 100 = как на воде.
+        /// </summary>
+        public static float GroundReverseSpeedCapPercentOfWater => GetGroundReverseSpeedCapPercentOfWater();
+        private static float GetGroundReverseSpeedCapPercentOfWater() => 100f;
+
+        /// <summary>
+        /// EN: Treat very shallow water as "grounded" for speed caps (escape/reverse limit), based on (waterSurface - floor) depth.
+        /// RU: Считать очень мелкую воду "мелью" для скоростных капов (escape/лимит заднего), по глубине (уровень воды - дно).
+        /// </summary>
+        public static float ShallowWaterDepthForGroundSpeedCaps => GetShallowWaterDepthForGroundSpeedCaps();
+        private static float GetShallowWaterDepthForGroundSpeedCaps() => 0.35f;
+
+        /// <summary>
         /// EN: Extra acceleration multiplier when throttle opposes current motion.
         /// RU: Доп. множитель ускорения, когда газ против текущего движения.
         /// </summary>
-        public static float OpposingThrottleAccelMul = 1.75f;
+        public static float OpposingThrottleAccelMul => GetOpposingThrottleAccelMul();
+        private static float GetOpposingThrottleAccelMul() => 1f;
 
         /// <summary>
         /// EN: Extra braking factor for opposing throttle (multiplies reverse/brake behavior).
         /// RU: Доп. торможение при противоположном газе.
         /// </summary>
-        public static float OpposingThrottleBrakeTuneMul = 1.2f;
+        public static float OpposingThrottleBrakeTuneMul => GetOpposingThrottleBrakeTuneMul();
+        private static float GetOpposingThrottleBrakeTuneMul() => 1f;
 
         /// <summary>
         /// EN: Steering responsiveness multiplier.
         /// RU: Множитель отзывчивости руля.
         /// </summary>
-        public static float SteeringResponsivenessMul = 1.45f;
+        public static float SteeringResponsivenessMul => GetSteeringResponsivenessMul();
+        private static float GetSteeringResponsivenessMul() => 1.45f;
 
         /// <summary>
         /// EN: Counter-steer responsiveness multiplier.
         /// RU: Множитель отзывчивости контрруления.
         /// </summary>
-        public static float CounterSteerResponsivenessMul = 1.35f;
+        public static float CounterSteerResponsivenessMul => GetCounterSteerResponsivenessMul();
+        private static float GetCounterSteerResponsivenessMul() => 1.35f;
 
         /// <summary>
         /// EN: Minimum turning factor at zero speed.
         /// RU: Минимальный фактор поворота на нулевой скорости.
         /// </summary>
-        public static float MinTurnFactorAtZeroSpeed = 0.5f;
+        public static float MinTurnFactorAtZeroSpeed => GetMinTurnFactorAtZeroSpeed();
+        private static float GetMinTurnFactorAtZeroSpeed() => 0.5f;
 
         /// <summary>
         /// EN: Speed at which turning reaches 100% (ship speed units).
         /// RU: Скорость, при которой поворот достигает 100% (в игровых единицах скорости).
         /// </summary>
-        public static float TurnFullFactorAtSpeed = 2.5f;
+        public static float TurnFullFactorAtSpeed => GetTurnFullFactorAtSpeed();
+        private static float GetTurnFullFactorAtSpeed() => 2.5f;
 
         /// <summary>
         /// EN: Fraction of speed removed at max yaw rate.
         /// RU: Доля снижения скорости на максимальной скорости поворота.
         /// </summary>
-        public static float TurnSpeedSlowdownFrac = 0.1f;
+        public static float TurnSpeedSlowdownFrac => GetTurnSpeedSlowdownFrac();
+        private static float GetTurnSpeedSlowdownFrac() => 0.1f;
 
         /// <summary>
         /// EN: Response for TurnSpeedVelocityMul smoothing (lambda).
         /// RU: Скорость сглаживания TurnSpeedVelocityMul (lambda).
         /// </summary>
-        public static float TurnSpeedVelocityMulResponse = 5.5f;
+        public static float TurnSpeedVelocityMulResponse => GetTurnSpeedVelocityMulResponse();
+        private static float GetTurnSpeedVelocityMulResponse() => 5.5f;
 
         /// <summary>
         /// EN: Minimum submergence to start upright stabilization (meters).
         /// RU: Минимальное погружение для выравнивания корпуса (метры).
         /// </summary>
-        public static float UprightStabilizeMinSubmergedMeters = 0.04f;
+        public static float UprightStabilizeMinSubmergedMeters => GetUprightStabilizeMinSubmergedMeters();
+        private static float GetUprightStabilizeMinSubmergedMeters() => 0.04f;
 
         /// <summary>
         /// EN: Max upright correction angular speed (rad/s).
         /// RU: Макс. скорость выравнивания (рад/с).
         /// </summary>
-        public static float UprightStabilizeMaxRadPerSec = 2.25f;
+        public static float UprightStabilizeMaxRadPerSec => GetUprightStabilizeMaxRadPerSec();
+        private static float GetUprightStabilizeMaxRadPerSec() => 2.25f;
 
         /// <summary>
         /// EN: Dead-zone for upright correction (radians).
         /// RU: Мёртвая зона выравнивания (радианы).
         /// </summary>
-        public static float UprightStabilizeAngleDeadZoneRad = 0.004f;
+        public static float UprightStabilizeAngleDeadZoneRad => GetUprightStabilizeAngleDeadZoneRad();
+        private static float GetUprightStabilizeAngleDeadZoneRad() => 0.004f;
 
         /// <summary>
         /// EN: Wind cone half-angle (degrees).
         /// RU: Полуугол конуса ветра (градусы).
         /// </summary>
-        public static float WindConeHalfAngleDeg = 15f;
+        public static float WindConeHalfAngleDeg => GetWindConeHalfAngleDeg();
+        private static float GetWindConeHalfAngleDeg() => 15f;
 
         /// <summary>
         /// EN: Max speed multiplier with wind.
         /// RU: Макс. множитель скорости по ветру.
         /// </summary>
-        public static float WindWithMaxMul = 1.15f;
+        public static float WindWithMaxMul => GetWindWithMaxMul();
+        private static float GetWindWithMaxMul() => 1.15f;
 
         /// <summary>
         /// EN: Max speed multiplier against wind.
         /// RU: Макс. множитель скорости против ветра.
         /// </summary>
-        public static float WindAgainstMaxMul = 0.85f;
+        public static float WindAgainstMaxMul => GetWindAgainstMaxMul();
+        private static float GetWindAgainstMaxMul() => 0.85f;
     }
 
     private static readonly ConcurrentDictionary<uint, long> _lastDetailMsgAtMs = new();
     private static readonly ConcurrentDictionary<uint, long> _lastAxesMsgAtMs = new();
     private static readonly ConcurrentDictionary<uint, long> _lastShorePenMsgAtMs = new();
+    private static readonly ConcurrentDictionary<uint, long> _lastSpeedMsgAtMs = new();
 
     private static readonly ConcurrentDictionary<uint, MarkerSet> _shipCornerMarkers = new();
     private static readonly ConcurrentDictionary<uint, MarkerSet> _shipAxisLenMarkers = new();
@@ -565,7 +698,34 @@ public static class ShipTuningDebug
 
         UpdateShipCornerMarkers(ship);
         UpdateShipAxisMarkers(ship);
+        UpdateShipSpeedDebug(ship);
         UpdateShipContactLatch(ship);
+    }
+
+    private static void UpdateShipSpeedDebug(Slave ship)
+    {
+        if (!ShipSpeedChatEnabled)
+            return;
+
+        var driver = TryGetDriver(ship);
+        if (driver is null || !CanReceive(driver))
+            return;
+
+        var nowMs = Environment.TickCount64;
+        var throttle = Math.Max(250, ThrottleMsPerShip);
+        var last = _lastSpeedMsgAtMs.GetOrAdd(ship.Id, 0);
+        if (nowMs - last < throttle)
+            return;
+        _lastSpeedMsgAtMs[ship.Id] = nowMs;
+
+        var isGrounded = (ship.CachedFloorLevel > ship.CachedWaterSurface) || ship.GroundContactLatched;
+        var escapeThrottleSign = ship.GroundedByStern ? 1 : -1;
+        var isEscapeInputOnGround = isGrounded && ship.ThrottleRequest != 0 && Math.Sign(ship.ThrottleRequest) == escapeThrottleSign;
+
+        var cap = ShipControllerTuning.GroundEscapeMaxSpeedAbs;
+
+        driver.SendDebugMessage(
+            $"[ShipSpeed] ship={ship.ObjId} v={ship.Speed:F2} grounded={isGrounded} latched={ship.GroundContactLatched} byStern={ship.GroundedByStern} thrReq={ship.ThrottleRequest} escape={isEscapeInputOnGround} escapeCap={cap:F2}");
     }
 
     private static void UpdateShipAxisMarkers(Slave ship)
@@ -714,7 +874,7 @@ public static class ShipTuningDebug
 
         // One short line to the driver's chat (sizes + centers).
         var driver = TryGetDriver(ship);
-        if (driver is null || !CanReceive(driver))
+        if (driver is null || !CanReceive(driver) || !ShipBoxChatEnabled)
             return;
 
         var nowMs = Environment.TickCount64;
@@ -989,6 +1149,7 @@ public static class ShipTuningDebug
         _lastDetailMsgAtMs.TryRemove(shipId, out _);
         _lastAxesMsgAtMs.TryRemove(shipId, out _);
         _lastShorePenMsgAtMs.TryRemove(shipId, out _);
+        _lastSpeedMsgAtMs.TryRemove(shipId, out _);
     }
 
     private static void DespawnMarkers(ConcurrentDictionary<uint, MarkerSet> dict, uint shipId)

--- a/AAEmu.Game/Physics/Debug/ShipTuningDebug.cs
+++ b/AAEmu.Game/Physics/Debug/ShipTuningDebug.cs
@@ -4,6 +4,7 @@ using System.Collections.Concurrent;
 using System.Numerics;
 
 using AAEmu.Game.Physics;
+using AAEmu.Game.Utils;
 
 using AAEmu.Game.Core.Managers.UnitManagers;
 using AAEmu.Game.Core.Packets.G2C;
@@ -219,12 +220,12 @@ public static class ShipTuningDebug
         var hy = ShipController.ShipMassBoxDefaults.GetSizeZ(model.MassBoxSizeZ) * scale * 0.5f;
         var hz = model.MassBoxSizeY * scale * 0.5f;
         var rotGame = GetTransformRotationMatrix(ship.Transform.Local.Rotation);
-        var posGame0 = PhysToGame(rb.Position);
+        var posGame0 = rb.Position.ToVector();
         var offsetLocalPhys = new JVector(
             model.MassCenterX * scale,
             ShipController.ShipMassBoxDefaults.GetCenterZ(model.MassCenterZ, model.MassBoxSizeZ) * scale,
             model.MassCenterY * scale);
-        var offsetLocalGame = PhysVecToGame(offsetLocalPhys);
+        var offsetLocalGame = offsetLocalPhys.ToVector();
         var centerGame = posGame0 + Vector3.TransformNormal(offsetLocalGame, rotGame);
         geo = new MassBoxGameGeometry(hx, hy, hz, centerGame, rotGame);
         return true;
@@ -232,14 +233,14 @@ public static class ShipTuningDebug
 
     private static void FillMassBoxLocalCornersGame(float hx, float hy, float hz, Span<Vector3> corners)
     {
-        corners[0] = PhysVecToGame(new JVector(+hx, +hy, +hz));
-        corners[1] = PhysVecToGame(new JVector(+hx, +hy, -hz));
-        corners[2] = PhysVecToGame(new JVector(+hx, -hy, +hz));
-        corners[3] = PhysVecToGame(new JVector(+hx, -hy, -hz));
-        corners[4] = PhysVecToGame(new JVector(-hx, +hy, +hz));
-        corners[5] = PhysVecToGame(new JVector(-hx, +hy, -hz));
-        corners[6] = PhysVecToGame(new JVector(-hx, -hy, +hz));
-        corners[7] = PhysVecToGame(new JVector(-hx, -hy, -hz));
+        corners[0] = new JVector(+hx, +hy, +hz).ToVector();
+        corners[1] = new JVector(+hx, +hy, -hz).ToVector();
+        corners[2] = new JVector(+hx, -hy, +hz).ToVector();
+        corners[3] = new JVector(+hx, -hy, -hz).ToVector();
+        corners[4] = new JVector(-hx, +hy, +hz).ToVector();
+        corners[5] = new JVector(-hx, +hy, -hz).ToVector();
+        corners[6] = new JVector(-hx, -hy, +hz).ToVector();
+        corners[7] = new JVector(-hx, -hy, -hz).ToVector();
     }
 
     private static void GetMassBoxWorldVerticalExtent(in MassBoxGameGeometry g, Span<Vector3> cornerScratch, out float minZ, out float maxZ)
@@ -397,9 +398,9 @@ public static class ShipTuningDebug
         var hyE = geo.Hy + extra;
 
         // +Length / +Beam / +Up: local +Z / +X / +Y of physics box (see ShipController.Build).
-        var posLen = geo.CenterGame + Vector3.TransformNormal(PhysVecToGame(new JVector(0f, 0f, hzE)), geo.RotGame);
-        var posBeam = geo.CenterGame + Vector3.TransformNormal(PhysVecToGame(new JVector(hxE, 0f, 0f)), geo.RotGame);
-        var posUp = geo.CenterGame + Vector3.TransformNormal(PhysVecToGame(new JVector(0f, hyE, 0f)), geo.RotGame);
+        var posLen = geo.CenterGame + Vector3.TransformNormal(new JVector(0f, 0f, hzE).ToVector(), geo.RotGame);
+        var posBeam = geo.CenterGame + Vector3.TransformNormal(new JVector(hxE, 0f, 0f).ToVector(), geo.RotGame);
+        var posUp = geo.CenterGame + Vector3.TransformNormal(new JVector(0f, hyE, 0f).ToVector(), geo.RotGame);
 
         Span<Vector3> cornerScratch = stackalloc Vector3[MassBoxCornerCount];
         GetMassBoxWorldVerticalExtent(in geo, cornerScratch, out var minZ, out var maxZ);
@@ -686,18 +687,6 @@ public static class ShipTuningDebug
     private static bool CanReceive(Character c)
     {
         return CharacterManager.Instance.GetEffectiveAccessLevel(c) >= MinAccessLevel;
-    }
-
-    private static Vector3 PhysToGame(JVector phys)
-    {
-        // Game coords: (X,Y,Z) == (phys X, phys Z, phys Y)
-        return new Vector3(phys.X, phys.Z, phys.Y);
-    }
-
-    private static Vector3 PhysVecToGame(JVector v)
-    {
-        // Same axis mapping as PhysToGame but for a vector (no translation).
-        return new Vector3(v.X, v.Z, v.Y);
     }
 
     private static Matrix4x4 GetTransformRotationMatrix(Vector3 rpy)

--- a/AAEmu.Game/Physics/Debug/ShipTuningDebug.cs
+++ b/AAEmu.Game/Physics/Debug/ShipTuningDebug.cs
@@ -3,6 +3,8 @@
 using System.Collections.Concurrent;
 using System.Numerics;
 
+using AAEmu.Game.Physics;
+
 using AAEmu.Game.Core.Managers.UnitManagers;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Char;
@@ -19,15 +21,17 @@ namespace AAEmu.Game.Physics.Debug;
 /// <summary>
 /// EN: Dev-only ship physics tuning & debug: ship↔ship, ship↔shore, plus ShipController tuning.
 /// RU: Dev-only тюнинг и дебаг корабельной физики: ship↔ship, ship↔shore, а также тюнинг ShipController.
+/// EN: Gimmick markers use template ids from table <c>gimmicks</c> — see <see cref="CornerMarkerTemplateId"/>, <see cref="ShoreMarkerTemplateId"/>, axis ids; set id to <c>0</c> or use flags (<see cref="Enabled"/>, <see cref="AxisMarkersEnabled"/>) to hide.
+/// RU: Маркеры-гиммики — template id из таблицы <c>gimmicks</c> (см. углы, берег, оси); выключить — id <c>0</c> или флаги (<see cref="Enabled"/>, <see cref="AxisMarkersEnabled"/>).
 /// </summary>
 public static class ShipTuningDebug
 {
     /// <summary>
-    /// EN: Master switch (use Hot Reload; no GM commands).
-    /// RU: Главный переключатель (через Hot Reload; без GM команд).
+    /// EN: Master switch (use Hot Reload; no GM commands). When false: all ship debug gimmicks despawn and runtime tuning overrides fall back to defaults in interaction classes — not only visuals.
+    /// RU: Главный переключатель (Hot Reload; без GM). Если false — снимаются все дебаг-маркеры кораблей и runtime-тюнинг из этого класса не применяется (подставляются дефолты в классах взаимодействий), не только картинка.
     /// </summary>
     public static bool Enabled => GetEnabled();
-    private static bool GetEnabled() => true;
+    private static bool GetEnabled() => false;
 
     /// <summary>
     /// EN: Minimum effective access level to receive chat debug messages.
@@ -55,42 +59,42 @@ public static class ShipTuningDebug
     /// RU: Включить/выключить строку `[ShipSpeed]` в чате (диагностика скорости/мели).
     /// </summary>
     public static bool ShipSpeedChatEnabled => GetShipSpeedChatEnabled();
-    private static bool GetShipSpeedChatEnabled() => true;
+    private static bool GetShipSpeedChatEnabled() => false;
 
     /// <summary>
-    /// EN: Corner markers template id (table <c>gimmicks</c>). Hot Reload: edit this return value.
-    /// RU: TemplateId маркеров углов (таблица <c>gimmicks</c>). Hot Reload: меняй return в этом методе.
+    /// EN: Eight corner markers on the mass-box (table <c>gimmicks</c>). Default id <c>65</c> (toy.flare). To disable only corners: return <c>0</c> (or turn off all visuals via <see cref="Enabled"/>).
+    /// RU: Восемь маркеров углов mass-box (таблица <c>gimmicks</c>). По умолчанию id <c>65</c> (toy.flare). Выключить только углы: <c>return 0</c> (или все маркеры — <see cref="Enabled"/>).
     /// </summary>
     public static uint CornerMarkerTemplateId => GetCornerMarkerTemplateId();
-    private static uint GetCornerMarkerTemplateId() => 65; // toy.flare
+    private static uint GetCornerMarkerTemplateId() => 0; // toy.flare
 
     /// <summary>
-    /// EN: Shore markers template id (table <c>gimmicks</c>). Hot Reload: edit this return value.
-    /// RU: TemplateId маркеров берега (таблица <c>gimmicks</c>). Hot Reload: меняй return в этом методе.
+    /// EN: Shore probe/contact markers (table <c>gimmicks</c>). Default id <c>28</c>. To disable only shore gimmicks: return <c>0</c>. Ship physics uses <see cref="ShipShoreInteraction.ShorePhysicsDefaults"/> when <see cref="Enabled"/> is false.
+    /// RU: Маркеры берега/проб (таблица <c>gimmicks</c>). По умолчанию id <c>28</c>. Выключить только маркеры берега: <c>return 0</c>. Физика берега — дефолты в <see cref="ShipShoreInteraction.ShorePhysicsDefaults"/>, если <see cref="Enabled"/> false.
     /// </summary>
     public static uint ShoreMarkerTemplateId => GetShoreMarkerTemplateId();
-    private static uint GetShoreMarkerTemplateId() => 28;
+    private static uint GetShoreMarkerTemplateId() => 0;
 
     /// <summary>
-    /// EN: Axis marker template id for +Length (local +Z of the physics box).
-    /// RU: TemplateId осевого маркера для +Length (локальная +Z физического бокса).
+    /// EN: Axis marker for +Length (local +Z of the physics box). Default id <c>16</c> (firecracker_green). To disable all axis markers at once: <see cref="AxisMarkersEnabled"/> = false; per-axis: return <c>0</c> here.
+    /// RU: Маркер оси +Length (локальная +Z бокса). По умолчанию id <c>16</c> (firecracker_green). Все оси сразу: <see cref="AxisMarkersEnabled"/> = false; только эта ось: <c>return 0</c>.
     /// </summary>
     public static uint AxisLengthMarkerTemplateId => GetAxisLengthMarkerTemplateId();
-    private static uint GetAxisLengthMarkerTemplateId() => 16; // firecracker_green
+    private static uint GetAxisLengthMarkerTemplateId() => 0; // firecracker_green
 
     /// <summary>
-    /// EN: Axis marker template id for +Beam (local +X of the physics box).
-    /// RU: TemplateId осевого маркера для +Beam (локальная +X физического бокса).
+    /// EN: Axis marker for +Beam (local +X). Default id <c>18</c> (firecracker_blue). Disable with <see cref="AxisMarkersEnabled"/> or return <c>0</c>.
+    /// RU: Маркер оси +Beam (локальная +X). По умолчанию id <c>18</c> (firecracker_blue). Выключение — <see cref="AxisMarkersEnabled"/> или <c>return 0</c>.
     /// </summary>
     public static uint AxisBeamMarkerTemplateId => GetAxisBeamMarkerTemplateId();
-    private static uint GetAxisBeamMarkerTemplateId() => 18; // firecracker_blue (assumed adjacent id)
+    private static uint GetAxisBeamMarkerTemplateId() => 0; // firecracker_blue (assumed adjacent id)
 
     /// <summary>
-    /// EN: Axis marker template id for +Up (local +Y of the physics box).
-    /// RU: TemplateId осевого маркера для +Up (локальная +Y физического бокса).
+    /// EN: Axis marker for +Up (local +Y). Default id <c>28</c> (same id as shore marker; change if you need a distinct look). Disable with <see cref="AxisMarkersEnabled"/> or return <c>0</c>.
+    /// RU: Маркер оси +Up (локальная +Y). По умолчанию id <c>28</c> (тот же id, что у берега; поменяй, если нужен другой вид). Выключение — <see cref="AxisMarkersEnabled"/> или <c>return 0</c>.
     /// </summary>
     public static uint AxisUpMarkerTemplateId => GetAxisUpMarkerTemplateId();
-    private static uint GetAxisUpMarkerTemplateId() => 28; // fallback: visible marker
+    private static uint GetAxisUpMarkerTemplateId() => 0; // fallback: visible marker
 
     /// <summary>
     /// EN: Marker scale.
@@ -107,18 +111,18 @@ public static class ShipTuningDebug
     private static bool GetDrawOnlyWhenDriven() => false;
 
     /// <summary>
-    /// EN: Enable ship↔shore debug (markers + latch messages + tuning override in ShipShoreInteraction).
-    /// RU: Включить ship↔shore дебаг (маркеры + сообщения latch + подмена тюнинга в ShipShoreInteraction).
+    /// EN: Reserved (not used for physics; shore behavior is gated by <see cref="Enabled"/> + <see cref="ShipShoreInteraction.ShorePhysicsDefaults"/>).
+    /// RU: Зарезервировано (физика берега завязана на <see cref="Enabled"/> и <see cref="ShipShoreInteraction.ShorePhysicsDefaults"/>).
     /// </summary>
     public static bool ShoreEnabled => GetShoreEnabled();
-    private static bool GetShoreEnabled() => true;
+    private static bool GetShoreEnabled() => false;
 
     /// <summary>
-    /// EN: Show two extra axis markers: +Length (local +Z of the physics box) and +Beam (local +X of the physics box).
-    /// RU: Показывать 2 дополнительных маркера осей: +Length (локальная +Z физ. бокса) и +Beam (локальная +X физ. бокса).
+    /// EN: Gimmicks for +Length, +Beam, +Up axis (three markers). When false, all three are despawned. Per-axis off: set that axis template id to 0.
+    /// RU: Гиммики для осей +Length, +Beam, +Up (три маркера). Если false — снимаются все три. Отдельную ось: template id этой оси = 0.
     /// </summary>
     public static bool AxisMarkersEnabled => GetAxisMarkersEnabled();
-    private static bool GetAxisMarkersEnabled() => true;
+    private static bool GetAxisMarkersEnabled() => false;
 
     /// <summary>
     /// EN: Extra distance (meters) beyond half-extent for axis markers.
@@ -138,28 +142,28 @@ public static class ShipTuningDebug
         /// RU: Аддитивный вертикальный сдвиг к MassCenterZ (метры). Положительное значение поднимает бокс вверх.
         /// </summary>
         public static float CenterZAddMeters => GetCenterZAddMeters();
-        private static float GetCenterZAddMeters() => 0f;
+        private static float GetCenterZAddMeters() => ShipController.ShipMassBoxDefaults.CenterZAddMeters;
 
         /// <summary>
         /// EN: Additive vertical offset to MassCenterZ as a fraction of MassBoxSizeZ. Example: 0.30 lifts the box by 30% of its height.
         /// RU: Аддитивный вертикальный сдвиг к MassCenterZ как доля MassBoxSizeZ. Например: 0.30 поднимает бокс на 30% его высоты.
         /// </summary>
         public static float CenterZAddFracOfSizeZ => GetCenterZAddFracOfSizeZ();
-        private static float GetCenterZAddFracOfSizeZ() => 0.0f;
+        private static float GetCenterZAddFracOfSizeZ() => ShipController.ShipMassBoxDefaults.CenterZAddFracOfSizeZ;
 
         /// <summary>
         /// EN: Multiply MassBoxSizeZ (height). 1 = no change.
         /// RU: Множитель MassBoxSizeZ (высота). 1 = без изменений.
         /// </summary>
         public static float SizeZMul => GetSizeZMul();
-        private static float GetSizeZMul() => 1f;
+        private static float GetSizeZMul() => ShipController.ShipMassBoxDefaults.SizeZMul;
 
         /// <summary>
         /// EN: Additive adjustment to MassBoxSizeZ (meters). Applied after SizeZMul.
         /// RU: Аддитивная поправка к MassBoxSizeZ (метры). Применяется после SizeZMul.
         /// </summary>
         public static float SizeZAddMeters => GetSizeZAddMeters();
-        private static float GetSizeZAddMeters() => 0f;
+        private static float GetSizeZAddMeters() => ShipController.ShipMassBoxDefaults.SizeZAddMeters;
 
         internal static float GetCenterZ(float baseCenterZ, float baseSizeZ) =>
             baseCenterZ + baseSizeZ * CenterZAddFracOfSizeZ + CenterZAddMeters;
@@ -182,161 +186,168 @@ public static class ShipTuningDebug
         /// RU: Множитель полу-длины только для SAT-детекта (держать близко к 1).
         /// </summary>
         public static float HullDetectInflateLength => GetHullDetectInflateLength();
-        private static float GetHullDetectInflateLength() => 1.025f;
+        private static float GetHullDetectInflateLength() => ShipShipInteraction.PhysicsDefaults.HullDetectInflateLength;
 
         /// <summary>
         /// EN: Half-beam multiplier for SAT overlap test only.
         /// RU: Множитель полу-ширины только для SAT-детекта.
         /// </summary>
         public static float HullDetectInflateBeam => GetHullDetectInflateBeam();
-        private static float GetHullDetectInflateBeam() => 1.015f;
+        private static float GetHullDetectInflateBeam() => ShipShipInteraction.PhysicsDefaults.HullDetectInflateBeam;
 
         /// <summary>
         /// EN: Extra tightening of beam in SAT only (reduces early side contact from oversized mass box).
         /// RU: Доп. ужатие ширины только в SAT (убирает ранний боковой контакт из-за широкого mass box).
         /// </summary>
         public static float BeamDetectTightenMul => GetBeamDetectTightenMul();
-        private static float GetBeamDetectTightenMul() => 0.78f;
+        private static float GetBeamDetectTightenMul() => ShipShipInteraction.PhysicsDefaults.BeamDetectTightenMul;
 
         /// <summary>
         /// EN: Ignore overlap response below this penetration depth (meters).
         /// RU: Игнорировать реакцию, если penetration меньше этого (метры).
         /// </summary>
         public static float MinPenetrationToAct => GetMinPenetrationToAct();
-        private static float GetMinPenetrationToAct() => 0.055f;
+        private static float GetMinPenetrationToAct() => ShipShipInteraction.PhysicsDefaults.MinPenetrationToAct;
 
         /// <summary>
         /// EN: Ignore periodic hull-damage below this penetration depth (meters).
         /// RU: Не наносить периодический урон корпусу, если penetration меньше этого (метры).
         /// </summary>
         public static float MinPenetrationToDamage => GetMinPenetrationToDamage();
-        private static float GetMinPenetrationToDamage() => MinPenetrationToAct * 1.15f;
+        private static float GetMinPenetrationToDamage() => ShipShipInteraction.PhysicsDefaults.MinPenetrationToDamage;
 
         /// <summary>
         /// EN: Ramp tangential slip damping over this depth range past MinPenetrationToAct (meters).
         /// RU: Наращивать демпф тангенциального скольжения на этом диапазоне глубины сверх MinPenetrationToAct (метры).
         /// </summary>
         public static float TangentialRampDepthMeters => GetTangentialRampDepthMeters();
-        private static float GetTangentialRampDepthMeters() => 0.22f;
+        private static float GetTangentialRampDepthMeters() => ShipShipInteraction.PhysicsDefaults.TangentialRampDepthMeters;
 
         /// <summary>
         /// EN: Multiplier on positional separation push once overlap exists.
         /// RU: Множитель раздвижения (push) после обнаружения overlap.
         /// </summary>
         public static float SeparationPushMultiplier => GetSeparationPushMultiplier();
-        private static float GetSeparationPushMultiplier() => 1.22f;
+        private static float GetSeparationPushMultiplier() => ShipShipInteraction.PhysicsDefaults.SeparationPushMultiplier;
 
         /// <summary>
         /// EN: Extra separation slack added to computed overlap (meters).
         /// RU: Доп. зазор к раздвижению сверх overlap (метры).
         /// </summary>
         public static float SeparationSlackMeters => GetSeparationSlackMeters();
-        private static float GetSeparationSlackMeters() => 0.020f;
+        private static float GetSeparationSlackMeters() => ShipShipInteraction.PhysicsDefaults.SeparationSlackMeters;
 
         /// <summary>
         /// EN: Fraction of relative closing speed along normal to remove (1 = full stop along normal).
         /// RU: Доля гашения относительной скорости вдоль нормали (1 = полностью убрать вдоль нормали).
         /// </summary>
         public static float ClosingSpeedDamp => GetClosingSpeedDamp();
-        private static float GetClosingSpeedDamp() => 1f;
+        private static float GetClosingSpeedDamp() => ShipShipInteraction.PhysicsDefaults.ClosingSpeedDamp;
 
         /// <summary>
         /// EN: Tangential slip damping factor while overlapping (0..1).
         /// RU: Коэффициент демпфа тангенциального скольжения при overlap (0..1).
         /// </summary>
         public static float TangentialSlipDamp => GetTangentialSlipDamp();
-        private static float GetTangentialSlipDamp() => 0.86f;
+        private static float GetTangentialSlipDamp() => ShipShipInteraction.PhysicsDefaults.TangentialSlipDamp;
 
         /// <summary>
         /// EN: Minimum vertical overlap (meters) to consider ships colliding.
         /// RU: Минимальный вертикальный overlap (метры) чтобы считать столкновение.
         /// </summary>
         public static float MinVerticalOverlap => GetMinVerticalOverlap();
-        private static float GetMinVerticalOverlap() => 0.12f;
+        private static float GetMinVerticalOverlap() => ShipShipInteraction.PhysicsDefaults.MinVerticalOverlap;
 
         /// <summary>
         /// EN: Outer resolve passes per tick (CPU vs stability).
         /// RU: Внешние проходы резолва за тик (CPU vs стабильность).
         /// </summary>
         public static int ResolvePasses => GetResolvePasses();
-        private static int GetResolvePasses() => 2;
+        private static int GetResolvePasses() => ShipShipInteraction.PhysicsDefaults.ResolvePasses;
 
         /// <summary>
         /// EN: Max depenetration iterations per pair per pass.
         /// RU: Макс. итераций раздвижения на пару за проход.
         /// </summary>
         public static int MaxPairIterations => GetMaxPairIterations();
-        private static int GetMaxPairIterations() => 12;
+        private static int GetMaxPairIterations() => ShipShipInteraction.PhysicsDefaults.MaxPairIterations;
 
         /// <summary>
         /// EN: Penetration depth where “deep penetration” push boost starts (meters).
         /// RU: Глубина penetration, с которой начинается усиление push (метры).
         /// </summary>
         public static float DeepPenetrationStart => GetDeepPenetrationStart();
-        private static float GetDeepPenetrationStart() => 0.12f;
+        private static float GetDeepPenetrationStart() => ShipShipInteraction.PhysicsDefaults.DeepPenetrationStart;
 
         /// <summary>
         /// EN: Boost factor applied as penetration exceeds DeepPenetrationStart.
         /// RU: Коэффициент усиления push при penetration больше DeepPenetrationStart.
         /// </summary>
         public static float DeepPenetrationBoost => GetDeepPenetrationBoost();
-        private static float GetDeepPenetrationBoost() => 0.72f;
+        private static float GetDeepPenetrationBoost() => ShipShipInteraction.PhysicsDefaults.DeepPenetrationBoost;
 
         /// <summary>
         /// EN: Floor on half-separation distance (meters).
         /// RU: Минимальная полу-дистанция раздвижения (метры).
         /// </summary>
         public static float MinHalfSeparationMeters => GetMinHalfSeparationMeters();
-        private static float GetMinHalfSeparationMeters() => 0.02f;
+        private static float GetMinHalfSeparationMeters() => ShipShipInteraction.PhysicsDefaults.MinHalfSeparationMeters;
 
         /// <summary>
         /// EN: Stop iterating if computed separation is below this (meters) to avoid micro-jitter.
         /// RU: Остановить итерации, если раздвижение меньше этого (метры), чтобы убрать микродрожь.
         /// </summary>
         public static float MinLinearSeparationToApplyMeters => GetMinLinearSeparationToApplyMeters();
-        private static float GetMinLinearSeparationToApplyMeters() => 0.018f;
+        private static float GetMinLinearSeparationToApplyMeters() => ShipShipInteraction.PhysicsDefaults.MinLinearSeparationToApplyMeters;
 
         /// <summary>
         /// EN: Cosine threshold for “nose cone” classification.
         /// RU: Порог косинуса для классификации “удар в нос”.
         /// </summary>
         public static float NoseContactCosThreshold => GetNoseContactCosThreshold();
-        private static float GetNoseContactCosThreshold() => 0.65f;
+        private static float GetNoseContactCosThreshold() => ShipShipInteraction.PhysicsDefaults.NoseContactCosThreshold;
 
         /// <summary>
         /// EN: Min interval between hull-collision damage ticks per other ship (seconds).
         /// RU: Минимальный интервал тиков урона от столкновения корпусом на конкретный другой корабль (сек).
         /// </summary>
         public static float HullCollisionDamageCooldownSec => GetHullCollisionDamageCooldownSec();
-        private static float GetHullCollisionDamageCooldownSec() => 1.5f;
+        private static float GetHullCollisionDamageCooldownSec() => ShipShipInteraction.PhysicsDefaults.HullCollisionDamageCooldownSec;
 
         /// <summary>
         /// EN: Relative speed threshold (m/s) where damage uses min % (non-nose).
         /// RU: Порог относительной скорости (м/с), ниже которого урон минимальный (не-носовые удары).
         /// </summary>
         public static float HullDamageLowSpeedThresholdMps => GetHullDamageLowSpeedThresholdMps();
-        private static float GetHullDamageLowSpeedThresholdMps() => 2f;
+        private static float GetHullDamageLowSpeedThresholdMps() => ShipShipInteraction.PhysicsDefaults.HullDamageLowSpeedThresholdMps;
 
         /// <summary>
         /// EN: Relative speed (m/s) where damage reaches max % (linear between thresholds).
         /// RU: Относительная скорость (м/с), при которой урон достигает максимума (линейно между порогами).
         /// </summary>
         public static float HullDamageInterpMaxMps => GetHullDamageInterpMaxMps();
-        private static float GetHullDamageInterpMaxMps() => 10f;
+        private static float GetHullDamageInterpMaxMps() => ShipShipInteraction.PhysicsDefaults.HullDamageSpeedInterpMaxMps;
 
         /// <summary>
         /// EN: Min % hull damage per tick.
         /// RU: Минимальный % урона корпуса за тик.
         /// </summary>
         public static int HullDamageSpeedScaledMinPercent => GetHullDamageSpeedScaledMinPercent();
-        private static int GetHullDamageSpeedScaledMinPercent() => 1;
+        private static int GetHullDamageSpeedScaledMinPercent() => ShipShipInteraction.PhysicsDefaults.HullDamageSpeedScaledMinPercent;
 
         /// <summary>
         /// EN: Max % hull damage per tick.
         /// RU: Максимальный % урона корпуса за тик.
         /// </summary>
         public static int HullDamageSpeedScaledMaxPercent => GetHullDamageSpeedScaledMaxPercent();
-        private static int GetHullDamageSpeedScaledMaxPercent() => 10;
+        private static int GetHullDamageSpeedScaledMaxPercent() => ShipShipInteraction.PhysicsDefaults.HullDamageSpeedScaledMaxPercent;
+
+        /// <summary>
+        /// EN: How strongly mass differences steer who gets pushed: 0 = 50/50, 1 = inverse-mass (physical), &gt;1 = exaggerate (lighter ship moves more; values clamped).
+        /// RU: Насколько масса влияет на раздвижение: 0 = поровну, 1 = обратно массе (как в физике), &gt;1 — усилить контраст (лёгкий сильнее отталкивается; края подрезаются).
+        /// </summary>
+        public static float MassPushStrength => GetMassPushStrength();
+        private static float GetMassPushStrength() => ShipShipInteraction.PhysicsDefaults.MassPushStrength;
     }
 
     /// <summary>
@@ -354,56 +365,56 @@ public static class ShipTuningDebug
         /// RU: Меньше ~0.4 — «дно» выше, меньше penetration и больше визуальный зазор; больше ~0.55 — риск глубокого вдавливания.
         /// </summary>
         public static float BoatBottomOffsetFracOfSizeZ => GetBoatBottomOffsetFracOfSizeZ();
-        private static float GetBoatBottomOffsetFracOfSizeZ() => 0f;
+        private static float GetBoatBottomOffsetFracOfSizeZ() => ShipShoreInteraction.ShorePhysicsDefaults.BoatBottomOffsetFracOfSizeZ;
 
         /// <summary>
         /// EN: Ground friction multiplier on dry ground.
         /// RU: Трение на суше.
         /// </summary>
         public static float GroundFriction => GetGroundFriction();
-        private static float GetGroundFriction() => 0.1f;
+        private static float GetGroundFriction() => ShipShoreInteraction.ShorePhysicsDefaults.GroundFriction;
 
         /// <summary>
         /// EN: Velocity/angular damping on dry ground.
         /// RU: Демпф скорости/угловой скорости на суше.
         /// </summary>
         public static float DryGroundCollisionDamping => GetDryGroundCollisionDamping();
-        private static float GetDryGroundCollisionDamping() => 1f;
+        private static float GetDryGroundCollisionDamping() => ShipShoreInteraction.ShorePhysicsDefaults.DryGroundCollisionDamping;
 
         /// <summary>
         /// EN: Roll correction dead-zone (radians).
         /// RU: Мёртвая зона коррекции roll (радианы).
         /// </summary>
         public static float DryGroundRollDeadZoneRad => GetDryGroundRollDeadZoneRad();
-        private static float GetDryGroundRollDeadZoneRad() => 0.1f;
+        private static float GetDryGroundRollDeadZoneRad() => ShipShoreInteraction.ShorePhysicsDefaults.DryGroundRollDeadZoneRad;
 
         /// <summary>
         /// EN: Roll correction torque factor (tuning).
         /// RU: Коэффициент коррекции roll (тюнинг).
         /// </summary>
         public static float DryGroundRollTorqueMul => GetDryGroundRollTorqueMul();
-        private static float GetDryGroundRollTorqueMul() => 0.1f;
+        private static float GetDryGroundRollTorqueMul() => ShipShoreInteraction.ShorePhysicsDefaults.DryGroundRollTorqueMul;
 
         /// <summary>
         /// EN: Bow probe distance multiplier vs MassBoxSizeY (hull length).
         /// RU: Множитель дистанции носовой пробы от MassBoxSizeY (длина корпуса).
         /// </summary>
         public static float BowProbeMul => GetBowProbeMul();
-        private static float GetBowProbeMul() => 1.5f;
+        private static float GetBowProbeMul() => ShipShoreInteraction.ShorePhysicsDefaults.BowProbeMul;
 
         /// <summary>
         /// EN: Stern probe distance multiplier vs MassBoxSizeY (hull length).
         /// RU: Множитель дистанции кормовой пробы от MassBoxSizeY (длина корпуса).
         /// </summary>
         public static float SternProbeMul => GetSternProbeMul();
-        private static float GetSternProbeMul() => 1.5f;
+        private static float GetSternProbeMul() => ShipShoreInteraction.ShorePhysicsDefaults.SternProbeMul;
 
         /// <summary>
         /// EN: Cliff probe distance multiplier vs MassBoxSizeY (hull length).
         /// RU: Множитель дистанции пробы “обрыва/стены” от MassBoxSizeY (длина корпуса).
         /// </summary>
         public static float CliffProbeMul => GetCliffProbeMul();
-        private static float GetCliffProbeMul() => 0f;
+        private static float GetCliffProbeMul() => ShipShoreInteraction.ShorePhysicsDefaults.CliffProbeMul;
 
         /// <summary>
         /// EN: Wall/cliff look-ahead distance as a fraction of half-length (added beyond the box edge).
@@ -412,112 +423,112 @@ public static class ShipTuningDebug
         /// RU: 0 = проба ровно на кромке бокса нос/корма; 0.2 = +20% half-length дальше.
         /// </summary>
         public static float CliffProbeLookAheadMulOfHalfLength => GetCliffProbeLookAheadMulOfHalfLength();
-        private static float GetCliffProbeLookAheadMulOfHalfLength() => 0.00f;
+        private static float GetCliffProbeLookAheadMulOfHalfLength() => ShipShoreInteraction.ShorePhysicsDefaults.CliffProbeLookAheadMulOfHalfLength;
 
         /// <summary>
         /// EN: Minimum look-ahead (meters) added beyond the box edge for wall/cliff probe.
         /// RU: Минимальный look-ahead (метры) за край бокса для пробы “стены/обрыва”.
         /// </summary>
         public static float CliffProbeMinLookAheadMeters => GetCliffProbeMinLookAheadMeters();
-        private static float GetCliffProbeMinLookAheadMeters() => 0.25f;
+        private static float GetCliffProbeMinLookAheadMeters() => ShipShoreInteraction.ShorePhysicsDefaults.CliffProbeMinLookAheadMeters;
 
         /// <summary>
         /// EN: Cliff slope threshold (Δh / dist).
         /// RU: Порог “крутизны” (Δh / dist).
         /// </summary>
         public static float CliffSlopeFracThreshold => GetCliffSlopeFracThreshold();
-        private static float GetCliffSlopeFracThreshold() => 0.70f;
+        private static float GetCliffSlopeFracThreshold() => ShipShoreInteraction.ShorePhysicsDefaults.CliffSlopeFracThreshold;
 
         /// <summary>
         /// EN: Cliff must be above water by this margin (meters).
         /// RU: “Обрыв” считается только если выше воды на этот запас (метры).
         /// </summary>
         public static float CliffAboveWaterMargin => GetCliffAboveWaterMargin();
-        private static float GetCliffAboveWaterMargin() => 0.30f;
+        private static float GetCliffAboveWaterMargin() => ShipShoreInteraction.ShorePhysicsDefaults.CliffAboveWaterMargin;
 
         /// <summary>
         /// EN: Shore latch enter hysteresis (meters).
         /// RU: Гистерезис входа в latch (метры).
         /// </summary>
         public static float ShoreEnterHyst => GetShoreEnterHyst();
-        private static float GetShoreEnterHyst() => 0.5f;
+        private static float GetShoreEnterHyst() => ShipShoreInteraction.ShorePhysicsDefaults.ShoreEnterHyst;
 
         /// <summary>
         /// EN: Shore latch exit hysteresis (meters).
         /// RU: Гистерезис выхода из latch (метры).
         /// </summary>
         public static float ShoreExitHyst => GetShoreExitHyst();
-        private static float GetShoreExitHyst() => 0.35f;
+        private static float GetShoreExitHyst() => ShipShoreInteraction.ShorePhysicsDefaults.ShoreExitHyst;
 
         /// <summary>
         /// EN: Floor height smoothing response (lambda).
         /// RU: Сглаживание высоты пола (lambda).
         /// </summary>
         public static float FloorSmoothResponse => GetFloorSmoothResponse();
-        private static float GetFloorSmoothResponse() => 16.0f;
+        private static float GetFloorSmoothResponse() => ShipShoreInteraction.ShorePhysicsDefaults.FloorSmoothResponse;
 
         /// <summary>
         /// EN: Pre-shore damping band (meters).
         /// RU: Полоса “перед берегом” для демпфа (метры).
         /// </summary>
         public static float PreShoreBand => GetPreShoreBand();
-        private static float GetPreShoreBand() => 0.5f;
+        private static float GetPreShoreBand() => ShipShoreInteraction.ShorePhysicsDefaults.PreShoreBand;
 
         /// <summary>
         /// EN: Penetration epsilon (meters).
         /// RU: Эпсилон penetration (метры).
         /// </summary>
         public static float PenetrationEpsilon => GetPenetrationEpsilon();
-        private static float GetPenetrationEpsilon() => 0.04f;
+        private static float GetPenetrationEpsilon() => ShipShoreInteraction.ShorePhysicsDefaults.PenetrationEpsilon;
 
         /// <summary>
         /// EN: Penetration response (lambda).
         /// RU: Скорость реакции на penetration (lambda).
         /// </summary>
         public static float PenetrationResponse => GetPenetrationResponse();
-        private static float GetPenetrationResponse() => 4.5f;
+        private static float GetPenetrationResponse() => ShipShoreInteraction.ShorePhysicsDefaults.PenetrationResponse;
 
         /// <summary>
         /// EN: Max up-step early after latching (m/tick).
         /// RU: Макс. подъём на раннем этапе latch (м/тик).
         /// </summary>
         public static float MaxUpStepEarly => GetMaxUpStepEarly();
-        private static float GetMaxUpStepEarly() => 0.04f;
+        private static float GetMaxUpStepEarly() => ShipShoreInteraction.ShorePhysicsDefaults.MaxUpStepEarly;
 
         /// <summary>
         /// EN: Max up-step later while latched (m/tick).
         /// RU: Макс. подъём после стабилизации latch (м/тик).
         /// </summary>
         public static float MaxUpStepLate => GetMaxUpStepLate();
-        private static float GetMaxUpStepLate() => 0.07f;
+        private static float GetMaxUpStepLate() => ShipShoreInteraction.ShorePhysicsDefaults.MaxUpStepLate;
 
         /// <summary>
         /// EN: Visual ground pitch max (degrees).
         /// RU: Макс. визуальный ground pitch (градусы).
         /// </summary>
         public static float VisualGroundPitchMaxDeg => GetVisualGroundPitchMaxDeg();
-        private static float GetVisualGroundPitchMaxDeg() => 8.0f;
+        private static float GetVisualGroundPitchMaxDeg() => ShipShoreInteraction.ShorePhysicsDefaults.VisualGroundPitchMaxDeg;
 
         /// <summary>
         /// EN: Visual ground pitch probe distance (meters).
         /// RU: Дистанция проб для визуального pitch (метры).
         /// </summary>
         public static float VisualGroundPitchProbeDistance => GetVisualGroundPitchProbeDistance();
-        private static float GetVisualGroundPitchProbeDistance() => 6.0f;
+        private static float GetVisualGroundPitchProbeDistance() => ShipShoreInteraction.ShorePhysicsDefaults.VisualGroundPitchProbeDistance;
 
         /// <summary>
         /// EN: Visual ground pitch response (lambda).
         /// RU: Скорость реакции визуального pitch (lambda).
         /// </summary>
         public static float VisualGroundPitchResponse => GetVisualGroundPitchResponse();
-        private static float GetVisualGroundPitchResponse() => 2.0f;
+        private static float GetVisualGroundPitchResponse() => ShipShoreInteraction.ShorePhysicsDefaults.VisualGroundPitchResponse;
 
         /// <summary>
         /// EN: Visual pitch floor smoothing response (lambda).
         /// RU: Сглаживание высот для визуального pitch (lambda).
         /// </summary>
         public static float VisualPitchFloorSmoothResponse => GetVisualPitchFloorSmoothResponse();
-        private static float GetVisualPitchFloorSmoothResponse() => 8.0f;
+        private static float GetVisualPitchFloorSmoothResponse() => ShipShoreInteraction.ShorePhysicsDefaults.VisualPitchFloorSmoothResponse;
     }
 
     /// <summary>
@@ -531,119 +542,119 @@ public static class ShipTuningDebug
         /// RU: Максимальная скорость (по модулю) на мели при правильном газе "на выезд".
         /// </summary>
         public static float GroundEscapeMaxSpeedAbs => GetGroundEscapeMaxSpeedAbs();
-        private static float GetGroundEscapeMaxSpeedAbs() => 1.5f;
+        private static float GetGroundEscapeMaxSpeedAbs() => ShipController.PhysicsDefaults.GroundEscapeMaxSpeedAbs;
 
         /// <summary>
         /// EN: On shoal ground, max reverse speed as percent of max reverse on water (same ship/wind basis). 100 = same as water cap.
         /// RU: На мели: макс. задняя скорость в процентах от макс. задней на воде (та же база корабля/ветра). 100 = как на воде.
         /// </summary>
         public static float GroundReverseSpeedCapPercentOfWater => GetGroundReverseSpeedCapPercentOfWater();
-        private static float GetGroundReverseSpeedCapPercentOfWater() => 100f;
+        private static float GetGroundReverseSpeedCapPercentOfWater() => ShipController.PhysicsDefaults.GroundReverseSpeedCapPercentOfWater;
 
         /// <summary>
         /// EN: Treat very shallow water as "grounded" for speed caps (escape/reverse limit), based on (waterSurface - floor) depth.
         /// RU: Считать очень мелкую воду "мелью" для скоростных капов (escape/лимит заднего), по глубине (уровень воды - дно).
         /// </summary>
         public static float ShallowWaterDepthForGroundSpeedCaps => GetShallowWaterDepthForGroundSpeedCaps();
-        private static float GetShallowWaterDepthForGroundSpeedCaps() => 0.35f;
+        private static float GetShallowWaterDepthForGroundSpeedCaps() => ShipController.PhysicsDefaults.ShallowWaterDepthForGroundSpeedCaps;
 
         /// <summary>
         /// EN: Extra acceleration multiplier when throttle opposes current motion.
         /// RU: Доп. множитель ускорения, когда газ против текущего движения.
         /// </summary>
         public static float OpposingThrottleAccelMul => GetOpposingThrottleAccelMul();
-        private static float GetOpposingThrottleAccelMul() => 1f;
+        private static float GetOpposingThrottleAccelMul() => ShipController.PhysicsDefaults.OpposingThrottleAccelMul;
 
         /// <summary>
         /// EN: Extra braking factor for opposing throttle (multiplies reverse/brake behavior).
         /// RU: Доп. торможение при противоположном газе.
         /// </summary>
         public static float OpposingThrottleBrakeTuneMul => GetOpposingThrottleBrakeTuneMul();
-        private static float GetOpposingThrottleBrakeTuneMul() => 1f;
+        private static float GetOpposingThrottleBrakeTuneMul() => ShipController.PhysicsDefaults.OpposingThrottleBrakeTuneMul;
 
         /// <summary>
         /// EN: Steering responsiveness multiplier.
         /// RU: Множитель отзывчивости руля.
         /// </summary>
         public static float SteeringResponsivenessMul => GetSteeringResponsivenessMul();
-        private static float GetSteeringResponsivenessMul() => 1.45f;
+        private static float GetSteeringResponsivenessMul() => ShipController.PhysicsDefaults.SteeringResponsivenessMul;
 
         /// <summary>
         /// EN: Counter-steer responsiveness multiplier.
         /// RU: Множитель отзывчивости контрруления.
         /// </summary>
         public static float CounterSteerResponsivenessMul => GetCounterSteerResponsivenessMul();
-        private static float GetCounterSteerResponsivenessMul() => 1.35f;
+        private static float GetCounterSteerResponsivenessMul() => ShipController.PhysicsDefaults.CounterSteerResponsivenessMul;
 
         /// <summary>
         /// EN: Minimum turning factor at zero speed.
         /// RU: Минимальный фактор поворота на нулевой скорости.
         /// </summary>
         public static float MinTurnFactorAtZeroSpeed => GetMinTurnFactorAtZeroSpeed();
-        private static float GetMinTurnFactorAtZeroSpeed() => 0.5f;
+        private static float GetMinTurnFactorAtZeroSpeed() => ShipController.PhysicsDefaults.MinTurnFactorAtZeroSpeed;
 
         /// <summary>
         /// EN: Speed at which turning reaches 100% (ship speed units).
         /// RU: Скорость, при которой поворот достигает 100% (в игровых единицах скорости).
         /// </summary>
         public static float TurnFullFactorAtSpeed => GetTurnFullFactorAtSpeed();
-        private static float GetTurnFullFactorAtSpeed() => 2.5f;
+        private static float GetTurnFullFactorAtSpeed() => ShipController.PhysicsDefaults.TurnFullFactorAtSpeed;
 
         /// <summary>
         /// EN: Fraction of speed removed at max yaw rate.
         /// RU: Доля снижения скорости на максимальной скорости поворота.
         /// </summary>
         public static float TurnSpeedSlowdownFrac => GetTurnSpeedSlowdownFrac();
-        private static float GetTurnSpeedSlowdownFrac() => 0.1f;
+        private static float GetTurnSpeedSlowdownFrac() => ShipController.PhysicsDefaults.TurnSpeedSlowdownFrac;
 
         /// <summary>
         /// EN: Response for TurnSpeedVelocityMul smoothing (lambda).
         /// RU: Скорость сглаживания TurnSpeedVelocityMul (lambda).
         /// </summary>
         public static float TurnSpeedVelocityMulResponse => GetTurnSpeedVelocityMulResponse();
-        private static float GetTurnSpeedVelocityMulResponse() => 5.5f;
+        private static float GetTurnSpeedVelocityMulResponse() => ShipController.PhysicsDefaults.TurnSpeedVelocityMulResponse;
 
         /// <summary>
         /// EN: Minimum submergence to start upright stabilization (meters).
         /// RU: Минимальное погружение для выравнивания корпуса (метры).
         /// </summary>
         public static float UprightStabilizeMinSubmergedMeters => GetUprightStabilizeMinSubmergedMeters();
-        private static float GetUprightStabilizeMinSubmergedMeters() => 0.04f;
+        private static float GetUprightStabilizeMinSubmergedMeters() => ShipController.PhysicsDefaults.UprightStabilizeMinSubmergedMeters;
 
         /// <summary>
         /// EN: Max upright correction angular speed (rad/s).
         /// RU: Макс. скорость выравнивания (рад/с).
         /// </summary>
         public static float UprightStabilizeMaxRadPerSec => GetUprightStabilizeMaxRadPerSec();
-        private static float GetUprightStabilizeMaxRadPerSec() => 2.25f;
+        private static float GetUprightStabilizeMaxRadPerSec() => ShipController.PhysicsDefaults.UprightStabilizeMaxRadPerSec;
 
         /// <summary>
         /// EN: Dead-zone for upright correction (radians).
         /// RU: Мёртвая зона выравнивания (радианы).
         /// </summary>
         public static float UprightStabilizeAngleDeadZoneRad => GetUprightStabilizeAngleDeadZoneRad();
-        private static float GetUprightStabilizeAngleDeadZoneRad() => 0.004f;
+        private static float GetUprightStabilizeAngleDeadZoneRad() => ShipController.PhysicsDefaults.UprightStabilizeAngleDeadZoneRad;
 
         /// <summary>
         /// EN: Wind cone half-angle (degrees).
         /// RU: Полуугол конуса ветра (градусы).
         /// </summary>
         public static float WindConeHalfAngleDeg => GetWindConeHalfAngleDeg();
-        private static float GetWindConeHalfAngleDeg() => 15f;
+        private static float GetWindConeHalfAngleDeg() => ShipController.PhysicsDefaults.WindConeHalfAngleDeg;
 
         /// <summary>
         /// EN: Max speed multiplier with wind.
         /// RU: Макс. множитель скорости по ветру.
         /// </summary>
         public static float WindWithMaxMul => GetWindWithMaxMul();
-        private static float GetWindWithMaxMul() => 1.15f;
+        private static float GetWindWithMaxMul() => ShipController.PhysicsDefaults.WindWithMaxMul;
 
         /// <summary>
         /// EN: Max speed multiplier against wind.
         /// RU: Макс. множитель скорости против ветра.
         /// </summary>
         public static float WindAgainstMaxMul => GetWindAgainstMaxMul();
-        private static float GetWindAgainstMaxMul() => 0.85f;
+        private static float GetWindAgainstMaxMul() => ShipController.PhysicsDefaults.WindAgainstMaxMul;
     }
 
     private static readonly ConcurrentDictionary<uint, long> _lastDetailMsgAtMs = new();
@@ -1026,7 +1037,7 @@ public static class ShipTuningDebug
     /// </summary>
     public static void OnShoreLatchChanged(Slave ship, bool latched)
     {
-        if (!Enabled || !ShoreEnabled)
+        if (!Enabled)
             return;
 
         var driver = TryGetDriver(ship);
@@ -1053,7 +1064,7 @@ public static class ShipTuningDebug
         if (ship is null)
             return;
 
-        if (!Enabled || !ShoreEnabled)
+        if (!Enabled)
             return;
 
         var templateId = ShoreMarkerTemplateId;

--- a/AAEmu.Game/Physics/Debug/ShipTuningDebug.cs
+++ b/AAEmu.Game/Physics/Debug/ShipTuningDebug.cs
@@ -181,6 +181,65 @@ public static class ShipTuningDebug
         }
     }
 
+    /// <summary>Half-extents (phys local X,Y,Z), box center and rotation in game space — same basis as <see cref="ShipController.Build"/>.</summary>
+    private readonly record struct MassBoxGameGeometry(float Hx, float Hy, float Hz, Vector3 CenterGame, Matrix4x4 RotGame);
+
+    private static bool TryGetMassBoxGameGeometry(Slave ship, out MassBoxGameGeometry geo)
+    {
+        geo = default;
+        var rb = ship.RigidBody;
+        var model = ship.ShipController?.ShipModel;
+        if (rb is null || model is null || ship.Transform is null)
+            return false;
+
+        var scale = MathF.Max(0.01f, ship.Scale);
+        var hx = model.MassBoxSizeX * scale * 0.5f;
+        var hy = ShipController.ShipMassBoxDefaults.GetSizeZ(model.MassBoxSizeZ) * scale * 0.5f;
+        var hz = model.MassBoxSizeY * scale * 0.5f;
+        var rotGame = GetTransformRotationMatrix(ship.Transform.Local.Rotation);
+        var posGame0 = PhysToGame(rb.Position);
+        var offsetLocalPhys = new JVector(
+            model.MassCenterX * scale,
+            ShipController.ShipMassBoxDefaults.GetCenterZ(model.MassCenterZ, model.MassBoxSizeZ) * scale,
+            model.MassCenterY * scale);
+        var offsetLocalGame = PhysVecToGame(offsetLocalPhys);
+        var centerGame = posGame0 + Vector3.TransformNormal(offsetLocalGame, rotGame);
+        geo = new MassBoxGameGeometry(hx, hy, hz, centerGame, rotGame);
+        return true;
+    }
+
+    private static void FillMassBoxLocalCornersGame(float hx, float hy, float hz, Span<Vector3> corners)
+    {
+        corners[0] = PhysVecToGame(new JVector(+hx, +hy, +hz));
+        corners[1] = PhysVecToGame(new JVector(+hx, +hy, -hz));
+        corners[2] = PhysVecToGame(new JVector(+hx, -hy, +hz));
+        corners[3] = PhysVecToGame(new JVector(+hx, -hy, -hz));
+        corners[4] = PhysVecToGame(new JVector(-hx, +hy, +hz));
+        corners[5] = PhysVecToGame(new JVector(-hx, +hy, -hz));
+        corners[6] = PhysVecToGame(new JVector(-hx, -hy, +hz));
+        corners[7] = PhysVecToGame(new JVector(-hx, -hy, -hz));
+    }
+
+    private static void GetMassBoxWorldVerticalExtent(in MassBoxGameGeometry g, Span<Vector3> cornerScratch, out float minZ, out float maxZ)
+    {
+        FillMassBoxLocalCornersGame(g.Hx, g.Hy, g.Hz, cornerScratch);
+        minZ = float.PositiveInfinity;
+        maxZ = float.NegativeInfinity;
+        for (var i = 0; i < 8; i++)
+        {
+            var w = g.CenterGame + Vector3.TransformNormal(cornerScratch[i], g.RotGame);
+            if (w.Z < minZ) minZ = w.Z;
+            if (w.Z > maxZ) maxZ = w.Z;
+        }
+    }
+
+    private static void DespawnAllAxisMarkerSets(uint shipId)
+    {
+        DespawnMarkers(_shipAxisLenMarkers, shipId);
+        DespawnMarkers(_shipAxisBeamMarkers, shipId);
+        DespawnMarkers(_shipAxisUpMarkers, shipId);
+    }
+
     /// <summary>
     /// EN: Per-ship debug tick. Updates corner markers and ship↔ship latch messages.
     /// RU: Дебаг-тик на корабль. Обновляет углы бокса и latch-сообщения ship↔ship.
@@ -238,9 +297,7 @@ public static class ShipTuningDebug
     {
         if (!AxisMarkersEnabled)
         {
-            DespawnMarkers(_shipAxisLenMarkers, ship.Id);
-            DespawnMarkers(_shipAxisBeamMarkers, ship.Id);
-            DespawnMarkers(_shipAxisUpMarkers, ship.Id);
+            DespawnAllAxisMarkerSets(ship.Id);
             return;
         }
 
@@ -249,19 +306,14 @@ public static class ShipTuningDebug
         var upTemplateId = AxisUpMarkerTemplateId;
         if ((lenTemplateId == 0 && beamTemplateId == 0 && upTemplateId == 0) || ship.ParentWorld is null)
         {
-            DespawnMarkers(_shipAxisLenMarkers, ship.Id);
-            DespawnMarkers(_shipAxisBeamMarkers, ship.Id);
-            DespawnMarkers(_shipAxisUpMarkers, ship.Id);
+            DespawnAllAxisMarkerSets(ship.Id);
             return;
         }
 
-        var rb = ship.RigidBody;
         var model = ship.ShipController?.ShipModel;
-        if (rb is null || model is null)
+        if (model is null || !TryGetMassBoxGameGeometry(ship, out var geo))
         {
-            DespawnMarkers(_shipAxisLenMarkers, ship.Id);
-            DespawnMarkers(_shipAxisBeamMarkers, ship.Id);
-            DespawnMarkers(_shipAxisUpMarkers, ship.Id);
+            DespawnAllAxisMarkerSets(ship.Id);
             return;
         }
 
@@ -317,59 +369,18 @@ public static class ShipTuningDebug
             DespawnMarkers(_shipAxisUpMarkers, ship.Id);
         }
 
-        // Same basis as UpdateShipCornerMarkers (ShipController.Build mapping).
-        var scale = MathF.Max(0.01f, ship.Scale);
-        var hx = model.MassBoxSizeX * scale * 0.5f;
-        var hy = ShipController.ShipMassBoxDefaults.GetSizeZ(model.MassBoxSizeZ) * scale * 0.5f;
-        var hz = model.MassBoxSizeY * scale * 0.5f;
-
-        // Use the already-synced Transform rotation (derived from physics via SyncTransformWithRigidBody)
-        // to avoid left/right inversion from phys<->game basis reflections.
-        var rotGame = GetTransformRotationMatrix(ship.Transform.Local.Rotation);
-
-        var posGame0 = PhysToGame(rb.Position);
-        var offsetLocalPhys = new JVector(
-            model.MassCenterX * scale,
-            ShipController.ShipMassBoxDefaults.GetCenterZ(model.MassCenterZ, model.MassBoxSizeZ) * scale,
-            model.MassCenterY * scale);
-        var offsetLocalGame = PhysVecToGame(offsetLocalPhys);
-        var centerGame = posGame0 + Vector3.TransformNormal(offsetLocalGame, rotGame);
-
         var extra = MathF.Max(0f, AxisMarkerExtraMeters);
+        var hzE = geo.Hz + extra;
+        var hxE = geo.Hx + extra;
+        var hyE = geo.Hy + extra;
 
-        // +Length marker: local +Z of the physics box (uses MassBoxSizeY via ShipController.Build third parameter).
-        var localLenGame = PhysVecToGame(new JVector(0f, 0f, hz + extra));
-        var posLen = centerGame + Vector3.TransformNormal(localLenGame, rotGame);
+        // +Length / +Beam / +Up: local +Z / +X / +Y of physics box (see ShipController.Build).
+        var posLen = geo.CenterGame + Vector3.TransformNormal(PhysVecToGame(new JVector(0f, 0f, hzE)), geo.RotGame);
+        var posBeam = geo.CenterGame + Vector3.TransformNormal(PhysVecToGame(new JVector(hxE, 0f, 0f)), geo.RotGame);
+        var posUp = geo.CenterGame + Vector3.TransformNormal(PhysVecToGame(new JVector(0f, hyE, 0f)), geo.RotGame);
 
-        // +Beam marker: local +X of the physics box (uses MassBoxSizeX via ShipController.Build first parameter).
-        var localBeamGame = PhysVecToGame(new JVector(hx + extra, 0f, 0f));
-        var posBeam = centerGame + Vector3.TransformNormal(localBeamGame, rotGame);
-
-        // +Up marker: local +Y of the physics box (uses MassBoxSizeZ via ShipController.Build second parameter).
-        var localUpGame = PhysVecToGame(new JVector(0f, hy + extra, 0f));
-        var posUp = centerGame + Vector3.TransformNormal(localUpGame, rotGame);
-
-        // Compute vertical extent of the OBB in world (game Z is up).
-        var minZ = float.PositiveInfinity;
-        var maxZ = float.NegativeInfinity;
-        Span<JVector> localCornersPhys =
-        [
-            new JVector(+hx, +hy, +hz),
-            new JVector(+hx, +hy, -hz),
-            new JVector(+hx, -hy, +hz),
-            new JVector(+hx, -hy, -hz),
-            new JVector(-hx, +hy, +hz),
-            new JVector(-hx, +hy, -hz),
-            new JVector(-hx, -hy, +hz),
-            new JVector(-hx, -hy, -hz),
-        ];
-        for (var i = 0; i < 8; i++)
-        {
-            var cGame = PhysVecToGame(localCornersPhys[i]);
-            var w = centerGame + Vector3.TransformNormal(cGame, rotGame);
-            if (w.Z < minZ) minZ = w.Z;
-            if (w.Z > maxZ) maxZ = w.Z;
-        }
+        Span<Vector3> cornerScratch = stackalloc Vector3[8];
+        GetMassBoxWorldVerticalExtent(in geo, cornerScratch, out var minZ, out var maxZ);
 
         if (setLen != null)
             UpdateMarker(ship.ParentWorld, setLen, 0, lenTemplateId, zoneId, posLen);
@@ -428,15 +439,13 @@ public static class ShipTuningDebug
             return;
         }
 
-        var rb = ship.RigidBody;
-        var model = ship.ShipController?.ShipModel;
-        if (rb is null || model is null)
+        if (!TryGetMassBoxGameGeometry(ship, out var geo))
         {
             DespawnMarkers(_shipCornerMarkers, ship.Id);
             return;
         }
 
-        var zoneId = ship.Transform.ZoneId;
+        var zoneId = ship.Transform!.ZoneId;
         var set = _shipCornerMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(8));
         if (set.ZoneId != zoneId || set.TemplateId != templateId)
         {
@@ -446,47 +455,11 @@ public static class ShipTuningDebug
             set.TemplateId = templateId;
         }
 
-        // REAL physics box corners, but expressed in GAME coordinates with the same quaternion component mapping
-        // used by PhysicsManager.SyncTransformWithRigidBody (rotation.X, rotation.Z, rotation.Y, rotation.W).
-        //
-        // Reason: a pure axis permutation (phys -> game) is an odd permutation (changes handedness),
-        // so "rotate in phys then permute" can appear to flip left/right in game space.
-        // Computing directly in game space with the mapped quaternion keeps turn direction consistent.
-        //
-        // ShipController.Build():
-        // - BoxShape(MassBoxSizeX, MassBoxSizeZ, MassBoxSizeY)
-        // - TransformedShape offset = (MassCenterX, MassCenterZ, MassCenterY)
-        var scale = MathF.Max(0.01f, ship.Scale);
-        var hx = model.MassBoxSizeX * scale * 0.5f;
-        var hy = ShipController.ShipMassBoxDefaults.GetSizeZ(model.MassBoxSizeZ) * scale * 0.5f;
-        var hz = model.MassBoxSizeY * scale * 0.5f;
-
-        // See UpdateShipAxisMarkers comment above.
-        var rotGame = GetTransformRotationMatrix(ship.Transform.Local.Rotation);
-
-        var posGame0 = PhysToGame(rb.Position);
-        var offsetLocalPhys = new JVector(
-            model.MassCenterX * scale,
-            ShipController.ShipMassBoxDefaults.GetCenterZ(model.MassCenterZ, model.MassBoxSizeZ) * scale,
-            model.MassCenterY * scale);
-        var offsetLocalGame = PhysVecToGame(offsetLocalPhys);
-        var centerGame = posGame0 + Vector3.TransformNormal(offsetLocalGame, rotGame);
-
-        Span<Vector3> localCornersGame =
-        [
-            PhysVecToGame(new JVector(+hx, +hy, +hz)),
-            PhysVecToGame(new JVector(+hx, +hy, -hz)),
-            PhysVecToGame(new JVector(+hx, -hy, +hz)),
-            PhysVecToGame(new JVector(+hx, -hy, -hz)),
-            PhysVecToGame(new JVector(-hx, +hy, +hz)),
-            PhysVecToGame(new JVector(-hx, +hy, -hz)),
-            PhysVecToGame(new JVector(-hx, -hy, +hz)),
-            PhysVecToGame(new JVector(-hx, -hy, -hz)),
-        ];
-
+        Span<Vector3> localCorners = stackalloc Vector3[8];
+        FillMassBoxLocalCornersGame(geo.Hx, geo.Hy, geo.Hz, localCorners);
         for (var i = 0; i < 8; i++)
         {
-            var posGame = centerGame + Vector3.TransformNormal(localCornersGame[i], rotGame);
+            var posGame = geo.CenterGame + Vector3.TransformNormal(localCorners[i], geo.RotGame);
             UpdateMarker(ship.ParentWorld, set, i, templateId, zoneId, posGame);
         }
     }

--- a/AAEmu.Game/Physics/Debug/ShipTuningDebug.cs
+++ b/AAEmu.Game/Physics/Debug/ShipTuningDebug.cs
@@ -639,7 +639,8 @@ public static class ShipTuningDebug
         g.BroadcastPacket(new SCGimmickMovementPacket(g), false);
     }
 
-    private static void DespawnAll(uint shipId)
+    /// <summary>Removes debug markers and per-ship throttle/latch state. Call when a ship leaves physics (e.g. despawn) so static dictionaries do not grow forever.</summary>
+    public static void DespawnAll(uint shipId)
     {
         DespawnMarkers(_shipCornerMarkers, shipId);
         DespawnMarkers(_shipAxisLenMarkers, shipId);

--- a/AAEmu.Game/Physics/Debug/ShipTuningDebug.cs
+++ b/AAEmu.Game/Physics/Debug/ShipTuningDebug.cs
@@ -19,16 +19,16 @@ using Jitter2.LinearMath;
 namespace AAEmu.Game.Physics.Debug;
 
 /// <summary>
-/// EN: Dev-only ship physics tuning & debug: ship↔ship, ship↔shore, plus ShipController tuning.
-/// RU: Dev-only тюнинг и дебаг корабельной физики: ship↔ship, ship↔shore, а также тюнинг ShipController.
-/// EN: Gimmick markers use template ids from table <c>gimmicks</c> — see <see cref="CornerMarkerTemplateId"/>, <see cref="ShoreMarkerTemplateId"/>, axis ids; set id to <c>0</c> or use flags (<see cref="Enabled"/>, <see cref="AxisMarkersEnabled"/>) to hide.
-/// RU: Маркеры-гиммики — template id из таблицы <c>gimmicks</c> (см. углы, берег, оси); выключить — id <c>0</c> или флаги (<see cref="Enabled"/>, <see cref="AxisMarkersEnabled"/>).
+/// EN: Dev-only ship physics debug: gimmick markers (mass box, axes, shore probes) and chat lines. Physics tuning lives in <see cref="ShipController.PhysicsDefaults"/>, <see cref="ShipController.ShipMassBoxDefaults"/>, interaction defaults classes — not here.
+/// RU: Только дебаг корабельной физики: маркеры-гиммики (бокс, оси, берег) и строки в чат. Тюнинг физики — в <see cref="ShipController.PhysicsDefaults"/>, <see cref="ShipController.ShipMassBoxDefaults"/> и дефолтах взаимодействий, не в этом классе.
+/// EN: Marker template ids come from table <c>gimmicks</c> — see <see cref="CornerMarkerTemplateId"/>, <see cref="ShoreMarkerTemplateId"/>, axis ids; set id to <c>0</c> or use <see cref="Enabled"/> / <see cref="AxisMarkersEnabled"/> to hide visuals.
+/// RU: Id шаблонов маркеров — таблица <c>gimmicks</c> (углы, берег, оси); <c>0</c> или флаги <see cref="Enabled"/> / <see cref="AxisMarkersEnabled"/> отключают визуал.
 /// </summary>
 public static class ShipTuningDebug
 {
     /// <summary>
-    /// EN: Master switch (use Hot Reload; no GM commands). When false: all ship debug gimmicks despawn and runtime tuning overrides fall back to defaults in interaction classes — not only visuals.
-    /// RU: Главный переключатель (Hot Reload; без GM). Если false — снимаются все дебаг-маркеры кораблей и runtime-тюнинг из этого класса не применяется (подставляются дефолты в классах взаимодействий), не только картинка.
+    /// EN: Master switch for gimmick markers and for per-tick debug (corners, axes, speed/box chat in <see cref="TickShip"/>). Callback chat (ship↔ship detail, shore latch/penetration) uses the separate flags below and may still run when this is false.
+    /// RU: Главный выключатель маркеров и тика <see cref="TickShip"/> (углы, оси, чат скорости/бокса). Чат из колбэков (детали ship↔shore, берег) — отдельные флаги ниже; часть может работать при false.
     /// </summary>
     public static bool Enabled => GetEnabled();
     private static bool GetEnabled() => false;
@@ -69,8 +69,8 @@ public static class ShipTuningDebug
     private static uint GetCornerMarkerTemplateId() => 0; // toy.flare
 
     /// <summary>
-    /// EN: Shore probe/contact markers (table <c>gimmicks</c>). Default id <c>28</c>. To disable only shore gimmicks: return <c>0</c>. Ship physics uses <see cref="ShipShoreInteraction.ShorePhysicsDefaults"/> when <see cref="Enabled"/> is false.
-    /// RU: Маркеры берега/проб (таблица <c>gimmicks</c>). По умолчанию id <c>28</c>. Выключить только маркеры берега: <c>return 0</c>. Физика берега — дефолты в <see cref="ShipShoreInteraction.ShorePhysicsDefaults"/>, если <see cref="Enabled"/> false.
+    /// EN: Shore probe/contact markers (table <c>gimmicks</c>). Return <c>0</c> to hide. Shore physics uses <see cref="ShipShoreInteraction.ShorePhysicsDefaults"/> regardless of this class.
+    /// RU: Маркеры берега/проб (таблица <c>gimmicks</c>). <c>return 0</c> — скрыть. Физика берега всегда из <see cref="ShipShoreInteraction.ShorePhysicsDefaults"/>.
     /// </summary>
     public static uint ShoreMarkerTemplateId => GetShoreMarkerTemplateId();
     private static uint GetShoreMarkerTemplateId() => 0;
@@ -104,6 +104,13 @@ public static class ShipTuningDebug
     private static float GetMarkerScale() => 0.35f;
 
     /// <summary>
+    /// EN: Offset axis gimmicks outward along each local axis (meters) so they sit outside the hull box; debug visuals only.
+    /// RU: Вынести маркеры осей наружу вдоль локальных осей (м), только для видимости дебага.
+    /// </summary>
+    public static float AxisMarkerExtraMeters => GetAxisMarkerExtraMeters();
+    private static float GetAxisMarkerExtraMeters() => 0f;
+
+    /// <summary>
     /// EN: If true, draw markers only for ships with a driver.
     /// RU: Если true — рисовать маркеры только для кораблей с водителем.
     /// </summary>
@@ -111,551 +118,39 @@ public static class ShipTuningDebug
     private static bool GetDrawOnlyWhenDriven() => false;
 
     /// <summary>
-    /// EN: Reserved (not used for physics; shore behavior is gated by <see cref="Enabled"/> + <see cref="ShipShoreInteraction.ShorePhysicsDefaults"/>).
-    /// RU: Зарезервировано (физика берега завязана на <see cref="Enabled"/> и <see cref="ShipShoreInteraction.ShorePhysicsDefaults"/>).
-    /// </summary>
-    public static bool ShoreEnabled => GetShoreEnabled();
-    private static bool GetShoreEnabled() => false;
-
-    /// <summary>
-    /// EN: Gimmicks for +Length, +Beam, +Up axis (three markers). When false, all three are despawned. Per-axis off: set that axis template id to 0.
-    /// RU: Гиммики для осей +Length, +Beam, +Up (три маркера). Если false — снимаются все три. Отдельную ось: template id этой оси = 0.
+    /// EN: Master switch for length/beam/up axis gimmick markers (independent of corner markers).
+    /// RU: Общий выключатель маркеров осей length/beam/up (независимо от углов бокса).
     /// </summary>
     public static bool AxisMarkersEnabled => GetAxisMarkersEnabled();
     private static bool GetAxisMarkersEnabled() => false;
 
     /// <summary>
-    /// EN: Extra distance (meters) beyond half-extent for axis markers.
-    /// RU: Доп. расстояние (метры) за пределы half-extent для осевых маркеров.
+    /// EN: Chat: ship↔ship hull contact started/ended (from <see cref="TickShip"/>; requires <see cref="Enabled"/>).
+    /// RU: Чат: начало/конец контакта корпусов ship↔ship (через <see cref="TickShip"/>, нужен <see cref="Enabled"/>).
     /// </summary>
-    public static float AxisMarkerExtraMeters => GetAxisMarkerExtraMeters();
-    private static float GetAxisMarkerExtraMeters() => 1.25f;
+    public static bool ShipShipContactLatchChatEnabled => GetShipShipContactLatchChatEnabled();
+    private static bool GetShipShipContactLatchChatEnabled() => false;
 
     /// <summary>
-    /// EN: Mass-box tuning (center/size overrides). Useful when the hull OBB is too low/high vs the visible hull.
-    /// RU: Тюнинг mass-box (переопределения центра/размера). Полезно, когда OBB корпуса слишком низко/высоко относительно модели.
+    /// EN: Chat: throttled ship↔ship resolve detail (penetration, normal, impact speed) from <see cref="OnResolvedShipPair"/>.
+    /// RU: Чат: детали резолва ship↔ship (проникновение, нормаль, скорость удара), троттлинг, из <see cref="OnResolvedShipPair"/>.
     /// </summary>
-    public static class HullBoxTuning
-    {
-        /// <summary>
-        /// EN: Additive vertical offset to MassCenterZ (meters). Positive lifts the box up.
-        /// RU: Аддитивный вертикальный сдвиг к MassCenterZ (метры). Положительное значение поднимает бокс вверх.
-        /// </summary>
-        public static float CenterZAddMeters => GetCenterZAddMeters();
-        private static float GetCenterZAddMeters() => ShipController.ShipMassBoxDefaults.CenterZAddMeters;
-
-        /// <summary>
-        /// EN: Additive vertical offset to MassCenterZ as a fraction of MassBoxSizeZ. Example: 0.30 lifts the box by 30% of its height.
-        /// RU: Аддитивный вертикальный сдвиг к MassCenterZ как доля MassBoxSizeZ. Например: 0.30 поднимает бокс на 30% его высоты.
-        /// </summary>
-        public static float CenterZAddFracOfSizeZ => GetCenterZAddFracOfSizeZ();
-        private static float GetCenterZAddFracOfSizeZ() => ShipController.ShipMassBoxDefaults.CenterZAddFracOfSizeZ;
-
-        /// <summary>
-        /// EN: Multiply MassBoxSizeZ (height). 1 = no change.
-        /// RU: Множитель MassBoxSizeZ (высота). 1 = без изменений.
-        /// </summary>
-        public static float SizeZMul => GetSizeZMul();
-        private static float GetSizeZMul() => ShipController.ShipMassBoxDefaults.SizeZMul;
-
-        /// <summary>
-        /// EN: Additive adjustment to MassBoxSizeZ (meters). Applied after SizeZMul.
-        /// RU: Аддитивная поправка к MassBoxSizeZ (метры). Применяется после SizeZMul.
-        /// </summary>
-        public static float SizeZAddMeters => GetSizeZAddMeters();
-        private static float GetSizeZAddMeters() => ShipController.ShipMassBoxDefaults.SizeZAddMeters;
-
-        internal static float GetCenterZ(float baseCenterZ, float baseSizeZ) =>
-            baseCenterZ + baseSizeZ * CenterZAddFracOfSizeZ + CenterZAddMeters;
-
-        internal static float GetSizeZ(float baseSizeZ)
-        {
-            var z = baseSizeZ * SizeZMul + SizeZAddMeters;
-            return MathF.Max(0.01f, z);
-        }
-    }
+    public static bool ShipShipResolveDetailChatEnabled => GetShipShipResolveDetailChatEnabled();
+    private static bool GetShipShipResolveDetailChatEnabled() => false;
 
     /// <summary>
-    /// EN: Ship↔ship SAT/response tuning (runtime fields for Hot Reload).
-    /// RU: Тюнинг ship↔ship SAT/реакции (runtime-поля для Hot Reload).
+    /// EN: Chat: shore latch ground / back in water (from <see cref="OnShoreLatchChanged"/>).
+    /// RU: Чат: береговой latch «на мели» / «снова в воде».
     /// </summary>
-    public static class ShipShipTuning
-    {
-        /// <summary>
-        /// EN: Half-length multiplier for SAT overlap test only (keep near 1).
-        /// RU: Множитель полу-длины только для SAT-детекта (держать близко к 1).
-        /// </summary>
-        public static float HullDetectInflateLength => GetHullDetectInflateLength();
-        private static float GetHullDetectInflateLength() => ShipShipInteraction.PhysicsDefaults.HullDetectInflateLength;
-
-        /// <summary>
-        /// EN: Half-beam multiplier for SAT overlap test only.
-        /// RU: Множитель полу-ширины только для SAT-детекта.
-        /// </summary>
-        public static float HullDetectInflateBeam => GetHullDetectInflateBeam();
-        private static float GetHullDetectInflateBeam() => ShipShipInteraction.PhysicsDefaults.HullDetectInflateBeam;
-
-        /// <summary>
-        /// EN: Extra tightening of beam in SAT only (reduces early side contact from oversized mass box).
-        /// RU: Доп. ужатие ширины только в SAT (убирает ранний боковой контакт из-за широкого mass box).
-        /// </summary>
-        public static float BeamDetectTightenMul => GetBeamDetectTightenMul();
-        private static float GetBeamDetectTightenMul() => ShipShipInteraction.PhysicsDefaults.BeamDetectTightenMul;
-
-        /// <summary>
-        /// EN: Ignore overlap response below this penetration depth (meters).
-        /// RU: Игнорировать реакцию, если penetration меньше этого (метры).
-        /// </summary>
-        public static float MinPenetrationToAct => GetMinPenetrationToAct();
-        private static float GetMinPenetrationToAct() => ShipShipInteraction.PhysicsDefaults.MinPenetrationToAct;
-
-        /// <summary>
-        /// EN: Ignore periodic hull-damage below this penetration depth (meters).
-        /// RU: Не наносить периодический урон корпусу, если penetration меньше этого (метры).
-        /// </summary>
-        public static float MinPenetrationToDamage => GetMinPenetrationToDamage();
-        private static float GetMinPenetrationToDamage() => ShipShipInteraction.PhysicsDefaults.MinPenetrationToDamage;
-
-        /// <summary>
-        /// EN: Ramp tangential slip damping over this depth range past MinPenetrationToAct (meters).
-        /// RU: Наращивать демпф тангенциального скольжения на этом диапазоне глубины сверх MinPenetrationToAct (метры).
-        /// </summary>
-        public static float TangentialRampDepthMeters => GetTangentialRampDepthMeters();
-        private static float GetTangentialRampDepthMeters() => ShipShipInteraction.PhysicsDefaults.TangentialRampDepthMeters;
-
-        /// <summary>
-        /// EN: Multiplier on positional separation push once overlap exists.
-        /// RU: Множитель раздвижения (push) после обнаружения overlap.
-        /// </summary>
-        public static float SeparationPushMultiplier => GetSeparationPushMultiplier();
-        private static float GetSeparationPushMultiplier() => ShipShipInteraction.PhysicsDefaults.SeparationPushMultiplier;
-
-        /// <summary>
-        /// EN: Extra separation slack added to computed overlap (meters).
-        /// RU: Доп. зазор к раздвижению сверх overlap (метры).
-        /// </summary>
-        public static float SeparationSlackMeters => GetSeparationSlackMeters();
-        private static float GetSeparationSlackMeters() => ShipShipInteraction.PhysicsDefaults.SeparationSlackMeters;
-
-        /// <summary>
-        /// EN: Fraction of relative closing speed along normal to remove (1 = full stop along normal).
-        /// RU: Доля гашения относительной скорости вдоль нормали (1 = полностью убрать вдоль нормали).
-        /// </summary>
-        public static float ClosingSpeedDamp => GetClosingSpeedDamp();
-        private static float GetClosingSpeedDamp() => ShipShipInteraction.PhysicsDefaults.ClosingSpeedDamp;
-
-        /// <summary>
-        /// EN: Tangential slip damping factor while overlapping (0..1).
-        /// RU: Коэффициент демпфа тангенциального скольжения при overlap (0..1).
-        /// </summary>
-        public static float TangentialSlipDamp => GetTangentialSlipDamp();
-        private static float GetTangentialSlipDamp() => ShipShipInteraction.PhysicsDefaults.TangentialSlipDamp;
-
-        /// <summary>
-        /// EN: Minimum vertical overlap (meters) to consider ships colliding.
-        /// RU: Минимальный вертикальный overlap (метры) чтобы считать столкновение.
-        /// </summary>
-        public static float MinVerticalOverlap => GetMinVerticalOverlap();
-        private static float GetMinVerticalOverlap() => ShipShipInteraction.PhysicsDefaults.MinVerticalOverlap;
-
-        /// <summary>
-        /// EN: Outer resolve passes per tick (CPU vs stability).
-        /// RU: Внешние проходы резолва за тик (CPU vs стабильность).
-        /// </summary>
-        public static int ResolvePasses => GetResolvePasses();
-        private static int GetResolvePasses() => ShipShipInteraction.PhysicsDefaults.ResolvePasses;
-
-        /// <summary>
-        /// EN: Max depenetration iterations per pair per pass.
-        /// RU: Макс. итераций раздвижения на пару за проход.
-        /// </summary>
-        public static int MaxPairIterations => GetMaxPairIterations();
-        private static int GetMaxPairIterations() => ShipShipInteraction.PhysicsDefaults.MaxPairIterations;
-
-        /// <summary>
-        /// EN: Penetration depth where “deep penetration” push boost starts (meters).
-        /// RU: Глубина penetration, с которой начинается усиление push (метры).
-        /// </summary>
-        public static float DeepPenetrationStart => GetDeepPenetrationStart();
-        private static float GetDeepPenetrationStart() => ShipShipInteraction.PhysicsDefaults.DeepPenetrationStart;
-
-        /// <summary>
-        /// EN: Boost factor applied as penetration exceeds DeepPenetrationStart.
-        /// RU: Коэффициент усиления push при penetration больше DeepPenetrationStart.
-        /// </summary>
-        public static float DeepPenetrationBoost => GetDeepPenetrationBoost();
-        private static float GetDeepPenetrationBoost() => ShipShipInteraction.PhysicsDefaults.DeepPenetrationBoost;
-
-        /// <summary>
-        /// EN: Floor on half-separation distance (meters).
-        /// RU: Минимальная полу-дистанция раздвижения (метры).
-        /// </summary>
-        public static float MinHalfSeparationMeters => GetMinHalfSeparationMeters();
-        private static float GetMinHalfSeparationMeters() => ShipShipInteraction.PhysicsDefaults.MinHalfSeparationMeters;
-
-        /// <summary>
-        /// EN: Stop iterating if computed separation is below this (meters) to avoid micro-jitter.
-        /// RU: Остановить итерации, если раздвижение меньше этого (метры), чтобы убрать микродрожь.
-        /// </summary>
-        public static float MinLinearSeparationToApplyMeters => GetMinLinearSeparationToApplyMeters();
-        private static float GetMinLinearSeparationToApplyMeters() => ShipShipInteraction.PhysicsDefaults.MinLinearSeparationToApplyMeters;
-
-        /// <summary>
-        /// EN: Cosine threshold for “nose cone” classification.
-        /// RU: Порог косинуса для классификации “удар в нос”.
-        /// </summary>
-        public static float NoseContactCosThreshold => GetNoseContactCosThreshold();
-        private static float GetNoseContactCosThreshold() => ShipShipInteraction.PhysicsDefaults.NoseContactCosThreshold;
-
-        /// <summary>
-        /// EN: Min interval between hull-collision damage ticks per other ship (seconds).
-        /// RU: Минимальный интервал тиков урона от столкновения корпусом на конкретный другой корабль (сек).
-        /// </summary>
-        public static float HullCollisionDamageCooldownSec => GetHullCollisionDamageCooldownSec();
-        private static float GetHullCollisionDamageCooldownSec() => ShipShipInteraction.PhysicsDefaults.HullCollisionDamageCooldownSec;
-
-        /// <summary>
-        /// EN: Relative speed threshold (m/s) where damage uses min % (non-nose).
-        /// RU: Порог относительной скорости (м/с), ниже которого урон минимальный (не-носовые удары).
-        /// </summary>
-        public static float HullDamageLowSpeedThresholdMps => GetHullDamageLowSpeedThresholdMps();
-        private static float GetHullDamageLowSpeedThresholdMps() => ShipShipInteraction.PhysicsDefaults.HullDamageLowSpeedThresholdMps;
-
-        /// <summary>
-        /// EN: Relative speed (m/s) where damage reaches max % (linear between thresholds).
-        /// RU: Относительная скорость (м/с), при которой урон достигает максимума (линейно между порогами).
-        /// </summary>
-        public static float HullDamageInterpMaxMps => GetHullDamageInterpMaxMps();
-        private static float GetHullDamageInterpMaxMps() => ShipShipInteraction.PhysicsDefaults.HullDamageSpeedInterpMaxMps;
-
-        /// <summary>
-        /// EN: Min % hull damage per tick.
-        /// RU: Минимальный % урона корпуса за тик.
-        /// </summary>
-        public static int HullDamageSpeedScaledMinPercent => GetHullDamageSpeedScaledMinPercent();
-        private static int GetHullDamageSpeedScaledMinPercent() => ShipShipInteraction.PhysicsDefaults.HullDamageSpeedScaledMinPercent;
-
-        /// <summary>
-        /// EN: Max % hull damage per tick.
-        /// RU: Максимальный % урона корпуса за тик.
-        /// </summary>
-        public static int HullDamageSpeedScaledMaxPercent => GetHullDamageSpeedScaledMaxPercent();
-        private static int GetHullDamageSpeedScaledMaxPercent() => ShipShipInteraction.PhysicsDefaults.HullDamageSpeedScaledMaxPercent;
-
-        /// <summary>
-        /// EN: How strongly mass differences steer who gets pushed: 0 = 50/50, 1 = inverse-mass (physical), &gt;1 = exaggerate (lighter ship moves more; values clamped).
-        /// RU: Насколько масса влияет на раздвижение: 0 = поровну, 1 = обратно массе (как в физике), &gt;1 — усилить контраст (лёгкий сильнее отталкивается; края подрезаются).
-        /// </summary>
-        public static float MassPushStrength => GetMassPushStrength();
-        private static float GetMassPushStrength() => ShipShipInteraction.PhysicsDefaults.MassPushStrength;
-    }
+    public static bool ShoreLatchChatEnabled => GetShoreLatchChatEnabled();
+    private static bool GetShoreLatchChatEnabled() => false;
 
     /// <summary>
-    /// EN: Ship↔shore tuning mirrors ShipShoreInteraction constants (runtime fields for Hot Reload).
-    /// RU: Тюнинг ship↔shore зеркалит константы ShipShoreInteraction (runtime-поля для Hot Reload).
+    /// EN: Chat: throttled shore penetration depth while aground (from <see cref="OnShoreProbe"/>).
+    /// RU: Чат: глубина проникновения в мель (троттлинг), из <see cref="OnShoreProbe"/>.
     /// </summary>
-    public static class ShoreTuning
-    {
-        /// <summary>
-        /// EN: Effective "boat bottom" offset as a fraction of MassBoxSizeZ (height).
-        /// EN: boatBottomY = rigidBodyY - MassBoxSizeZ*scale*frac. ~0.5 = keel near half-box below COM (matches legacy fallback).
-        /// EN: Values &lt; ~0.4 lift the effective bottom (less penetration, more air gap); &gt; ~0.55 can over-embed.
-        /// RU: Смещение "дна" как доля MassBoxSizeZ (высота).
-        /// RU: boatBottomY = rigidBodyY - MassBoxSizeZ*scale*frac. ~0.5 — киль около половины высоты под COM (как legacy 0.5).
-        /// RU: Меньше ~0.4 — «дно» выше, меньше penetration и больше визуальный зазор; больше ~0.55 — риск глубокого вдавливания.
-        /// </summary>
-        public static float BoatBottomOffsetFracOfSizeZ => GetBoatBottomOffsetFracOfSizeZ();
-        private static float GetBoatBottomOffsetFracOfSizeZ() => ShipShoreInteraction.ShorePhysicsDefaults.BoatBottomOffsetFracOfSizeZ;
-
-        /// <summary>
-        /// EN: Ground friction multiplier on dry ground.
-        /// RU: Трение на суше.
-        /// </summary>
-        public static float GroundFriction => GetGroundFriction();
-        private static float GetGroundFriction() => ShipShoreInteraction.ShorePhysicsDefaults.GroundFriction;
-
-        /// <summary>
-        /// EN: Velocity/angular damping on dry ground.
-        /// RU: Демпф скорости/угловой скорости на суше.
-        /// </summary>
-        public static float DryGroundCollisionDamping => GetDryGroundCollisionDamping();
-        private static float GetDryGroundCollisionDamping() => ShipShoreInteraction.ShorePhysicsDefaults.DryGroundCollisionDamping;
-
-        /// <summary>
-        /// EN: Roll correction dead-zone (radians).
-        /// RU: Мёртвая зона коррекции roll (радианы).
-        /// </summary>
-        public static float DryGroundRollDeadZoneRad => GetDryGroundRollDeadZoneRad();
-        private static float GetDryGroundRollDeadZoneRad() => ShipShoreInteraction.ShorePhysicsDefaults.DryGroundRollDeadZoneRad;
-
-        /// <summary>
-        /// EN: Roll correction torque factor (tuning).
-        /// RU: Коэффициент коррекции roll (тюнинг).
-        /// </summary>
-        public static float DryGroundRollTorqueMul => GetDryGroundRollTorqueMul();
-        private static float GetDryGroundRollTorqueMul() => ShipShoreInteraction.ShorePhysicsDefaults.DryGroundRollTorqueMul;
-
-        /// <summary>
-        /// EN: Bow probe distance multiplier vs MassBoxSizeY (hull length).
-        /// RU: Множитель дистанции носовой пробы от MassBoxSizeY (длина корпуса).
-        /// </summary>
-        public static float BowProbeMul => GetBowProbeMul();
-        private static float GetBowProbeMul() => ShipShoreInteraction.ShorePhysicsDefaults.BowProbeMul;
-
-        /// <summary>
-        /// EN: Stern probe distance multiplier vs MassBoxSizeY (hull length).
-        /// RU: Множитель дистанции кормовой пробы от MassBoxSizeY (длина корпуса).
-        /// </summary>
-        public static float SternProbeMul => GetSternProbeMul();
-        private static float GetSternProbeMul() => ShipShoreInteraction.ShorePhysicsDefaults.SternProbeMul;
-
-        /// <summary>
-        /// EN: Cliff probe distance multiplier vs MassBoxSizeY (hull length).
-        /// RU: Множитель дистанции пробы “обрыва/стены” от MassBoxSizeY (длина корпуса).
-        /// </summary>
-        public static float CliffProbeMul => GetCliffProbeMul();
-        private static float GetCliffProbeMul() => ShipShoreInteraction.ShorePhysicsDefaults.CliffProbeMul;
-
-        /// <summary>
-        /// EN: Wall/cliff look-ahead distance as a fraction of half-length (added beyond the box edge).
-        /// EN: 0 = probe exactly at bow/stern box edge; 0.2 = +20% of half-length further.
-        /// RU: Дистанция look-ahead для “стены/обрыва” как доля half-length (прибавляется за край бокса).
-        /// RU: 0 = проба ровно на кромке бокса нос/корма; 0.2 = +20% half-length дальше.
-        /// </summary>
-        public static float CliffProbeLookAheadMulOfHalfLength => GetCliffProbeLookAheadMulOfHalfLength();
-        private static float GetCliffProbeLookAheadMulOfHalfLength() => ShipShoreInteraction.ShorePhysicsDefaults.CliffProbeLookAheadMulOfHalfLength;
-
-        /// <summary>
-        /// EN: Minimum look-ahead (meters) added beyond the box edge for wall/cliff probe.
-        /// RU: Минимальный look-ahead (метры) за край бокса для пробы “стены/обрыва”.
-        /// </summary>
-        public static float CliffProbeMinLookAheadMeters => GetCliffProbeMinLookAheadMeters();
-        private static float GetCliffProbeMinLookAheadMeters() => ShipShoreInteraction.ShorePhysicsDefaults.CliffProbeMinLookAheadMeters;
-
-        /// <summary>
-        /// EN: Cliff slope threshold (Δh / dist).
-        /// RU: Порог “крутизны” (Δh / dist).
-        /// </summary>
-        public static float CliffSlopeFracThreshold => GetCliffSlopeFracThreshold();
-        private static float GetCliffSlopeFracThreshold() => ShipShoreInteraction.ShorePhysicsDefaults.CliffSlopeFracThreshold;
-
-        /// <summary>
-        /// EN: Cliff must be above water by this margin (meters).
-        /// RU: “Обрыв” считается только если выше воды на этот запас (метры).
-        /// </summary>
-        public static float CliffAboveWaterMargin => GetCliffAboveWaterMargin();
-        private static float GetCliffAboveWaterMargin() => ShipShoreInteraction.ShorePhysicsDefaults.CliffAboveWaterMargin;
-
-        /// <summary>
-        /// EN: Shore latch enter hysteresis (meters).
-        /// RU: Гистерезис входа в latch (метры).
-        /// </summary>
-        public static float ShoreEnterHyst => GetShoreEnterHyst();
-        private static float GetShoreEnterHyst() => ShipShoreInteraction.ShorePhysicsDefaults.ShoreEnterHyst;
-
-        /// <summary>
-        /// EN: Shore latch exit hysteresis (meters).
-        /// RU: Гистерезис выхода из latch (метры).
-        /// </summary>
-        public static float ShoreExitHyst => GetShoreExitHyst();
-        private static float GetShoreExitHyst() => ShipShoreInteraction.ShorePhysicsDefaults.ShoreExitHyst;
-
-        /// <summary>
-        /// EN: Floor height smoothing response (lambda).
-        /// RU: Сглаживание высоты пола (lambda).
-        /// </summary>
-        public static float FloorSmoothResponse => GetFloorSmoothResponse();
-        private static float GetFloorSmoothResponse() => ShipShoreInteraction.ShorePhysicsDefaults.FloorSmoothResponse;
-
-        /// <summary>
-        /// EN: Pre-shore damping band (meters).
-        /// RU: Полоса “перед берегом” для демпфа (метры).
-        /// </summary>
-        public static float PreShoreBand => GetPreShoreBand();
-        private static float GetPreShoreBand() => ShipShoreInteraction.ShorePhysicsDefaults.PreShoreBand;
-
-        /// <summary>
-        /// EN: Penetration epsilon (meters).
-        /// RU: Эпсилон penetration (метры).
-        /// </summary>
-        public static float PenetrationEpsilon => GetPenetrationEpsilon();
-        private static float GetPenetrationEpsilon() => ShipShoreInteraction.ShorePhysicsDefaults.PenetrationEpsilon;
-
-        /// <summary>
-        /// EN: Penetration response (lambda).
-        /// RU: Скорость реакции на penetration (lambda).
-        /// </summary>
-        public static float PenetrationResponse => GetPenetrationResponse();
-        private static float GetPenetrationResponse() => ShipShoreInteraction.ShorePhysicsDefaults.PenetrationResponse;
-
-        /// <summary>
-        /// EN: Max up-step early after latching (m/tick).
-        /// RU: Макс. подъём на раннем этапе latch (м/тик).
-        /// </summary>
-        public static float MaxUpStepEarly => GetMaxUpStepEarly();
-        private static float GetMaxUpStepEarly() => ShipShoreInteraction.ShorePhysicsDefaults.MaxUpStepEarly;
-
-        /// <summary>
-        /// EN: Max up-step later while latched (m/tick).
-        /// RU: Макс. подъём после стабилизации latch (м/тик).
-        /// </summary>
-        public static float MaxUpStepLate => GetMaxUpStepLate();
-        private static float GetMaxUpStepLate() => ShipShoreInteraction.ShorePhysicsDefaults.MaxUpStepLate;
-
-        /// <summary>
-        /// EN: Visual ground pitch max (degrees).
-        /// RU: Макс. визуальный ground pitch (градусы).
-        /// </summary>
-        public static float VisualGroundPitchMaxDeg => GetVisualGroundPitchMaxDeg();
-        private static float GetVisualGroundPitchMaxDeg() => ShipShoreInteraction.ShorePhysicsDefaults.VisualGroundPitchMaxDeg;
-
-        /// <summary>
-        /// EN: Visual ground pitch probe distance (meters).
-        /// RU: Дистанция проб для визуального pitch (метры).
-        /// </summary>
-        public static float VisualGroundPitchProbeDistance => GetVisualGroundPitchProbeDistance();
-        private static float GetVisualGroundPitchProbeDistance() => ShipShoreInteraction.ShorePhysicsDefaults.VisualGroundPitchProbeDistance;
-
-        /// <summary>
-        /// EN: Visual ground pitch response (lambda).
-        /// RU: Скорость реакции визуального pitch (lambda).
-        /// </summary>
-        public static float VisualGroundPitchResponse => GetVisualGroundPitchResponse();
-        private static float GetVisualGroundPitchResponse() => ShipShoreInteraction.ShorePhysicsDefaults.VisualGroundPitchResponse;
-
-        /// <summary>
-        /// EN: Visual pitch floor smoothing response (lambda).
-        /// RU: Сглаживание высот для визуального pitch (lambda).
-        /// </summary>
-        public static float VisualPitchFloorSmoothResponse => GetVisualPitchFloorSmoothResponse();
-        private static float GetVisualPitchFloorSmoothResponse() => ShipShoreInteraction.ShorePhysicsDefaults.VisualPitchFloorSmoothResponse;
-    }
-
-    /// <summary>
-    /// EN: ShipController tuning (runtime fields for Hot Reload).
-    /// RU: Тюнинг ShipController (runtime-поля для Hot Reload).
-    /// </summary>
-    public static class ShipControllerTuning
-    {
-        /// <summary>
-        /// EN: Max allowed speed (abs) while grounded AND using the correct "escape" throttle direction.
-        /// RU: Максимальная скорость (по модулю) на мели при правильном газе "на выезд".
-        /// </summary>
-        public static float GroundEscapeMaxSpeedAbs => GetGroundEscapeMaxSpeedAbs();
-        private static float GetGroundEscapeMaxSpeedAbs() => ShipController.PhysicsDefaults.GroundEscapeMaxSpeedAbs;
-
-        /// <summary>
-        /// EN: On shoal ground, max reverse speed as percent of max reverse on water (same ship/wind basis). 100 = same as water cap.
-        /// RU: На мели: макс. задняя скорость в процентах от макс. задней на воде (та же база корабля/ветра). 100 = как на воде.
-        /// </summary>
-        public static float GroundReverseSpeedCapPercentOfWater => GetGroundReverseSpeedCapPercentOfWater();
-        private static float GetGroundReverseSpeedCapPercentOfWater() => ShipController.PhysicsDefaults.GroundReverseSpeedCapPercentOfWater;
-
-        /// <summary>
-        /// EN: Treat very shallow water as "grounded" for speed caps (escape/reverse limit), based on (waterSurface - floor) depth.
-        /// RU: Считать очень мелкую воду "мелью" для скоростных капов (escape/лимит заднего), по глубине (уровень воды - дно).
-        /// </summary>
-        public static float ShallowWaterDepthForGroundSpeedCaps => GetShallowWaterDepthForGroundSpeedCaps();
-        private static float GetShallowWaterDepthForGroundSpeedCaps() => ShipController.PhysicsDefaults.ShallowWaterDepthForGroundSpeedCaps;
-
-        /// <summary>
-        /// EN: Extra acceleration multiplier when throttle opposes current motion.
-        /// RU: Доп. множитель ускорения, когда газ против текущего движения.
-        /// </summary>
-        public static float OpposingThrottleAccelMul => GetOpposingThrottleAccelMul();
-        private static float GetOpposingThrottleAccelMul() => ShipController.PhysicsDefaults.OpposingThrottleAccelMul;
-
-        /// <summary>
-        /// EN: Extra braking factor for opposing throttle (multiplies reverse/brake behavior).
-        /// RU: Доп. торможение при противоположном газе.
-        /// </summary>
-        public static float OpposingThrottleBrakeTuneMul => GetOpposingThrottleBrakeTuneMul();
-        private static float GetOpposingThrottleBrakeTuneMul() => ShipController.PhysicsDefaults.OpposingThrottleBrakeTuneMul;
-
-        /// <summary>
-        /// EN: Steering responsiveness multiplier.
-        /// RU: Множитель отзывчивости руля.
-        /// </summary>
-        public static float SteeringResponsivenessMul => GetSteeringResponsivenessMul();
-        private static float GetSteeringResponsivenessMul() => ShipController.PhysicsDefaults.SteeringResponsivenessMul;
-
-        /// <summary>
-        /// EN: Counter-steer responsiveness multiplier.
-        /// RU: Множитель отзывчивости контрруления.
-        /// </summary>
-        public static float CounterSteerResponsivenessMul => GetCounterSteerResponsivenessMul();
-        private static float GetCounterSteerResponsivenessMul() => ShipController.PhysicsDefaults.CounterSteerResponsivenessMul;
-
-        /// <summary>
-        /// EN: Minimum turning factor at zero speed.
-        /// RU: Минимальный фактор поворота на нулевой скорости.
-        /// </summary>
-        public static float MinTurnFactorAtZeroSpeed => GetMinTurnFactorAtZeroSpeed();
-        private static float GetMinTurnFactorAtZeroSpeed() => ShipController.PhysicsDefaults.MinTurnFactorAtZeroSpeed;
-
-        /// <summary>
-        /// EN: Speed at which turning reaches 100% (ship speed units).
-        /// RU: Скорость, при которой поворот достигает 100% (в игровых единицах скорости).
-        /// </summary>
-        public static float TurnFullFactorAtSpeed => GetTurnFullFactorAtSpeed();
-        private static float GetTurnFullFactorAtSpeed() => ShipController.PhysicsDefaults.TurnFullFactorAtSpeed;
-
-        /// <summary>
-        /// EN: Fraction of speed removed at max yaw rate.
-        /// RU: Доля снижения скорости на максимальной скорости поворота.
-        /// </summary>
-        public static float TurnSpeedSlowdownFrac => GetTurnSpeedSlowdownFrac();
-        private static float GetTurnSpeedSlowdownFrac() => ShipController.PhysicsDefaults.TurnSpeedSlowdownFrac;
-
-        /// <summary>
-        /// EN: Response for TurnSpeedVelocityMul smoothing (lambda).
-        /// RU: Скорость сглаживания TurnSpeedVelocityMul (lambda).
-        /// </summary>
-        public static float TurnSpeedVelocityMulResponse => GetTurnSpeedVelocityMulResponse();
-        private static float GetTurnSpeedVelocityMulResponse() => ShipController.PhysicsDefaults.TurnSpeedVelocityMulResponse;
-
-        /// <summary>
-        /// EN: Minimum submergence to start upright stabilization (meters).
-        /// RU: Минимальное погружение для выравнивания корпуса (метры).
-        /// </summary>
-        public static float UprightStabilizeMinSubmergedMeters => GetUprightStabilizeMinSubmergedMeters();
-        private static float GetUprightStabilizeMinSubmergedMeters() => ShipController.PhysicsDefaults.UprightStabilizeMinSubmergedMeters;
-
-        /// <summary>
-        /// EN: Max upright correction angular speed (rad/s).
-        /// RU: Макс. скорость выравнивания (рад/с).
-        /// </summary>
-        public static float UprightStabilizeMaxRadPerSec => GetUprightStabilizeMaxRadPerSec();
-        private static float GetUprightStabilizeMaxRadPerSec() => ShipController.PhysicsDefaults.UprightStabilizeMaxRadPerSec;
-
-        /// <summary>
-        /// EN: Dead-zone for upright correction (radians).
-        /// RU: Мёртвая зона выравнивания (радианы).
-        /// </summary>
-        public static float UprightStabilizeAngleDeadZoneRad => GetUprightStabilizeAngleDeadZoneRad();
-        private static float GetUprightStabilizeAngleDeadZoneRad() => ShipController.PhysicsDefaults.UprightStabilizeAngleDeadZoneRad;
-
-        /// <summary>
-        /// EN: Wind cone half-angle (degrees).
-        /// RU: Полуугол конуса ветра (градусы).
-        /// </summary>
-        public static float WindConeHalfAngleDeg => GetWindConeHalfAngleDeg();
-        private static float GetWindConeHalfAngleDeg() => ShipController.PhysicsDefaults.WindConeHalfAngleDeg;
-
-        /// <summary>
-        /// EN: Max speed multiplier with wind.
-        /// RU: Макс. множитель скорости по ветру.
-        /// </summary>
-        public static float WindWithMaxMul => GetWindWithMaxMul();
-        private static float GetWindWithMaxMul() => ShipController.PhysicsDefaults.WindWithMaxMul;
-
-        /// <summary>
-        /// EN: Max speed multiplier against wind.
-        /// RU: Макс. множитель скорости против ветра.
-        /// </summary>
-        public static float WindAgainstMaxMul => GetWindAgainstMaxMul();
-        private static float GetWindAgainstMaxMul() => ShipController.PhysicsDefaults.WindAgainstMaxMul;
-    }
+    public static bool ShorePenetrationChatEnabled => GetShorePenetrationChatEnabled();
+    private static bool GetShorePenetrationChatEnabled() => false;
 
     private static readonly ConcurrentDictionary<uint, long> _lastDetailMsgAtMs = new();
     private static readonly ConcurrentDictionary<uint, long> _lastAxesMsgAtMs = new();
@@ -733,7 +228,7 @@ public static class ShipTuningDebug
         var escapeThrottleSign = ship.GroundedByStern ? 1 : -1;
         var isEscapeInputOnGround = isGrounded && ship.ThrottleRequest != 0 && Math.Sign(ship.ThrottleRequest) == escapeThrottleSign;
 
-        var cap = ShipControllerTuning.GroundEscapeMaxSpeedAbs;
+        var cap = ShipController.PhysicsDefaults.GroundEscapeMaxSpeedAbs;
 
         driver.SendDebugMessage(
             $"[ShipSpeed] ship={ship.ObjId} v={ship.Speed:F2} grounded={isGrounded} latched={ship.GroundContactLatched} byStern={ship.GroundedByStern} thrReq={ship.ThrottleRequest} escape={isEscapeInputOnGround} escapeCap={cap:F2}");
@@ -825,7 +320,7 @@ public static class ShipTuningDebug
         // Same basis as UpdateShipCornerMarkers (ShipController.Build mapping).
         var scale = MathF.Max(0.01f, ship.Scale);
         var hx = model.MassBoxSizeX * scale * 0.5f;
-        var hy = HullBoxTuning.GetSizeZ(model.MassBoxSizeZ) * scale * 0.5f;
+        var hy = ShipController.ShipMassBoxDefaults.GetSizeZ(model.MassBoxSizeZ) * scale * 0.5f;
         var hz = model.MassBoxSizeY * scale * 0.5f;
 
         // Use the already-synced Transform rotation (derived from physics via SyncTransformWithRigidBody)
@@ -835,7 +330,7 @@ public static class ShipTuningDebug
         var posGame0 = PhysToGame(rb.Position);
         var offsetLocalPhys = new JVector(
             model.MassCenterX * scale,
-            HullBoxTuning.GetCenterZ(model.MassCenterZ, model.MassBoxSizeZ) * scale,
+            ShipController.ShipMassBoxDefaults.GetCenterZ(model.MassCenterZ, model.MassBoxSizeZ) * scale,
             model.MassCenterY * scale);
         var offsetLocalGame = PhysVecToGame(offsetLocalPhys);
         var centerGame = posGame0 + Vector3.TransformNormal(offsetLocalGame, rotGame);
@@ -912,6 +407,9 @@ public static class ShipTuningDebug
             return;
 
         _shipContactLatched[ship.Id] = hasContact;
+        if (!ShipShipContactLatchChatEnabled)
+            return;
+
         var driver = TryGetDriver(ship);
         if (driver is null || !CanReceive(driver))
             return;
@@ -960,7 +458,7 @@ public static class ShipTuningDebug
         // - TransformedShape offset = (MassCenterX, MassCenterZ, MassCenterY)
         var scale = MathF.Max(0.01f, ship.Scale);
         var hx = model.MassBoxSizeX * scale * 0.5f;
-        var hy = HullBoxTuning.GetSizeZ(model.MassBoxSizeZ) * scale * 0.5f;
+        var hy = ShipController.ShipMassBoxDefaults.GetSizeZ(model.MassBoxSizeZ) * scale * 0.5f;
         var hz = model.MassBoxSizeY * scale * 0.5f;
 
         // See UpdateShipAxisMarkers comment above.
@@ -969,7 +467,7 @@ public static class ShipTuningDebug
         var posGame0 = PhysToGame(rb.Position);
         var offsetLocalPhys = new JVector(
             model.MassCenterX * scale,
-            HullBoxTuning.GetCenterZ(model.MassCenterZ, model.MassBoxSizeZ) * scale,
+            ShipController.ShipMassBoxDefaults.GetCenterZ(model.MassCenterZ, model.MassBoxSizeZ) * scale,
             model.MassCenterY * scale);
         var offsetLocalGame = PhysVecToGame(offsetLocalPhys);
         var centerGame = posGame0 + Vector3.TransformNormal(offsetLocalGame, rotGame);
@@ -999,14 +497,18 @@ public static class ShipTuningDebug
     /// </summary>
     public static void OnResolvedShipPair(Slave a, Slave b, float penetrationMeters, float nx, float nz, float impactSpeedMps)
     {
-        if (!Enabled)
+        var anyShipShipDebug = Enabled || ShipShipContactLatchChatEnabled || ShipShipResolveDetailChatEnabled;
+        if (!anyShipShipDebug)
             return;
 
-        // Extend "contact active" window; TickShip will emit start/end messages.
+        // Extend "contact active" window; TickShip will emit start/end messages when Enabled.
         var nowMs = Environment.TickCount64;
         const int holdMs = 800;
         _shipContactUntilMs[a.Id] = nowMs + holdMs;
         _shipContactUntilMs[b.Id] = nowMs + holdMs;
+
+        if (!ShipShipResolveDetailChatEnabled)
+            return;
 
         SendShipShipDetail(a, b, penetrationMeters, nx, nz, impactSpeedMps);
         SendShipShipDetail(b, a, penetrationMeters, -nx, -nz, impactSpeedMps);
@@ -1037,7 +539,7 @@ public static class ShipTuningDebug
     /// </summary>
     public static void OnShoreLatchChanged(Slave ship, bool latched)
     {
-        if (!Enabled)
+        if (!ShoreLatchChatEnabled)
             return;
 
         var driver = TryGetDriver(ship);
@@ -1065,48 +567,48 @@ public static class ShipTuningDebug
             return;
 
         if (!Enabled)
-            return;
-
-        var templateId = ShoreMarkerTemplateId;
-        if (templateId == 0 || ship.ParentWorld is null || ship.Transform is null)
-        {
             DespawnMarkers(_shoreMarkers, ship.Id);
-            return;
-        }
-
-        var zoneId = ship.Transform.ZoneId;
-        var set = _shoreMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(4));
-        if (set.ZoneId != zoneId || set.TemplateId != templateId)
+        else
         {
-            DespawnMarkers(_shoreMarkers, ship.Id);
-            set = _shoreMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(4));
-            set.ZoneId = zoneId;
-            set.TemplateId = templateId;
-        }
-
-        UpdateMarker(ship.ParentWorld, set, 0, templateId, zoneId, new Vector3(probeX, probeY, floorZ));
-        UpdateMarker(ship.ParentWorld, set, 1, templateId, zoneId, new Vector3(cliffX, cliffY, cliffZ));
-        UpdateMarker(ship.ParentWorld, set, 2, templateId, zoneId, new Vector3(boatCenterX, boatCenterY, boatBottomZ));
-        UpdateMarker(ship.ParentWorld, set, 3, templateId, zoneId, new Vector3(probeX, probeY, waterSurfaceZ));
-
-        // Optional detail line while penetrating
-        if (penetrationMeters > 0.0f)
-        {
-            var driver = TryGetDriver(ship);
-            if (driver != null && CanReceive(driver))
+            var templateId = ShoreMarkerTemplateId;
+            if (templateId == 0 || ship.ParentWorld is null || ship.Transform is null)
+                DespawnMarkers(_shoreMarkers, ship.Id);
+            else
             {
-                var nowMs = Environment.TickCount64;
-                if (ThrottleMsPerShip > 0)
+                var zoneId = ship.Transform.ZoneId;
+                var set = _shoreMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(4));
+                if (set.ZoneId != zoneId || set.TemplateId != templateId)
                 {
-                    var last = _lastShorePenMsgAtMs.GetOrAdd(ship.Id, 0);
-                    if (nowMs - last < ThrottleMsPerShip)
-                        return;
-                    _lastShorePenMsgAtMs[ship.Id] = nowMs;
+                    DespawnMarkers(_shoreMarkers, ship.Id);
+                    set = _shoreMarkers.GetOrAdd(ship.Id, _ => new MarkerSet(4));
+                    set.ZoneId = zoneId;
+                    set.TemplateId = templateId;
                 }
 
-                driver.SendDebugMessage($"[ShipShore] ship={ship.ObjId} pen={penetrationMeters:F3}m");
+                UpdateMarker(ship.ParentWorld, set, 0, templateId, zoneId, new Vector3(probeX, probeY, floorZ));
+                UpdateMarker(ship.ParentWorld, set, 1, templateId, zoneId, new Vector3(cliffX, cliffY, cliffZ));
+                UpdateMarker(ship.ParentWorld, set, 2, templateId, zoneId, new Vector3(boatCenterX, boatCenterY, boatBottomZ));
+                UpdateMarker(ship.ParentWorld, set, 3, templateId, zoneId, new Vector3(probeX, probeY, waterSurfaceZ));
             }
         }
+
+        if (penetrationMeters <= 0.0f || !ShorePenetrationChatEnabled)
+            return;
+
+        var driver = TryGetDriver(ship);
+        if (driver is null || !CanReceive(driver))
+            return;
+
+        var nowMs = Environment.TickCount64;
+        if (ThrottleMsPerShip > 0)
+        {
+            var last = _lastShorePenMsgAtMs.GetOrAdd(ship.Id, 0);
+            if (nowMs - last < ThrottleMsPerShip)
+                return;
+            _lastShorePenMsgAtMs[ship.Id] = nowMs;
+        }
+
+        driver.SendDebugMessage($"[ShipShore] ship={ship.ObjId} pen={penetrationMeters:F3}m");
     }
 
     private static void UpdateMarker(AAEmu.Game.Models.Game.World.WorldInstance world, MarkerSet set, int idx, uint templateId, uint zoneId, Vector3 pos)

--- a/AAEmu.Game/Physics/ReplicationSmoothing.cs
+++ b/AAEmu.Game/Physics/ReplicationSmoothing.cs
@@ -1,0 +1,34 @@
+#nullable enable
+
+using AAEmu.Game.Models.Game.Units;
+
+using Jitter2.Dynamics;
+
+namespace AAEmu.Game.Physics;
+
+/// <summary>
+/// Smoothed position, linear velocity, turn bank, and shore trim for packets.
+/// Hull yaw and physics euler from <see cref="RigidBody"/> stay unsmoothed in replication (no yaw smoothing).
+/// </summary>
+public sealed class ReplicationSmoothing
+{
+    public bool Seeded { get; set; }
+    public float PosX { get; set; }
+    public float PosY { get; set; }
+    public float PosZ { get; set; }
+    public float VelPx { get; set; }
+    public float VelPy { get; set; }
+    public float VelPz { get; set; }
+    /// <summary>Second low-pass on turn bank for replication (softer λ than vertical; targets <see cref="Slave.BankAngle"/>).</summary>
+    public float BankSmoothed { get; set; }
+    /// <summary>Second low-pass on shore pitch delta for replication (targets <see cref="Slave.GroundPitchAngle"/>).</summary>
+    public float GroundPitchSmoothed { get; set; }
+    /// <summary>Remaining movement broadcasts with stronger smoothing after hull–hull resolution.</summary>
+    public byte ContactHoldTicks { get; set; }
+
+    public void Reset()
+    {
+        Seeded = false;
+        ContactHoldTicks = 0;
+    }
+}

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -1,5 +1,7 @@
 #nullable enable
 
+using System.Numerics;
+
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Models;
 using AAEmu.Game.Models.Game;
@@ -22,6 +24,35 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
 
     public RigidBody Hull { get; private set; } = null!;
     public ShipModelV1 ShipModel { get; init; } = shipModel ?? throw new ArgumentNullException(nameof(shipModel));
+
+    /// <summary>
+    /// Smoothed position, linear velocity, turn bank, and shore trim for packets (see nested type).
+    /// Hull yaw and physics euler from <see cref="RigidBody"/> stay unsmoothed in replication (no yaw smoothing).
+    /// </summary>
+    public ReplicationSmoothing Replication { get; } = new();
+
+    public sealed class ReplicationSmoothing
+    {
+        public bool Seeded { get; set; }
+        public float PosX { get; set; }
+        public float PosY { get; set; }
+        public float PosZ { get; set; }
+        public float VelPx { get; set; }
+        public float VelPy { get; set; }
+        public float VelPz { get; set; }
+        /// <summary>Second low-pass on turn bank for replication (softer λ than vertical; targets <see cref="Slave.BankAngle"/>).</summary>
+        public float BankSmoothed { get; set; }
+        /// <summary>Second low-pass on shore différent for replication (targets <see cref="Slave.GroundPitchAngle"/>).</summary>
+        public float GroundPitchSmoothed { get; set; }
+        /// <summary>Remaining movement broadcasts with stronger smoothing after hull–hull resolution.</summary>
+        public byte ContactHoldTicks { get; set; }
+
+        public void Reset()
+        {
+            Seeded = false;
+            ContactHoldTicks = 0;
+        }
+    }
 
     private readonly float _waterLevel = waterLevel;
     private const float FluidDensity = 1025f; // kg/m³
@@ -53,10 +84,23 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
     /// <summary>Higher = snappier convergence of <see cref="Slave.TurnSpeedVelocityMul"/> toward the turn target.</summary>
     private const float TurnSpeedVelocityMulResponse = 5.5f;
 
+    /// <summary>Min hull submergence (m) before water upright stabilization runs.</summary>
+    private const float UprightStabilizeMinSubmergedMeters = 0.04f;
+
+    /// <summary>Max rotation (rad/s) toward upright per tick — avoids snaps after collisions.</summary>
+    private const float UprightStabilizeMaxRadPerSec = 2.25f;
+
+    /// <summary>Skip correction when deck normal is already this close to world up (rad).</summary>
+    private const float UprightStabilizeAngleDeadZoneRad = 0.004f;
+
     /// <summary>
     /// Fixed max yaw rate (degrees/s) by <see cref="SlaveKind"/>.
     /// NOTE: We intentionally do NOT use ship_models.steer_vel because values in DB are not in valid units.
     /// </summary>
+    /// <remarks>
+    /// When adding a <see cref="SlaveKind"/>, review this table and any other per-kind ship tuning.
+    /// Visual turn bank in <see cref="PhysicsManager"/> uses <c>ship_models</c> mass box + mass instead.
+    /// </remarks>
     private static float GetSteerMaxDegFixed(SlaveKind kind) => kind switch
     {
         SlaveKind.Boat => 4.35f,
@@ -606,8 +650,65 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         // Apply directional force
         rigidBody.Velocity = new JVector(forceThrottle * MathF.Cos(slaveRotRad), 0.0f, forceThrottle * MathF.Sin(slaveRotRad));
 
+        if (!isGrounded)
+        {
+            var submerged = MathF.Max(0f, slave.CachedWaterSurface - rigidBody.Position.Y);
+            if (submerged >= UprightStabilizeMinSubmergedMeters)
+                ApplyWaterUprightStabilization(rigidBody, dtSec);
+        }
+
         rigidBody.AngularVelocity = new JVector(0, slave.RotSpeed * -1f, 0);
 
         //Logger.Debug($"Slave: {slave.Name}, Throttle: {throttleFloatVal:F1} ({slave.ThrottleRequest}), Steering {steeringFloatVal:F1} ({slave.SteeringRequest}), speed: {slave.Speed}, rotSpeed: {slave.RotSpeed}");
+    }
+
+    /// <summary>
+    /// Nudges <paramref name="body"/> so local +Y matches world up (shortest path), limited per frame.
+    /// Collision/physics can leave pitch/roll in the quaternion while angular velocity is yaw-only; this corrects that on open water.
+    /// </summary>
+    private static void ApplyWaterUprightStabilization(RigidBody body, float dtSec)
+    {
+        if (dtSec <= 0f)
+            return;
+
+        var jo = body.Orientation;
+        var q = Quaternion.Normalize(new Quaternion(jo.X, jo.Y, jo.Z, jo.W));
+        var bodyUp = Vector3.Transform(Vector3.UnitY, q);
+        var worldUp = Vector3.UnitY;
+
+        var axis = Vector3.Cross(bodyUp, worldUp);
+        var lenSq = axis.LengthSquared();
+        float angle;
+
+        if (lenSq < 1e-14f)
+        {
+            var dotParallel = Vector3.Dot(bodyUp, worldUp);
+            if (dotParallel > 1f - 1e-6f)
+                return;
+            if (dotParallel < -1f + 1e-6f)
+            {
+                axis = Vector3.Normalize(Vector3.Cross(bodyUp, Vector3.UnitX));
+                if (axis.LengthSquared() < 1e-12f)
+                    axis = Vector3.Normalize(Vector3.Cross(bodyUp, Vector3.UnitZ));
+                angle = MathF.PI;
+            }
+            else
+                return;
+        }
+        else
+        {
+            axis = Vector3.Normalize(axis);
+            var dot = Math.Clamp(Vector3.Dot(bodyUp, worldUp), -1f, 1f);
+            angle = MathF.Acos(dot);
+        }
+
+        if (angle < UprightStabilizeAngleDeadZoneRad)
+            return;
+
+        var maxStep = UprightStabilizeMaxRadPerSec * dtSec;
+        var step = MathF.Min(angle, maxStep);
+        var deltaQ = Quaternion.CreateFromAxisAngle(axis, step);
+        var qNew = Quaternion.Normalize(Quaternion.Multiply(deltaQ, q));
+        body.Orientation = new JQuaternion(qNew.X, qNew.Y, qNew.Z, qNew.W);
     }
 }

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -57,7 +57,7 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
     private readonly float _waterLevel = waterLevel;
     private const float FluidDensity = 1025f; // kg/m³
 
-    /// <summary>Identity mass-box Z when <see cref="Debug.ShipTuningDebug.Enabled"/> is false (matches default <see cref="Debug.ShipTuningDebug.HullBoxTuning"/>).</summary>
+    /// <summary>Default mass-box Z center/size (identity; matches physics hull build).</summary>
     public static class ShipMassBoxDefaults
     {
         public const float CenterZAddMeters = 0f;
@@ -75,7 +75,7 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         }
     }
 
-    /// <summary>Production defaults when <see cref="Debug.ShipTuningDebug.Enabled"/> is false. <see cref="Debug.ShipTuningDebug.ShipControllerTuning"/> mirrors these for Hot Reload.</summary>
+    /// <summary>Production ship motion constants (single source of truth).</summary>
     public static class PhysicsDefaults
     {
         public const float GroundEscapeMaxSpeedAbs = 1.5f;
@@ -98,62 +98,40 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
     }
 
     /// <summary>Extra deceleration when throttle opposes current speed (reverse while moving forward, etc.).</summary>
-    private static float OpposingThrottleAccelMul => Debug.ShipTuningDebug.Enabled
-        ? Debug.ShipTuningDebug.ShipControllerTuning.OpposingThrottleAccelMul
-        : PhysicsDefaults.OpposingThrottleAccelMul;
+    private static float OpposingThrottleAccelMul => PhysicsDefaults.OpposingThrottleAccelMul;
 
     /// <summary>Only for opposing throttle — extra braking on top (does not affect forward accel).</summary>
-    private static float OpposingThrottleBrakeTuneMul => Debug.ShipTuningDebug.Enabled
-        ? Debug.ShipTuningDebug.ShipControllerTuning.OpposingThrottleBrakeTuneMul
-        : PhysicsDefaults.OpposingThrottleBrakeTuneMul;
+    private static float OpposingThrottleBrakeTuneMul => PhysicsDefaults.OpposingThrottleBrakeTuneMul;
 
     /// <summary>Steering builds turn rate faster without changing the max turn cap.</summary>
-    private static float SteeringResponsivenessMul => Debug.ShipTuningDebug.Enabled
-        ? Debug.ShipTuningDebug.ShipControllerTuning.SteeringResponsivenessMul
-        : PhysicsDefaults.SteeringResponsivenessMul;
+    private static float SteeringResponsivenessMul => PhysicsDefaults.SteeringResponsivenessMul;
 
     /// <summary>When rudder fights current yaw rate — faster decay; same-direction turn rate unchanged.</summary>
-    private static float CounterSteerResponsivenessMul => Debug.ShipTuningDebug.Enabled
-        ? Debug.ShipTuningDebug.ShipControllerTuning.CounterSteerResponsivenessMul
-        : PhysicsDefaults.CounterSteerResponsivenessMul;
+    private static float CounterSteerResponsivenessMul => PhysicsDefaults.CounterSteerResponsivenessMul;
 
     /// <summary>ship_models.steer_vel is often a small coefficient (~1), not °/s — only trust it above this.</summary>
     private const float MinSteerVelAsDegPerSec = 8f;
 
     /// <summary>At zero speed, keep this fraction of turning ability (so you can still rotate in place).</summary>
-    private static float MinTurnFactorAtZeroSpeed => Debug.ShipTuningDebug.Enabled
-        ? Debug.ShipTuningDebug.ShipControllerTuning.MinTurnFactorAtZeroSpeed
-        : PhysicsDefaults.MinTurnFactorAtZeroSpeed;
+    private static float MinTurnFactorAtZeroSpeed => PhysicsDefaults.MinTurnFactorAtZeroSpeed;
 
     /// <summary>Speed (in current ship speed units) at which turning reaches 100%.</summary>
-    private static float TurnFullFactorAtSpeed => Debug.ShipTuningDebug.Enabled
-        ? Debug.ShipTuningDebug.ShipControllerTuning.TurnFullFactorAtSpeed
-        : PhysicsDefaults.TurnFullFactorAtSpeed;
+    private static float TurnFullFactorAtSpeed => PhysicsDefaults.TurnFullFactorAtSpeed;
 
     /// <summary>Max forward/back speed multiplier removed at full yaw rate (linear in |ω|/ω_max).</summary>
-    private static float TurnSpeedSlowdownFrac => Debug.ShipTuningDebug.Enabled
-        ? Debug.ShipTuningDebug.ShipControllerTuning.TurnSpeedSlowdownFrac
-        : PhysicsDefaults.TurnSpeedSlowdownFrac;
+    private static float TurnSpeedSlowdownFrac => PhysicsDefaults.TurnSpeedSlowdownFrac;
 
     /// <summary>Higher = snappier convergence of <see cref="Slave.TurnSpeedVelocityMul"/> toward the turn target.</summary>
-    private static float TurnSpeedVelocityMulResponse => Debug.ShipTuningDebug.Enabled
-        ? Debug.ShipTuningDebug.ShipControllerTuning.TurnSpeedVelocityMulResponse
-        : PhysicsDefaults.TurnSpeedVelocityMulResponse;
+    private static float TurnSpeedVelocityMulResponse => PhysicsDefaults.TurnSpeedVelocityMulResponse;
 
     /// <summary>Min hull submergence (m) before water upright stabilization runs.</summary>
-    private static float UprightStabilizeMinSubmergedMeters => Debug.ShipTuningDebug.Enabled
-        ? Debug.ShipTuningDebug.ShipControllerTuning.UprightStabilizeMinSubmergedMeters
-        : PhysicsDefaults.UprightStabilizeMinSubmergedMeters;
+    private static float UprightStabilizeMinSubmergedMeters => PhysicsDefaults.UprightStabilizeMinSubmergedMeters;
 
     /// <summary>Max rotation (rad/s) toward upright per tick — avoids snaps after collisions.</summary>
-    private static float UprightStabilizeMaxRadPerSec => Debug.ShipTuningDebug.Enabled
-        ? Debug.ShipTuningDebug.ShipControllerTuning.UprightStabilizeMaxRadPerSec
-        : PhysicsDefaults.UprightStabilizeMaxRadPerSec;
+    private static float UprightStabilizeMaxRadPerSec => PhysicsDefaults.UprightStabilizeMaxRadPerSec;
 
     /// <summary>Skip correction when deck normal is already this close to world up (rad).</summary>
-    private static float UprightStabilizeAngleDeadZoneRad => Debug.ShipTuningDebug.Enabled
-        ? Debug.ShipTuningDebug.ShipControllerTuning.UprightStabilizeAngleDeadZoneRad
-        : PhysicsDefaults.UprightStabilizeAngleDeadZoneRad;
+    private static float UprightStabilizeAngleDeadZoneRad => PhysicsDefaults.UprightStabilizeAngleDeadZoneRad;
 
     /// <summary>
     /// Fixed max yaw rate (degrees/s) by <see cref="SlaveKind"/>.
@@ -185,17 +163,11 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
     private const float WindTimePhaseOffsetHours = 0f;
 
     /// <summary>Within this cone from wind axis (±15°) apply full ±15% speed limits.</summary>
-    private static float WindConeHalfAngleDeg => Debug.ShipTuningDebug.Enabled
-        ? Debug.ShipTuningDebug.ShipControllerTuning.WindConeHalfAngleDeg
-        : PhysicsDefaults.WindConeHalfAngleDeg;
+    private static float WindConeHalfAngleDeg => PhysicsDefaults.WindConeHalfAngleDeg;
 
-    private static float WindWithMaxMul => Debug.ShipTuningDebug.Enabled
-        ? Debug.ShipTuningDebug.ShipControllerTuning.WindWithMaxMul
-        : PhysicsDefaults.WindWithMaxMul;
+    private static float WindWithMaxMul => PhysicsDefaults.WindWithMaxMul;
 
-    private static float WindAgainstMaxMul => Debug.ShipTuningDebug.Enabled
-        ? Debug.ShipTuningDebug.ShipControllerTuning.WindAgainstMaxMul
-        : PhysicsDefaults.WindAgainstMaxMul;
+    private static float WindAgainstMaxMul => PhysicsDefaults.WindAgainstMaxMul;
 
     /// <summary>How wind affects max speed: none (rowing/motor), square (downwind best), lateen (beam reach best).</summary>
     private enum ShipWindProfile
@@ -382,12 +354,8 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         // - local +X uses MassBoxSizeX (beam)
         // - local +Y uses MassBoxSizeZ (height)
         // - local +Z uses MassBoxSizeY (length)
-        var sizeZ = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.HullBoxTuning.GetSizeZ(ShipModel.MassBoxSizeZ)
-            : ShipMassBoxDefaults.GetSizeZ(ShipModel.MassBoxSizeZ);
-        var centerZ = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.HullBoxTuning.GetCenterZ(ShipModel.MassCenterZ, ShipModel.MassBoxSizeZ)
-            : ShipMassBoxDefaults.GetCenterZ(ShipModel.MassCenterZ, ShipModel.MassBoxSizeZ);
+        var sizeZ = ShipMassBoxDefaults.GetSizeZ(ShipModel.MassBoxSizeZ);
+        var centerZ = ShipMassBoxDefaults.GetCenterZ(ShipModel.MassCenterZ, ShipModel.MassBoxSizeZ);
 
         var shipBoxShape = new BoxShape(ShipModel.MassBoxSizeX, sizeZ, ShipModel.MassBoxSizeY);
         // Center offset
@@ -425,9 +393,7 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         // Use the latched ground contact from PhysicsManager to avoid shoreline jitter causing
         // abrupt control/velocity changes ("jerks") when transitioning water<->land.
         var isGrounded = (slave.CachedFloorLevel > slave.CachedWaterSurface) || slave.GroundContactLatched;
-        var shallowDepthForCaps = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipControllerTuning.ShallowWaterDepthForGroundSpeedCaps
-            : PhysicsDefaults.ShallowWaterDepthForGroundSpeedCaps;
+        var shallowDepthForCaps = PhysicsDefaults.ShallowWaterDepthForGroundSpeedCaps;
         shallowDepthForCaps = MathF.Max(0f, shallowDepthForCaps);
         var waterDepth = slave.CachedWaterSurface - slave.CachedFloorLevel; // meters
         var isShallowForCaps = waterDepth >= 0f && waterDepth <= shallowDepthForCaps;
@@ -543,9 +509,7 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         // Shoal: limit max reverse vs the same water-based cap (percent of |maxBackward| on water).
         if (isGroundedForSpeedCaps)
         {
-            var revPct = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-                ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipControllerTuning.GroundReverseSpeedCapPercentOfWater
-                : PhysicsDefaults.GroundReverseSpeedCapPercentOfWater;
+            var revPct = PhysicsDefaults.GroundReverseSpeedCapPercentOfWater;
             revPct = Math.Clamp(revPct, 0f, 100f);
             maxBackward = -waterMaxReverseAbs * (revPct / 100f);
         }
@@ -561,9 +525,7 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
 
         if (isGroundedForSpeedCaps && (isEscapeInputOnGround || isFallbackEscapeOnGround))
         {
-            var groundEscapeMaxSpeedAbs = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-                ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipControllerTuning.GroundEscapeMaxSpeedAbs
-                : PhysicsDefaults.GroundEscapeMaxSpeedAbs;
+            var groundEscapeMaxSpeedAbs = PhysicsDefaults.GroundEscapeMaxSpeedAbs;
             var escapeSign = isEscapeInputOnGround ? escapeThrottleSignOnGround : Math.Sign(slave.ThrottleRequest);
             if (escapeSign > 0)
                 maxForward = MathF.Max(maxForward, groundEscapeMaxSpeedAbs);
@@ -601,9 +563,7 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         // Anti-stall nudge: when grounded and escape input is held, avoid jitter around zero.
         if (isGroundedForSpeedCaps && isEscapeInputOnGround && slave.GroundStuckTime > 0.35f)
         {
-            var targetEscapeSpeed = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-                ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipControllerTuning.GroundEscapeMaxSpeedAbs
-                : PhysicsDefaults.GroundEscapeMaxSpeedAbs;
+            var targetEscapeSpeed = PhysicsDefaults.GroundEscapeMaxSpeedAbs;
             var escapeA = 1f - MathF.Exp(-(6.0f + 2.0f * slave.GroundEscapeAssist) * MathF.Max(0f, dtSec));
             var target = escapeThrottleSignOnGround * targetEscapeSpeed;
             slave.Speed += (target - slave.Speed) * escapeA;

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -67,22 +67,39 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
     /// <summary>Production ship motion constants (single source of truth).</summary>
     public static class ShipMotionDefaults
     {
+        /// <summary>Hard cap (|m/s|) for the assisted “escape” speed target while grounded/beached.</summary>
         public const float GroundEscapeMaxSpeedAbs = 1.5f;
+        /// <summary>Reverse speed cap on ground, as a percent of the current water max speed cap.</summary>
         public const float GroundReverseSpeedCapPercentOfWater = 100f;
+        /// <summary>Below this water depth (m), apply the ground-related speed caps/logic (shoals).</summary>
         public const float ShallowWaterDepthForGroundSpeedCaps = 0.35f;
+        /// <summary>Extra acceleration multiplier when throttle opposes current motion (e.g. reverse while moving forward).</summary>
         public const float OpposingThrottleAccelMul = 1f;
+        /// <summary>Additional braking multiplier for opposing throttle only (does not affect forward accel).</summary>
         public const float OpposingThrottleBrakeTuneMul = 1f;
+        /// <summary>Steering builds yaw rate faster without raising the max yaw cap.</summary>
         public const float SteeringResponsivenessMul = 1.45f;
+        /// <summary>When rudder fights current yaw rate, decay faster (counter-steer responsiveness).</summary>
         public const float CounterSteerResponsivenessMul = 1.35f;
+        /// <summary>At (near) zero speed, keep this fraction of turning ability (so you can still rotate in place).</summary>
         public const float MinTurnFactorAtZeroSpeed = 0.5f;
+        /// <summary>Speed at which turning reaches full effectiveness (used to scale turn factor).</summary>
         public const float TurnFullFactorAtSpeed = 2.5f;
+        /// <summary>Max fraction of forward/back speed removed at full yaw rate (speed loss while turning).</summary>
         public const float TurnSpeedSlowdownFrac = 0.1f;
+        /// <summary>Response rate for smoothing <see cref="Slave.TurnSpeedVelocityMul"/> toward the target (higher = snappier).</summary>
         public const float TurnSpeedVelocityMulResponse = 5.5f;
+        /// <summary>Minimum hull submergence (m) before upright stabilization starts applying torque.</summary>
         public const float UprightStabilizeMinSubmergedMeters = 0.04f;
+        /// <summary>Max angular correction speed (rad/s) toward upright per tick (prevents snapping).</summary>
         public const float UprightStabilizeMaxRadPerSec = 2.25f;
+        /// <summary>Dead-zone angle (rad) under which upright stabilization does nothing.</summary>
         public const float UprightStabilizeAngleDeadZoneRad = 0.004f;
+        /// <summary>Half-angle (deg) of the “with wind / against wind” cone used by the wind speed model.</summary>
         public const float WindConeHalfAngleDeg = 15f;
+        /// <summary>Max speed multiplier when moving “with wind” (inside the cone).</summary>
         public const float WindWithMaxMul = 1.15f;
+        /// <summary>Max speed multiplier when moving “against wind” (inside the opposite cone).</summary>
         public const float WindAgainstMaxMul = 0.85f;
     }
 

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -25,34 +25,8 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
     public RigidBody Hull { get; private set; } = null!;
     public ShipModelV1 ShipModel { get; init; } = shipModel ?? throw new ArgumentNullException(nameof(shipModel));
 
-    /// <summary>
-    /// Smoothed position, linear velocity, turn bank, and shore trim for packets (see nested type).
-    /// Hull yaw and physics euler from <see cref="RigidBody"/> stay unsmoothed in replication (no yaw smoothing).
-    /// </summary>
+    /// <summary>Per-ship replication smoothing state; see <see cref="ReplicationSmoothing"/>.</summary>
     public ReplicationSmoothing Replication { get; } = new();
-
-    public sealed class ReplicationSmoothing
-    {
-        public bool Seeded { get; set; }
-        public float PosX { get; set; }
-        public float PosY { get; set; }
-        public float PosZ { get; set; }
-        public float VelPx { get; set; }
-        public float VelPy { get; set; }
-        public float VelPz { get; set; }
-        /// <summary>Second low-pass on turn bank for replication (softer λ than vertical; targets <see cref="Slave.BankAngle"/>).</summary>
-        public float BankSmoothed { get; set; }
-        /// <summary>Second low-pass on shore pitch delta for replication (targets <see cref="Slave.GroundPitchAngle"/>).</summary>
-        public float GroundPitchSmoothed { get; set; }
-        /// <summary>Remaining movement broadcasts with stronger smoothing after hull–hull resolution.</summary>
-        public byte ContactHoldTicks { get; set; }
-
-        public void Reset()
-        {
-            Seeded = false;
-            ContactHoldTicks = 0;
-        }
-    }
 
     private readonly float _waterLevel = waterLevel;
 

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -18,7 +18,7 @@ using Jitter2.LinearMath;
 
 namespace AAEmu.Game.Physics;
 
-public class ShipController(World world, ShipModelV1 shipModel, float waterLevel = 100f)
+public class ShipController(World world, ShipModelV1 shipModel)
 {
     private readonly World _world = world ?? throw new ArgumentNullException(nameof(world));
 
@@ -27,8 +27,6 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
 
     /// <summary>Per-ship replication smoothing state; see <see cref="ReplicationSmoothing"/>.</summary>
     public ReplicationSmoothing Replication { get; } = new();
-
-    private readonly float _waterLevel = waterLevel;
 
     /// <summary>Mass-box Z center/size used by <see cref="Build"/>; change implementations if hull height needs server-side tuning.</summary>
     public static class ShipMassBoxDefaults

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -57,41 +57,103 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
     private readonly float _waterLevel = waterLevel;
     private const float FluidDensity = 1025f; // kg/m³
 
+    /// <summary>Identity mass-box Z when <see cref="Debug.ShipTuningDebug.Enabled"/> is false (matches default <see cref="Debug.ShipTuningDebug.HullBoxTuning"/>).</summary>
+    public static class ShipMassBoxDefaults
+    {
+        public const float CenterZAddMeters = 0f;
+        public const float CenterZAddFracOfSizeZ = 0f;
+        public const float SizeZMul = 1f;
+        public const float SizeZAddMeters = 0f;
+
+        public static float GetCenterZ(float baseCenterZ, float baseSizeZ) =>
+            baseCenterZ + baseSizeZ * CenterZAddFracOfSizeZ + CenterZAddMeters;
+
+        public static float GetSizeZ(float baseSizeZ)
+        {
+            var z = baseSizeZ * SizeZMul + SizeZAddMeters;
+            return MathF.Max(0.01f, z);
+        }
+    }
+
+    /// <summary>Production defaults when <see cref="Debug.ShipTuningDebug.Enabled"/> is false. <see cref="Debug.ShipTuningDebug.ShipControllerTuning"/> mirrors these for Hot Reload.</summary>
+    public static class PhysicsDefaults
+    {
+        public const float GroundEscapeMaxSpeedAbs = 1.5f;
+        public const float GroundReverseSpeedCapPercentOfWater = 100f;
+        public const float ShallowWaterDepthForGroundSpeedCaps = 0.35f;
+        public const float OpposingThrottleAccelMul = 1f;
+        public const float OpposingThrottleBrakeTuneMul = 1f;
+        public const float SteeringResponsivenessMul = 1.45f;
+        public const float CounterSteerResponsivenessMul = 1.35f;
+        public const float MinTurnFactorAtZeroSpeed = 0.5f;
+        public const float TurnFullFactorAtSpeed = 2.5f;
+        public const float TurnSpeedSlowdownFrac = 0.1f;
+        public const float TurnSpeedVelocityMulResponse = 5.5f;
+        public const float UprightStabilizeMinSubmergedMeters = 0.04f;
+        public const float UprightStabilizeMaxRadPerSec = 2.25f;
+        public const float UprightStabilizeAngleDeadZoneRad = 0.004f;
+        public const float WindConeHalfAngleDeg = 15f;
+        public const float WindWithMaxMul = 1.15f;
+        public const float WindAgainstMaxMul = 0.85f;
+    }
+
     /// <summary>Extra deceleration when throttle opposes current speed (reverse while moving forward, etc.).</summary>
-    private static float OpposingThrottleAccelMul => Debug.ShipTuningDebug.ShipControllerTuning.OpposingThrottleAccelMul;
+    private static float OpposingThrottleAccelMul => Debug.ShipTuningDebug.Enabled
+        ? Debug.ShipTuningDebug.ShipControllerTuning.OpposingThrottleAccelMul
+        : PhysicsDefaults.OpposingThrottleAccelMul;
 
     /// <summary>Only for opposing throttle — extra braking on top (does not affect forward accel).</summary>
-    private static float OpposingThrottleBrakeTuneMul => Debug.ShipTuningDebug.ShipControllerTuning.OpposingThrottleBrakeTuneMul;
+    private static float OpposingThrottleBrakeTuneMul => Debug.ShipTuningDebug.Enabled
+        ? Debug.ShipTuningDebug.ShipControllerTuning.OpposingThrottleBrakeTuneMul
+        : PhysicsDefaults.OpposingThrottleBrakeTuneMul;
 
     /// <summary>Steering builds turn rate faster without changing the max turn cap.</summary>
-    private static float SteeringResponsivenessMul => Debug.ShipTuningDebug.ShipControllerTuning.SteeringResponsivenessMul;
+    private static float SteeringResponsivenessMul => Debug.ShipTuningDebug.Enabled
+        ? Debug.ShipTuningDebug.ShipControllerTuning.SteeringResponsivenessMul
+        : PhysicsDefaults.SteeringResponsivenessMul;
 
     /// <summary>When rudder fights current yaw rate — faster decay; same-direction turn rate unchanged.</summary>
-    private static float CounterSteerResponsivenessMul => Debug.ShipTuningDebug.ShipControllerTuning.CounterSteerResponsivenessMul;
+    private static float CounterSteerResponsivenessMul => Debug.ShipTuningDebug.Enabled
+        ? Debug.ShipTuningDebug.ShipControllerTuning.CounterSteerResponsivenessMul
+        : PhysicsDefaults.CounterSteerResponsivenessMul;
 
     /// <summary>ship_models.steer_vel is often a small coefficient (~1), not °/s — only trust it above this.</summary>
     private const float MinSteerVelAsDegPerSec = 8f;
 
     /// <summary>At zero speed, keep this fraction of turning ability (so you can still rotate in place).</summary>
-    private static float MinTurnFactorAtZeroSpeed => Debug.ShipTuningDebug.ShipControllerTuning.MinTurnFactorAtZeroSpeed;
+    private static float MinTurnFactorAtZeroSpeed => Debug.ShipTuningDebug.Enabled
+        ? Debug.ShipTuningDebug.ShipControllerTuning.MinTurnFactorAtZeroSpeed
+        : PhysicsDefaults.MinTurnFactorAtZeroSpeed;
 
     /// <summary>Speed (in current ship speed units) at which turning reaches 100%.</summary>
-    private static float TurnFullFactorAtSpeed => Debug.ShipTuningDebug.ShipControllerTuning.TurnFullFactorAtSpeed;
+    private static float TurnFullFactorAtSpeed => Debug.ShipTuningDebug.Enabled
+        ? Debug.ShipTuningDebug.ShipControllerTuning.TurnFullFactorAtSpeed
+        : PhysicsDefaults.TurnFullFactorAtSpeed;
 
     /// <summary>Max forward/back speed multiplier removed at full yaw rate (linear in |ω|/ω_max).</summary>
-    private static float TurnSpeedSlowdownFrac => Debug.ShipTuningDebug.ShipControllerTuning.TurnSpeedSlowdownFrac;
+    private static float TurnSpeedSlowdownFrac => Debug.ShipTuningDebug.Enabled
+        ? Debug.ShipTuningDebug.ShipControllerTuning.TurnSpeedSlowdownFrac
+        : PhysicsDefaults.TurnSpeedSlowdownFrac;
 
     /// <summary>Higher = snappier convergence of <see cref="Slave.TurnSpeedVelocityMul"/> toward the turn target.</summary>
-    private static float TurnSpeedVelocityMulResponse => Debug.ShipTuningDebug.ShipControllerTuning.TurnSpeedVelocityMulResponse;
+    private static float TurnSpeedVelocityMulResponse => Debug.ShipTuningDebug.Enabled
+        ? Debug.ShipTuningDebug.ShipControllerTuning.TurnSpeedVelocityMulResponse
+        : PhysicsDefaults.TurnSpeedVelocityMulResponse;
 
     /// <summary>Min hull submergence (m) before water upright stabilization runs.</summary>
-    private static float UprightStabilizeMinSubmergedMeters => Debug.ShipTuningDebug.ShipControllerTuning.UprightStabilizeMinSubmergedMeters;
+    private static float UprightStabilizeMinSubmergedMeters => Debug.ShipTuningDebug.Enabled
+        ? Debug.ShipTuningDebug.ShipControllerTuning.UprightStabilizeMinSubmergedMeters
+        : PhysicsDefaults.UprightStabilizeMinSubmergedMeters;
 
     /// <summary>Max rotation (rad/s) toward upright per tick — avoids snaps after collisions.</summary>
-    private static float UprightStabilizeMaxRadPerSec => Debug.ShipTuningDebug.ShipControllerTuning.UprightStabilizeMaxRadPerSec;
+    private static float UprightStabilizeMaxRadPerSec => Debug.ShipTuningDebug.Enabled
+        ? Debug.ShipTuningDebug.ShipControllerTuning.UprightStabilizeMaxRadPerSec
+        : PhysicsDefaults.UprightStabilizeMaxRadPerSec;
 
     /// <summary>Skip correction when deck normal is already this close to world up (rad).</summary>
-    private static float UprightStabilizeAngleDeadZoneRad => Debug.ShipTuningDebug.ShipControllerTuning.UprightStabilizeAngleDeadZoneRad;
+    private static float UprightStabilizeAngleDeadZoneRad => Debug.ShipTuningDebug.Enabled
+        ? Debug.ShipTuningDebug.ShipControllerTuning.UprightStabilizeAngleDeadZoneRad
+        : PhysicsDefaults.UprightStabilizeAngleDeadZoneRad;
 
     /// <summary>
     /// Fixed max yaw rate (degrees/s) by <see cref="SlaveKind"/>.
@@ -123,10 +185,17 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
     private const float WindTimePhaseOffsetHours = 0f;
 
     /// <summary>Within this cone from wind axis (±15°) apply full ±15% speed limits.</summary>
-    private static float WindConeHalfAngleDeg => Debug.ShipTuningDebug.ShipControllerTuning.WindConeHalfAngleDeg;
+    private static float WindConeHalfAngleDeg => Debug.ShipTuningDebug.Enabled
+        ? Debug.ShipTuningDebug.ShipControllerTuning.WindConeHalfAngleDeg
+        : PhysicsDefaults.WindConeHalfAngleDeg;
 
-    private static float WindWithMaxMul => Debug.ShipTuningDebug.ShipControllerTuning.WindWithMaxMul;
-    private static float WindAgainstMaxMul => Debug.ShipTuningDebug.ShipControllerTuning.WindAgainstMaxMul;
+    private static float WindWithMaxMul => Debug.ShipTuningDebug.Enabled
+        ? Debug.ShipTuningDebug.ShipControllerTuning.WindWithMaxMul
+        : PhysicsDefaults.WindWithMaxMul;
+
+    private static float WindAgainstMaxMul => Debug.ShipTuningDebug.Enabled
+        ? Debug.ShipTuningDebug.ShipControllerTuning.WindAgainstMaxMul
+        : PhysicsDefaults.WindAgainstMaxMul;
 
     /// <summary>How wind affects max speed: none (rowing/motor), square (downwind best), lateen (beam reach best).</summary>
     private enum ShipWindProfile
@@ -315,10 +384,10 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         // - local +Z uses MassBoxSizeY (length)
         var sizeZ = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.HullBoxTuning.GetSizeZ(ShipModel.MassBoxSizeZ)
-            : ShipModel.MassBoxSizeZ;
+            : ShipMassBoxDefaults.GetSizeZ(ShipModel.MassBoxSizeZ);
         var centerZ = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.HullBoxTuning.GetCenterZ(ShipModel.MassCenterZ, ShipModel.MassBoxSizeZ)
-            : ShipModel.MassCenterZ;
+            : ShipMassBoxDefaults.GetCenterZ(ShipModel.MassCenterZ, ShipModel.MassBoxSizeZ);
 
         var shipBoxShape = new BoxShape(ShipModel.MassBoxSizeX, sizeZ, ShipModel.MassBoxSizeY);
         // Center offset
@@ -356,7 +425,9 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         // Use the latched ground contact from PhysicsManager to avoid shoreline jitter causing
         // abrupt control/velocity changes ("jerks") when transitioning water<->land.
         var isGrounded = (slave.CachedFloorLevel > slave.CachedWaterSurface) || slave.GroundContactLatched;
-        var shallowDepthForCaps = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipControllerTuning.ShallowWaterDepthForGroundSpeedCaps;
+        var shallowDepthForCaps = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipControllerTuning.ShallowWaterDepthForGroundSpeedCaps
+            : PhysicsDefaults.ShallowWaterDepthForGroundSpeedCaps;
         shallowDepthForCaps = MathF.Max(0f, shallowDepthForCaps);
         var waterDepth = slave.CachedWaterSurface - slave.CachedFloorLevel; // meters
         var isShallowForCaps = waterDepth >= 0f && waterDepth <= shallowDepthForCaps;
@@ -472,7 +543,9 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         // Shoal: limit max reverse vs the same water-based cap (percent of |maxBackward| on water).
         if (isGroundedForSpeedCaps)
         {
-            var revPct = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipControllerTuning.GroundReverseSpeedCapPercentOfWater;
+            var revPct = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+                ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipControllerTuning.GroundReverseSpeedCapPercentOfWater
+                : PhysicsDefaults.GroundReverseSpeedCapPercentOfWater;
             revPct = Math.Clamp(revPct, 0f, 100f);
             maxBackward = -waterMaxReverseAbs * (revPct / 100f);
         }
@@ -488,7 +561,9 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
 
         if (isGroundedForSpeedCaps && (isEscapeInputOnGround || isFallbackEscapeOnGround))
         {
-            var groundEscapeMaxSpeedAbs = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipControllerTuning.GroundEscapeMaxSpeedAbs;
+            var groundEscapeMaxSpeedAbs = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+                ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipControllerTuning.GroundEscapeMaxSpeedAbs
+                : PhysicsDefaults.GroundEscapeMaxSpeedAbs;
             var escapeSign = isEscapeInputOnGround ? escapeThrottleSignOnGround : Math.Sign(slave.ThrottleRequest);
             if (escapeSign > 0)
                 maxForward = MathF.Max(maxForward, groundEscapeMaxSpeedAbs);
@@ -526,7 +601,9 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         // Anti-stall nudge: when grounded and escape input is held, avoid jitter around zero.
         if (isGroundedForSpeedCaps && isEscapeInputOnGround && slave.GroundStuckTime > 0.35f)
         {
-            var targetEscapeSpeed = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipControllerTuning.GroundEscapeMaxSpeedAbs;
+            var targetEscapeSpeed = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+                ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipControllerTuning.GroundEscapeMaxSpeedAbs
+                : PhysicsDefaults.GroundEscapeMaxSpeedAbs;
             var escapeA = 1f - MathF.Exp(-(6.0f + 2.0f * slave.GroundEscapeAssist) * MathF.Max(0f, dtSec));
             var target = escapeThrottleSignOnGround * targetEscapeSpeed;
             slave.Speed += (target - slave.Speed) * escapeA;

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -58,40 +58,40 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
     private const float FluidDensity = 1025f; // kg/m³
 
     /// <summary>Extra deceleration when throttle opposes current speed (reverse while moving forward, etc.).</summary>
-    private const float OpposingThrottleAccelMul = 1.75f;
+    private static float OpposingThrottleAccelMul => Debug.ShipTuningDebug.ShipControllerTuning.OpposingThrottleAccelMul;
 
     /// <summary>Only for opposing throttle — extra braking on top (does not affect forward accel).</summary>
-    private const float OpposingThrottleBrakeTuneMul = 1.2f;
+    private static float OpposingThrottleBrakeTuneMul => Debug.ShipTuningDebug.ShipControllerTuning.OpposingThrottleBrakeTuneMul;
 
     /// <summary>Steering builds turn rate faster without changing the max turn cap.</summary>
-    private const float SteeringResponsivenessMul = 1.45f;
+    private static float SteeringResponsivenessMul => Debug.ShipTuningDebug.ShipControllerTuning.SteeringResponsivenessMul;
 
     /// <summary>When rudder fights current yaw rate — faster decay; same-direction turn rate unchanged.</summary>
-    private const float CounterSteerResponsivenessMul = 1.35f;
+    private static float CounterSteerResponsivenessMul => Debug.ShipTuningDebug.ShipControllerTuning.CounterSteerResponsivenessMul;
 
     /// <summary>ship_models.steer_vel is often a small coefficient (~1), not °/s — only trust it above this.</summary>
     private const float MinSteerVelAsDegPerSec = 8f;
 
     /// <summary>At zero speed, keep this fraction of turning ability (so you can still rotate in place).</summary>
-    private const float MinTurnFactorAtZeroSpeed = 0.5f;
+    private static float MinTurnFactorAtZeroSpeed => Debug.ShipTuningDebug.ShipControllerTuning.MinTurnFactorAtZeroSpeed;
 
     /// <summary>Speed (in current ship speed units) at which turning reaches 100%.</summary>
-    private const float TurnFullFactorAtSpeed = 2.5f;
+    private static float TurnFullFactorAtSpeed => Debug.ShipTuningDebug.ShipControllerTuning.TurnFullFactorAtSpeed;
 
     /// <summary>Max forward/back speed multiplier removed at full yaw rate (linear in |ω|/ω_max).</summary>
-    private const float TurnSpeedSlowdownFrac = 0.1f;
+    private static float TurnSpeedSlowdownFrac => Debug.ShipTuningDebug.ShipControllerTuning.TurnSpeedSlowdownFrac;
 
     /// <summary>Higher = snappier convergence of <see cref="Slave.TurnSpeedVelocityMul"/> toward the turn target.</summary>
-    private const float TurnSpeedVelocityMulResponse = 5.5f;
+    private static float TurnSpeedVelocityMulResponse => Debug.ShipTuningDebug.ShipControllerTuning.TurnSpeedVelocityMulResponse;
 
     /// <summary>Min hull submergence (m) before water upright stabilization runs.</summary>
-    private const float UprightStabilizeMinSubmergedMeters = 0.04f;
+    private static float UprightStabilizeMinSubmergedMeters => Debug.ShipTuningDebug.ShipControllerTuning.UprightStabilizeMinSubmergedMeters;
 
     /// <summary>Max rotation (rad/s) toward upright per tick — avoids snaps after collisions.</summary>
-    private const float UprightStabilizeMaxRadPerSec = 2.25f;
+    private static float UprightStabilizeMaxRadPerSec => Debug.ShipTuningDebug.ShipControllerTuning.UprightStabilizeMaxRadPerSec;
 
     /// <summary>Skip correction when deck normal is already this close to world up (rad).</summary>
-    private const float UprightStabilizeAngleDeadZoneRad = 0.004f;
+    private static float UprightStabilizeAngleDeadZoneRad => Debug.ShipTuningDebug.ShipControllerTuning.UprightStabilizeAngleDeadZoneRad;
 
     /// <summary>
     /// Fixed max yaw rate (degrees/s) by <see cref="SlaveKind"/>.
@@ -123,10 +123,10 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
     private const float WindTimePhaseOffsetHours = 0f;
 
     /// <summary>Within this cone from wind axis (±15°) apply full ±15% speed limits.</summary>
-    private const float WindConeHalfAngleDeg = 15f;
+    private static float WindConeHalfAngleDeg => Debug.ShipTuningDebug.ShipControllerTuning.WindConeHalfAngleDeg;
 
-    private const float WindWithMaxMul = 1.15f;
-    private const float WindAgainstMaxMul = 0.85f;
+    private static float WindWithMaxMul => Debug.ShipTuningDebug.ShipControllerTuning.WindWithMaxMul;
+    private static float WindAgainstMaxMul => Debug.ShipTuningDebug.ShipControllerTuning.WindAgainstMaxMul;
 
     /// <summary>How wind affects max speed: none (rowing/motor), square (downwind best), lateen (beam reach best).</summary>
     private enum ShipWindProfile
@@ -306,9 +306,23 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         Hull.Position = initialPosition;
         Hull.Orientation = initialOrientation;
         // Ship shape
-        var shipBoxShape = new BoxShape(ShipModel.MassBoxSizeY, ShipModel.MassBoxSizeZ, ShipModel.MassBoxSizeX);
+        // Interpretation:
+        // - MassBoxSizeY = length (forward/back)
+        // - MassBoxSizeX = beam (right/left)
+        // Axis mapping to physics box local axes:
+        // - local +X uses MassBoxSizeX (beam)
+        // - local +Y uses MassBoxSizeZ (height)
+        // - local +Z uses MassBoxSizeY (length)
+        var sizeZ = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.HullBoxTuning.GetSizeZ(ShipModel.MassBoxSizeZ)
+            : ShipModel.MassBoxSizeZ;
+        var centerZ = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.HullBoxTuning.GetCenterZ(ShipModel.MassCenterZ, ShipModel.MassBoxSizeZ)
+            : ShipModel.MassCenterZ;
+
+        var shipBoxShape = new BoxShape(ShipModel.MassBoxSizeX, sizeZ, ShipModel.MassBoxSizeY);
         // Center offset
-        var shipCenterPoint = new TransformedShape(shipBoxShape, new JVector(ShipModel.MassCenterX, ShipModel.MassCenterZ, ShipModel.MassCenterY));
+        var shipCenterPoint = new TransformedShape(shipBoxShape, new JVector(ShipModel.MassCenterX, centerZ, ShipModel.MassCenterY));
         // Add shape
         Hull.AddShape(shipCenterPoint);
         // Set Mass

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -61,6 +61,8 @@ public class ShipController(World world, ShipModelV1 shipModel)
         public const float TurnSpeedSlowdownFrac = 0.1f;
         /// <summary>Response rate for smoothing <see cref="Slave.TurnSpeedVelocityMul"/> toward the target (higher = snappier).</summary>
         public const float TurnSpeedVelocityMulResponse = 5.5f;
+        /// <summary>Exponential damping (1/s) for velocity perpendicular to bow in XZ on open water — keeps brief sideways drift after hull impulses without a separate lateral state on <see cref="Slave"/>.</summary>
+        public const float LateralVelocityDampPerSec = 5f;
         /// <summary>Minimum hull submergence (m) before upright stabilization starts applying torque.</summary>
         public const float UprightStabilizeMinSubmergedMeters = 0.04f;
         /// <summary>Max angular correction speed (rad/s) toward upright per tick (prevents snapping).</summary>
@@ -649,8 +651,24 @@ public class ShipController(World world, ShipModelV1 shipModel)
 
         var forceThrottle = slave.Speed * slave.MoveSpeedMul / 4f * slave.TurnSpeedVelocityMul; // Not sure if correct, but it feels correct
 
-        // Apply directional force
-        rigidBody.Velocity = new JVector(forceThrottle * MathF.Cos(slaveRotRad), 0.0f, forceThrottle * MathF.Sin(slaveRotRad));
+        // Longitudinal speed from Slave.Speed; preserve damped lateral XZ (perpendicular to bow) so hull impulses can briefly show sideways motion.
+        // On land/shore keep the old overwrite-only model (avoids odd sliding while beached).
+        var fx = MathF.Cos(slaveRotRad);
+        var fz = MathF.Sin(slaveRotRad);
+        if (!isGrounded)
+        {
+            var v = rigidBody.Velocity;
+            var alongDot = v.X * fx + v.Z * fz;
+            var perpX = v.X - alongDot * fx;
+            var perpZ = v.Z - alongDot * fz;
+            var lateralDamp = MathF.Exp(-ShipMotionDefaults.LateralVelocityDampPerSec * MathF.Max(0f, dtSec));
+            rigidBody.Velocity = new JVector(
+                forceThrottle * fx + perpX * lateralDamp,
+                0f,
+                forceThrottle * fz + perpZ * lateralDamp);
+        }
+        else
+            rigidBody.Velocity = new JVector(forceThrottle * fx, 0f, forceThrottle * fz);
 
         if (!isGrounded)
         {

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -97,41 +97,8 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         public const float WindAgainstMaxMul = 0.85f;
     }
 
-    /// <summary>Extra deceleration when throttle opposes current speed (reverse while moving forward, etc.).</summary>
-    private static float OpposingThrottleAccelMul => PhysicsDefaults.OpposingThrottleAccelMul;
-
-    /// <summary>Only for opposing throttle — extra braking on top (does not affect forward accel).</summary>
-    private static float OpposingThrottleBrakeTuneMul => PhysicsDefaults.OpposingThrottleBrakeTuneMul;
-
-    /// <summary>Steering builds turn rate faster without changing the max turn cap.</summary>
-    private static float SteeringResponsivenessMul => PhysicsDefaults.SteeringResponsivenessMul;
-
-    /// <summary>When rudder fights current yaw rate — faster decay; same-direction turn rate unchanged.</summary>
-    private static float CounterSteerResponsivenessMul => PhysicsDefaults.CounterSteerResponsivenessMul;
-
     /// <summary>ship_models.steer_vel is often a small coefficient (~1), not °/s — only trust it above this.</summary>
     private const float MinSteerVelAsDegPerSec = 8f;
-
-    /// <summary>At zero speed, keep this fraction of turning ability (so you can still rotate in place).</summary>
-    private static float MinTurnFactorAtZeroSpeed => PhysicsDefaults.MinTurnFactorAtZeroSpeed;
-
-    /// <summary>Speed (in current ship speed units) at which turning reaches 100%.</summary>
-    private static float TurnFullFactorAtSpeed => PhysicsDefaults.TurnFullFactorAtSpeed;
-
-    /// <summary>Max forward/back speed multiplier removed at full yaw rate (linear in |ω|/ω_max).</summary>
-    private static float TurnSpeedSlowdownFrac => PhysicsDefaults.TurnSpeedSlowdownFrac;
-
-    /// <summary>Higher = snappier convergence of <see cref="Slave.TurnSpeedVelocityMul"/> toward the turn target.</summary>
-    private static float TurnSpeedVelocityMulResponse => PhysicsDefaults.TurnSpeedVelocityMulResponse;
-
-    /// <summary>Min hull submergence (m) before water upright stabilization runs.</summary>
-    private static float UprightStabilizeMinSubmergedMeters => PhysicsDefaults.UprightStabilizeMinSubmergedMeters;
-
-    /// <summary>Max rotation (rad/s) toward upright per tick — avoids snaps after collisions.</summary>
-    private static float UprightStabilizeMaxRadPerSec => PhysicsDefaults.UprightStabilizeMaxRadPerSec;
-
-    /// <summary>Skip correction when deck normal is already this close to world up (rad).</summary>
-    private static float UprightStabilizeAngleDeadZoneRad => PhysicsDefaults.UprightStabilizeAngleDeadZoneRad;
 
     /// <summary>
     /// Fixed max yaw rate (degrees/s) by <see cref="SlaveKind"/>.
@@ -161,13 +128,6 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
 
     /// <summary>Shift wind phase in game hours (e.g. if «полночь» в клиенте не совпадает с 0:00).</summary>
     private const float WindTimePhaseOffsetHours = 0f;
-
-    /// <summary>Within this cone from wind axis (±15°) apply full ±15% speed limits.</summary>
-    private static float WindConeHalfAngleDeg => PhysicsDefaults.WindConeHalfAngleDeg;
-
-    private static float WindWithMaxMul => PhysicsDefaults.WindWithMaxMul;
-
-    private static float WindAgainstMaxMul => PhysicsDefaults.WindAgainstMaxMul;
 
     /// <summary>How wind affects max speed: none (rowing/motor), square (downwind best), lateen (beam reach best).</summary>
     private enum ShipWindProfile
@@ -268,25 +228,25 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
     /// <summary>Square rig: best speed down/up wind (same as original).</summary>
     private static float GetWindSpeedMulSquareRig(float dotMove)
     {
-        var cosCone = MathF.Cos(WindConeHalfAngleDeg * MathF.PI / 180f);
+        var cosCone = MathF.Cos(PhysicsDefaults.WindConeHalfAngleDeg * MathF.PI / 180f);
         if (dotMove >= cosCone)
-            return WindWithMaxMul;
+            return PhysicsDefaults.WindWithMaxMul;
         if (dotMove <= -cosCone)
-            return WindAgainstMaxMul;
-        return 1f + (WindWithMaxMul - 1f) * (dotMove / cosCone);
+            return PhysicsDefaults.WindAgainstMaxMul;
+        return 1f + (PhysicsDefaults.WindWithMaxMul - 1f) * (dotMove / cosCone);
     }
 
     /// <summary>Lateen / fore-and-aft: best speed on a beam reach (perpendicular to wind).</summary>
     private static float GetWindSpeedMulLateenRig(float dotMove)
     {
-        var cosCone = MathF.Cos(WindConeHalfAngleDeg * MathF.PI / 180f);
-        var sinCone = MathF.Sin(WindConeHalfAngleDeg * MathF.PI / 180f);
+        var cosCone = MathF.Cos(PhysicsDefaults.WindConeHalfAngleDeg * MathF.PI / 180f);
+        var sinCone = MathF.Sin(PhysicsDefaults.WindConeHalfAngleDeg * MathF.PI / 180f);
         var p = 1f - MathF.Abs(dotMove);
         if (p >= cosCone)
-            return WindWithMaxMul;
+            return PhysicsDefaults.WindWithMaxMul;
         if (p <= sinCone)
-            return WindAgainstMaxMul;
-        return WindAgainstMaxMul + (p - sinCone) / (cosCone - sinCone) * (WindWithMaxMul - WindAgainstMaxMul);
+            return PhysicsDefaults.WindAgainstMaxMul;
+        return PhysicsDefaults.WindAgainstMaxMul + (p - sinCone) / (cosCone - sinCone) * (PhysicsDefaults.WindWithMaxMul - PhysicsDefaults.WindAgainstMaxMul);
     }
 
     /// <summary>Multiplier for max speed from wind; depends on <see cref="ResolveShipWindProfile"/>.</summary>
@@ -310,10 +270,10 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
                 return 1f;
 
             // Retail-like: +15% within ±15° of the N↔S axis, both directions (no "against wind" penalty).
-            var cosCone = MathF.Cos(WindConeHalfAngleDeg * MathF.PI / 180f);
+            var cosCone = MathF.Cos(PhysicsDefaults.WindConeHalfAngleDeg * MathF.PI / 180f);
             var dotAbs = MathF.Abs(dotBow);
             // Hard cutoff: bonus disappears immediately beyond the angle threshold.
-            return dotAbs >= cosCone ? WindWithMaxMul : 1f;
+            return dotAbs >= cosCone ? PhysicsDefaults.WindWithMaxMul : 1f;
         }
 
         return profile switch
@@ -539,7 +499,7 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         if (isOpposingThrottle)
         {
             var reverseCap = shipModel.ReverseAccel > 0f ? shipModel.ReverseAccel : shipModel.Accel;
-            linearAccel = Math.Max(shipModel.Accel, reverseCap) * OpposingThrottleAccelMul * OpposingThrottleBrakeTuneMul;
+            linearAccel = Math.Max(shipModel.Accel, reverseCap) * PhysicsDefaults.OpposingThrottleAccelMul * PhysicsDefaults.OpposingThrottleBrakeTuneMul;
         }
 
         // Non-linear approach to max speed: accelerate strongly at low speed, taper off near the cap.
@@ -596,8 +556,8 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
 
         // Turning factor scales with ship speed, but never reaches zero (so the ship can still turn in place).
         var speedAbs = MathF.Abs(slave.Speed);
-        var speed01 = Math.Clamp(speedAbs / TurnFullFactorAtSpeed, 0f, 1f);
-        var turnFactor = MinTurnFactorAtZeroSpeed + (1f - MinTurnFactorAtZeroSpeed) * speed01;
+        var speed01 = Math.Clamp(speedAbs / PhysicsDefaults.TurnFullFactorAtSpeed, 0f, 1f);
+        var turnFactor = PhysicsDefaults.MinTurnFactorAtZeroSpeed + (1f - PhysicsDefaults.MinTurnFactorAtZeroSpeed) * speed01;
 
         // Reverse steering should be handled at input→rotSpeed stage, not at the final angular velocity assignment.
         // Otherwise when speed crosses zero (e.g. releasing reverse), the last-step inversion toggles and the ship appears
@@ -619,9 +579,9 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         // TurnSpeed is now a multiplier (1.0, 1.3, ...). Keep steering response at the previous "stat-scale"
         // baseline so counter-steer and turn build-up remain responsive.
         var turnSpeed = 100f * turnSpeedBonusMul * (float)deltaTime.TotalSeconds * MathF.PI;
-        var rotDelta = effectiveSteeringNorm * (turnSpeed / 100f) * (shipModel.TurnAccel / 360f) * SteeringResponsivenessMul * turnFactor;
+        var rotDelta = effectiveSteeringNorm * (turnSpeed / 100f) * (shipModel.TurnAccel / 360f) * PhysicsDefaults.SteeringResponsivenessMul * turnFactor;
         if (slave.RotSpeed != 0f && effectiveSteeringNorm != 0f && Math.Sign(slave.RotSpeed) != Math.Sign(effectiveSteeringNorm))
-            rotDelta *= CounterSteerResponsivenessMul;
+            rotDelta *= PhysicsDefaults.CounterSteerResponsivenessMul;
 
         // Non-linear approach: turning accelerates normally at low yaw rates, but slows down as we approach the cap.
         // This prevents the turn rate from building linearly all the way up to the limit.
@@ -663,11 +623,11 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
 
         var steerMax = (steerMaxDegNormal * turnFactor).DegToRad();
 
-        // Up to TurnSpeedSlowdownFrac slower at full yaw rate; smooth return on straight course (forward and reverse).
+        // Up to configured turn-speed slowdown at full yaw rate; smooth return on straight course (forward and reverse).
         var steerMaxSafe = Math.Max(steerMax, 1e-5f);
         var turnRateNorm = Math.Clamp(MathF.Abs(slave.RotSpeed) / steerMaxSafe, 0f, 1f);
-        var targetTurnVelMul = 1f - TurnSpeedSlowdownFrac * turnRateNorm;
-        var turnMulA = 1f - MathF.Exp(-TurnSpeedVelocityMulResponse * MathF.Max(0f, dtSec));
+        var targetTurnVelMul = 1f - PhysicsDefaults.TurnSpeedSlowdownFrac * turnRateNorm;
+        var turnMulA = 1f - MathF.Exp(-PhysicsDefaults.TurnSpeedVelocityMulResponse * MathF.Max(0f, dtSec));
         slave.TurnSpeedVelocityMul += (targetTurnVelMul - slave.TurnSpeedVelocityMul) * turnMulA;
 
         // Slow down turning if no steering active
@@ -736,7 +696,7 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         if (!isGrounded)
         {
             var submerged = MathF.Max(0f, slave.CachedWaterSurface - rigidBody.Position.Y);
-            if (submerged >= UprightStabilizeMinSubmergedMeters)
+            if (submerged >= PhysicsDefaults.UprightStabilizeMinSubmergedMeters)
                 ApplyWaterUprightStabilization(rigidBody, dtSec);
         }
 
@@ -785,10 +745,10 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
             angle = MathF.Acos(dot);
         }
 
-        if (angle < UprightStabilizeAngleDeadZoneRad)
+        if (angle < PhysicsDefaults.UprightStabilizeAngleDeadZoneRad)
             return;
 
-        var maxStep = UprightStabilizeMaxRadPerSec * dtSec;
+        var maxStep = PhysicsDefaults.UprightStabilizeMaxRadPerSec * dtSec;
         var step = MathF.Min(angle, maxStep);
         var deltaQ = Quaternion.CreateFromAxisAngle(axis, step);
         var qNew = Quaternion.Normalize(Quaternion.Multiply(deltaQ, q));

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -356,6 +356,11 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         // Use the latched ground contact from PhysicsManager to avoid shoreline jitter causing
         // abrupt control/velocity changes ("jerks") when transitioning water<->land.
         var isGrounded = (slave.CachedFloorLevel > slave.CachedWaterSurface) || slave.GroundContactLatched;
+        var shallowDepthForCaps = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipControllerTuning.ShallowWaterDepthForGroundSpeedCaps;
+        shallowDepthForCaps = MathF.Max(0f, shallowDepthForCaps);
+        var waterDepth = slave.CachedWaterSurface - slave.CachedFloorLevel; // meters
+        var isShallowForCaps = waterDepth >= 0f && waterDepth <= shallowDepthForCaps;
+        var isGroundedForSpeedCaps = isGrounded || isShallowForCaps;
 
         // Still compute movement direction for stern/bow logic.
         var rpy0 = PhysicsUtil.GetYawPitchRollFromMatrix(JMatrix.CreateFromQuaternion(rigidBody.Orientation));
@@ -367,7 +372,7 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         var isEscapeInputOnGround = false;
         var escapeThrottleSignOnGround = 0;
 
-        if (isGrounded)
+        if (isGroundedForSpeedCaps)
         {
             // Latch grounding side only when entering ground state.
             // Recomputing it every tick from current speed causes escape direction to flip mid-maneuver.
@@ -378,7 +383,6 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
             var escapeThrottleSign = groundedByStern ? 1 : -1; // forward to escape stern-grounding, reverse to escape bow-grounding
             escapeThrottleSignOnGround = escapeThrottleSign;
             isEscapeInputOnGround = slave.ThrottleRequest != 0 && Math.Sign(slave.ThrottleRequest) == escapeThrottleSign;
-            var isTryingMoveDeeper = slave.ThrottleRequest != 0 && !isEscapeInputOnGround;
             var isStuckOnGround = MathF.Abs(slave.Speed) < 0.08f && slave.ThrottleRequest != 0;
 
             if (isStuckOnGround)
@@ -386,14 +390,7 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
             else
                 slave.GroundStuckTime = 0f;
 
-            // Hard-stop "digging into shore": when stern is the leading edge and player keeps reverse,
-            // do not allow building/keeping significant backward speed on land.
-            if (groundedByStern && slave.ThrottleRequest < 0 && isTryingMoveDeeper)
-            {
-                // Kill the "run-on" distance: clamp backward speed and add extra damping.
-                slave.Speed = Math.Max(slave.Speed, -0.15f);
-                slave.Speed *= 0.75f;
-            }
+            // Reverse cap on shoal: GroundReverseSpeedCapPercentOfWater (see speed clamp below).
 
             // If player keeps trying the "escape direction" but ship stays almost still, gradually assist.
             var assistTarget = isEscapeInputOnGround && slave.GroundStuckTime > 1.2f ? 1f : 0f;
@@ -401,8 +398,9 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
             slave.GroundEscapeAssist += (assistTarget - slave.GroundEscapeAssist) * assistA;
 
             // Base asymmetric throttle on ground differs by contact side.
+            // NOTE: per tuning request we do not reduce reverse throttle on ground.
             var groundThrottleForwardMul = groundedByStern ? 0.78f : 0.10f;
-            var groundThrottleReverseMul = groundedByStern ? 0.02f : 0.85f;
+            var groundThrottleReverseMul = 1.0f;
 
             // Boost only the "escape" direction while stuck; suppress direction that digs deeper inland.
             if (isEscapeInputOnGround)
@@ -413,7 +411,7 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
                 else
                     groundThrottleReverseMul = MathF.Min(1f, groundThrottleReverseMul * escapeBoost);
             }
-            else if (isTryingMoveDeeper)
+            else if (slave.ThrottleRequest != 0 && !isEscapeInputOnGround)
             {
                 if (slave.ThrottleRequest > 0)
                     groundThrottleForwardMul *= 0.55f;
@@ -443,7 +441,9 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
             slave.GroundStuckTime = 0f;
             slave.GroundEscapeAssist = 0f;
         }
-        slave.GroundedLastTick = isGrounded;
+        // Must match the same "grounded for controls/caps" predicate; otherwise shallow-water-only frames
+        // never latch GroundedLastTick and GroundedByStern gets recomputed every tick (breaks escape direction).
+        slave.GroundedLastTick = isGroundedForSpeedCaps;
 
         // Minimum crawl speed when starting in that direction only. Do not apply while still moving
         // the other way — otherwise forward+reverse snaps Speed to ±1 and the ship stops instantly.
@@ -466,7 +466,35 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         // Clamp speed between min and max Velocity (wind: ±15% of max speed when within ±15° of with/against wind)
         var windMul = GetWindSpeedMul(slave, slaveRotRad);
         var maxForward = shipModel.Velocity * slave.MoveSpeedMul / 2f * windMul;
-        var maxBackward = -shipModel.ReverseVelocity * slave.MoveSpeedMul / 2f * windMul;
+        var waterMaxReverseAbs = shipModel.ReverseVelocity * slave.MoveSpeedMul / 2f * windMul;
+        var maxBackward = -waterMaxReverseAbs;
+
+        // Shoal: limit max reverse vs the same water-based cap (percent of |maxBackward| on water).
+        if (isGroundedForSpeedCaps)
+        {
+            var revPct = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipControllerTuning.GroundReverseSpeedCapPercentOfWater;
+            revPct = Math.Clamp(revPct, 0f, 100f);
+            maxBackward = -waterMaxReverseAbs * (revPct / 100f);
+        }
+
+        // Ground escape cap override:
+        // When grounded and the player holds the correct "escape" throttle direction, allow a higher cap than
+        // shipModel.Velocity-driven maxForward/maxBackward. Otherwise some ship models get stuck around ~0.6 m/s
+        // and cannot reliably climb off the shoal.
+        // Fallback: if the ship is grounded and effectively "stuck" (can't get moving) but the player keeps applying throttle,
+        // still allow the higher escape cap in the input direction. This prevents a wrong stern/bow latch from trapping ships
+        // at low model-based caps (~0.6 m/s) on some hulls.
+        var isFallbackEscapeOnGround = isGroundedForSpeedCaps && !isEscapeInputOnGround && slave.ThrottleRequest != 0 && slave.GroundStuckTime > 0.35f;
+
+        if (isGroundedForSpeedCaps && (isEscapeInputOnGround || isFallbackEscapeOnGround))
+        {
+            var groundEscapeMaxSpeedAbs = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipControllerTuning.GroundEscapeMaxSpeedAbs;
+            var escapeSign = isEscapeInputOnGround ? escapeThrottleSignOnGround : Math.Sign(slave.ThrottleRequest);
+            if (escapeSign > 0)
+                maxForward = MathF.Max(maxForward, groundEscapeMaxSpeedAbs);
+            else if (escapeSign < 0)
+                maxBackward = MathF.Min(maxBackward, -groundEscapeMaxSpeedAbs);
+        }
 
         // Use data reverse_accel for braking; scale up when fighting current motion (feels less sluggish than forward-only Accel).
         var linearAccel = shipModel.Accel;
@@ -496,9 +524,9 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         slave.Speed += throttleNorm * (linearAccel * dtSec) / 2f;
 
         // Anti-stall nudge: when grounded and escape input is held, avoid jitter around zero.
-        if (isGrounded && isEscapeInputOnGround && slave.GroundStuckTime > 0.35f)
+        if (isGroundedForSpeedCaps && isEscapeInputOnGround && slave.GroundStuckTime > 0.35f)
         {
-            const float targetEscapeSpeed = 1.6f;
+            var targetEscapeSpeed = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipControllerTuning.GroundEscapeMaxSpeedAbs;
             var escapeA = 1f - MathF.Exp(-(6.0f + 2.0f * slave.GroundEscapeAssist) * MathF.Max(0f, dtSec));
             var target = escapeThrottleSignOnGround * targetEscapeSpeed;
             slave.Speed += (target - slave.Speed) * escapeA;
@@ -614,15 +642,19 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
 
         // If not in water, seriously slow down the velocity
         const float FloorCollisionSpeedMultiplier = 0.96f;
-        if (isGrounded)
+        if (isGroundedForSpeedCaps)
         {
-            // While applying escape throttle, preserve more momentum to avoid "stuck in place" feel.
-            var groundDamping = isEscapeInputOnGround
-                ? 0.97f + 0.01f * slave.GroundEscapeAssist
-                : FloorCollisionSpeedMultiplier;
+            // While applying escape throttle, do not damp speed/velocity — otherwise it creates an artificial
+            // steady-state ceiling well below GroundEscapeMaxSpeedAbs (e.g. ~0.7).
+            var groundDamping = isEscapeInputOnGround ? 1.0f : FloorCollisionSpeedMultiplier;
             slave.Speed *= groundDamping;
             slave.RigidBody.Velocity *= groundDamping;
         }
+
+        // Holding throttle into the beach (e.g. reverse while stern-grounded) can settle at a tiny non-zero
+        // speed (~0.1) from accel/damping balance and MoveDirEpsilon; snap to full stop when nearly still.
+        if (isGroundedForSpeedCaps && slave.ThrottleRequest != 0 && !isEscapeInputOnGround && MathF.Abs(slave.Speed) < 0.12f)
+            slave.Speed = 0f;
 
         // this needs to be fixed : ships need to apply a static drag, and slowly ship away at the speed instead of doing it like this
         if (slave.Throttle == 0)

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -75,9 +75,6 @@ public class ShipController(World world, ShipModelV1 shipModel)
         public const float WindAgainstMaxMul = 0.85f;
     }
 
-    /// <summary>ship_models.steer_vel is often a small coefficient (~1), not °/s — only trust it above this.</summary>
-    private const float MinSteerVelAsDegPerSec = 8f;
-
     /// <summary>
     /// Fixed max yaw rate (degrees/s) by <see cref="SlaveKind"/>.
     /// NOTE: We intentionally do NOT use ship_models.steer_vel because values in DB are not in valid units.

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -42,7 +42,7 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         public float VelPz { get; set; }
         /// <summary>Second low-pass on turn bank for replication (softer λ than vertical; targets <see cref="Slave.BankAngle"/>).</summary>
         public float BankSmoothed { get; set; }
-        /// <summary>Second low-pass on shore différent for replication (targets <see cref="Slave.GroundPitchAngle"/>).</summary>
+        /// <summary>Second low-pass on shore pitch delta for replication (targets <see cref="Slave.GroundPitchAngle"/>).</summary>
         public float GroundPitchSmoothed { get; set; }
         /// <summary>Remaining movement broadcasts with stronger smoothing after hull–hull resolution.</summary>
         public byte ContactHoldTicks { get; set; }
@@ -55,28 +55,17 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
     }
 
     private readonly float _waterLevel = waterLevel;
-    private const float FluidDensity = 1025f; // kg/m³
 
-    /// <summary>Default mass-box Z center/size (identity; matches physics hull build).</summary>
+    /// <summary>Mass-box Z center/size used by <see cref="Build"/>; change implementations if hull height needs server-side tuning.</summary>
     public static class ShipMassBoxDefaults
     {
-        public const float CenterZAddMeters = 0f;
-        public const float CenterZAddFracOfSizeZ = 0f;
-        public const float SizeZMul = 1f;
-        public const float SizeZAddMeters = 0f;
+        public static float GetCenterZ(float baseCenterZ, float baseSizeZ) => baseCenterZ;
 
-        public static float GetCenterZ(float baseCenterZ, float baseSizeZ) =>
-            baseCenterZ + baseSizeZ * CenterZAddFracOfSizeZ + CenterZAddMeters;
-
-        public static float GetSizeZ(float baseSizeZ)
-        {
-            var z = baseSizeZ * SizeZMul + SizeZAddMeters;
-            return MathF.Max(0.01f, z);
-        }
+        public static float GetSizeZ(float baseSizeZ) => MathF.Max(0.01f, baseSizeZ);
     }
 
     /// <summary>Production ship motion constants (single source of truth).</summary>
-    public static class PhysicsDefaults
+    public static class ShipMotionDefaults
     {
         public const float GroundEscapeMaxSpeedAbs = 1.5f;
         public const float GroundReverseSpeedCapPercentOfWater = 100f;
@@ -137,25 +126,9 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         LateenRig
     }
 
-    /// <summary>Override: these <see cref="SlaveTemplate.Id"/> use lateen (e.g. trimaran under SmallSailingShip).</summary>
-    private static readonly HashSet<uint> WindProfileLateenTemplateIds = [];
-
-    /// <summary>Override: these template ids use square rig (e.g. Harani sailboat under SmallSailingShip).</summary>
-    private static readonly HashSet<uint> WindProfileSquareTemplateIds = [];
-
-    /// <summary>Override: force no wind (e.g. a sail template you want to treat as motor-only).</summary>
-    private static readonly HashSet<uint> WindProfileNoneTemplateIds = [];
-
+    /// <summary>Per-<see cref="SlaveTemplate.Id"/> wind overrides can branch here before the <see cref="SlaveKind"/> fallback.</summary>
     private static ShipWindProfile ResolveShipWindProfile(Slave slave)
     {
-        var tid = slave.Template.Id;
-        if (WindProfileNoneTemplateIds.Contains(tid))
-            return ShipWindProfile.None;
-        if (WindProfileLateenTemplateIds.Contains(tid))
-            return ShipWindProfile.LateenRig;
-        if (WindProfileSquareTemplateIds.Contains(tid))
-            return ShipWindProfile.SquareRig;
-
         return slave.Template.SlaveKind switch
         {
             SlaveKind.Boat or SlaveKind.Fishboat => ShipWindProfile.None,
@@ -228,25 +201,25 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
     /// <summary>Square rig: best speed down/up wind (same as original).</summary>
     private static float GetWindSpeedMulSquareRig(float dotMove)
     {
-        var cosCone = MathF.Cos(PhysicsDefaults.WindConeHalfAngleDeg * MathF.PI / 180f);
+        var cosCone = MathF.Cos(ShipMotionDefaults.WindConeHalfAngleDeg * MathF.PI / 180f);
         if (dotMove >= cosCone)
-            return PhysicsDefaults.WindWithMaxMul;
+            return ShipMotionDefaults.WindWithMaxMul;
         if (dotMove <= -cosCone)
-            return PhysicsDefaults.WindAgainstMaxMul;
-        return 1f + (PhysicsDefaults.WindWithMaxMul - 1f) * (dotMove / cosCone);
+            return ShipMotionDefaults.WindAgainstMaxMul;
+        return 1f + (ShipMotionDefaults.WindWithMaxMul - 1f) * (dotMove / cosCone);
     }
 
     /// <summary>Lateen / fore-and-aft: best speed on a beam reach (perpendicular to wind).</summary>
     private static float GetWindSpeedMulLateenRig(float dotMove)
     {
-        var cosCone = MathF.Cos(PhysicsDefaults.WindConeHalfAngleDeg * MathF.PI / 180f);
-        var sinCone = MathF.Sin(PhysicsDefaults.WindConeHalfAngleDeg * MathF.PI / 180f);
+        var cosCone = MathF.Cos(ShipMotionDefaults.WindConeHalfAngleDeg * MathF.PI / 180f);
+        var sinCone = MathF.Sin(ShipMotionDefaults.WindConeHalfAngleDeg * MathF.PI / 180f);
         var p = 1f - MathF.Abs(dotMove);
         if (p >= cosCone)
-            return PhysicsDefaults.WindWithMaxMul;
+            return ShipMotionDefaults.WindWithMaxMul;
         if (p <= sinCone)
-            return PhysicsDefaults.WindAgainstMaxMul;
-        return PhysicsDefaults.WindAgainstMaxMul + (p - sinCone) / (cosCone - sinCone) * (PhysicsDefaults.WindWithMaxMul - PhysicsDefaults.WindAgainstMaxMul);
+            return ShipMotionDefaults.WindAgainstMaxMul;
+        return ShipMotionDefaults.WindAgainstMaxMul + (p - sinCone) / (cosCone - sinCone) * (ShipMotionDefaults.WindWithMaxMul - ShipMotionDefaults.WindAgainstMaxMul);
     }
 
     /// <summary>Multiplier for max speed from wind; depends on <see cref="ResolveShipWindProfile"/>.</summary>
@@ -270,10 +243,10 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
                 return 1f;
 
             // Retail-like: +15% within ±15° of the N↔S axis, both directions (no "against wind" penalty).
-            var cosCone = MathF.Cos(PhysicsDefaults.WindConeHalfAngleDeg * MathF.PI / 180f);
+            var cosCone = MathF.Cos(ShipMotionDefaults.WindConeHalfAngleDeg * MathF.PI / 180f);
             var dotAbs = MathF.Abs(dotBow);
             // Hard cutoff: bonus disappears immediately beyond the angle threshold.
-            return dotAbs >= cosCone ? PhysicsDefaults.WindWithMaxMul : 1f;
+            return dotAbs >= cosCone ? ShipMotionDefaults.WindWithMaxMul : 1f;
         }
 
         return profile switch
@@ -353,7 +326,7 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         // Use the latched ground contact from PhysicsManager to avoid shoreline jitter causing
         // abrupt control/velocity changes ("jerks") when transitioning water<->land.
         var isGrounded = (slave.CachedFloorLevel > slave.CachedWaterSurface) || slave.GroundContactLatched;
-        var shallowDepthForCaps = PhysicsDefaults.ShallowWaterDepthForGroundSpeedCaps;
+        var shallowDepthForCaps = ShipMotionDefaults.ShallowWaterDepthForGroundSpeedCaps;
         shallowDepthForCaps = MathF.Max(0f, shallowDepthForCaps);
         var waterDepth = slave.CachedWaterSurface - slave.CachedFloorLevel; // meters
         var isShallowForCaps = waterDepth >= 0f && waterDepth <= shallowDepthForCaps;
@@ -394,8 +367,8 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
             var assistA = 1f - MathF.Exp(-4.0f * MathF.Max(0f, dtSec));
             slave.GroundEscapeAssist += (assistTarget - slave.GroundEscapeAssist) * assistA;
 
-            // Base asymmetric throttle on ground differs by contact side.
-            // NOTE: per tuning request we do not reduce reverse throttle on ground.
+            // Base asymmetric throttle on ground differs by contact side. Full reverse mul pairs with
+            // no collision damping for escape-direction throttle in ShipShoreInteraction.
             var groundThrottleForwardMul = groundedByStern ? 0.78f : 0.10f;
             var groundThrottleReverseMul = 1.0f;
 
@@ -469,7 +442,7 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         // Shoal: limit max reverse vs the same water-based cap (percent of |maxBackward| on water).
         if (isGroundedForSpeedCaps)
         {
-            var revPct = PhysicsDefaults.GroundReverseSpeedCapPercentOfWater;
+            var revPct = ShipMotionDefaults.GroundReverseSpeedCapPercentOfWater;
             revPct = Math.Clamp(revPct, 0f, 100f);
             maxBackward = -waterMaxReverseAbs * (revPct / 100f);
         }
@@ -485,7 +458,7 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
 
         if (isGroundedForSpeedCaps && (isEscapeInputOnGround || isFallbackEscapeOnGround))
         {
-            var groundEscapeMaxSpeedAbs = PhysicsDefaults.GroundEscapeMaxSpeedAbs;
+            var groundEscapeMaxSpeedAbs = ShipMotionDefaults.GroundEscapeMaxSpeedAbs;
             var escapeSign = isEscapeInputOnGround ? escapeThrottleSignOnGround : Math.Sign(slave.ThrottleRequest);
             if (escapeSign > 0)
                 maxForward = MathF.Max(maxForward, groundEscapeMaxSpeedAbs);
@@ -499,7 +472,7 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         if (isOpposingThrottle)
         {
             var reverseCap = shipModel.ReverseAccel > 0f ? shipModel.ReverseAccel : shipModel.Accel;
-            linearAccel = Math.Max(shipModel.Accel, reverseCap) * PhysicsDefaults.OpposingThrottleAccelMul * PhysicsDefaults.OpposingThrottleBrakeTuneMul;
+            linearAccel = Math.Max(shipModel.Accel, reverseCap) * ShipMotionDefaults.OpposingThrottleAccelMul * ShipMotionDefaults.OpposingThrottleBrakeTuneMul;
         }
 
         // Non-linear approach to max speed: accelerate strongly at low speed, taper off near the cap.
@@ -523,7 +496,7 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         // Anti-stall nudge: when grounded and escape input is held, avoid jitter around zero.
         if (isGroundedForSpeedCaps && isEscapeInputOnGround && slave.GroundStuckTime > 0.35f)
         {
-            var targetEscapeSpeed = PhysicsDefaults.GroundEscapeMaxSpeedAbs;
+            var targetEscapeSpeed = ShipMotionDefaults.GroundEscapeMaxSpeedAbs;
             var escapeA = 1f - MathF.Exp(-(6.0f + 2.0f * slave.GroundEscapeAssist) * MathF.Max(0f, dtSec));
             var target = escapeThrottleSignOnGround * targetEscapeSpeed;
             slave.Speed += (target - slave.Speed) * escapeA;
@@ -556,8 +529,8 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
 
         // Turning factor scales with ship speed, but never reaches zero (so the ship can still turn in place).
         var speedAbs = MathF.Abs(slave.Speed);
-        var speed01 = Math.Clamp(speedAbs / PhysicsDefaults.TurnFullFactorAtSpeed, 0f, 1f);
-        var turnFactor = PhysicsDefaults.MinTurnFactorAtZeroSpeed + (1f - PhysicsDefaults.MinTurnFactorAtZeroSpeed) * speed01;
+        var speed01 = Math.Clamp(speedAbs / ShipMotionDefaults.TurnFullFactorAtSpeed, 0f, 1f);
+        var turnFactor = ShipMotionDefaults.MinTurnFactorAtZeroSpeed + (1f - ShipMotionDefaults.MinTurnFactorAtZeroSpeed) * speed01;
 
         // Reverse steering should be handled at input→rotSpeed stage, not at the final angular velocity assignment.
         // Otherwise when speed crosses zero (e.g. releasing reverse), the last-step inversion toggles and the ship appears
@@ -579,9 +552,9 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         // TurnSpeed is now a multiplier (1.0, 1.3, ...). Keep steering response at the previous "stat-scale"
         // baseline so counter-steer and turn build-up remain responsive.
         var turnSpeed = 100f * turnSpeedBonusMul * (float)deltaTime.TotalSeconds * MathF.PI;
-        var rotDelta = effectiveSteeringNorm * (turnSpeed / 100f) * (shipModel.TurnAccel / 360f) * PhysicsDefaults.SteeringResponsivenessMul * turnFactor;
+        var rotDelta = effectiveSteeringNorm * (turnSpeed / 100f) * (shipModel.TurnAccel / 360f) * ShipMotionDefaults.SteeringResponsivenessMul * turnFactor;
         if (slave.RotSpeed != 0f && effectiveSteeringNorm != 0f && Math.Sign(slave.RotSpeed) != Math.Sign(effectiveSteeringNorm))
-            rotDelta *= PhysicsDefaults.CounterSteerResponsivenessMul;
+            rotDelta *= ShipMotionDefaults.CounterSteerResponsivenessMul;
 
         // Non-linear approach: turning accelerates normally at low yaw rates, but slows down as we approach the cap.
         // This prevents the turn rate from building linearly all the way up to the limit.
@@ -626,8 +599,8 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         // Up to configured turn-speed slowdown at full yaw rate; smooth return on straight course (forward and reverse).
         var steerMaxSafe = Math.Max(steerMax, 1e-5f);
         var turnRateNorm = Math.Clamp(MathF.Abs(slave.RotSpeed) / steerMaxSafe, 0f, 1f);
-        var targetTurnVelMul = 1f - PhysicsDefaults.TurnSpeedSlowdownFrac * turnRateNorm;
-        var turnMulA = 1f - MathF.Exp(-PhysicsDefaults.TurnSpeedVelocityMulResponse * MathF.Max(0f, dtSec));
+        var targetTurnVelMul = 1f - ShipMotionDefaults.TurnSpeedSlowdownFrac * turnRateNorm;
+        var turnMulA = 1f - MathF.Exp(-ShipMotionDefaults.TurnSpeedVelocityMulResponse * MathF.Max(0f, dtSec));
         slave.TurnSpeedVelocityMul += (targetTurnVelMul - slave.TurnSpeedVelocityMul) * turnMulA;
 
         // Slow down turning if no steering active
@@ -696,7 +669,7 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
         if (!isGrounded)
         {
             var submerged = MathF.Max(0f, slave.CachedWaterSurface - rigidBody.Position.Y);
-            if (submerged >= PhysicsDefaults.UprightStabilizeMinSubmergedMeters)
+            if (submerged >= ShipMotionDefaults.UprightStabilizeMinSubmergedMeters)
                 ApplyWaterUprightStabilization(rigidBody, dtSec);
         }
 
@@ -745,10 +718,10 @@ public class ShipController(World world, ShipModelV1 shipModel, float waterLevel
             angle = MathF.Acos(dot);
         }
 
-        if (angle < PhysicsDefaults.UprightStabilizeAngleDeadZoneRad)
+        if (angle < ShipMotionDefaults.UprightStabilizeAngleDeadZoneRad)
             return;
 
-        var maxStep = PhysicsDefaults.UprightStabilizeMaxRadPerSec * dtSec;
+        var maxStep = ShipMotionDefaults.UprightStabilizeMaxRadPerSec * dtSec;
         var step = MathF.Min(angle, maxStep);
         var deltaQ = Quaternion.CreateFromAxisAngle(axis, step);
         var qNew = Quaternion.Normalize(Quaternion.Multiply(deltaQ, q));

--- a/AAEmu.Game/Physics/ShipShipInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShipInteraction.cs
@@ -52,6 +52,8 @@ public sealed class ShipShipInteraction
 
     /// <summary>
     /// Run after all ships have had <see cref="ShipController.ApplyForceAndTorque"/> for this frame.
+    /// Pair loop is O(N²); <see cref="TryResolvePair"/> cheaply rejects distant hulls via world AABB on XZ before SAT.
+    /// For very large N, add a spatial hash / uniform grid on XZ so only nearby indices are paired.
     /// </summary>
     public void ResolveAllPairs(IReadOnlyList<Slave> ships, TimeSpan deltaTime)
     {
@@ -203,6 +205,14 @@ public sealed class ShipShipInteraction
         return (int)MathF.Round(f);
     }
 
+    /// <summary>True if world-space AABBs overlap on X and Z (conservative broadphase for hull SAT on XZ).</summary>
+    private static bool HaveWorldAabbOverlapXz(in JBoundingBox bbA, in JBoundingBox bbB)
+    {
+        var ox = MathF.Min(bbA.Max.X, bbB.Max.X) - MathF.Max(bbA.Min.X, bbB.Min.X);
+        var oz = MathF.Min(bbA.Max.Z, bbB.Max.Z) - MathF.Max(bbA.Min.Z, bbB.Min.Z);
+        return ox > 0f && oz > 0f;
+    }
+
     private static bool TryResolvePair(Slave sa, Slave sb, out float impactSpeedMps, out float maxPenetration)
     {
         impactSpeedMps = 0f;
@@ -218,6 +228,9 @@ public sealed class ShipShipInteraction
         var peakImpactSpeedMps = 0f;
         var bbA = bodyA.Shapes[0].WorldBoundingBox;
         var bbB = bodyB.Shapes[0].WorldBoundingBox;
+        if (!HaveWorldAabbOverlapXz(in bbA, in bbB))
+            return false;
+
         var overlapY = MathF.Min(bbA.Max.Y, bbB.Max.Y) - MathF.Max(bbA.Min.Y, bbB.Min.Y);
         if (overlapY < MinVerticalOverlap)
             return false;
@@ -240,6 +253,9 @@ public sealed class ShipShipInteraction
         {
             bbA = bodyA.Shapes[0].WorldBoundingBox;
             bbB = bodyB.Shapes[0].WorldBoundingBox;
+            if (!HaveWorldAabbOverlapXz(in bbA, in bbB))
+                break;
+
             overlapY = MathF.Min(bbA.Max.Y, bbB.Max.Y) - MathF.Max(bbA.Min.Y, bbB.Min.Y);
             if (overlapY < MinVerticalOverlap)
                 break;

--- a/AAEmu.Game/Physics/ShipShipInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShipInteraction.cs
@@ -191,13 +191,13 @@ public sealed class ShipShipInteraction
 
         if (!sa.ShipHullCollisionDamageCooldownByOtherShipId.TryGetValue(sb.Id, out var cdA) || cdA <= 0f)
         {
-            sa.ApplyShipHullCollisionDamage(sb, dmgA, collisionImpactMps: impactSpeedMps);
+            sa.ApplyShipHullCollisionDamage(sb, dmgA);
             sa.ShipHullCollisionDamageCooldownByOtherShipId[sb.Id] = HullCollisionDamageCooldownSec;
         }
 
         if (!sb.ShipHullCollisionDamageCooldownByOtherShipId.TryGetValue(sa.Id, out var cdB) || cdB <= 0f)
         {
-            sb.ApplyShipHullCollisionDamage(sa, dmgB, collisionImpactMps: impactSpeedMps);
+            sb.ApplyShipHullCollisionDamage(sa, dmgB);
             sb.ShipHullCollisionDamageCooldownByOtherShipId[sa.Id] = HullCollisionDamageCooldownSec;
         }
     }

--- a/AAEmu.Game/Physics/ShipShipInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShipInteraction.cs
@@ -14,7 +14,7 @@ namespace AAEmu.Game.Physics;
 /// so Jitter contacts do not prevent mesh-deep penetration — we depenetrate in XZ and damp closing speed.
 /// SAT overlap uses a tight mass box (near physics hull) so reaction does not start far before visuals meet.
 /// After overlap is detected, separation is scaled up to approximate client mesh extent without enlarging the hit test.
-/// Separation and velocity damping are mass-weighted; see <see cref="PhysicsDefaults.MassPushStrength"/>.
+/// Separation and velocity damping are mass-weighted; see <see cref="ShipShipInteraction.PhysicsDefaults.MassPushStrength"/>.
 /// Centers use the same local mass-center offset as <see cref="ShipController.Build"/> (TransformedShape).
 /// </summary>
 public sealed class ShipShipInteraction
@@ -48,34 +48,6 @@ public sealed class ShipShipInteraction
         public const float MassPushStrength = 2f;
     }
 
-    private static class Tune
-    {
-        public static float HullDetectInflateLength => PhysicsDefaults.HullDetectInflateLength;
-        public static float HullDetectInflateBeam => PhysicsDefaults.HullDetectInflateBeam;
-        public static float BeamDetectTightenMul => PhysicsDefaults.BeamDetectTightenMul;
-        public static float MinPenetrationToAct => PhysicsDefaults.MinPenetrationToAct;
-        public static float MinPenetrationToDamage => PhysicsDefaults.MinPenetrationToDamage;
-        public static float TangentialRampDepthMeters => PhysicsDefaults.TangentialRampDepthMeters;
-        public static float SeparationPushMultiplier => PhysicsDefaults.SeparationPushMultiplier;
-        public static float SeparationSlackMeters => PhysicsDefaults.SeparationSlackMeters;
-        public static float ClosingSpeedDamp => PhysicsDefaults.ClosingSpeedDamp;
-        public static float TangentialSlipDamp => PhysicsDefaults.TangentialSlipDamp;
-        public static float MinVerticalOverlap => PhysicsDefaults.MinVerticalOverlap;
-        public static int ResolvePasses => PhysicsDefaults.ResolvePasses;
-        public static int MaxPairIterations => PhysicsDefaults.MaxPairIterations;
-        public static float DeepPenetrationStart => PhysicsDefaults.DeepPenetrationStart;
-        public static float DeepPenetrationBoost => PhysicsDefaults.DeepPenetrationBoost;
-        public static float MinHalfSeparationMeters => PhysicsDefaults.MinHalfSeparationMeters;
-        public static float MinLinearSeparationToApplyMeters => PhysicsDefaults.MinLinearSeparationToApplyMeters;
-        public static float NoseContactCosThreshold => PhysicsDefaults.NoseContactCosThreshold;
-        public static float HullCollisionDamageCooldownSec => PhysicsDefaults.HullCollisionDamageCooldownSec;
-        public static float HullDamageLowSpeedThresholdMps => PhysicsDefaults.HullDamageLowSpeedThresholdMps;
-        public static float HullDamageSpeedInterpMaxMps => PhysicsDefaults.HullDamageSpeedInterpMaxMps;
-        public static int HullDamageSpeedScaledMinPercent => PhysicsDefaults.HullDamageSpeedScaledMinPercent;
-        public static int HullDamageSpeedScaledMaxPercent => PhysicsDefaults.HullDamageSpeedScaledMaxPercent;
-        public static float MassPushStrength => PhysicsDefaults.MassPushStrength;
-    }
-
     /// <summary>
     /// Run after all ships have had <see cref="ShipController.ApplyForceAndTorque"/> for this frame.
     /// </summary>
@@ -93,7 +65,7 @@ public sealed class ShipShipInteraction
 
         var pairDamagedThisTick = new HashSet<ulong>();
 
-        for (var pass = 0; pass < Tune.ResolvePasses; pass++)
+        for (var pass = 0; pass < PhysicsDefaults.ResolvePasses; pass++)
         {
             for (var i = 0; i < ships.Count; i++)
             {
@@ -112,7 +84,7 @@ public sealed class ShipShipInteraction
 
                     // If SAT only detects a marginal overlap (e.g. due to discrete steps / tight mass-box),
                     // keep the depenetration but don't apply periodic hull damage.
-                    if (maxPenetration < Tune.MinPenetrationToDamage)
+                    if (maxPenetration < PhysicsDefaults.MinPenetrationToDamage)
                         continue;
 
                     const byte holdTicks = 10;
@@ -186,19 +158,19 @@ public sealed class ShipShipInteraction
         var scaledDamage = GetSpeedScaledHullDamagePercent(impactSpeedMps);
         var aHitsWithNose = IsOtherShipInNoseCone(bx - ax, bz - az, bowA);
         var bHitsWithNose = IsOtherShipInNoseCone(ax - bx, az - bz, bowB);
-        var dmgA = aHitsWithNose ? Tune.HullDamageSpeedScaledMinPercent : scaledDamage;
-        var dmgB = bHitsWithNose ? Tune.HullDamageSpeedScaledMinPercent : scaledDamage;
+        var dmgA = aHitsWithNose ? PhysicsDefaults.HullDamageSpeedScaledMinPercent : scaledDamage;
+        var dmgB = bHitsWithNose ? PhysicsDefaults.HullDamageSpeedScaledMinPercent : scaledDamage;
 
         if (!sa.ShipHullCollisionDamageCooldownByOtherShipId.TryGetValue(sb.Id, out var cdA) || cdA <= 0f)
         {
             sa.ApplyShipHullCollisionDamage(sb, dmgA);
-            sa.ShipHullCollisionDamageCooldownByOtherShipId[sb.Id] = Tune.HullCollisionDamageCooldownSec;
+            sa.ShipHullCollisionDamageCooldownByOtherShipId[sb.Id] = PhysicsDefaults.HullCollisionDamageCooldownSec;
         }
 
         if (!sb.ShipHullCollisionDamageCooldownByOtherShipId.TryGetValue(sa.Id, out var cdB) || cdB <= 0f)
         {
             sb.ApplyShipHullCollisionDamage(sa, dmgB);
-            sb.ShipHullCollisionDamageCooldownByOtherShipId[sa.Id] = Tune.HullCollisionDamageCooldownSec;
+            sb.ShipHullCollisionDamageCooldownByOtherShipId[sa.Id] = PhysicsDefaults.HullCollisionDamageCooldownSec;
         }
     }
 
@@ -212,20 +184,20 @@ public sealed class ShipShipInteraction
         var fx = MathF.Cos(bowRadians);
         var fz = MathF.Sin(bowRadians);
         var cosAng = (toOtherX * fx + toOtherZ * fz) * invLen;
-            return cosAng >= Tune.NoseContactCosThreshold;
+            return cosAng >= PhysicsDefaults.NoseContactCosThreshold;
     }
 
     private static int GetSpeedScaledHullDamagePercent(float relativeSpeedMps)
     {
-        if (relativeSpeedMps <= Tune.HullDamageLowSpeedThresholdMps)
-            return Tune.HullDamageSpeedScaledMinPercent;
-        if (relativeSpeedMps >= Tune.HullDamageSpeedInterpMaxMps)
-            return Tune.HullDamageSpeedScaledMaxPercent;
+        if (relativeSpeedMps <= PhysicsDefaults.HullDamageLowSpeedThresholdMps)
+            return PhysicsDefaults.HullDamageSpeedScaledMinPercent;
+        if (relativeSpeedMps >= PhysicsDefaults.HullDamageSpeedInterpMaxMps)
+            return PhysicsDefaults.HullDamageSpeedScaledMaxPercent;
 
-        var span = Tune.HullDamageSpeedInterpMaxMps - Tune.HullDamageLowSpeedThresholdMps;
-        var t = (relativeSpeedMps - Tune.HullDamageLowSpeedThresholdMps) / span;
-        var f = Tune.HullDamageSpeedScaledMinPercent +
-                t * (Tune.HullDamageSpeedScaledMaxPercent - Tune.HullDamageSpeedScaledMinPercent);
+        var span = PhysicsDefaults.HullDamageSpeedInterpMaxMps - PhysicsDefaults.HullDamageLowSpeedThresholdMps;
+        var t = (relativeSpeedMps - PhysicsDefaults.HullDamageLowSpeedThresholdMps) / span;
+        var f = PhysicsDefaults.HullDamageSpeedScaledMinPercent +
+                t * (PhysicsDefaults.HullDamageSpeedScaledMaxPercent - PhysicsDefaults.HullDamageSpeedScaledMinPercent);
         return (int)MathF.Round(f);
     }
 
@@ -245,7 +217,7 @@ public sealed class ShipShipInteraction
         var bbA = bodyA.Shapes[0].WorldBoundingBox;
         var bbB = bodyB.Shapes[0].WorldBoundingBox;
         var overlapY = MathF.Min(bbA.Max.Y, bbB.Max.Y) - MathF.Max(bbA.Min.Y, bbB.Min.Y);
-        if (overlapY < Tune.MinVerticalOverlap)
+        if (overlapY < PhysicsDefaults.MinVerticalOverlap)
             return false;
 
         var rpyA = PhysicsUtil.GetYawPitchRollFromMatrix(JMatrix.CreateFromQuaternion(bodyA.Orientation));
@@ -256,18 +228,18 @@ public sealed class ShipShipInteraction
         // Interpretation:
         // - MassBoxSizeY = length (forward/back)
         // - MassBoxSizeX = beam (right/left)
-        var halfLenA = ma.MassBoxSizeY * sa.Scale * 0.5f * Tune.HullDetectInflateLength;
-        var halfLenB = mb.MassBoxSizeY * sb.Scale * 0.5f * Tune.HullDetectInflateLength;
-        var satHalfWidA = ma.MassBoxSizeX * sa.Scale * 0.5f * Tune.HullDetectInflateBeam * Tune.BeamDetectTightenMul;
-        var satHalfWidB = mb.MassBoxSizeX * sb.Scale * 0.5f * Tune.HullDetectInflateBeam * Tune.BeamDetectTightenMul;
+        var halfLenA = ma.MassBoxSizeY * sa.Scale * 0.5f * PhysicsDefaults.HullDetectInflateLength;
+        var halfLenB = mb.MassBoxSizeY * sb.Scale * 0.5f * PhysicsDefaults.HullDetectInflateLength;
+        var satHalfWidA = ma.MassBoxSizeX * sa.Scale * 0.5f * PhysicsDefaults.HullDetectInflateBeam * PhysicsDefaults.BeamDetectTightenMul;
+        var satHalfWidB = mb.MassBoxSizeX * sb.Scale * 0.5f * PhysicsDefaults.HullDetectInflateBeam * PhysicsDefaults.BeamDetectTightenMul;
 
         float ax, az, bx, bz, penetration, nx, nz;
-        for (var iter = 0; iter < Tune.MaxPairIterations; iter++)
+        for (var iter = 0; iter < PhysicsDefaults.MaxPairIterations; iter++)
         {
             bbA = bodyA.Shapes[0].WorldBoundingBox;
             bbB = bodyB.Shapes[0].WorldBoundingBox;
             overlapY = MathF.Min(bbA.Max.Y, bbB.Max.Y) - MathF.Max(bbA.Min.Y, bbB.Min.Y);
-            if (overlapY < Tune.MinVerticalOverlap)
+            if (overlapY < PhysicsDefaults.MinVerticalOverlap)
                 break;
 
             GetMassBoxCenterXz(bodyA, ma, sa.Scale, out ax, out az);
@@ -281,7 +253,7 @@ public sealed class ShipShipInteraction
                     out nz))
                 break;
 
-            if (penetration <= 1e-4f || penetration < Tune.MinPenetrationToAct)
+            if (penetration <= 1e-4f || penetration < PhysicsDefaults.MinPenetrationToAct)
                 break;
 
             maxPenetration = MathF.Max(maxPenetration, penetration);
@@ -295,14 +267,14 @@ public sealed class ShipShipInteraction
             }
 
             var halfSep = penetration * 0.5f;
-            var deep = MathF.Max(0f, penetration - Tune.DeepPenetrationStart);
-            halfSep *= 1f + Tune.DeepPenetrationBoost * MathF.Min(1.25f, deep);
-            var linearSep = halfSep + Tune.SeparationSlackMeters;
-            if (linearSep < Tune.MinLinearSeparationToApplyMeters)
+            var deep = MathF.Max(0f, penetration - PhysicsDefaults.DeepPenetrationStart);
+            halfSep *= 1f + PhysicsDefaults.DeepPenetrationBoost * MathF.Min(1.25f, deep);
+            var linearSep = halfSep + PhysicsDefaults.SeparationSlackMeters;
+            if (linearSep < PhysicsDefaults.MinLinearSeparationToApplyMeters)
                 break;
 
-            var move = MathF.Max(linearSep, Tune.MinHalfSeparationMeters);
-            move *= Tune.SeparationPushMultiplier;
+            var move = MathF.Max(linearSep, PhysicsDefaults.MinHalfSeparationMeters);
+            move *= PhysicsDefaults.SeparationPushMultiplier;
 
             var va = bodyA.Velocity;
             var vb = bodyB.Velocity;
@@ -343,17 +315,17 @@ public sealed class ShipShipInteraction
         var closing = (va.X - vb.X) * nx + (va.Z - vb.Z) * nz;
         if (closing > 0f)
         {
-            var removeA = closing * weightA * Tune.ClosingSpeedDamp;
-            var removeB = closing * weightB * Tune.ClosingSpeedDamp;
+            var removeA = closing * weightA * PhysicsDefaults.ClosingSpeedDamp;
+            var removeB = closing * weightB * PhysicsDefaults.ClosingSpeedDamp;
             va = new JVector(va.X - nx * removeA, va.Y, va.Z - nz * removeA);
             vb = new JVector(vb.X + nx * removeB, vb.Y, vb.Z + nz * removeB);
         }
 
-        var tangentialBlend = Math.Clamp((penetrationDepth - Tune.MinPenetrationToAct) / Tune.TangentialRampDepthMeters, 0f, 1f);
+        var tangentialBlend = Math.Clamp((penetrationDepth - PhysicsDefaults.MinPenetrationToAct) / PhysicsDefaults.TangentialRampDepthMeters, 0f, 1f);
         var tx = -nz;
         var tz = nx;
         var relT = (va.X - vb.X) * tx + (va.Z - vb.Z) * tz;
-        var slipK = (1f - Tune.TangentialSlipDamp) * tangentialBlend;
+        var slipK = (1f - PhysicsDefaults.TangentialSlipDamp) * tangentialBlend;
         var slipA = relT * weightA * slipK;
         var slipB = relT * weightB * slipK;
         va = new JVector(va.X - tx * slipA, va.Y, va.Z - tz * slipA);
@@ -364,7 +336,7 @@ public sealed class ShipShipInteraction
     }
 
     /// <summary>
-    /// Mass-based split from inverse mass ratio, scaled by <see cref="Tune.MassPushStrength"/> (blend toward 50/50 or exaggerate).
+    /// Mass-based split from inverse mass ratio, scaled by <see cref="ShipShipInteraction.PhysicsDefaults.MassPushStrength"/> (blend toward 50/50 or exaggerate).
     /// </summary>
     private static void GetPairMassWeights(float massA, float massB, out float weightA, out float weightB)
     {
@@ -378,7 +350,7 @@ public sealed class ShipShipInteraction
         var inv = 1f / sum;
         var wPhysA = massB * inv;
         var wPhysB = massA * inv;
-        var t = Tune.MassPushStrength;
+        var t = PhysicsDefaults.MassPushStrength;
         weightA = 0.5f + (wPhysA - 0.5f) * t;
         weightB = 0.5f + (wPhysB - 0.5f) * t;
         const float eps = 1e-4f;

--- a/AAEmu.Game/Physics/ShipShipInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShipInteraction.cs
@@ -14,13 +14,13 @@ namespace AAEmu.Game.Physics;
 /// so Jitter contacts do not prevent mesh-deep penetration — we depenetrate in XZ and damp closing speed.
 /// SAT overlap uses a tight mass box (near physics hull) so reaction does not start far before visuals meet.
 /// After overlap is detected, separation is scaled up to approximate client mesh extent without enlarging the hit test.
-/// Separation and velocity damping are mass-weighted; see <see cref="ShipShipInteraction.PhysicsDefaults.MassPushStrength"/>.
+/// Separation and velocity damping are mass-weighted; see <see cref="ShipShipInteraction.ShipHullPairDefaults.MassPushStrength"/>.
 /// Centers use the same local mass-center offset as <see cref="ShipController.Build"/> (TransformedShape).
 /// </summary>
 public sealed class ShipShipInteraction
 {
-    /// <summary>Production constants for ship↔ship SAT/response (single source of truth).</summary>
-    public static class PhysicsDefaults
+    /// <summary>Ship↔ship SAT/response constants (single source of truth).</summary>
+    public static class ShipHullPairDefaults
     {
         public const float HullDetectInflateLength = 1.025f;
         public const float HullDetectInflateBeam = 1.015f;
@@ -65,7 +65,7 @@ public sealed class ShipShipInteraction
 
         var pairDamagedThisTick = new HashSet<ulong>();
 
-        for (var pass = 0; pass < PhysicsDefaults.ResolvePasses; pass++)
+        for (var pass = 0; pass < ShipHullPairDefaults.ResolvePasses; pass++)
         {
             for (var i = 0; i < ships.Count; i++)
             {
@@ -84,7 +84,7 @@ public sealed class ShipShipInteraction
 
                     // If SAT only detects a marginal overlap (e.g. due to discrete steps / tight mass-box),
                     // keep the depenetration but don't apply periodic hull damage.
-                    if (maxPenetration < PhysicsDefaults.MinPenetrationToDamage)
+                    if (maxPenetration < ShipHullPairDefaults.MinPenetrationToDamage)
                         continue;
 
                     const byte holdTicks = 10;
@@ -158,19 +158,19 @@ public sealed class ShipShipInteraction
         var scaledDamage = GetSpeedScaledHullDamagePercent(impactSpeedMps);
         var aHitsWithNose = IsOtherShipInNoseCone(bx - ax, bz - az, bowA);
         var bHitsWithNose = IsOtherShipInNoseCone(ax - bx, az - bz, bowB);
-        var dmgA = aHitsWithNose ? PhysicsDefaults.HullDamageSpeedScaledMinPercent : scaledDamage;
-        var dmgB = bHitsWithNose ? PhysicsDefaults.HullDamageSpeedScaledMinPercent : scaledDamage;
+        var dmgA = aHitsWithNose ? ShipHullPairDefaults.HullDamageSpeedScaledMinPercent : scaledDamage;
+        var dmgB = bHitsWithNose ? ShipHullPairDefaults.HullDamageSpeedScaledMinPercent : scaledDamage;
 
         if (!sa.ShipHullCollisionDamageCooldownByOtherShipId.TryGetValue(sb.Id, out var cdA) || cdA <= 0f)
         {
             sa.ApplyShipHullCollisionDamage(sb, dmgA);
-            sa.ShipHullCollisionDamageCooldownByOtherShipId[sb.Id] = PhysicsDefaults.HullCollisionDamageCooldownSec;
+            sa.ShipHullCollisionDamageCooldownByOtherShipId[sb.Id] = ShipHullPairDefaults.HullCollisionDamageCooldownSec;
         }
 
         if (!sb.ShipHullCollisionDamageCooldownByOtherShipId.TryGetValue(sa.Id, out var cdB) || cdB <= 0f)
         {
             sb.ApplyShipHullCollisionDamage(sa, dmgB);
-            sb.ShipHullCollisionDamageCooldownByOtherShipId[sa.Id] = PhysicsDefaults.HullCollisionDamageCooldownSec;
+            sb.ShipHullCollisionDamageCooldownByOtherShipId[sa.Id] = ShipHullPairDefaults.HullCollisionDamageCooldownSec;
         }
     }
 
@@ -184,20 +184,20 @@ public sealed class ShipShipInteraction
         var fx = MathF.Cos(bowRadians);
         var fz = MathF.Sin(bowRadians);
         var cosAng = (toOtherX * fx + toOtherZ * fz) * invLen;
-            return cosAng >= PhysicsDefaults.NoseContactCosThreshold;
+            return cosAng >= ShipHullPairDefaults.NoseContactCosThreshold;
     }
 
     private static int GetSpeedScaledHullDamagePercent(float relativeSpeedMps)
     {
-        if (relativeSpeedMps <= PhysicsDefaults.HullDamageLowSpeedThresholdMps)
-            return PhysicsDefaults.HullDamageSpeedScaledMinPercent;
-        if (relativeSpeedMps >= PhysicsDefaults.HullDamageSpeedInterpMaxMps)
-            return PhysicsDefaults.HullDamageSpeedScaledMaxPercent;
+        if (relativeSpeedMps <= ShipHullPairDefaults.HullDamageLowSpeedThresholdMps)
+            return ShipHullPairDefaults.HullDamageSpeedScaledMinPercent;
+        if (relativeSpeedMps >= ShipHullPairDefaults.HullDamageSpeedInterpMaxMps)
+            return ShipHullPairDefaults.HullDamageSpeedScaledMaxPercent;
 
-        var span = PhysicsDefaults.HullDamageSpeedInterpMaxMps - PhysicsDefaults.HullDamageLowSpeedThresholdMps;
-        var t = (relativeSpeedMps - PhysicsDefaults.HullDamageLowSpeedThresholdMps) / span;
-        var f = PhysicsDefaults.HullDamageSpeedScaledMinPercent +
-                t * (PhysicsDefaults.HullDamageSpeedScaledMaxPercent - PhysicsDefaults.HullDamageSpeedScaledMinPercent);
+        var span = ShipHullPairDefaults.HullDamageSpeedInterpMaxMps - ShipHullPairDefaults.HullDamageLowSpeedThresholdMps;
+        var t = (relativeSpeedMps - ShipHullPairDefaults.HullDamageLowSpeedThresholdMps) / span;
+        var f = ShipHullPairDefaults.HullDamageSpeedScaledMinPercent +
+                t * (ShipHullPairDefaults.HullDamageSpeedScaledMaxPercent - ShipHullPairDefaults.HullDamageSpeedScaledMinPercent);
         return (int)MathF.Round(f);
     }
 
@@ -217,7 +217,7 @@ public sealed class ShipShipInteraction
         var bbA = bodyA.Shapes[0].WorldBoundingBox;
         var bbB = bodyB.Shapes[0].WorldBoundingBox;
         var overlapY = MathF.Min(bbA.Max.Y, bbB.Max.Y) - MathF.Max(bbA.Min.Y, bbB.Min.Y);
-        if (overlapY < PhysicsDefaults.MinVerticalOverlap)
+        if (overlapY < ShipHullPairDefaults.MinVerticalOverlap)
             return false;
 
         var rpyA = PhysicsUtil.GetYawPitchRollFromMatrix(JMatrix.CreateFromQuaternion(bodyA.Orientation));
@@ -228,18 +228,18 @@ public sealed class ShipShipInteraction
         // Interpretation:
         // - MassBoxSizeY = length (forward/back)
         // - MassBoxSizeX = beam (right/left)
-        var halfLenA = ma.MassBoxSizeY * sa.Scale * 0.5f * PhysicsDefaults.HullDetectInflateLength;
-        var halfLenB = mb.MassBoxSizeY * sb.Scale * 0.5f * PhysicsDefaults.HullDetectInflateLength;
-        var satHalfWidA = ma.MassBoxSizeX * sa.Scale * 0.5f * PhysicsDefaults.HullDetectInflateBeam * PhysicsDefaults.BeamDetectTightenMul;
-        var satHalfWidB = mb.MassBoxSizeX * sb.Scale * 0.5f * PhysicsDefaults.HullDetectInflateBeam * PhysicsDefaults.BeamDetectTightenMul;
+        var halfLenA = ma.MassBoxSizeY * sa.Scale * 0.5f * ShipHullPairDefaults.HullDetectInflateLength;
+        var halfLenB = mb.MassBoxSizeY * sb.Scale * 0.5f * ShipHullPairDefaults.HullDetectInflateLength;
+        var satHalfWidA = ma.MassBoxSizeX * sa.Scale * 0.5f * ShipHullPairDefaults.HullDetectInflateBeam * ShipHullPairDefaults.BeamDetectTightenMul;
+        var satHalfWidB = mb.MassBoxSizeX * sb.Scale * 0.5f * ShipHullPairDefaults.HullDetectInflateBeam * ShipHullPairDefaults.BeamDetectTightenMul;
 
         float ax, az, bx, bz, penetration, nx, nz;
-        for (var iter = 0; iter < PhysicsDefaults.MaxPairIterations; iter++)
+        for (var iter = 0; iter < ShipHullPairDefaults.MaxPairIterations; iter++)
         {
             bbA = bodyA.Shapes[0].WorldBoundingBox;
             bbB = bodyB.Shapes[0].WorldBoundingBox;
             overlapY = MathF.Min(bbA.Max.Y, bbB.Max.Y) - MathF.Max(bbA.Min.Y, bbB.Min.Y);
-            if (overlapY < PhysicsDefaults.MinVerticalOverlap)
+            if (overlapY < ShipHullPairDefaults.MinVerticalOverlap)
                 break;
 
             GetMassBoxCenterXz(bodyA, ma, sa.Scale, out ax, out az);
@@ -253,7 +253,7 @@ public sealed class ShipShipInteraction
                     out nz))
                 break;
 
-            if (penetration <= 1e-4f || penetration < PhysicsDefaults.MinPenetrationToAct)
+            if (penetration <= 1e-4f || penetration < ShipHullPairDefaults.MinPenetrationToAct)
                 break;
 
             maxPenetration = MathF.Max(maxPenetration, penetration);
@@ -267,14 +267,14 @@ public sealed class ShipShipInteraction
             }
 
             var halfSep = penetration * 0.5f;
-            var deep = MathF.Max(0f, penetration - PhysicsDefaults.DeepPenetrationStart);
-            halfSep *= 1f + PhysicsDefaults.DeepPenetrationBoost * MathF.Min(1.25f, deep);
-            var linearSep = halfSep + PhysicsDefaults.SeparationSlackMeters;
-            if (linearSep < PhysicsDefaults.MinLinearSeparationToApplyMeters)
+            var deep = MathF.Max(0f, penetration - ShipHullPairDefaults.DeepPenetrationStart);
+            halfSep *= 1f + ShipHullPairDefaults.DeepPenetrationBoost * MathF.Min(1.25f, deep);
+            var linearSep = halfSep + ShipHullPairDefaults.SeparationSlackMeters;
+            if (linearSep < ShipHullPairDefaults.MinLinearSeparationToApplyMeters)
                 break;
 
-            var move = MathF.Max(linearSep, PhysicsDefaults.MinHalfSeparationMeters);
-            move *= PhysicsDefaults.SeparationPushMultiplier;
+            var move = MathF.Max(linearSep, ShipHullPairDefaults.MinHalfSeparationMeters);
+            move *= ShipHullPairDefaults.SeparationPushMultiplier;
 
             var va = bodyA.Velocity;
             var vb = bodyB.Velocity;
@@ -315,17 +315,17 @@ public sealed class ShipShipInteraction
         var closing = (va.X - vb.X) * nx + (va.Z - vb.Z) * nz;
         if (closing > 0f)
         {
-            var removeA = closing * weightA * PhysicsDefaults.ClosingSpeedDamp;
-            var removeB = closing * weightB * PhysicsDefaults.ClosingSpeedDamp;
+            var removeA = closing * weightA * ShipHullPairDefaults.ClosingSpeedDamp;
+            var removeB = closing * weightB * ShipHullPairDefaults.ClosingSpeedDamp;
             va = new JVector(va.X - nx * removeA, va.Y, va.Z - nz * removeA);
             vb = new JVector(vb.X + nx * removeB, vb.Y, vb.Z + nz * removeB);
         }
 
-        var tangentialBlend = Math.Clamp((penetrationDepth - PhysicsDefaults.MinPenetrationToAct) / PhysicsDefaults.TangentialRampDepthMeters, 0f, 1f);
+        var tangentialBlend = Math.Clamp((penetrationDepth - ShipHullPairDefaults.MinPenetrationToAct) / ShipHullPairDefaults.TangentialRampDepthMeters, 0f, 1f);
         var tx = -nz;
         var tz = nx;
         var relT = (va.X - vb.X) * tx + (va.Z - vb.Z) * tz;
-        var slipK = (1f - PhysicsDefaults.TangentialSlipDamp) * tangentialBlend;
+        var slipK = (1f - ShipHullPairDefaults.TangentialSlipDamp) * tangentialBlend;
         var slipA = relT * weightA * slipK;
         var slipB = relT * weightB * slipK;
         va = new JVector(va.X - tx * slipA, va.Y, va.Z - tz * slipA);
@@ -336,7 +336,7 @@ public sealed class ShipShipInteraction
     }
 
     /// <summary>
-    /// Mass-based split from inverse mass ratio, scaled by <see cref="ShipShipInteraction.PhysicsDefaults.MassPushStrength"/> (blend toward 50/50 or exaggerate).
+    /// Mass-based split from inverse mass ratio, scaled by <see cref="ShipShipInteraction.ShipHullPairDefaults.MassPushStrength"/> (blend toward 50/50 or exaggerate).
     /// </summary>
     private static void GetPairMassWeights(float massA, float massB, out float weightA, out float weightB)
     {
@@ -350,7 +350,7 @@ public sealed class ShipShipInteraction
         var inv = 1f / sum;
         var wPhysA = massB * inv;
         var wPhysB = massA * inv;
-        var t = PhysicsDefaults.MassPushStrength;
+        var t = ShipHullPairDefaults.MassPushStrength;
         weightA = 0.5f + (wPhysA - 0.5f) * t;
         weightB = 0.5f + (wPhysB - 0.5f) * t;
         const float eps = 1e-4f;

--- a/AAEmu.Game/Physics/ShipShipInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShipInteraction.cs
@@ -28,19 +28,22 @@ public sealed class ShipShipInteraction
     /// Extra tightening of beam in SAT only: <c>MassBoxSizeY</c> is often full deck/rail width, so side-by-side
     /// contact triggered long before hulls meet; length stays full for nose-to-nose.
     /// </summary>
-    private const float BeamDetectTightenMul = 0.86f;
+    private const float BeamDetectTightenMul = 0.78f;
 
     /// <summary>Ignore overlap response below this depth (m) — kills ghost drag from marginal SAT positives.</summary>
     private const float MinPenetrationToAct = 0.055f;
+
+    /// <summary>Ignore periodic hull-damage for marginal SAT overlaps (m) — prevents "rubbing damage" from false contact.</summary>
+    private const float MinPenetrationToDamage = MinPenetrationToAct * 1.15f;
 
     /// <summary>Ramp tangential slip damp from 0 to full over this depth past <see cref="MinPenetrationToAct"/>.</summary>
     private const float TangentialRampDepthMeters = 0.22f;
 
     /// <summary>Multiplies positional separation once overlap exists (mesh wider than mass box).</summary>
-    private const float SeparationPushMultiplier = 1.34f;
+    private const float SeparationPushMultiplier = 1.22f;
 
     /// <summary>Extra push after computed overlap so hulls do not sit exactly tangent (reduces z-fight / next-frame re-entry).</summary>
-    private const float SeparationSlackMeters = 0.032f;
+    private const float SeparationSlackMeters = 0.020f;
 
     /// <summary>When overlapping, relative speed along separation normal is removed this fraction (1 = full stop along normal).</summary>
     private const float ClosingSpeedDamp = 1f;
@@ -115,7 +118,12 @@ public sealed class ShipShipInteraction
                     if (sb.RigidBody is null || sb.RigidBody.Shapes.Count == 0)
                         continue;
 
-                    if (!TryResolvePair(sa, sb, out var impactSpeedMps))
+                    if (!TryResolvePair(sa, sb, out var impactSpeedMps, out var maxPenetration))
+                        continue;
+
+                    // If SAT only detects a marginal overlap (e.g. due to discrete steps / tight mass-box),
+                    // keep the depenetration but don't apply periodic hull damage.
+                    if (maxPenetration < MinPenetrationToDamage)
                         continue;
 
                     const byte holdTicks = 10;
@@ -232,9 +240,10 @@ public sealed class ShipShipInteraction
         return (int)MathF.Round(f);
     }
 
-    private static bool TryResolvePair(Slave sa, Slave sb, out float impactSpeedMps)
+    private static bool TryResolvePair(Slave sa, Slave sb, out float impactSpeedMps, out float maxPenetration)
     {
         impactSpeedMps = 0f;
+        maxPenetration = 0f;
         var bodyA = sa.RigidBody!;
         var bodyB = sb.RigidBody!;
         var ma = sa.ShipController?.ShipModel;
@@ -282,6 +291,8 @@ public sealed class ShipShipInteraction
 
             if (penetration <= 1e-4f || penetration < MinPenetrationToAct)
                 break;
+
+            maxPenetration = MathF.Max(maxPenetration, penetration);
 
             var dx = bx - ax;
             var dz = bz - az;

--- a/AAEmu.Game/Physics/ShipShipInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShipInteraction.cs
@@ -2,7 +2,9 @@
 
 using AAEmu.Game.Models.Game.Models;
 using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Physics.Debug;
 using AAEmu.Game.Physics.Util;
+using static AAEmu.Game.Physics.ShipShipInteraction.ShipHullPairDefaults;
 
 using Jitter2.Dynamics;
 using Jitter2.LinearMath;
@@ -65,7 +67,7 @@ public sealed class ShipShipInteraction
 
         var pairDamagedThisTick = new HashSet<ulong>();
 
-        for (var pass = 0; pass < ShipHullPairDefaults.ResolvePasses; pass++)
+        for (var pass = 0; pass < ResolvePasses; pass++)
         {
             for (var i = 0; i < ships.Count; i++)
             {
@@ -84,7 +86,7 @@ public sealed class ShipShipInteraction
 
                     // If SAT only detects a marginal overlap (e.g. due to discrete steps / tight mass-box),
                     // keep the depenetration but don't apply periodic hull damage.
-                    if (maxPenetration < ShipHullPairDefaults.MinPenetrationToDamage)
+                    if (maxPenetration < MinPenetrationToDamage)
                         continue;
 
                     const byte holdTicks = 10;
@@ -158,19 +160,19 @@ public sealed class ShipShipInteraction
         var scaledDamage = GetSpeedScaledHullDamagePercent(impactSpeedMps);
         var aHitsWithNose = IsOtherShipInNoseCone(bx - ax, bz - az, bowA);
         var bHitsWithNose = IsOtherShipInNoseCone(ax - bx, az - bz, bowB);
-        var dmgA = aHitsWithNose ? ShipHullPairDefaults.HullDamageSpeedScaledMinPercent : scaledDamage;
-        var dmgB = bHitsWithNose ? ShipHullPairDefaults.HullDamageSpeedScaledMinPercent : scaledDamage;
+        var dmgA = aHitsWithNose ? HullDamageSpeedScaledMinPercent : scaledDamage;
+        var dmgB = bHitsWithNose ? HullDamageSpeedScaledMinPercent : scaledDamage;
 
         if (!sa.ShipHullCollisionDamageCooldownByOtherShipId.TryGetValue(sb.Id, out var cdA) || cdA <= 0f)
         {
             sa.ApplyShipHullCollisionDamage(sb, dmgA);
-            sa.ShipHullCollisionDamageCooldownByOtherShipId[sb.Id] = ShipHullPairDefaults.HullCollisionDamageCooldownSec;
+            sa.ShipHullCollisionDamageCooldownByOtherShipId[sb.Id] = HullCollisionDamageCooldownSec;
         }
 
         if (!sb.ShipHullCollisionDamageCooldownByOtherShipId.TryGetValue(sa.Id, out var cdB) || cdB <= 0f)
         {
             sb.ApplyShipHullCollisionDamage(sa, dmgB);
-            sb.ShipHullCollisionDamageCooldownByOtherShipId[sa.Id] = ShipHullPairDefaults.HullCollisionDamageCooldownSec;
+            sb.ShipHullCollisionDamageCooldownByOtherShipId[sa.Id] = HullCollisionDamageCooldownSec;
         }
     }
 
@@ -184,20 +186,20 @@ public sealed class ShipShipInteraction
         var fx = MathF.Cos(bowRadians);
         var fz = MathF.Sin(bowRadians);
         var cosAng = (toOtherX * fx + toOtherZ * fz) * invLen;
-            return cosAng >= ShipHullPairDefaults.NoseContactCosThreshold;
+            return cosAng >= NoseContactCosThreshold;
     }
 
     private static int GetSpeedScaledHullDamagePercent(float relativeSpeedMps)
     {
-        if (relativeSpeedMps <= ShipHullPairDefaults.HullDamageLowSpeedThresholdMps)
-            return ShipHullPairDefaults.HullDamageSpeedScaledMinPercent;
-        if (relativeSpeedMps >= ShipHullPairDefaults.HullDamageSpeedInterpMaxMps)
-            return ShipHullPairDefaults.HullDamageSpeedScaledMaxPercent;
+        if (relativeSpeedMps <= HullDamageLowSpeedThresholdMps)
+            return HullDamageSpeedScaledMinPercent;
+        if (relativeSpeedMps >= HullDamageSpeedInterpMaxMps)
+            return HullDamageSpeedScaledMaxPercent;
 
-        var span = ShipHullPairDefaults.HullDamageSpeedInterpMaxMps - ShipHullPairDefaults.HullDamageLowSpeedThresholdMps;
-        var t = (relativeSpeedMps - ShipHullPairDefaults.HullDamageLowSpeedThresholdMps) / span;
-        var f = ShipHullPairDefaults.HullDamageSpeedScaledMinPercent +
-                t * (ShipHullPairDefaults.HullDamageSpeedScaledMaxPercent - ShipHullPairDefaults.HullDamageSpeedScaledMinPercent);
+        var span = HullDamageSpeedInterpMaxMps - HullDamageLowSpeedThresholdMps;
+        var t = (relativeSpeedMps - HullDamageLowSpeedThresholdMps) / span;
+        var f = HullDamageSpeedScaledMinPercent +
+                t * (HullDamageSpeedScaledMaxPercent - HullDamageSpeedScaledMinPercent);
         return (int)MathF.Round(f);
     }
 
@@ -217,7 +219,7 @@ public sealed class ShipShipInteraction
         var bbA = bodyA.Shapes[0].WorldBoundingBox;
         var bbB = bodyB.Shapes[0].WorldBoundingBox;
         var overlapY = MathF.Min(bbA.Max.Y, bbB.Max.Y) - MathF.Max(bbA.Min.Y, bbB.Min.Y);
-        if (overlapY < ShipHullPairDefaults.MinVerticalOverlap)
+        if (overlapY < MinVerticalOverlap)
             return false;
 
         var rpyA = PhysicsUtil.GetYawPitchRollFromMatrix(JMatrix.CreateFromQuaternion(bodyA.Orientation));
@@ -228,18 +230,18 @@ public sealed class ShipShipInteraction
         // Interpretation:
         // - MassBoxSizeY = length (forward/back)
         // - MassBoxSizeX = beam (right/left)
-        var halfLenA = ma.MassBoxSizeY * sa.Scale * 0.5f * ShipHullPairDefaults.HullDetectInflateLength;
-        var halfLenB = mb.MassBoxSizeY * sb.Scale * 0.5f * ShipHullPairDefaults.HullDetectInflateLength;
-        var satHalfWidA = ma.MassBoxSizeX * sa.Scale * 0.5f * ShipHullPairDefaults.HullDetectInflateBeam * ShipHullPairDefaults.BeamDetectTightenMul;
-        var satHalfWidB = mb.MassBoxSizeX * sb.Scale * 0.5f * ShipHullPairDefaults.HullDetectInflateBeam * ShipHullPairDefaults.BeamDetectTightenMul;
+        var halfLenA = ma.MassBoxSizeY * sa.Scale * 0.5f * HullDetectInflateLength;
+        var halfLenB = mb.MassBoxSizeY * sb.Scale * 0.5f * HullDetectInflateLength;
+        var satHalfWidA = ma.MassBoxSizeX * sa.Scale * 0.5f * HullDetectInflateBeam * BeamDetectTightenMul;
+        var satHalfWidB = mb.MassBoxSizeX * sb.Scale * 0.5f * HullDetectInflateBeam * BeamDetectTightenMul;
 
         float ax, az, bx, bz, penetration, nx, nz;
-        for (var iter = 0; iter < ShipHullPairDefaults.MaxPairIterations; iter++)
+        for (var iter = 0; iter < MaxPairIterations; iter++)
         {
             bbA = bodyA.Shapes[0].WorldBoundingBox;
             bbB = bodyB.Shapes[0].WorldBoundingBox;
             overlapY = MathF.Min(bbA.Max.Y, bbB.Max.Y) - MathF.Max(bbA.Min.Y, bbB.Min.Y);
-            if (overlapY < ShipHullPairDefaults.MinVerticalOverlap)
+            if (overlapY < MinVerticalOverlap)
                 break;
 
             GetMassBoxCenterXz(bodyA, ma, sa.Scale, out ax, out az);
@@ -253,7 +255,7 @@ public sealed class ShipShipInteraction
                     out nz))
                 break;
 
-            if (penetration <= 1e-4f || penetration < ShipHullPairDefaults.MinPenetrationToAct)
+            if (penetration <= 1e-4f || penetration < MinPenetrationToAct)
                 break;
 
             maxPenetration = MathF.Max(maxPenetration, penetration);
@@ -267,14 +269,14 @@ public sealed class ShipShipInteraction
             }
 
             var halfSep = penetration * 0.5f;
-            var deep = MathF.Max(0f, penetration - ShipHullPairDefaults.DeepPenetrationStart);
-            halfSep *= 1f + ShipHullPairDefaults.DeepPenetrationBoost * MathF.Min(1.25f, deep);
-            var linearSep = halfSep + ShipHullPairDefaults.SeparationSlackMeters;
-            if (linearSep < ShipHullPairDefaults.MinLinearSeparationToApplyMeters)
+            var deep = MathF.Max(0f, penetration - DeepPenetrationStart);
+            halfSep *= 1f + DeepPenetrationBoost * MathF.Min(1.25f, deep);
+            var linearSep = halfSep + SeparationSlackMeters;
+            if (linearSep < MinLinearSeparationToApplyMeters)
                 break;
 
-            var move = MathF.Max(linearSep, ShipHullPairDefaults.MinHalfSeparationMeters);
-            move *= ShipHullPairDefaults.SeparationPushMultiplier;
+            var move = MathF.Max(linearSep, MinHalfSeparationMeters);
+            move *= SeparationPushMultiplier;
 
             var va = bodyA.Velocity;
             var vb = bodyB.Velocity;
@@ -290,7 +292,7 @@ public sealed class ShipShipInteraction
 
             DampPairVelocities(bodyA, bodyB, nx, nz, penetration, wA, wB);
 
-            AAEmu.Game.Physics.Debug.ShipTuningDebug.OnResolvedShipPair(sa, sb, penetration, nx, nz, peakImpactSpeedMps);
+            ShipTuningDebug.OnResolvedShipPair(sa, sb, penetration, nx, nz, peakImpactSpeedMps);
         }
 
         if (hadResponse)
@@ -315,17 +317,17 @@ public sealed class ShipShipInteraction
         var closing = (va.X - vb.X) * nx + (va.Z - vb.Z) * nz;
         if (closing > 0f)
         {
-            var removeA = closing * weightA * ShipHullPairDefaults.ClosingSpeedDamp;
-            var removeB = closing * weightB * ShipHullPairDefaults.ClosingSpeedDamp;
+            var removeA = closing * weightA * ClosingSpeedDamp;
+            var removeB = closing * weightB * ClosingSpeedDamp;
             va = new JVector(va.X - nx * removeA, va.Y, va.Z - nz * removeA);
             vb = new JVector(vb.X + nx * removeB, vb.Y, vb.Z + nz * removeB);
         }
 
-        var tangentialBlend = Math.Clamp((penetrationDepth - ShipHullPairDefaults.MinPenetrationToAct) / ShipHullPairDefaults.TangentialRampDepthMeters, 0f, 1f);
+        var tangentialBlend = Math.Clamp((penetrationDepth - MinPenetrationToAct) / TangentialRampDepthMeters, 0f, 1f);
         var tx = -nz;
         var tz = nx;
         var relT = (va.X - vb.X) * tx + (va.Z - vb.Z) * tz;
-        var slipK = (1f - ShipHullPairDefaults.TangentialSlipDamp) * tangentialBlend;
+        var slipK = (1f - TangentialSlipDamp) * tangentialBlend;
         var slipA = relT * weightA * slipK;
         var slipB = relT * weightB * slipK;
         va = new JVector(va.X - tx * slipA, va.Y, va.Z - tz * slipA);
@@ -350,7 +352,7 @@ public sealed class ShipShipInteraction
         var inv = 1f / sum;
         var wPhysA = massB * inv;
         var wPhysB = massA * inv;
-        var t = ShipHullPairDefaults.MassPushStrength;
+        var t = MassPushStrength;
         weightA = 0.5f + (wPhysA - 0.5f) * t;
         weightB = 0.5f + (wPhysB - 0.5f) * t;
         const float eps = 1e-4f;

--- a/AAEmu.Game/Physics/ShipShipInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShipInteraction.cs
@@ -24,29 +24,53 @@ public sealed class ShipShipInteraction
     /// <summary>Ship↔ship SAT/response constants (single source of truth).</summary>
     public static class ShipHullPairDefaults
     {
+        /// <summary>Length inflation for the SAT hit-test OBB (starts detection slightly earlier along bow/stern).</summary>
         public const float HullDetectInflateLength = 1.025f;
+        /// <summary>Beam inflation for the SAT hit-test OBB (starts detection slightly earlier side-to-side).</summary>
         public const float HullDetectInflateBeam = 1.015f;
+        /// <summary>Tighten the beam used for detection (helps keep “air gap” drag low when ships pass nearby).</summary>
         public const float BeamDetectTightenMul = 0.78f;
+        /// <summary>Ignore overlaps smaller than this (m) to avoid jitter from tiny penetrations.</summary>
         public const float MinPenetrationToAct = 0.055f;
+        /// <summary>Minimum overlap depth (m) required to apply periodic hull collision damage.</summary>
         public const float MinPenetrationToDamage = MinPenetrationToAct * 1.15f;
+        /// <summary>Penetration depth (m) over which tangential slip damping ramps from 0 to full.</summary>
         public const float TangentialRampDepthMeters = 0.22f;
+        /// <summary>Multiplier for the computed separation distance (stronger push-out when overlapped).</summary>
         public const float SeparationPushMultiplier = 1.22f;
+        /// <summary>Extra separation slack (m) added to prevent immediate re-penetration after depenetration.</summary>
         public const float SeparationSlackMeters = 0.020f;
+        /// <summary>Damping factor for relative closing speed into the contact normal (1 = remove fully).</summary>
         public const float ClosingSpeedDamp = 1f;
+        /// <summary>Fraction of tangential relative motion removed at full ramp (lower = more slip).</summary>
         public const float TangentialSlipDamp = 0.86f;
+        /// <summary>Minimum vertical (Y) AABB overlap (m) required before attempting XZ SAT (cheap reject).</summary>
         public const float MinVerticalOverlap = 0.12f;
+        /// <summary>Number of passes over all ship pairs per tick (extra passes help resolve chain overlaps).</summary>
         public const int ResolvePasses = 2;
+        /// <summary>Max iterations per pair while still overlapping (prevents pathological loops).</summary>
         public const int MaxPairIterations = 12;
+        /// <summary>Penetration depth (m) above which separation begins to get an extra “deep overlap” boost.</summary>
         public const float DeepPenetrationStart = 0.12f;
+        /// <summary>Scale of the “deep overlap” separation boost.</summary>
         public const float DeepPenetrationBoost = 0.72f;
+        /// <summary>Minimum per-side separation (m) to apply even when computed overlap is tiny.</summary>
         public const float MinHalfSeparationMeters = 0.02f;
+        /// <summary>Skip applying separation if computed linear separation is below this (m) (noise guard).</summary>
         public const float MinLinearSeparationToApplyMeters = 0.018f;
+        /// <summary>Cosine threshold for considering a contact “nose/bow hit” (affects damage logic).</summary>
         public const float NoseContactCosThreshold = 0.65f;
+        /// <summary>Cooldown (seconds) per other ship for applying %HP hull collision damage.</summary>
         public const float HullCollisionDamageCooldownSec = 1.5f;
+        /// <summary>Below this relative impact speed (m/s), hull damage uses the minimum percent.</summary>
         public const float HullDamageLowSpeedThresholdMps = 2f;
+        /// <summary>At or above this relative impact speed (m/s), hull damage uses the maximum percent.</summary>
         public const float HullDamageSpeedInterpMaxMps = 10f;
+        /// <summary>Minimum periodic hull damage (percent of max HP) for eligible collisions.</summary>
         public const int HullDamageSpeedScaledMinPercent = 1;
+        /// <summary>Maximum periodic hull damage (percent of max HP) for eligible collisions.</summary>
         public const int HullDamageSpeedScaledMaxPercent = 10;
+        /// <summary>How strongly mass affects who gets pushed more (1 = pure inverse-mass split; &gt;1 exaggerates).</summary>
         public const float MassPushStrength = 2f;
     }
 

--- a/AAEmu.Game/Physics/ShipShipInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShipInteraction.cs
@@ -14,173 +14,141 @@ namespace AAEmu.Game.Physics;
 /// so Jitter contacts do not prevent mesh-deep penetration — we depenetrate in XZ and damp closing speed.
 /// SAT overlap uses a tight mass box (near physics hull) so reaction does not start far before visuals meet.
 /// After overlap is detected, separation is scaled up to approximate client mesh extent without enlarging the hit test.
+/// Separation and velocity damping are mass-weighted; <see cref="AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.MassPushStrength"/> blends toward 50/50 (0) or exaggerates beyond inverse-mass (&gt;1).
 /// Centers use the same local mass-center offset as <see cref="ShipController.Build"/> (TransformedShape).
 /// </summary>
 public sealed class ShipShipInteraction
 {
+    /// <summary>
+    /// Production defaults for ship↔ship SAT/response when <see cref="AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled"/> is false.
+    /// <see cref="AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning"/> mirrors these for Hot Reload.
+    /// </summary>
+    public static class PhysicsDefaults
+    {
+        public const float HullDetectInflateLength = 1.025f;
+        public const float HullDetectInflateBeam = 1.015f;
+        public const float BeamDetectTightenMul = 0.78f;
+        public const float MinPenetrationToAct = 0.055f;
+        public const float MinPenetrationToDamage = MinPenetrationToAct * 1.15f;
+        public const float TangentialRampDepthMeters = 0.22f;
+        public const float SeparationPushMultiplier = 1.22f;
+        public const float SeparationSlackMeters = 0.020f;
+        public const float ClosingSpeedDamp = 1f;
+        public const float TangentialSlipDamp = 0.86f;
+        public const float MinVerticalOverlap = 0.12f;
+        public const int ResolvePasses = 2;
+        public const int MaxPairIterations = 12;
+        public const float DeepPenetrationStart = 0.12f;
+        public const float DeepPenetrationBoost = 0.72f;
+        public const float MinHalfSeparationMeters = 0.02f;
+        public const float MinLinearSeparationToApplyMeters = 0.018f;
+        public const float NoseContactCosThreshold = 0.65f;
+        public const float HullCollisionDamageCooldownSec = 1.5f;
+        public const float HullDamageLowSpeedThresholdMps = 2f;
+        public const float HullDamageSpeedInterpMaxMps = 10f;
+        public const int HullDamageSpeedScaledMinPercent = 1;
+        public const int HullDamageSpeedScaledMaxPercent = 10;
+        public const float MassPushStrength = 2f;
+    }
+
     private static class Tune
     {
         public static float HullDetectInflateLength => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.HullDetectInflateLength
-            : HullDetectInflateLengthDefault;
+            : PhysicsDefaults.HullDetectInflateLength;
 
         public static float HullDetectInflateBeam => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.HullDetectInflateBeam
-            : HullDetectInflateBeamDefault;
+            : PhysicsDefaults.HullDetectInflateBeam;
 
         public static float BeamDetectTightenMul => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.BeamDetectTightenMul
-            : BeamDetectTightenMulDefault;
+            : PhysicsDefaults.BeamDetectTightenMul;
 
         public static float MinPenetrationToAct => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.MinPenetrationToAct
-            : MinPenetrationToActDefault;
+            : PhysicsDefaults.MinPenetrationToAct;
 
         public static float MinPenetrationToDamage => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.MinPenetrationToDamage
-            : MinPenetrationToDamageDefault;
+            : PhysicsDefaults.MinPenetrationToDamage;
 
         public static float TangentialRampDepthMeters => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.TangentialRampDepthMeters
-            : TangentialRampDepthMetersDefault;
+            : PhysicsDefaults.TangentialRampDepthMeters;
 
         public static float SeparationPushMultiplier => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.SeparationPushMultiplier
-            : SeparationPushMultiplierDefault;
+            : PhysicsDefaults.SeparationPushMultiplier;
 
         public static float SeparationSlackMeters => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.SeparationSlackMeters
-            : SeparationSlackMetersDefault;
+            : PhysicsDefaults.SeparationSlackMeters;
 
         public static float ClosingSpeedDamp => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.ClosingSpeedDamp
-            : ClosingSpeedDampDefault;
+            : PhysicsDefaults.ClosingSpeedDamp;
 
         public static float TangentialSlipDamp => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.TangentialSlipDamp
-            : TangentialSlipDampDefault;
+            : PhysicsDefaults.TangentialSlipDamp;
 
         public static float MinVerticalOverlap => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.MinVerticalOverlap
-            : MinVerticalOverlapDefault;
+            : PhysicsDefaults.MinVerticalOverlap;
 
         public static int ResolvePasses => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.ResolvePasses
-            : ResolvePassesDefault;
+            : PhysicsDefaults.ResolvePasses;
 
         public static int MaxPairIterations => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.MaxPairIterations
-            : MaxPairIterationsDefault;
+            : PhysicsDefaults.MaxPairIterations;
 
         public static float DeepPenetrationStart => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.DeepPenetrationStart
-            : DeepPenetrationStartDefault;
+            : PhysicsDefaults.DeepPenetrationStart;
 
         public static float DeepPenetrationBoost => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.DeepPenetrationBoost
-            : DeepPenetrationBoostDefault;
+            : PhysicsDefaults.DeepPenetrationBoost;
 
         public static float MinHalfSeparationMeters => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.MinHalfSeparationMeters
-            : MinHalfSeparationMetersDefault;
+            : PhysicsDefaults.MinHalfSeparationMeters;
 
         public static float MinLinearSeparationToApplyMeters => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.MinLinearSeparationToApplyMeters
-            : MinLinearSeparationToApplyMetersDefault;
+            : PhysicsDefaults.MinLinearSeparationToApplyMeters;
 
         public static float NoseContactCosThreshold => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.NoseContactCosThreshold
-            : NoseContactCosThresholdDefault;
+            : PhysicsDefaults.NoseContactCosThreshold;
 
         public static float HullCollisionDamageCooldownSec => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.HullCollisionDamageCooldownSec
-            : HullCollisionDamageCooldownSecDefault;
+            : PhysicsDefaults.HullCollisionDamageCooldownSec;
 
         public static float HullDamageLowSpeedThresholdMps => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.HullDamageLowSpeedThresholdMps
-            : HullDamageLowSpeedThresholdMpsDefault;
+            : PhysicsDefaults.HullDamageLowSpeedThresholdMps;
 
         public static float HullDamageSpeedInterpMaxMps => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.HullDamageInterpMaxMps
-            : HullDamageSpeedInterpMaxMpsDefault;
+            : PhysicsDefaults.HullDamageSpeedInterpMaxMps;
 
         public static int HullDamageSpeedScaledMinPercent => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.HullDamageSpeedScaledMinPercent
-            : HullDamageSpeedScaledMinPercentDefault;
+            : PhysicsDefaults.HullDamageSpeedScaledMinPercent;
 
         public static int HullDamageSpeedScaledMaxPercent => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.HullDamageSpeedScaledMaxPercent
-            : HullDamageSpeedScaledMaxPercentDefault;
+            : PhysicsDefaults.HullDamageSpeedScaledMaxPercent;
+
+        public static float MassPushStrength => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.MassPushStrength
+            : PhysicsDefaults.MassPushStrength;
     }
-
-    /// <summary>Length half-axis multiplier for overlap test only — keep close to 1.</summary>
-    private const float HullDetectInflateLengthDefault = 1.025f;
-
-    /// <summary>Beam half-axis multiplier for overlap test only.</summary>
-    private const float HullDetectInflateBeamDefault = 1.015f;
-
-    /// <summary>
-    /// Extra tightening of beam in SAT only: <c>MassBoxSizeY</c> is often full deck/rail width, so side-by-side
-    /// contact triggered long before hulls meet; length stays full for nose-to-nose.
-    /// </summary>
-    private const float BeamDetectTightenMulDefault = 0.78f;
-
-    /// <summary>Ignore overlap response below this depth (m) — kills ghost drag from marginal SAT positives.</summary>
-    private const float MinPenetrationToActDefault = 0.055f;
-
-    /// <summary>Ignore periodic hull-damage for marginal SAT overlaps (m) — prevents "rubbing damage" from false contact.</summary>
-    private const float MinPenetrationToDamageDefault = MinPenetrationToActDefault * 1.15f;
-
-    /// <summary>Ramp tangential slip damp from 0 to full over this depth past <see cref="MinPenetrationToAct"/>.</summary>
-    private const float TangentialRampDepthMetersDefault = 0.22f;
-
-    /// <summary>Multiplies positional separation once overlap exists (mesh wider than mass box).</summary>
-    private const float SeparationPushMultiplierDefault = 1.22f;
-
-    /// <summary>Extra push after computed overlap so hulls do not sit exactly tangent (reduces z-fight / next-frame re-entry).</summary>
-    private const float SeparationSlackMetersDefault = 0.020f;
-
-    /// <summary>When overlapping, relative speed along separation normal is removed this fraction (1 = full stop along normal).</summary>
-    private const float ClosingSpeedDampDefault = 1f;
-
-    /// <summary>While hulls overlap, damp relative tangential slip in XZ to reduce slow grind-through.</summary>
-    private const float TangentialSlipDampDefault = 0.86f;
-
-    /// <summary>Minimum vertical overlap (m) to count as colliding (ignore ships far above/below).</summary>
-    private const float MinVerticalOverlapDefault = 0.12f;
-
-    private const int ResolvePassesDefault = 2;
-
-    /// <summary>Per pair, per outer pass: depenetrate until separated or cap (handles sustained rubbing in one tick).</summary>
-    private const int MaxPairIterationsDefault = 12;
-
-    /// <summary>Extra separation scale when penetration exceeds this depth (m).</summary>
-    private const float DeepPenetrationStartDefault = 0.12f;
-
-    private const float DeepPenetrationBoostDefault = 0.72f;
-
-    /// <summary>Floor on half-separation distance (m) so tiny SAT depths still produce a visible push.</summary>
-    private const float MinHalfSeparationMetersDefault = 0.02f;
-
-    /// <summary>
-    /// If <c>halfSep + SeparationSlack</c> is below this (m), stop iterating — avoids high-frequency micro-pushes at marginal overlap.
-    /// </summary>
-    private const float MinLinearSeparationToApplyMetersDefault = 0.018f;
-
-    /// <summary>Cosine threshold: other hull in this forward cone counts as “nose” hit (1% hull); else 3%.</summary>
-    private const float NoseContactCosThresholdDefault = 0.65f;
-
-    /// <summary>Min interval between hull-collision %HP ticks per ship while contact persists.</summary>
-    private const float HullCollisionDamageCooldownSecDefault = 1.5f;
-
-    /// <summary>At or below this relative speed (m/s) along separation axis, non–nose-to-nose hits use min % damage.</summary>
-    private const float HullDamageLowSpeedThresholdMpsDefault = 2f;
-
-    /// <summary>Relative speed (m/s) at which non–nose damage reaches <see cref="HullDamageSpeedScaledMaxPercent"/> (linear between thresholds).</summary>
-    private const float HullDamageSpeedInterpMaxMpsDefault = 10f;
-
-    private const int HullDamageSpeedScaledMinPercentDefault = 1;
-    private const int HullDamageSpeedScaledMaxPercentDefault = 10;
 
     /// <summary>
     /// Run after all ships have had <see cref="ShipController.ApplyForceAndTorque"/> for this frame.
@@ -415,11 +383,14 @@ public sealed class ShipShipInteraction
             var relAlongN = (va.X - vb.X) * nx + (va.Z - vb.Z) * nz;
             peakImpactSpeedMps = Math.Max(peakImpactSpeedMps, MathF.Abs(relAlongN));
 
-            bodyA.Position -= new JVector(nx * move, 0f, nz * move);
-            bodyB.Position += new JVector(nx * move, 0f, nz * move);
+            GetPairMassWeights(bodyA.Mass, bodyB.Mass, out var wA, out var wB);
+            var moveA = 2f * move * wA;
+            var moveB = 2f * move * wB;
+            bodyA.Position -= new JVector(nx * moveA, 0f, nz * moveA);
+            bodyB.Position += new JVector(nx * moveB, 0f, nz * moveB);
             hadResponse = true;
 
-            DampPairVelocities(bodyA, bodyB, nx, nz, penetration);
+            DampPairVelocities(bodyA, bodyB, nx, nz, penetration, wA, wB);
 
             AAEmu.Game.Physics.Debug.ShipTuningDebug.OnResolvedShipPair(sa, sb, penetration, nx, nz, peakImpactSpeedMps);
         }
@@ -431,7 +402,14 @@ public sealed class ShipShipInteraction
     }
 
     /// <summary>Removes relative motion into the other hull along <paramref name="nx"/>,<paramref name="nz"/>; tangential damp scales with penetration so parallel “air gap” drag stays low.</summary>
-    private static void DampPairVelocities(RigidBody bodyA, RigidBody bodyB, float nx, float nz, float penetrationDepth)
+    private static void DampPairVelocities(
+        RigidBody bodyA,
+        RigidBody bodyB,
+        float nx,
+        float nz,
+        float penetrationDepth,
+        float weightA,
+        float weightB)
     {
         var va = bodyA.Velocity;
         var vb = bodyB.Velocity;
@@ -439,21 +417,47 @@ public sealed class ShipShipInteraction
         var closing = (va.X - vb.X) * nx + (va.Z - vb.Z) * nz;
         if (closing > 0f)
         {
-            var remove = closing * 0.5f * Tune.ClosingSpeedDamp;
-            va = new JVector(va.X - nx * remove, va.Y, va.Z - nz * remove);
-            vb = new JVector(vb.X + nx * remove, vb.Y, vb.Z + nz * remove);
+            var removeA = closing * weightA * Tune.ClosingSpeedDamp;
+            var removeB = closing * weightB * Tune.ClosingSpeedDamp;
+            va = new JVector(va.X - nx * removeA, va.Y, va.Z - nz * removeA);
+            vb = new JVector(vb.X + nx * removeB, vb.Y, vb.Z + nz * removeB);
         }
 
         var tangentialBlend = Math.Clamp((penetrationDepth - Tune.MinPenetrationToAct) / Tune.TangentialRampDepthMeters, 0f, 1f);
         var tx = -nz;
         var tz = nx;
         var relT = (va.X - vb.X) * tx + (va.Z - vb.Z) * tz;
-        var slipRemove = relT * 0.5f * (1f - Tune.TangentialSlipDamp) * tangentialBlend;
-        va = new JVector(va.X - tx * slipRemove, va.Y, va.Z - tz * slipRemove);
-        vb = new JVector(vb.X + tx * slipRemove, vb.Y, vb.Z + tz * slipRemove);
+        var slipK = (1f - Tune.TangentialSlipDamp) * tangentialBlend;
+        var slipA = relT * weightA * slipK;
+        var slipB = relT * weightB * slipK;
+        va = new JVector(va.X - tx * slipA, va.Y, va.Z - tz * slipA);
+        vb = new JVector(vb.X + tx * slipB, vb.Y, vb.Z + tz * slipB);
 
         bodyA.Velocity = va;
         bodyB.Velocity = vb;
+    }
+
+    /// <summary>
+    /// Mass-based split from inverse mass ratio, scaled by <see cref="Tune.MassPushStrength"/> (blend toward 50/50 or exaggerate).
+    /// </summary>
+    private static void GetPairMassWeights(float massA, float massB, out float weightA, out float weightB)
+    {
+        var sum = massA + massB;
+        if (sum < 1e-6f || massA <= 0f || massB <= 0f)
+        {
+            weightA = weightB = 0.5f;
+            return;
+        }
+
+        var inv = 1f / sum;
+        var wPhysA = massB * inv;
+        var wPhysB = massA * inv;
+        var t = Tune.MassPushStrength;
+        weightA = 0.5f + (wPhysA - 0.5f) * t;
+        weightB = 0.5f + (wPhysB - 0.5f) * t;
+        const float eps = 1e-4f;
+        weightA = Math.Clamp(weightA, eps, 1f - eps);
+        weightB = 1f - weightA;
     }
 
     /// <summary>2D SAT on XZ for rectangles aligned with ship bow (same convention as <see cref="ShipController"/>).</summary>

--- a/AAEmu.Game/Physics/ShipShipInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShipInteraction.cs
@@ -14,15 +14,12 @@ namespace AAEmu.Game.Physics;
 /// so Jitter contacts do not prevent mesh-deep penetration — we depenetrate in XZ and damp closing speed.
 /// SAT overlap uses a tight mass box (near physics hull) so reaction does not start far before visuals meet.
 /// After overlap is detected, separation is scaled up to approximate client mesh extent without enlarging the hit test.
-/// Separation and velocity damping are mass-weighted; <see cref="AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.MassPushStrength"/> blends toward 50/50 (0) or exaggerates beyond inverse-mass (&gt;1).
+/// Separation and velocity damping are mass-weighted; see <see cref="PhysicsDefaults.MassPushStrength"/>.
 /// Centers use the same local mass-center offset as <see cref="ShipController.Build"/> (TransformedShape).
 /// </summary>
 public sealed class ShipShipInteraction
 {
-    /// <summary>
-    /// Production defaults for ship↔ship SAT/response when <see cref="AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled"/> is false.
-    /// <see cref="AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning"/> mirrors these for Hot Reload.
-    /// </summary>
+    /// <summary>Production constants for ship↔ship SAT/response (single source of truth).</summary>
     public static class PhysicsDefaults
     {
         public const float HullDetectInflateLength = 1.025f;
@@ -53,101 +50,30 @@ public sealed class ShipShipInteraction
 
     private static class Tune
     {
-        public static float HullDetectInflateLength => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.HullDetectInflateLength
-            : PhysicsDefaults.HullDetectInflateLength;
-
-        public static float HullDetectInflateBeam => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.HullDetectInflateBeam
-            : PhysicsDefaults.HullDetectInflateBeam;
-
-        public static float BeamDetectTightenMul => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.BeamDetectTightenMul
-            : PhysicsDefaults.BeamDetectTightenMul;
-
-        public static float MinPenetrationToAct => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.MinPenetrationToAct
-            : PhysicsDefaults.MinPenetrationToAct;
-
-        public static float MinPenetrationToDamage => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.MinPenetrationToDamage
-            : PhysicsDefaults.MinPenetrationToDamage;
-
-        public static float TangentialRampDepthMeters => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.TangentialRampDepthMeters
-            : PhysicsDefaults.TangentialRampDepthMeters;
-
-        public static float SeparationPushMultiplier => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.SeparationPushMultiplier
-            : PhysicsDefaults.SeparationPushMultiplier;
-
-        public static float SeparationSlackMeters => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.SeparationSlackMeters
-            : PhysicsDefaults.SeparationSlackMeters;
-
-        public static float ClosingSpeedDamp => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.ClosingSpeedDamp
-            : PhysicsDefaults.ClosingSpeedDamp;
-
-        public static float TangentialSlipDamp => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.TangentialSlipDamp
-            : PhysicsDefaults.TangentialSlipDamp;
-
-        public static float MinVerticalOverlap => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.MinVerticalOverlap
-            : PhysicsDefaults.MinVerticalOverlap;
-
-        public static int ResolvePasses => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.ResolvePasses
-            : PhysicsDefaults.ResolvePasses;
-
-        public static int MaxPairIterations => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.MaxPairIterations
-            : PhysicsDefaults.MaxPairIterations;
-
-        public static float DeepPenetrationStart => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.DeepPenetrationStart
-            : PhysicsDefaults.DeepPenetrationStart;
-
-        public static float DeepPenetrationBoost => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.DeepPenetrationBoost
-            : PhysicsDefaults.DeepPenetrationBoost;
-
-        public static float MinHalfSeparationMeters => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.MinHalfSeparationMeters
-            : PhysicsDefaults.MinHalfSeparationMeters;
-
-        public static float MinLinearSeparationToApplyMeters => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.MinLinearSeparationToApplyMeters
-            : PhysicsDefaults.MinLinearSeparationToApplyMeters;
-
-        public static float NoseContactCosThreshold => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.NoseContactCosThreshold
-            : PhysicsDefaults.NoseContactCosThreshold;
-
-        public static float HullCollisionDamageCooldownSec => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.HullCollisionDamageCooldownSec
-            : PhysicsDefaults.HullCollisionDamageCooldownSec;
-
-        public static float HullDamageLowSpeedThresholdMps => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.HullDamageLowSpeedThresholdMps
-            : PhysicsDefaults.HullDamageLowSpeedThresholdMps;
-
-        public static float HullDamageSpeedInterpMaxMps => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.HullDamageInterpMaxMps
-            : PhysicsDefaults.HullDamageSpeedInterpMaxMps;
-
-        public static int HullDamageSpeedScaledMinPercent => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.HullDamageSpeedScaledMinPercent
-            : PhysicsDefaults.HullDamageSpeedScaledMinPercent;
-
-        public static int HullDamageSpeedScaledMaxPercent => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.HullDamageSpeedScaledMaxPercent
-            : PhysicsDefaults.HullDamageSpeedScaledMaxPercent;
-
-        public static float MassPushStrength => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.MassPushStrength
-            : PhysicsDefaults.MassPushStrength;
+        public static float HullDetectInflateLength => PhysicsDefaults.HullDetectInflateLength;
+        public static float HullDetectInflateBeam => PhysicsDefaults.HullDetectInflateBeam;
+        public static float BeamDetectTightenMul => PhysicsDefaults.BeamDetectTightenMul;
+        public static float MinPenetrationToAct => PhysicsDefaults.MinPenetrationToAct;
+        public static float MinPenetrationToDamage => PhysicsDefaults.MinPenetrationToDamage;
+        public static float TangentialRampDepthMeters => PhysicsDefaults.TangentialRampDepthMeters;
+        public static float SeparationPushMultiplier => PhysicsDefaults.SeparationPushMultiplier;
+        public static float SeparationSlackMeters => PhysicsDefaults.SeparationSlackMeters;
+        public static float ClosingSpeedDamp => PhysicsDefaults.ClosingSpeedDamp;
+        public static float TangentialSlipDamp => PhysicsDefaults.TangentialSlipDamp;
+        public static float MinVerticalOverlap => PhysicsDefaults.MinVerticalOverlap;
+        public static int ResolvePasses => PhysicsDefaults.ResolvePasses;
+        public static int MaxPairIterations => PhysicsDefaults.MaxPairIterations;
+        public static float DeepPenetrationStart => PhysicsDefaults.DeepPenetrationStart;
+        public static float DeepPenetrationBoost => PhysicsDefaults.DeepPenetrationBoost;
+        public static float MinHalfSeparationMeters => PhysicsDefaults.MinHalfSeparationMeters;
+        public static float MinLinearSeparationToApplyMeters => PhysicsDefaults.MinLinearSeparationToApplyMeters;
+        public static float NoseContactCosThreshold => PhysicsDefaults.NoseContactCosThreshold;
+        public static float HullCollisionDamageCooldownSec => PhysicsDefaults.HullCollisionDamageCooldownSec;
+        public static float HullDamageLowSpeedThresholdMps => PhysicsDefaults.HullDamageLowSpeedThresholdMps;
+        public static float HullDamageSpeedInterpMaxMps => PhysicsDefaults.HullDamageSpeedInterpMaxMps;
+        public static int HullDamageSpeedScaledMinPercent => PhysicsDefaults.HullDamageSpeedScaledMinPercent;
+        public static int HullDamageSpeedScaledMaxPercent => PhysicsDefaults.HullDamageSpeedScaledMaxPercent;
+        public static float MassPushStrength => PhysicsDefaults.MassPushStrength;
     }
 
     /// <summary>

--- a/AAEmu.Game/Physics/ShipShipInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShipInteraction.cs
@@ -18,74 +18,169 @@ namespace AAEmu.Game.Physics;
 /// </summary>
 public sealed class ShipShipInteraction
 {
+    private static class Tune
+    {
+        public static float HullDetectInflateLength => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.HullDetectInflateLength
+            : HullDetectInflateLengthDefault;
+
+        public static float HullDetectInflateBeam => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.HullDetectInflateBeam
+            : HullDetectInflateBeamDefault;
+
+        public static float BeamDetectTightenMul => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.BeamDetectTightenMul
+            : BeamDetectTightenMulDefault;
+
+        public static float MinPenetrationToAct => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.MinPenetrationToAct
+            : MinPenetrationToActDefault;
+
+        public static float MinPenetrationToDamage => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.MinPenetrationToDamage
+            : MinPenetrationToDamageDefault;
+
+        public static float TangentialRampDepthMeters => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.TangentialRampDepthMeters
+            : TangentialRampDepthMetersDefault;
+
+        public static float SeparationPushMultiplier => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.SeparationPushMultiplier
+            : SeparationPushMultiplierDefault;
+
+        public static float SeparationSlackMeters => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.SeparationSlackMeters
+            : SeparationSlackMetersDefault;
+
+        public static float ClosingSpeedDamp => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.ClosingSpeedDamp
+            : ClosingSpeedDampDefault;
+
+        public static float TangentialSlipDamp => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.TangentialSlipDamp
+            : TangentialSlipDampDefault;
+
+        public static float MinVerticalOverlap => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.MinVerticalOverlap
+            : MinVerticalOverlapDefault;
+
+        public static int ResolvePasses => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.ResolvePasses
+            : ResolvePassesDefault;
+
+        public static int MaxPairIterations => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.MaxPairIterations
+            : MaxPairIterationsDefault;
+
+        public static float DeepPenetrationStart => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.DeepPenetrationStart
+            : DeepPenetrationStartDefault;
+
+        public static float DeepPenetrationBoost => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.DeepPenetrationBoost
+            : DeepPenetrationBoostDefault;
+
+        public static float MinHalfSeparationMeters => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.MinHalfSeparationMeters
+            : MinHalfSeparationMetersDefault;
+
+        public static float MinLinearSeparationToApplyMeters => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.MinLinearSeparationToApplyMeters
+            : MinLinearSeparationToApplyMetersDefault;
+
+        public static float NoseContactCosThreshold => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.NoseContactCosThreshold
+            : NoseContactCosThresholdDefault;
+
+        public static float HullCollisionDamageCooldownSec => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.HullCollisionDamageCooldownSec
+            : HullCollisionDamageCooldownSecDefault;
+
+        public static float HullDamageLowSpeedThresholdMps => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.HullDamageLowSpeedThresholdMps
+            : HullDamageLowSpeedThresholdMpsDefault;
+
+        public static float HullDamageSpeedInterpMaxMps => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.HullDamageInterpMaxMps
+            : HullDamageSpeedInterpMaxMpsDefault;
+
+        public static int HullDamageSpeedScaledMinPercent => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.HullDamageSpeedScaledMinPercent
+            : HullDamageSpeedScaledMinPercentDefault;
+
+        public static int HullDamageSpeedScaledMaxPercent => AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShipShipTuning.HullDamageSpeedScaledMaxPercent
+            : HullDamageSpeedScaledMaxPercentDefault;
+    }
+
     /// <summary>Length half-axis multiplier for overlap test only — keep close to 1.</summary>
-    private const float HullDetectInflateLength = 1.025f;
+    private const float HullDetectInflateLengthDefault = 1.025f;
 
     /// <summary>Beam half-axis multiplier for overlap test only.</summary>
-    private const float HullDetectInflateBeam = 1.015f;
+    private const float HullDetectInflateBeamDefault = 1.015f;
 
     /// <summary>
     /// Extra tightening of beam in SAT only: <c>MassBoxSizeY</c> is often full deck/rail width, so side-by-side
     /// contact triggered long before hulls meet; length stays full for nose-to-nose.
     /// </summary>
-    private const float BeamDetectTightenMul = 0.78f;
+    private const float BeamDetectTightenMulDefault = 0.78f;
 
     /// <summary>Ignore overlap response below this depth (m) — kills ghost drag from marginal SAT positives.</summary>
-    private const float MinPenetrationToAct = 0.055f;
+    private const float MinPenetrationToActDefault = 0.055f;
 
     /// <summary>Ignore periodic hull-damage for marginal SAT overlaps (m) — prevents "rubbing damage" from false contact.</summary>
-    private const float MinPenetrationToDamage = MinPenetrationToAct * 1.15f;
+    private const float MinPenetrationToDamageDefault = MinPenetrationToActDefault * 1.15f;
 
     /// <summary>Ramp tangential slip damp from 0 to full over this depth past <see cref="MinPenetrationToAct"/>.</summary>
-    private const float TangentialRampDepthMeters = 0.22f;
+    private const float TangentialRampDepthMetersDefault = 0.22f;
 
     /// <summary>Multiplies positional separation once overlap exists (mesh wider than mass box).</summary>
-    private const float SeparationPushMultiplier = 1.22f;
+    private const float SeparationPushMultiplierDefault = 1.22f;
 
     /// <summary>Extra push after computed overlap so hulls do not sit exactly tangent (reduces z-fight / next-frame re-entry).</summary>
-    private const float SeparationSlackMeters = 0.020f;
+    private const float SeparationSlackMetersDefault = 0.020f;
 
     /// <summary>When overlapping, relative speed along separation normal is removed this fraction (1 = full stop along normal).</summary>
-    private const float ClosingSpeedDamp = 1f;
+    private const float ClosingSpeedDampDefault = 1f;
 
     /// <summary>While hulls overlap, damp relative tangential slip in XZ to reduce slow grind-through.</summary>
-    private const float TangentialSlipDamp = 0.86f;
+    private const float TangentialSlipDampDefault = 0.86f;
 
     /// <summary>Minimum vertical overlap (m) to count as colliding (ignore ships far above/below).</summary>
-    private const float MinVerticalOverlap = 0.12f;
+    private const float MinVerticalOverlapDefault = 0.12f;
 
-    private const int ResolvePasses = 2;
+    private const int ResolvePassesDefault = 2;
 
     /// <summary>Per pair, per outer pass: depenetrate until separated or cap (handles sustained rubbing in one tick).</summary>
-    private const int MaxPairIterations = 12;
+    private const int MaxPairIterationsDefault = 12;
 
     /// <summary>Extra separation scale when penetration exceeds this depth (m).</summary>
-    private const float DeepPenetrationStart = 0.12f;
+    private const float DeepPenetrationStartDefault = 0.12f;
 
-    private const float DeepPenetrationBoost = 0.72f;
+    private const float DeepPenetrationBoostDefault = 0.72f;
 
     /// <summary>Floor on half-separation distance (m) so tiny SAT depths still produce a visible push.</summary>
-    private const float MinHalfSeparationMeters = 0.02f;
+    private const float MinHalfSeparationMetersDefault = 0.02f;
 
     /// <summary>
     /// If <c>halfSep + SeparationSlack</c> is below this (m), stop iterating — avoids high-frequency micro-pushes at marginal overlap.
     /// </summary>
-    private const float MinLinearSeparationToApplyMeters = 0.018f;
+    private const float MinLinearSeparationToApplyMetersDefault = 0.018f;
 
     /// <summary>Cosine threshold: other hull in this forward cone counts as “nose” hit (1% hull); else 3%.</summary>
-    private const float NoseContactCosThreshold = 0.65f;
+    private const float NoseContactCosThresholdDefault = 0.65f;
 
     /// <summary>Min interval between hull-collision %HP ticks per ship while contact persists.</summary>
-    private const float HullCollisionDamageCooldownSec = 1.5f;
+    private const float HullCollisionDamageCooldownSecDefault = 1.5f;
 
     /// <summary>At or below this relative speed (m/s) along separation axis, non–nose-to-nose hits use min % damage.</summary>
-    private const float HullDamageLowSpeedThresholdMps = 2f;
+    private const float HullDamageLowSpeedThresholdMpsDefault = 2f;
 
     /// <summary>Relative speed (m/s) at which non–nose damage reaches <see cref="HullDamageSpeedScaledMaxPercent"/> (linear between thresholds).</summary>
-    private const float HullDamageSpeedInterpMaxMps = 10f;
+    private const float HullDamageSpeedInterpMaxMpsDefault = 10f;
 
-    private const int HullDamageSpeedScaledMinPercent = 1;
-    private const int HullDamageSpeedScaledMaxPercent = 10;
+    private const int HullDamageSpeedScaledMinPercentDefault = 1;
+    private const int HullDamageSpeedScaledMaxPercentDefault = 10;
 
     /// <summary>
     /// Run after all ships have had <see cref="ShipController.ApplyForceAndTorque"/> for this frame.
@@ -104,7 +199,7 @@ public sealed class ShipShipInteraction
 
         var pairDamagedThisTick = new HashSet<ulong>();
 
-        for (var pass = 0; pass < ResolvePasses; pass++)
+        for (var pass = 0; pass < Tune.ResolvePasses; pass++)
         {
             for (var i = 0; i < ships.Count; i++)
             {
@@ -123,7 +218,7 @@ public sealed class ShipShipInteraction
 
                     // If SAT only detects a marginal overlap (e.g. due to discrete steps / tight mass-box),
                     // keep the depenetration but don't apply periodic hull damage.
-                    if (maxPenetration < MinPenetrationToDamage)
+                    if (maxPenetration < Tune.MinPenetrationToDamage)
                         continue;
 
                     const byte holdTicks = 10;
@@ -197,19 +292,19 @@ public sealed class ShipShipInteraction
         var scaledDamage = GetSpeedScaledHullDamagePercent(impactSpeedMps);
         var aHitsWithNose = IsOtherShipInNoseCone(bx - ax, bz - az, bowA);
         var bHitsWithNose = IsOtherShipInNoseCone(ax - bx, az - bz, bowB);
-        var dmgA = aHitsWithNose ? HullDamageSpeedScaledMinPercent : scaledDamage;
-        var dmgB = bHitsWithNose ? HullDamageSpeedScaledMinPercent : scaledDamage;
+        var dmgA = aHitsWithNose ? Tune.HullDamageSpeedScaledMinPercent : scaledDamage;
+        var dmgB = bHitsWithNose ? Tune.HullDamageSpeedScaledMinPercent : scaledDamage;
 
         if (!sa.ShipHullCollisionDamageCooldownByOtherShipId.TryGetValue(sb.Id, out var cdA) || cdA <= 0f)
         {
             sa.ApplyShipHullCollisionDamage(sb, dmgA);
-            sa.ShipHullCollisionDamageCooldownByOtherShipId[sb.Id] = HullCollisionDamageCooldownSec;
+            sa.ShipHullCollisionDamageCooldownByOtherShipId[sb.Id] = Tune.HullCollisionDamageCooldownSec;
         }
 
         if (!sb.ShipHullCollisionDamageCooldownByOtherShipId.TryGetValue(sa.Id, out var cdB) || cdB <= 0f)
         {
             sb.ApplyShipHullCollisionDamage(sa, dmgB);
-            sb.ShipHullCollisionDamageCooldownByOtherShipId[sa.Id] = HullCollisionDamageCooldownSec;
+            sb.ShipHullCollisionDamageCooldownByOtherShipId[sa.Id] = Tune.HullCollisionDamageCooldownSec;
         }
     }
 
@@ -223,20 +318,20 @@ public sealed class ShipShipInteraction
         var fx = MathF.Cos(bowRadians);
         var fz = MathF.Sin(bowRadians);
         var cosAng = (toOtherX * fx + toOtherZ * fz) * invLen;
-        return cosAng >= NoseContactCosThreshold;
+            return cosAng >= Tune.NoseContactCosThreshold;
     }
 
     private static int GetSpeedScaledHullDamagePercent(float relativeSpeedMps)
     {
-        if (relativeSpeedMps <= HullDamageLowSpeedThresholdMps)
-            return HullDamageSpeedScaledMinPercent;
-        if (relativeSpeedMps >= HullDamageSpeedInterpMaxMps)
-            return HullDamageSpeedScaledMaxPercent;
+        if (relativeSpeedMps <= Tune.HullDamageLowSpeedThresholdMps)
+            return Tune.HullDamageSpeedScaledMinPercent;
+        if (relativeSpeedMps >= Tune.HullDamageSpeedInterpMaxMps)
+            return Tune.HullDamageSpeedScaledMaxPercent;
 
-        var span = HullDamageSpeedInterpMaxMps - HullDamageLowSpeedThresholdMps;
-        var t = (relativeSpeedMps - HullDamageLowSpeedThresholdMps) / span;
-        var f = HullDamageSpeedScaledMinPercent +
-                t * (HullDamageSpeedScaledMaxPercent - HullDamageSpeedScaledMinPercent);
+        var span = Tune.HullDamageSpeedInterpMaxMps - Tune.HullDamageLowSpeedThresholdMps;
+        var t = (relativeSpeedMps - Tune.HullDamageLowSpeedThresholdMps) / span;
+        var f = Tune.HullDamageSpeedScaledMinPercent +
+                t * (Tune.HullDamageSpeedScaledMaxPercent - Tune.HullDamageSpeedScaledMinPercent);
         return (int)MathF.Round(f);
     }
 
@@ -256,7 +351,7 @@ public sealed class ShipShipInteraction
         var bbA = bodyA.Shapes[0].WorldBoundingBox;
         var bbB = bodyB.Shapes[0].WorldBoundingBox;
         var overlapY = MathF.Min(bbA.Max.Y, bbB.Max.Y) - MathF.Max(bbA.Min.Y, bbB.Min.Y);
-        if (overlapY < MinVerticalOverlap)
+        if (overlapY < Tune.MinVerticalOverlap)
             return false;
 
         var rpyA = PhysicsUtil.GetYawPitchRollFromMatrix(JMatrix.CreateFromQuaternion(bodyA.Orientation));
@@ -264,18 +359,21 @@ public sealed class ShipShipInteraction
         var bowA = rpyA.Item1 + 1.57f;
         var bowB = rpyB.Item1 + 1.57f;
 
-        var halfLenA = ma.MassBoxSizeX * sa.Scale * 0.5f * HullDetectInflateLength;
-        var halfLenB = mb.MassBoxSizeX * sb.Scale * 0.5f * HullDetectInflateLength;
-        var satHalfWidA = ma.MassBoxSizeY * sa.Scale * 0.5f * HullDetectInflateBeam * BeamDetectTightenMul;
-        var satHalfWidB = mb.MassBoxSizeY * sb.Scale * 0.5f * HullDetectInflateBeam * BeamDetectTightenMul;
+        // Interpretation:
+        // - MassBoxSizeY = length (forward/back)
+        // - MassBoxSizeX = beam (right/left)
+        var halfLenA = ma.MassBoxSizeY * sa.Scale * 0.5f * Tune.HullDetectInflateLength;
+        var halfLenB = mb.MassBoxSizeY * sb.Scale * 0.5f * Tune.HullDetectInflateLength;
+        var satHalfWidA = ma.MassBoxSizeX * sa.Scale * 0.5f * Tune.HullDetectInflateBeam * Tune.BeamDetectTightenMul;
+        var satHalfWidB = mb.MassBoxSizeX * sb.Scale * 0.5f * Tune.HullDetectInflateBeam * Tune.BeamDetectTightenMul;
 
         float ax, az, bx, bz, penetration, nx, nz;
-        for (var iter = 0; iter < MaxPairIterations; iter++)
+        for (var iter = 0; iter < Tune.MaxPairIterations; iter++)
         {
             bbA = bodyA.Shapes[0].WorldBoundingBox;
             bbB = bodyB.Shapes[0].WorldBoundingBox;
             overlapY = MathF.Min(bbA.Max.Y, bbB.Max.Y) - MathF.Max(bbA.Min.Y, bbB.Min.Y);
-            if (overlapY < MinVerticalOverlap)
+            if (overlapY < Tune.MinVerticalOverlap)
                 break;
 
             GetMassBoxCenterXz(bodyA, ma, sa.Scale, out ax, out az);
@@ -289,7 +387,7 @@ public sealed class ShipShipInteraction
                     out nz))
                 break;
 
-            if (penetration <= 1e-4f || penetration < MinPenetrationToAct)
+            if (penetration <= 1e-4f || penetration < Tune.MinPenetrationToAct)
                 break;
 
             maxPenetration = MathF.Max(maxPenetration, penetration);
@@ -303,14 +401,14 @@ public sealed class ShipShipInteraction
             }
 
             var halfSep = penetration * 0.5f;
-            var deep = MathF.Max(0f, penetration - DeepPenetrationStart);
-            halfSep *= 1f + DeepPenetrationBoost * MathF.Min(1.25f, deep);
-            var linearSep = halfSep + SeparationSlackMeters;
-            if (linearSep < MinLinearSeparationToApplyMeters)
+            var deep = MathF.Max(0f, penetration - Tune.DeepPenetrationStart);
+            halfSep *= 1f + Tune.DeepPenetrationBoost * MathF.Min(1.25f, deep);
+            var linearSep = halfSep + Tune.SeparationSlackMeters;
+            if (linearSep < Tune.MinLinearSeparationToApplyMeters)
                 break;
 
-            var move = MathF.Max(linearSep, MinHalfSeparationMeters);
-            move *= SeparationPushMultiplier;
+            var move = MathF.Max(linearSep, Tune.MinHalfSeparationMeters);
+            move *= Tune.SeparationPushMultiplier;
 
             var va = bodyA.Velocity;
             var vb = bodyB.Velocity;
@@ -322,6 +420,8 @@ public sealed class ShipShipInteraction
             hadResponse = true;
 
             DampPairVelocities(bodyA, bodyB, nx, nz, penetration);
+
+            AAEmu.Game.Physics.Debug.ShipTuningDebug.OnResolvedShipPair(sa, sb, penetration, nx, nz, peakImpactSpeedMps);
         }
 
         if (hadResponse)
@@ -339,16 +439,16 @@ public sealed class ShipShipInteraction
         var closing = (va.X - vb.X) * nx + (va.Z - vb.Z) * nz;
         if (closing > 0f)
         {
-            var remove = closing * 0.5f * ClosingSpeedDamp;
+            var remove = closing * 0.5f * Tune.ClosingSpeedDamp;
             va = new JVector(va.X - nx * remove, va.Y, va.Z - nz * remove);
             vb = new JVector(vb.X + nx * remove, vb.Y, vb.Z + nz * remove);
         }
 
-        var tangentialBlend = Math.Clamp((penetrationDepth - MinPenetrationToAct) / TangentialRampDepthMeters, 0f, 1f);
+        var tangentialBlend = Math.Clamp((penetrationDepth - Tune.MinPenetrationToAct) / Tune.TangentialRampDepthMeters, 0f, 1f);
         var tx = -nz;
         var tz = nx;
         var relT = (va.X - vb.X) * tx + (va.Z - vb.Z) * tz;
-        var slipRemove = relT * 0.5f * (1f - TangentialSlipDamp) * tangentialBlend;
+        var slipRemove = relT * 0.5f * (1f - Tune.TangentialSlipDamp) * tangentialBlend;
         va = new JVector(va.X - tx * slipRemove, va.Y, va.Z - tz * slipRemove);
         vb = new JVector(vb.X + tx * slipRemove, vb.Y, vb.Z + tz * slipRemove);
 

--- a/AAEmu.Game/Physics/ShipShipInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShipInteraction.cs
@@ -1,0 +1,454 @@
+#nullable enable
+
+using AAEmu.Game.Models.Game.Models;
+using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Physics.Util;
+
+using Jitter2.Dynamics;
+using Jitter2.LinearMath;
+
+namespace AAEmu.Game.Physics;
+
+/// <summary>
+/// Ship–hull overlap resolution. Server motion overwrites <see cref="RigidBody.Velocity"/> each tick from <see cref="Slave.Speed"/>,
+/// so Jitter contacts do not prevent mesh-deep penetration — we depenetrate in XZ and damp closing speed.
+/// SAT overlap uses a tight mass box (near physics hull) so reaction does not start far before visuals meet.
+/// After overlap is detected, separation is scaled up to approximate client mesh extent without enlarging the hit test.
+/// Centers use the same local mass-center offset as <see cref="ShipController.Build"/> (TransformedShape).
+/// </summary>
+public sealed class ShipShipInteraction
+{
+    /// <summary>Length half-axis multiplier for overlap test only — keep close to 1.</summary>
+    private const float HullDetectInflateLength = 1.025f;
+
+    /// <summary>Beam half-axis multiplier for overlap test only.</summary>
+    private const float HullDetectInflateBeam = 1.015f;
+
+    /// <summary>
+    /// Extra tightening of beam in SAT only: <c>MassBoxSizeY</c> is often full deck/rail width, so side-by-side
+    /// contact triggered long before hulls meet; length stays full for nose-to-nose.
+    /// </summary>
+    private const float BeamDetectTightenMul = 0.86f;
+
+    /// <summary>Ignore overlap response below this depth (m) — kills ghost drag from marginal SAT positives.</summary>
+    private const float MinPenetrationToAct = 0.055f;
+
+    /// <summary>Ramp tangential slip damp from 0 to full over this depth past <see cref="MinPenetrationToAct"/>.</summary>
+    private const float TangentialRampDepthMeters = 0.22f;
+
+    /// <summary>Multiplies positional separation once overlap exists (mesh wider than mass box).</summary>
+    private const float SeparationPushMultiplier = 1.34f;
+
+    /// <summary>Extra push after computed overlap so hulls do not sit exactly tangent (reduces z-fight / next-frame re-entry).</summary>
+    private const float SeparationSlackMeters = 0.032f;
+
+    /// <summary>When overlapping, relative speed along separation normal is removed this fraction (1 = full stop along normal).</summary>
+    private const float ClosingSpeedDamp = 1f;
+
+    /// <summary>While hulls overlap, damp relative tangential slip in XZ to reduce slow grind-through.</summary>
+    private const float TangentialSlipDamp = 0.86f;
+
+    /// <summary>Minimum vertical overlap (m) to count as colliding (ignore ships far above/below).</summary>
+    private const float MinVerticalOverlap = 0.12f;
+
+    private const int ResolvePasses = 2;
+
+    /// <summary>Per pair, per outer pass: depenetrate until separated or cap (handles sustained rubbing in one tick).</summary>
+    private const int MaxPairIterations = 12;
+
+    /// <summary>Extra separation scale when penetration exceeds this depth (m).</summary>
+    private const float DeepPenetrationStart = 0.12f;
+
+    private const float DeepPenetrationBoost = 0.72f;
+
+    /// <summary>Floor on half-separation distance (m) so tiny SAT depths still produce a visible push.</summary>
+    private const float MinHalfSeparationMeters = 0.02f;
+
+    /// <summary>
+    /// If <c>halfSep + SeparationSlack</c> is below this (m), stop iterating — avoids high-frequency micro-pushes at marginal overlap.
+    /// </summary>
+    private const float MinLinearSeparationToApplyMeters = 0.018f;
+
+    /// <summary>Cosine threshold: other hull in this forward cone counts as “nose” hit (1% hull); else 3%.</summary>
+    private const float NoseContactCosThreshold = 0.65f;
+
+    /// <summary>Min interval between hull-collision %HP ticks per ship while contact persists.</summary>
+    private const float HullCollisionDamageCooldownSec = 1.5f;
+
+    /// <summary>At or below this relative speed (m/s) along separation axis, non–nose-to-nose hits use min % damage.</summary>
+    private const float HullDamageLowSpeedThresholdMps = 2f;
+
+    /// <summary>Relative speed (m/s) at which non–nose damage reaches <see cref="HullDamageSpeedScaledMaxPercent"/> (linear between thresholds).</summary>
+    private const float HullDamageSpeedInterpMaxMps = 10f;
+
+    private const int HullDamageSpeedScaledMinPercent = 1;
+    private const int HullDamageSpeedScaledMaxPercent = 10;
+
+    /// <summary>
+    /// Run after all ships have had <see cref="ShipController.ApplyForceAndTorque"/> for this frame.
+    /// </summary>
+    public void ResolveAllPairs(IReadOnlyList<Slave> ships, TimeSpan deltaTime)
+    {
+        var dt = (float)deltaTime.TotalSeconds;
+        if (ships.Count < 2)
+            return;
+
+        if (dt > 0f)
+        {
+            foreach (var s in ships)
+                TickHullCollisionCooldowns(s, dt);
+        }
+
+        var pairDamagedThisTick = new HashSet<ulong>();
+
+        for (var pass = 0; pass < ResolvePasses; pass++)
+        {
+            for (var i = 0; i < ships.Count; i++)
+            {
+                var sa = ships[i];
+                if (sa.RigidBody is null || sa.RigidBody.Shapes.Count == 0)
+                    continue;
+
+                for (var j = i + 1; j < ships.Count; j++)
+                {
+                    var sb = ships[j];
+                    if (sb.RigidBody is null || sb.RigidBody.Shapes.Count == 0)
+                        continue;
+
+                    if (!TryResolvePair(sa, sb, out var impactSpeedMps))
+                        continue;
+
+                    const byte holdTicks = 10;
+                    if (sa.ShipController != null)
+                        sa.ShipController.Replication.ContactHoldTicks =
+                            Math.Max(sa.ShipController.Replication.ContactHoldTicks, holdTicks);
+                    if (sb.ShipController != null)
+                        sb.ShipController.Replication.ContactHoldTicks =
+                            Math.Max(sb.ShipController.Replication.ContactHoldTicks, holdTicks);
+
+                    var minId = sa.Id < sb.Id ? sa.Id : sb.Id;
+                    var maxId = sa.Id < sb.Id ? sb.Id : sa.Id;
+                    var pairKey = ((ulong)minId << 32) | maxId;
+                    if (!pairDamagedThisTick.Add(pairKey))
+                        continue;
+
+                    ApplyPairHullDamage(sa, sb, impactSpeedMps);
+                }
+            }
+        }
+
+        foreach (var slave in ships)
+            SyncSlaveSpeedFromBowVelocity(slave);
+    }
+
+    private static void TickHullCollisionCooldowns(Slave s, float dt)
+    {
+        var map = s.ShipHullCollisionDamageCooldownByOtherShipId;
+        if (map.Count == 0)
+            return;
+
+        var keys = new uint[map.Count];
+        var n = 0;
+        foreach (var k in map.Keys)
+            keys[n++] = k;
+
+        for (var i = 0; i < n; i++)
+        {
+            var k = keys[i];
+            if (!map.TryGetValue(k, out var v))
+                continue;
+            v -= dt;
+            if (v <= 0f)
+                map.Remove(k);
+            else
+                map[k] = v;
+        }
+    }
+
+    /// <summary>
+    /// Ship with the other hull in its nose cone (contact through the bow) takes flat 1% — strong stem.
+    /// The other takes speed-interpolated % (see <see cref="GetSpeedScaledHullDamagePercent"/>). Both can be 1% in a true nose-to-nose if each qualifies.
+    /// </summary>
+    private static void ApplyPairHullDamage(Slave sa, Slave sb, float impactSpeedMps)
+    {
+        var bodyA = sa.RigidBody!;
+        var bodyB = sb.RigidBody!;
+        var ma = sa.ShipController?.ShipModel;
+        var mb = sb.ShipController?.ShipModel;
+        if (ma is null || mb is null)
+            return;
+
+        var rpyA = PhysicsUtil.GetYawPitchRollFromMatrix(JMatrix.CreateFromQuaternion(bodyA.Orientation));
+        var rpyB = PhysicsUtil.GetYawPitchRollFromMatrix(JMatrix.CreateFromQuaternion(bodyB.Orientation));
+        var bowA = rpyA.Item1 + 1.57f;
+        var bowB = rpyB.Item1 + 1.57f;
+
+        GetMassBoxCenterXz(bodyA, ma, sa.Scale, out var ax, out var az);
+        GetMassBoxCenterXz(bodyB, mb, sb.Scale, out var bx, out var bz);
+
+        var scaledDamage = GetSpeedScaledHullDamagePercent(impactSpeedMps);
+        var aHitsWithNose = IsOtherShipInNoseCone(bx - ax, bz - az, bowA);
+        var bHitsWithNose = IsOtherShipInNoseCone(ax - bx, az - bz, bowB);
+        var dmgA = aHitsWithNose ? HullDamageSpeedScaledMinPercent : scaledDamage;
+        var dmgB = bHitsWithNose ? HullDamageSpeedScaledMinPercent : scaledDamage;
+
+        if (!sa.ShipHullCollisionDamageCooldownByOtherShipId.TryGetValue(sb.Id, out var cdA) || cdA <= 0f)
+        {
+            sa.ApplyShipHullCollisionDamage(sb, dmgA);
+            sa.ShipHullCollisionDamageCooldownByOtherShipId[sb.Id] = HullCollisionDamageCooldownSec;
+        }
+
+        if (!sb.ShipHullCollisionDamageCooldownByOtherShipId.TryGetValue(sa.Id, out var cdB) || cdB <= 0f)
+        {
+            sb.ApplyShipHullCollisionDamage(sa, dmgB);
+            sb.ShipHullCollisionDamageCooldownByOtherShipId[sa.Id] = HullCollisionDamageCooldownSec;
+        }
+    }
+
+    private static bool IsOtherShipInNoseCone(float toOtherX, float toOtherZ, float bowRadians)
+    {
+        var lenSq = toOtherX * toOtherX + toOtherZ * toOtherZ;
+        if (lenSq < 0.04f)
+            return false;
+
+        var invLen = 1f / MathF.Sqrt(lenSq);
+        var fx = MathF.Cos(bowRadians);
+        var fz = MathF.Sin(bowRadians);
+        var cosAng = (toOtherX * fx + toOtherZ * fz) * invLen;
+        return cosAng >= NoseContactCosThreshold;
+    }
+
+    private static int GetSpeedScaledHullDamagePercent(float relativeSpeedMps)
+    {
+        if (relativeSpeedMps <= HullDamageLowSpeedThresholdMps)
+            return HullDamageSpeedScaledMinPercent;
+        if (relativeSpeedMps >= HullDamageSpeedInterpMaxMps)
+            return HullDamageSpeedScaledMaxPercent;
+
+        var span = HullDamageSpeedInterpMaxMps - HullDamageLowSpeedThresholdMps;
+        var t = (relativeSpeedMps - HullDamageLowSpeedThresholdMps) / span;
+        var f = HullDamageSpeedScaledMinPercent +
+                t * (HullDamageSpeedScaledMaxPercent - HullDamageSpeedScaledMinPercent);
+        return (int)MathF.Round(f);
+    }
+
+    private static bool TryResolvePair(Slave sa, Slave sb, out float impactSpeedMps)
+    {
+        impactSpeedMps = 0f;
+        var bodyA = sa.RigidBody!;
+        var bodyB = sb.RigidBody!;
+        var ma = sa.ShipController?.ShipModel;
+        var mb = sb.ShipController?.ShipModel;
+        if (ma is null || mb is null)
+            return false;
+
+        var hadResponse = false;
+        var peakImpactSpeedMps = 0f;
+        var bbA = bodyA.Shapes[0].WorldBoundingBox;
+        var bbB = bodyB.Shapes[0].WorldBoundingBox;
+        var overlapY = MathF.Min(bbA.Max.Y, bbB.Max.Y) - MathF.Max(bbA.Min.Y, bbB.Min.Y);
+        if (overlapY < MinVerticalOverlap)
+            return false;
+
+        var rpyA = PhysicsUtil.GetYawPitchRollFromMatrix(JMatrix.CreateFromQuaternion(bodyA.Orientation));
+        var rpyB = PhysicsUtil.GetYawPitchRollFromMatrix(JMatrix.CreateFromQuaternion(bodyB.Orientation));
+        var bowA = rpyA.Item1 + 1.57f;
+        var bowB = rpyB.Item1 + 1.57f;
+
+        var halfLenA = ma.MassBoxSizeX * sa.Scale * 0.5f * HullDetectInflateLength;
+        var halfLenB = mb.MassBoxSizeX * sb.Scale * 0.5f * HullDetectInflateLength;
+        var satHalfWidA = ma.MassBoxSizeY * sa.Scale * 0.5f * HullDetectInflateBeam * BeamDetectTightenMul;
+        var satHalfWidB = mb.MassBoxSizeY * sb.Scale * 0.5f * HullDetectInflateBeam * BeamDetectTightenMul;
+
+        float ax, az, bx, bz, penetration, nx, nz;
+        for (var iter = 0; iter < MaxPairIterations; iter++)
+        {
+            bbA = bodyA.Shapes[0].WorldBoundingBox;
+            bbB = bodyB.Shapes[0].WorldBoundingBox;
+            overlapY = MathF.Min(bbA.Max.Y, bbB.Max.Y) - MathF.Max(bbA.Min.Y, bbB.Min.Y);
+            if (overlapY < MinVerticalOverlap)
+                break;
+
+            GetMassBoxCenterXz(bodyA, ma, sa.Scale, out ax, out az);
+            GetMassBoxCenterXz(bodyB, mb, sb.Scale, out bx, out bz);
+
+            if (!TryObbXzMinPenetration(
+                    ax, az, bowA, halfLenA, satHalfWidA,
+                    bx, bz, bowB, halfLenB, satHalfWidB,
+                    out penetration,
+                    out nx,
+                    out nz))
+                break;
+
+            if (penetration <= 1e-4f || penetration < MinPenetrationToAct)
+                break;
+
+            var dx = bx - ax;
+            var dz = bz - az;
+            if (nx * dx + nz * dz < 0f)
+            {
+                nx = -nx;
+                nz = -nz;
+            }
+
+            var halfSep = penetration * 0.5f;
+            var deep = MathF.Max(0f, penetration - DeepPenetrationStart);
+            halfSep *= 1f + DeepPenetrationBoost * MathF.Min(1.25f, deep);
+            var linearSep = halfSep + SeparationSlackMeters;
+            if (linearSep < MinLinearSeparationToApplyMeters)
+                break;
+
+            var move = MathF.Max(linearSep, MinHalfSeparationMeters);
+            move *= SeparationPushMultiplier;
+
+            var va = bodyA.Velocity;
+            var vb = bodyB.Velocity;
+            var relAlongN = (va.X - vb.X) * nx + (va.Z - vb.Z) * nz;
+            peakImpactSpeedMps = Math.Max(peakImpactSpeedMps, MathF.Abs(relAlongN));
+
+            bodyA.Position -= new JVector(nx * move, 0f, nz * move);
+            bodyB.Position += new JVector(nx * move, 0f, nz * move);
+            hadResponse = true;
+
+            DampPairVelocities(bodyA, bodyB, nx, nz, penetration);
+        }
+
+        if (hadResponse)
+            impactSpeedMps = peakImpactSpeedMps;
+
+        return hadResponse;
+    }
+
+    /// <summary>Removes relative motion into the other hull along <paramref name="nx"/>,<paramref name="nz"/>; tangential damp scales with penetration so parallel “air gap” drag stays low.</summary>
+    private static void DampPairVelocities(RigidBody bodyA, RigidBody bodyB, float nx, float nz, float penetrationDepth)
+    {
+        var va = bodyA.Velocity;
+        var vb = bodyB.Velocity;
+
+        var closing = (va.X - vb.X) * nx + (va.Z - vb.Z) * nz;
+        if (closing > 0f)
+        {
+            var remove = closing * 0.5f * ClosingSpeedDamp;
+            va = new JVector(va.X - nx * remove, va.Y, va.Z - nz * remove);
+            vb = new JVector(vb.X + nx * remove, vb.Y, vb.Z + nz * remove);
+        }
+
+        var tangentialBlend = Math.Clamp((penetrationDepth - MinPenetrationToAct) / TangentialRampDepthMeters, 0f, 1f);
+        var tx = -nz;
+        var tz = nx;
+        var relT = (va.X - vb.X) * tx + (va.Z - vb.Z) * tz;
+        var slipRemove = relT * 0.5f * (1f - TangentialSlipDamp) * tangentialBlend;
+        va = new JVector(va.X - tx * slipRemove, va.Y, va.Z - tz * slipRemove);
+        vb = new JVector(vb.X + tx * slipRemove, vb.Y, vb.Z + tz * slipRemove);
+
+        bodyA.Velocity = va;
+        bodyB.Velocity = vb;
+    }
+
+    /// <summary>2D SAT on XZ for rectangles aligned with ship bow (same convention as <see cref="ShipController"/>).</summary>
+    private static bool TryObbXzMinPenetration(
+        float ax, float az, float bowA, float halfLenA, float halfWidA,
+        float bx, float bz, float bowB, float halfLenB, float halfWidB,
+        out float minPenetration,
+        out float bestNx,
+        out float bestNz)
+    {
+        minPenetration = 0f;
+        bestNx = 1f;
+        bestNz = 0f;
+
+        ReadOnlySpan<(float x, float z)> axes =
+        [
+            (MathF.Cos(bowA), MathF.Sin(bowA)),
+            (-MathF.Sin(bowA), MathF.Cos(bowA)),
+            (MathF.Cos(bowB), MathF.Sin(bowB)),
+            (-MathF.Sin(bowB), MathF.Cos(bowB)),
+        ];
+
+        var found = false;
+        var minO = float.MaxValue;
+
+        foreach (var (ux, uz) in axes)
+        {
+            var len = MathF.Sqrt(ux * ux + uz * uz);
+            if (len < 1e-6f)
+                continue;
+            var nx = ux / len;
+            var nz = uz / len;
+
+            var cA = ax * nx + az * nz;
+            var cB = bx * nx + bz * nz;
+            var rA = ProjectObbRadiusXz(halfLenA, halfWidA, bowA, nx, nz);
+            var rB = ProjectObbRadiusXz(halfLenB, halfWidB, bowB, nx, nz);
+
+            var overlap = MathF.Min(cA + rA, cB + rB) - MathF.Max(cA - rA, cB - rB);
+            if (overlap <= 0f)
+                return false;
+
+            if (overlap < minO)
+            {
+                minO = overlap;
+                bestNx = nx;
+                bestNz = nz;
+                found = true;
+            }
+        }
+
+        if (!found)
+            return false;
+
+        minPenetration = minO;
+        return true;
+    }
+
+    private static float ProjectObbRadiusXz(float halfLen, float halfWid, float bow, float nx, float nz)
+    {
+        var d1 = MathF.Cos(bow) * nx + MathF.Sin(bow) * nz;
+        var d2 = -MathF.Sin(bow) * nx + MathF.Cos(bow) * nz;
+        return halfLen * MathF.Abs(d1) + halfWid * MathF.Abs(d2);
+    }
+
+    /// <summary>World XZ of mass-box center (matches <see cref="ShipController"/> TransformedShape offset).</summary>
+    private static void GetMassBoxCenterXz(RigidBody body, ShipModelV1 model, float scale, out float cx, out float cz)
+    {
+        var local = new JVector(model.MassCenterX * scale, model.MassCenterZ * scale, model.MassCenterY * scale);
+        var w = RotateVectorByQuaternion(local, body.Orientation);
+        cx = body.Position.X + w.X;
+        cz = body.Position.Z + w.Z;
+    }
+
+    private static JVector RotateVectorByQuaternion(JVector v, JQuaternion q)
+    {
+        var qx = q.X;
+        var qy = q.Y;
+        var qz = q.Z;
+        var qw = q.W;
+        var tx = 2f * (qy * v.Z - qz * v.Y);
+        var ty = 2f * (qz * v.X - qx * v.Z);
+        var tz = 2f * (qx * v.Y - qy * v.X);
+        return new JVector(
+            v.X + qw * tx + (qy * tz - qz * ty),
+            v.Y + qw * ty + (qz * tx - qx * tz),
+            v.Z + qw * tz + (qx * ty - qy * tx));
+    }
+
+    /// <summary>
+    /// <see cref="ShipController.ApplyForceAndTorque"/> maps game <see cref="Slave.Speed"/> to horizontal velocity as
+    /// <c>Speed * MoveSpeedMul / 4 * TurnSpeedVelocityMul</c> along the bow — not 1:1 with physics m/s.
+    /// After we edit <see cref="RigidBody.Velocity"/>, game speed must be recovered with the same scale.
+    /// </summary>
+    private static void SyncSlaveSpeedFromBowVelocity(Slave slave)
+    {
+        var rb = slave.RigidBody;
+        if (rb is null)
+            return;
+
+        var rpy = PhysicsUtil.GetYawPitchRollFromMatrix(JMatrix.CreateFromQuaternion(rb.Orientation));
+        var bow = rpy.Item1 + 1.57f;
+        var alongPhys = rb.Velocity.X * MathF.Cos(bow) + rb.Velocity.Z * MathF.Sin(bow);
+        var denom = (slave.MoveSpeedMul / 4f) * slave.TurnSpeedVelocityMul;
+        if (denom < 1e-5f)
+            return;
+        slave.Speed = alongPhys / denom;
+    }
+}

--- a/AAEmu.Game/Physics/ShipShipInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShipInteraction.cs
@@ -191,13 +191,13 @@ public sealed class ShipShipInteraction
 
         if (!sa.ShipHullCollisionDamageCooldownByOtherShipId.TryGetValue(sb.Id, out var cdA) || cdA <= 0f)
         {
-            sa.ApplyShipHullCollisionDamage(sb, dmgA);
+            sa.ApplyShipHullCollisionDamage(sb, dmgA, collisionImpactMps: impactSpeedMps);
             sa.ShipHullCollisionDamageCooldownByOtherShipId[sb.Id] = HullCollisionDamageCooldownSec;
         }
 
         if (!sb.ShipHullCollisionDamageCooldownByOtherShipId.TryGetValue(sa.Id, out var cdB) || cdB <= 0f)
         {
-            sb.ApplyShipHullCollisionDamage(sa, dmgB);
+            sb.ApplyShipHullCollisionDamage(sa, dmgB, collisionImpactMps: impactSpeedMps);
             sb.ShipHullCollisionDamageCooldownByOtherShipId[sa.Id] = HullCollisionDamageCooldownSec;
         }
     }

--- a/AAEmu.Game/Physics/ShipShoreInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShoreInteraction.cs
@@ -16,10 +16,7 @@ namespace AAEmu.Game.Physics;
 /// </summary>
 public sealed class ShipShoreInteraction
 {
-    /// <summary>
-    /// Production defaults when <see cref="AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled"/> is false.
-    /// <see cref="AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning"/> mirrors these for Hot Reload.
-    /// </summary>
+    /// <summary>Production constants for ship↔shore (single source of truth).</summary>
     public static class ShorePhysicsDefaults
     {
         public const float BoatBottomOffsetFracOfSizeZ = 0f;
@@ -64,15 +61,11 @@ public sealed class ShipShoreInteraction
         if (!isOnLand)
             return;
 
-        var groundFriction = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.GroundFriction
-            : ShorePhysicsDefaults.GroundFriction;
+        var groundFriction = ShorePhysicsDefaults.GroundFriction;
         var frictionForce = new JVector(-slave.RigidBody.Velocity.X * groundFriction, 0, -slave.RigidBody.Velocity.Z * groundFriction);
         slave.RigidBody.AddForce(frictionForce);
 
-        var dryDamp = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.DryGroundCollisionDamping
-            : ShorePhysicsDefaults.DryGroundCollisionDamping;
+        var dryDamp = ShorePhysicsDefaults.DryGroundCollisionDamping;
         slave.RigidBody.Velocity *= dryDamp;
         slave.RigidBody.AngularVelocity *= dryDamp;
 
@@ -82,14 +75,10 @@ public sealed class ShipShoreInteraction
             slave.RigidBody.AngularVelocity = JVector.Zero;
 
             var rollAngle = PhysicsUtil.GetYawPitchRollFromJMatrix(JMatrix.CreateFromQuaternion(slave.RigidBody.Orientation)).Item2;
-            var rollDeadZone = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-                ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.DryGroundRollDeadZoneRad
-                : ShorePhysicsDefaults.DryGroundRollDeadZoneRad;
+            var rollDeadZone = ShorePhysicsDefaults.DryGroundRollDeadZoneRad;
             if (Math.Abs(rollAngle) < rollDeadZone)
             {
-                var rollTorqueMul = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-                    ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.DryGroundRollTorqueMul
-                    : ShorePhysicsDefaults.DryGroundRollTorqueMul;
+                var rollTorqueMul = ShorePhysicsDefaults.DryGroundRollTorqueMul;
                 var correctionTorque = new JVector(0, 0, -rollAngle * slave.RigidBody.Mass * rollTorqueMul);
                 slave.RigidBody.AddForce(correctionTorque);
             }
@@ -125,15 +114,9 @@ public sealed class ShipShoreInteraction
         var dt = Math.Max(0.0001f, (float)deltaTime.TotalSeconds);
         var rpy = PhysicsUtil.GetYawPitchRollFromMatrix(JMatrix.CreateFromQuaternion(rigidBody.Orientation));
 
-        var groundPitchMaxDeg = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.VisualGroundPitchMaxDeg
-            : ShorePhysicsDefaults.VisualGroundPitchMaxDeg;
-        var groundPitchProbeDistance = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.VisualGroundPitchProbeDistance
-            : ShorePhysicsDefaults.VisualGroundPitchProbeDistance;
-        var groundPitchResponse = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.VisualGroundPitchResponse
-            : ShorePhysicsDefaults.VisualGroundPitchResponse;
+        var groundPitchMaxDeg = ShorePhysicsDefaults.VisualGroundPitchMaxDeg;
+        var groundPitchProbeDistance = ShorePhysicsDefaults.VisualGroundPitchProbeDistance;
+        var groundPitchResponse = ShorePhysicsDefaults.VisualGroundPitchResponse;
         var targetGroundPitch = 0f;
         if (slave.ParentWorld != null && (slave.CachedFloorLevel > slave.CachedWaterSurface || slave.GroundContactLatched))
         {
@@ -149,9 +132,7 @@ public sealed class ShipShoreInteraction
             var frontH = slave.ParentWorld.GetHeight(frontX, frontY);
             var backH = slave.ParentWorld.GetHeight(backX, backY);
 
-            var pitchFloorSmoothResponse = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-                ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.VisualPitchFloorSmoothResponse
-                : ShorePhysicsDefaults.VisualPitchFloorSmoothResponse;
+            var pitchFloorSmoothResponse = ShorePhysicsDefaults.VisualPitchFloorSmoothResponse;
             var floorA = 1f - MathF.Exp(-pitchFloorSmoothResponse * dt);
             if (!slave.GroundPitchFloorSmoothingSeeded)
             {
@@ -187,9 +168,7 @@ public sealed class ShipShoreInteraction
 
         // "Bottom" for penetration is not the rigidbody center. Use a tunable fraction of hull height.
         // This reduces the visible gap when the ship becomes grounded/beached.
-        var boatBottomOffsetFrac = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.BoatBottomOffsetFracOfSizeZ
-            : ShorePhysicsDefaults.BoatBottomOffsetFracOfSizeZ;
+        var boatBottomOffsetFrac = ShorePhysicsDefaults.BoatBottomOffsetFracOfSizeZ;
         var hullHeight = MathF.Max(0.01f, slave.ShipController.ShipModel.MassBoxSizeZ * slave.Scale);
         var boatBottom = slave.RigidBody.Position.Y - hullHeight * boatBottomOffsetFrac;
 
@@ -227,16 +206,10 @@ public sealed class ShipShoreInteraction
         var cliffY = probeY;
         var cliffFloor = contactFloor;
 
-        var shoreEnterHyst = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.ShoreEnterHyst
-            : ShorePhysicsDefaults.ShoreEnterHyst;
-        var shoreExitHyst = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.ShoreExitHyst
-            : ShorePhysicsDefaults.ShoreExitHyst;
+        var shoreEnterHyst = ShorePhysicsDefaults.ShoreEnterHyst;
+        var shoreExitHyst = ShorePhysicsDefaults.ShoreExitHyst;
 
-        var floorSmoothResponse = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.FloorSmoothResponse
-            : ShorePhysicsDefaults.FloorSmoothResponse;
+        var floorSmoothResponse = ShorePhysicsDefaults.FloorSmoothResponse;
         {
             var a = 1f - MathF.Exp(-floorSmoothResponse * dt);
             if (!slave.GroundContactLatched && !slave.GroundContactFloorSmoothingSeeded)
@@ -249,9 +222,7 @@ public sealed class ShipShoreInteraction
         }
         var floorSmoothed = slave.GroundContactFloorSmoothed;
 
-        var preShoreBand = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.PreShoreBand
-            : ShorePhysicsDefaults.PreShoreBand;
+        var preShoreBand = ShorePhysicsDefaults.PreShoreBand;
         // Use water surface at the probe point, not at ship center; near shore these can differ.
         var enterDelta = (waterAtProbe + shoreEnterHyst) - floorSmoothed;
         if (!slave.GroundContactLatched && enterDelta >= 0f && enterDelta <= preShoreBand)
@@ -298,15 +269,11 @@ public sealed class ShipShoreInteraction
             out _);
         var centerAboveWaterline = slave.RigidBody.Position.Y > waterAtCenter + 0.001f;
 
-        var penetrationEpsilon = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.PenetrationEpsilon
-            : ShorePhysicsDefaults.PenetrationEpsilon;
-        var penetrationResponse = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.PenetrationResponse
-            : ShorePhysicsDefaults.PenetrationResponse;
+        var penetrationEpsilon = ShorePhysicsDefaults.PenetrationEpsilon;
+        var penetrationResponse = ShorePhysicsDefaults.PenetrationResponse;
         var maxUpStepPerTick = slave.GroundContactLatchedTime < 0.30f
-            ? (AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.MaxUpStepEarly : ShorePhysicsDefaults.MaxUpStepEarly)
-            : (AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.MaxUpStepLate : ShorePhysicsDefaults.MaxUpStepLate);
+            ? ShorePhysicsDefaults.MaxUpStepEarly
+            : ShorePhysicsDefaults.MaxUpStepLate;
         if (penetration > penetrationEpsilon && !centerAboveWaterline)
         {
             var a = 1f - MathF.Exp(-penetrationResponse * dt);

--- a/AAEmu.Game/Physics/ShipShoreInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShoreInteraction.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Physics.Debug;
 using AAEmu.Game.Physics.Util;
 using AAEmu.Game.Utils;
 
@@ -247,7 +248,7 @@ public sealed class ShipShoreInteraction
             {
                 slave.GroundContactLatched = false;
                 slave.GroundContactLatchedTime = 0f;
-                AAEmu.Game.Physics.Debug.ShipTuningDebug.OnShoreLatchChanged(slave, latched: false);
+                ShipTuningDebug.OnShoreLatchChanged(slave, latched: false);
                 return;
             }
         }
@@ -301,7 +302,7 @@ public sealed class ShipShoreInteraction
         slave.RigidBody.Velocity *= collisionDamping;
         slave.RigidBody.AngularVelocity *= collisionDamping;
 
-        AAEmu.Game.Physics.Debug.ShipTuningDebug.OnShoreProbe(
+        ShipTuningDebug.OnShoreProbe(
             slave,
             probeX, probeY, floorSmoothed,
             cliffX, cliffY, cliffFloor,

--- a/AAEmu.Game/Physics/ShipShoreInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShoreInteraction.cs
@@ -285,8 +285,6 @@ public sealed class ShipShoreInteraction
         slave.GroundContactLatchedTime += Math.Max(0f, (float)deltaTime.TotalSeconds);
 
         var penetration = floorSmoothed - boatBottom;
-        slave.CachedGroundCollisionPos = new Vector3(probeX, probeY, floorSmoothed);
-        slave.CachedGroundCollisionImpact = Math.Max(0f, penetration);
         if (penetration <= 0.0f)
             return;
 

--- a/AAEmu.Game/Physics/ShipShoreInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShoreInteraction.cs
@@ -81,7 +81,8 @@ public sealed class ShipShoreInteraction
 
         var submergedDepth = Math.Max(0, slave.CachedWaterSurface - slave.RigidBody.Position.Y);
         var isOnWater = submergedDepth > 0;
-        var isOnLand = !isOnWater && submergedDepth <= 0;
+        // With Max(0, …), depth is never negative: !isOnWater implies depth == 0.
+        var isOnLand = !isOnWater;
 
         if (!isOnLand)
             return;

--- a/AAEmu.Game/Physics/ShipShoreInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShoreInteraction.cs
@@ -20,29 +20,53 @@ public sealed class ShipShoreInteraction
     /// <summary>Production constants for ship↔shore (single source of truth).</summary>
     public static class ShorePhysicsDefaults
     {
+        /// <summary>Offset of the “bottom” point used for penetration, as a fraction of hull height (0 = rigidbody center).</summary>
         public const float BoatBottomOffsetFracOfSizeZ = 0f;
+        /// <summary>Linear damping strength on dry ground (higher = faster slowdown on land).</summary>
         public const float GroundFriction = 0.1f;
+        /// <summary>Extra velocity/ang-vel damping multiplier when fully on land (1 = no extra damping).</summary>
         public const float DryGroundCollisionDamping = 1f;
+        /// <summary>Roll dead-zone (rad) when “settled” on land before applying corrective torque.</summary>
         public const float DryGroundRollDeadZoneRad = 0.1f;
+        /// <summary>Strength of the corrective roll torque on land (scaled by mass).</summary>
         public const float DryGroundRollTorqueMul = 0.1f;
+        /// <summary>Bow probe distance multiplier (legacy; current probe is clamped to OBB face).</summary>
         public const float BowProbeMul = 1.5f;
+        /// <summary>Stern probe distance multiplier (legacy; current probe is clamped to OBB face).</summary>
         public const float SternProbeMul = 1.5f;
+        /// <summary>Cliff/wall probe multiplier (0 disables the cliff probe logic).</summary>
         public const float CliffProbeMul = 0f;
+        /// <summary>Look-ahead for cliff probe, as a multiple of half-length (0 disables).</summary>
         public const float CliffProbeLookAheadMulOfHalfLength = 0f;
+        /// <summary>Minimum cliff probe look-ahead (m) when enabled.</summary>
         public const float CliffProbeMinLookAheadMeters = 0.25f;
+        /// <summary>Threshold for treating terrain as “cliff” based on slope fraction.</summary>
         public const float CliffSlopeFracThreshold = 0.70f;
+        /// <summary>Required margin above water (m) to consider a cliff valid (helps ignore wave noise).</summary>
         public const float CliffAboveWaterMargin = 0.30f;
+        /// <summary>Hysteresis (m): how far below water the probe floor must be to latch “aground”.</summary>
         public const float ShoreEnterHyst = 0.5f;
+        /// <summary>Hysteresis (m): how far below water the probe floor must be to release back to water.</summary>
         public const float ShoreExitHyst = 0.35f;
+        /// <summary>Low-pass response rate for floor height smoothing (higher = less lag, more noise).</summary>
         public const float FloorSmoothResponse = 16.0f;
+        /// <summary>Band (m) near shore where pre-latch damping is applied to soften the approach.</summary>
         public const float PreShoreBand = 0.5f;
+        /// <summary>Penetration depth epsilon (m) below which we don't push the hull up (noise guard).</summary>
         public const float PenetrationEpsilon = 0.04f;
+        /// <summary>Response rate for penetration resolution (higher = faster “push up” out of terrain).</summary>
         public const float PenetrationResponse = 4.5f;
+        /// <summary>Max upward correction step (m) per tick shortly after latching (prevents snapping).</summary>
         public const float MaxUpStepEarly = 0.04f;
+        /// <summary>Max upward correction step (m) per tick after the early window (allows stronger escape).</summary>
         public const float MaxUpStepLate = 0.07f;
+        /// <summary>Max visual pitch (deg) applied while grounded (client feedback only).</summary>
         public const float VisualGroundPitchMaxDeg = 8.0f;
+        /// <summary>Probe distance (m) used to compute visual ground pitch (client feedback only).</summary>
         public const float VisualGroundPitchProbeDistance = 6.0f;
+        /// <summary>Response rate for visual ground pitch smoothing (higher = snappier).</summary>
         public const float VisualGroundPitchResponse = 2.0f;
+        /// <summary>Secondary smoothing response for the visual pitch floor sample (reduces jitter).</summary>
         public const float VisualPitchFloorSmoothResponse = 8.0f;
     }
 

--- a/AAEmu.Game/Physics/ShipShoreInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShoreInteraction.cs
@@ -4,6 +4,8 @@ using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Physics.Util;
 using AAEmu.Game.Utils;
 
+using System.Numerics;
+
 using Jitter2.Dynamics;
 using Jitter2.LinearMath;
 
@@ -60,12 +62,17 @@ public sealed class ShipShoreInteraction
                 slave.RigidBody.AddForce(correctionTorque);
             }
 
-            slave.ThrottleRequest = 0;
-            slave.SteeringRequest = 0;
-            slave.Throttle = 0;
-            slave.Steering = 0;
-            slave.ThrottleSmoothed = 0f;
-            slave.SteeringSmoothed = 0f;
+            // Only clear controls when the ship is settled AND player is not actively providing input.
+            // Otherwise we can accidentally cancel "escape throttle" attempts while beached.
+            if (slave.ThrottleRequest == 0 && slave.SteeringRequest == 0)
+            {
+                slave.ThrottleRequest = 0;
+                slave.SteeringRequest = 0;
+                slave.Throttle = 0;
+                slave.Steering = 0;
+                slave.ThrottleSmoothed = 0f;
+                slave.SteeringSmoothed = 0f;
+            }
         }
     }
 
@@ -146,7 +153,13 @@ public sealed class ShipShoreInteraction
 
         var dt = Math.Max(0.0001f, (float)deltaTime.TotalSeconds);
 
-        var boatBottom = slave.RigidBody.Position.Y;
+        // "Bottom" for penetration is not the rigidbody center. Use a tunable fraction of hull height.
+        // This reduces the visible gap when the ship becomes grounded/beached.
+        var boatBottomOffsetFrac = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.BoatBottomOffsetFracOfSizeZ
+            : 0.5f;
+        var hullHeight = MathF.Max(0.01f, slave.ShipController.ShipModel.MassBoxSizeZ * slave.Scale);
+        var boatBottom = slave.RigidBody.Position.Y - hullHeight * boatBottomOffsetFrac;
 
         var rpy = PhysicsUtil.GetYawPitchRollFromMatrix(JMatrix.CreateFromQuaternion(slave.RigidBody.Orientation));
         var heading = rpy.Item1 + 1.57f;
@@ -158,60 +171,29 @@ public sealed class ShipShoreInteraction
         var along = vX * dirX + vZ * dirZ;
         var movingBackward = along < -0.05f || (MathF.Abs(along) <= 0.05f && slave.ThrottleRequest < 0);
 
-        var bowProbeMul = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.BowProbeMul
-            : 1.5f;
-        var sternProbeMul = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.SternProbeMul
-            : 1.5f;
         var useSternProbe = slave.GroundContactLatched ? slave.GroundedByStern : movingBackward;
-        var probeMul = useSternProbe ? sternProbeMul : bowProbeMul;
-        // MassBoxSizeY is treated as hull length (forward/back).
-        var probeDist = MathF.Max(1.0f, slave.ShipController.ShipModel.MassBoxSizeY * probeMul * slave.Scale);
         var probeSign = useSternProbe ? -1f : 1f;
+        // Shore probe: ray from rigidbody center to OBB face (bow/stern) only.
+        // Do NOT add Bow/SternProbeMul * halfLength here — that pushed the sample far past the box face (~+0.75 hull length
+        // with default 1.5 mul) and caused early shore latch / "invisible wall" meters before the hull reached terrain.
+        var halfLength = 0.5f * slave.ShipController.ShipModel.MassBoxSizeY * slave.Scale;
+        var centerOffsetAlongLength = slave.ShipController.ShipModel.MassCenterY * slave.Scale;
+        var distFromCenterToFace = probeSign > 0f ? (halfLength + centerOffsetAlongLength) : (halfLength - centerOffsetAlongLength);
+        distFromCenterToFace = MathF.Max(0.01f, distFromCenterToFace);
+
+        var probeDist = distFromCenterToFace;
         var probeX = slave.RigidBody.Position.X + dirX * probeDist * probeSign;
         var probeY = slave.RigidBody.Position.Z + dirZ * probeDist * probeSign;
         var contactFloor = slave.ParentWorld.GetHeight(probeX, probeY);
+        var waterAtProbe = slave.ParentWorld.Water.GetWaterSurface(
+            new Vector3(probeX, slave.RigidBody.Position.Y, probeY),
+            out _);
 
-        var cliffProbeMul = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.CliffProbeMul
-            : 1.45f;
-        var cliffSlopeFracThreshold = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.CliffSlopeFracThreshold
-            : 0.57f;
-        // MassBoxSizeY is treated as hull length (forward/back).
-        var cliffDist = MathF.Max(1.0f, slave.ShipController.ShipModel.MassBoxSizeY * cliffProbeMul * slave.Scale);
-        var cliffX = slave.RigidBody.Position.X + dirX * cliffDist * probeSign;
-        var cliffY = slave.RigidBody.Position.Z + dirZ * cliffDist * probeSign;
-        var cliffFloor = slave.ParentWorld.GetHeight(cliffX, cliffY);
-        var cliffAboveWaterMargin = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
-            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.CliffAboveWaterMargin
-            : 0.20f;
-        if (cliffFloor > slave.CachedWaterSurface + cliffAboveWaterMargin)
-        {
-            var dh = cliffFloor - slave.CachedFloorLevel;
-            var slopeFrac = dh / MathF.Max(0.01f, cliffDist);
-            if (slopeFrac > cliffSlopeFracThreshold)
-            {
-                var v = slave.RigidBody.Velocity;
-                var vAlong = v.X * dirX + v.Z * dirZ;
-                var pushingIntoBarrier = useSternProbe ? (vAlong < 0f) : (vAlong > 0f);
-                if (pushingIntoBarrier)
-                {
-                    slave.Speed = 0f;
-                    var newVX = v.X - vAlong * dirX;
-                    var newVZ = v.Z - vAlong * dirZ;
-                    slave.RigidBody.Velocity = new JVector(newVX * 0.85f, 0f, newVZ * 0.85f);
-                    slave.RigidBody.AngularVelocity *= 0.85f;
-                }
-
-                var pushDirSign = useSternProbe ? 1f : -1f;
-                var pushStep = MathF.Min(0.50f, MathF.Max(0.08f, MathF.Abs(vAlong) * dt * 1.10f));
-                slave.RigidBody.Position += new JVector(dirX * pushStep * pushDirSign, 0f, dirZ * pushStep * pushDirSign);
-
-                return;
-            }
-        }
+        // WALL/CLIFF logic removed per request.
+        // Keep debug probe output fields populated to avoid changing debug marker wiring.
+        var cliffX = probeX;
+        var cliffY = probeY;
+        var cliffFloor = contactFloor;
 
         var shoreEnterHyst = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.ShoreEnterHyst
@@ -238,7 +220,8 @@ public sealed class ShipShoreInteraction
         var preShoreBand = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.PreShoreBand
             : 0.25f;
-        var enterDelta = (slave.CachedWaterSurface + shoreEnterHyst) - floorSmoothed;
+        // Use water surface at the probe point, not at ship center; near shore these can differ.
+        var enterDelta = (waterAtProbe + shoreEnterHyst) - floorSmoothed;
         if (!slave.GroundContactLatched && enterDelta >= 0f && enterDelta <= preShoreBand)
         {
             var v = slave.RigidBody.Velocity;
@@ -249,7 +232,7 @@ public sealed class ShipShoreInteraction
 
         if (!slave.GroundContactLatched)
         {
-            if (slave.CachedWaterSurface + shoreEnterHyst >= floorSmoothed)
+            if (waterAtProbe + shoreEnterHyst >= floorSmoothed)
                 return;
             slave.GroundContactLatched = true;
             slave.GroundContactLatchedTime = 0f;
@@ -257,7 +240,7 @@ public sealed class ShipShoreInteraction
         }
         else
         {
-            if (slave.CachedWaterSurface + shoreExitHyst >= floorSmoothed)
+            if (waterAtProbe + shoreExitHyst >= floorSmoothed)
             {
                 slave.GroundContactLatched = false;
                 slave.GroundContactLatchedTime = 0f;
@@ -302,7 +285,9 @@ public sealed class ShipShoreInteraction
         var escapeThrottleSign = slave.GroundedByStern ? 1 : -1;
         var isEscapeThrottle = slave.ThrottleRequest != 0 && Math.Sign(slave.ThrottleRequest) == escapeThrottleSign;
         var deepContact = penetration > 0.25f;
-        var collisionDamping = isEscapeThrottle ? 0.99f : (deepContact ? 0.88f : 0.95f);
+        // NOTE: per tuning request we do not dampen velocity while applying valid "escape" throttle on ground,
+        // to avoid artificially capping reverse/escape speed on shoals.
+        var collisionDamping = isEscapeThrottle ? 1.0f : (deepContact ? 0.88f : 0.95f);
         slave.RigidBody.Velocity *= collisionDamping;
         slave.RigidBody.AngularVelocity *= collisionDamping;
 
@@ -313,7 +298,7 @@ public sealed class ShipShoreInteraction
             boatCenterX: slave.RigidBody.Position.X,
             boatCenterY: slave.RigidBody.Position.Z,
             boatBottomZ: boatBottom,
-            waterSurfaceZ: slave.CachedWaterSurface,
+            waterSurfaceZ: waterAtProbe,
             penetrationMeters: penetration);
     }
 }

--- a/AAEmu.Game/Physics/ShipShoreInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShoreInteraction.cs
@@ -249,6 +249,7 @@ public sealed class ShipShoreInteraction
         var preShoreBand = ShorePhysicsDefaults.PreShoreBand;
         // Use water surface at the probe point, not at ship center; near shore these can differ.
         var enterDelta = (waterAtProbe + shoreEnterHyst) - floorSmoothed;
+        var exitDelta = (waterAtProbe + shoreExitHyst) - floorSmoothed;
         if (!slave.GroundContactLatched && enterDelta >= 0f && enterDelta <= preShoreBand)
         {
             var v = slave.RigidBody.Velocity;
@@ -259,21 +260,14 @@ public sealed class ShipShoreInteraction
 
         if (!slave.GroundContactLatched)
         {
-            if (waterAtProbe + shoreEnterHyst >= floorSmoothed)
+            if (enterDelta >= 0f)
                 return;
-            slave.GroundContactLatched = true;
-            slave.GroundContactLatchedTime = 0f;
-            ShipTuningDebug.OnShoreLatchChanged(slave, latched: true);
+            SetGroundContactLatch(slave, latched: true);
         }
-        else
+        else if (exitDelta >= 0f)
         {
-            if (waterAtProbe + shoreExitHyst >= floorSmoothed)
-            {
-                slave.GroundContactLatched = false;
-                slave.GroundContactLatchedTime = 0f;
-                ShipTuningDebug.OnShoreLatchChanged(slave, latched: false);
-                return;
-            }
+            SetGroundContactLatch(slave, latched: false);
+            return;
         }
 
         {
@@ -334,5 +328,12 @@ public sealed class ShipShoreInteraction
             boatBottomZ: boatBottom,
             waterSurfaceZ: waterAtProbe,
             penetrationMeters: penetration);
+    }
+
+    private static void SetGroundContactLatch(Slave slave, bool latched)
+    {
+        slave.GroundContactLatched = latched;
+        slave.GroundContactLatchedTime = 0f;
+        ShipTuningDebug.OnShoreLatchChanged(slave, latched: latched);
     }
 }

--- a/AAEmu.Game/Physics/ShipShoreInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShoreInteraction.cs
@@ -113,8 +113,6 @@ public sealed class ShipShoreInteraction
             // Otherwise we can accidentally cancel "escape throttle" attempts while beached.
             if (slave.ThrottleRequest == 0 && slave.SteeringRequest == 0)
             {
-                slave.ThrottleRequest = 0;
-                slave.SteeringRequest = 0;
                 slave.Throttle = 0;
                 slave.Steering = 0;
                 slave.ThrottleSmoothed = 0f;

--- a/AAEmu.Game/Physics/ShipShoreInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShoreInteraction.cs
@@ -263,7 +263,7 @@ public sealed class ShipShoreInteraction
                 return;
             slave.GroundContactLatched = true;
             slave.GroundContactLatchedTime = 0f;
-            AAEmu.Game.Physics.Debug.ShipTuningDebug.OnShoreLatchChanged(slave, latched: true);
+            ShipTuningDebug.OnShoreLatchChanged(slave, latched: true);
         }
         else
         {

--- a/AAEmu.Game/Physics/ShipShoreInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShoreInteraction.cs
@@ -296,8 +296,7 @@ public sealed class ShipShoreInteraction
         var escapeThrottleSign = slave.GroundedByStern ? 1 : -1;
         var isEscapeThrottle = slave.ThrottleRequest != 0 && Math.Sign(slave.ThrottleRequest) == escapeThrottleSign;
         var deepContact = penetration > 0.25f;
-        // NOTE: per tuning request we do not dampen velocity while applying valid "escape" throttle on ground,
-        // to avoid artificially capping reverse/escape speed on shoals.
+        // Escape-direction throttle: no extra damping (pairs with full reverse mul on ground in ShipController).
         var collisionDamping = isEscapeThrottle ? 1.0f : (deepContact ? 0.88f : 0.95f);
         slave.RigidBody.Velocity *= collisionDamping;
         slave.RigidBody.AngularVelocity *= collisionDamping;

--- a/AAEmu.Game/Physics/ShipShoreInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShoreInteraction.cs
@@ -285,6 +285,8 @@ public sealed class ShipShoreInteraction
         slave.GroundContactLatchedTime += Math.Max(0f, (float)deltaTime.TotalSeconds);
 
         var penetration = floorSmoothed - boatBottom;
+        slave.CachedGroundCollisionPos = new Vector3(probeX, probeY, floorSmoothed);
+        slave.CachedGroundCollisionImpact = Math.Max(0f, penetration);
         if (penetration <= 0.0f)
             return;
 

--- a/AAEmu.Game/Physics/ShipShoreInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShoreInteraction.cs
@@ -260,6 +260,12 @@ public sealed class ShipShoreInteraction
         if (penetration <= 0.0f)
             return;
 
+        // Mass-box center (rigid body origin) above local waterline: stop vertical "pop" from penetration resolve.
+        var waterAtCenter = slave.ParentWorld.Water.GetWaterSurface(
+            new Vector3(slave.RigidBody.Position.X, slave.RigidBody.Position.Y, slave.RigidBody.Position.Z),
+            out _);
+        var centerAboveWaterline = slave.RigidBody.Position.Y > waterAtCenter + 0.001f;
+
         var penetrationEpsilon = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.PenetrationEpsilon
             : 0.02f;
@@ -269,7 +275,7 @@ public sealed class ShipShoreInteraction
         var maxUpStepPerTick = slave.GroundContactLatchedTime < 0.30f
             ? (AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.MaxUpStepEarly : 0.04f)
             : (AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.MaxUpStepLate : 0.07f);
-        if (penetration > penetrationEpsilon)
+        if (penetration > penetrationEpsilon && !centerAboveWaterline)
         {
             var a = 1f - MathF.Exp(-penetrationResponse * dt);
             var step = MathF.Min(penetration * a, maxUpStepPerTick);
@@ -277,6 +283,12 @@ public sealed class ShipShoreInteraction
 
             var v = slave.RigidBody.Velocity;
             if (MathF.Abs(v.Y) > 0.01f)
+                slave.RigidBody.Velocity = new JVector(v.X, 0f, v.Z);
+        }
+        else if (centerAboveWaterline)
+        {
+            var v = slave.RigidBody.Velocity;
+            if (v.Y > 0f)
                 slave.RigidBody.Velocity = new JVector(v.X, 0f, v.Z);
         }
         var collisionForce = physWorld.Gravity * -1f;

--- a/AAEmu.Game/Physics/ShipShoreInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShoreInteraction.cs
@@ -17,6 +17,38 @@ namespace AAEmu.Game.Physics;
 public sealed class ShipShoreInteraction
 {
     /// <summary>
+    /// Production defaults when <see cref="AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled"/> is false.
+    /// <see cref="AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning"/> mirrors these for Hot Reload.
+    /// </summary>
+    public static class ShorePhysicsDefaults
+    {
+        public const float BoatBottomOffsetFracOfSizeZ = 0f;
+        public const float GroundFriction = 0.1f;
+        public const float DryGroundCollisionDamping = 1f;
+        public const float DryGroundRollDeadZoneRad = 0.1f;
+        public const float DryGroundRollTorqueMul = 0.1f;
+        public const float BowProbeMul = 1.5f;
+        public const float SternProbeMul = 1.5f;
+        public const float CliffProbeMul = 0f;
+        public const float CliffProbeLookAheadMulOfHalfLength = 0f;
+        public const float CliffProbeMinLookAheadMeters = 0.25f;
+        public const float CliffSlopeFracThreshold = 0.70f;
+        public const float CliffAboveWaterMargin = 0.30f;
+        public const float ShoreEnterHyst = 0.5f;
+        public const float ShoreExitHyst = 0.35f;
+        public const float FloorSmoothResponse = 16.0f;
+        public const float PreShoreBand = 0.5f;
+        public const float PenetrationEpsilon = 0.04f;
+        public const float PenetrationResponse = 4.5f;
+        public const float MaxUpStepEarly = 0.04f;
+        public const float MaxUpStepLate = 0.07f;
+        public const float VisualGroundPitchMaxDeg = 8.0f;
+        public const float VisualGroundPitchProbeDistance = 6.0f;
+        public const float VisualGroundPitchResponse = 2.0f;
+        public const float VisualPitchFloorSmoothResponse = 8.0f;
+    }
+
+    /// <summary>
     /// When the hull center reads as above water (no submergence), apply ground friction and clear controls if settled.
     /// Call before rudder/throttle smoothing in the ship physics tick.
     /// </summary>
@@ -32,15 +64,15 @@ public sealed class ShipShoreInteraction
         if (!isOnLand)
             return;
 
-        var groundFriction = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+        var groundFriction = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.GroundFriction
-            : 0.4f;
+            : ShorePhysicsDefaults.GroundFriction;
         var frictionForce = new JVector(-slave.RigidBody.Velocity.X * groundFriction, 0, -slave.RigidBody.Velocity.Z * groundFriction);
         slave.RigidBody.AddForce(frictionForce);
 
-        var dryDamp = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+        var dryDamp = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.DryGroundCollisionDamping
-            : 0.5f;
+            : ShorePhysicsDefaults.DryGroundCollisionDamping;
         slave.RigidBody.Velocity *= dryDamp;
         slave.RigidBody.AngularVelocity *= dryDamp;
 
@@ -50,14 +82,14 @@ public sealed class ShipShoreInteraction
             slave.RigidBody.AngularVelocity = JVector.Zero;
 
             var rollAngle = PhysicsUtil.GetYawPitchRollFromJMatrix(JMatrix.CreateFromQuaternion(slave.RigidBody.Orientation)).Item2;
-            var rollDeadZone = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+            var rollDeadZone = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
                 ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.DryGroundRollDeadZoneRad
-                : 0.1f;
+                : ShorePhysicsDefaults.DryGroundRollDeadZoneRad;
             if (Math.Abs(rollAngle) < rollDeadZone)
             {
-                var rollTorqueMul = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+                var rollTorqueMul = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
                     ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.DryGroundRollTorqueMul
-                    : 0.1f;
+                    : ShorePhysicsDefaults.DryGroundRollTorqueMul;
                 var correctionTorque = new JVector(0, 0, -rollAngle * slave.RigidBody.Mass * rollTorqueMul);
                 slave.RigidBody.AddForce(correctionTorque);
             }
@@ -93,15 +125,15 @@ public sealed class ShipShoreInteraction
         var dt = Math.Max(0.0001f, (float)deltaTime.TotalSeconds);
         var rpy = PhysicsUtil.GetYawPitchRollFromMatrix(JMatrix.CreateFromQuaternion(rigidBody.Orientation));
 
-        var groundPitchMaxDeg = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+        var groundPitchMaxDeg = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.VisualGroundPitchMaxDeg
-            : 8.0f;
-        var groundPitchProbeDistance = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+            : ShorePhysicsDefaults.VisualGroundPitchMaxDeg;
+        var groundPitchProbeDistance = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.VisualGroundPitchProbeDistance
-            : 6.0f;
-        var groundPitchResponse = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+            : ShorePhysicsDefaults.VisualGroundPitchProbeDistance;
+        var groundPitchResponse = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.VisualGroundPitchResponse
-            : 2.0f;
+            : ShorePhysicsDefaults.VisualGroundPitchResponse;
         var targetGroundPitch = 0f;
         if (slave.ParentWorld != null && (slave.CachedFloorLevel > slave.CachedWaterSurface || slave.GroundContactLatched))
         {
@@ -117,9 +149,9 @@ public sealed class ShipShoreInteraction
             var frontH = slave.ParentWorld.GetHeight(frontX, frontY);
             var backH = slave.ParentWorld.GetHeight(backX, backY);
 
-            var pitchFloorSmoothResponse = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+            var pitchFloorSmoothResponse = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
                 ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.VisualPitchFloorSmoothResponse
-                : 8.0f;
+                : ShorePhysicsDefaults.VisualPitchFloorSmoothResponse;
             var floorA = 1f - MathF.Exp(-pitchFloorSmoothResponse * dt);
             if (!slave.GroundPitchFloorSmoothingSeeded)
             {
@@ -155,9 +187,9 @@ public sealed class ShipShoreInteraction
 
         // "Bottom" for penetration is not the rigidbody center. Use a tunable fraction of hull height.
         // This reduces the visible gap when the ship becomes grounded/beached.
-        var boatBottomOffsetFrac = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+        var boatBottomOffsetFrac = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.BoatBottomOffsetFracOfSizeZ
-            : 0.5f;
+            : ShorePhysicsDefaults.BoatBottomOffsetFracOfSizeZ;
         var hullHeight = MathF.Max(0.01f, slave.ShipController.ShipModel.MassBoxSizeZ * slave.Scale);
         var boatBottom = slave.RigidBody.Position.Y - hullHeight * boatBottomOffsetFrac;
 
@@ -195,16 +227,16 @@ public sealed class ShipShoreInteraction
         var cliffY = probeY;
         var cliffFloor = contactFloor;
 
-        var shoreEnterHyst = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+        var shoreEnterHyst = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.ShoreEnterHyst
-            : 0.35f;
-        var shoreExitHyst = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+            : ShorePhysicsDefaults.ShoreEnterHyst;
+        var shoreExitHyst = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.ShoreExitHyst
-            : 0.10f;
+            : ShorePhysicsDefaults.ShoreExitHyst;
 
-        var floorSmoothResponse = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+        var floorSmoothResponse = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.FloorSmoothResponse
-            : 10.0f;
+            : ShorePhysicsDefaults.FloorSmoothResponse;
         {
             var a = 1f - MathF.Exp(-floorSmoothResponse * dt);
             if (!slave.GroundContactLatched && !slave.GroundContactFloorSmoothingSeeded)
@@ -217,9 +249,9 @@ public sealed class ShipShoreInteraction
         }
         var floorSmoothed = slave.GroundContactFloorSmoothed;
 
-        var preShoreBand = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+        var preShoreBand = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.PreShoreBand
-            : 0.25f;
+            : ShorePhysicsDefaults.PreShoreBand;
         // Use water surface at the probe point, not at ship center; near shore these can differ.
         var enterDelta = (waterAtProbe + shoreEnterHyst) - floorSmoothed;
         if (!slave.GroundContactLatched && enterDelta >= 0f && enterDelta <= preShoreBand)
@@ -266,15 +298,15 @@ public sealed class ShipShoreInteraction
             out _);
         var centerAboveWaterline = slave.RigidBody.Position.Y > waterAtCenter + 0.001f;
 
-        var penetrationEpsilon = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+        var penetrationEpsilon = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.PenetrationEpsilon
-            : 0.02f;
-        var penetrationResponse = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+            : ShorePhysicsDefaults.PenetrationEpsilon;
+        var penetrationResponse = AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled
             ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.PenetrationResponse
-            : 4.5f;
+            : ShorePhysicsDefaults.PenetrationResponse;
         var maxUpStepPerTick = slave.GroundContactLatchedTime < 0.30f
-            ? (AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.MaxUpStepEarly : 0.04f)
-            : (AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.MaxUpStepLate : 0.07f);
+            ? (AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.MaxUpStepEarly : ShorePhysicsDefaults.MaxUpStepEarly)
+            : (AAEmu.Game.Physics.Debug.ShipTuningDebug.Enabled ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.MaxUpStepLate : ShorePhysicsDefaults.MaxUpStepLate);
         if (penetration > penetrationEpsilon && !centerAboveWaterline)
         {
             var a = 1f - MathF.Exp(-penetrationResponse * dt);

--- a/AAEmu.Game/Physics/ShipShoreInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShoreInteraction.cs
@@ -1,0 +1,263 @@
+#nullable enable
+
+using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Physics.Util;
+using AAEmu.Game.Utils;
+
+using Jitter2.Dynamics;
+using Jitter2.LinearMath;
+
+namespace AAEmu.Game.Physics;
+
+/// <summary>
+/// Ship interaction with terrain / shoreline: friction on dry ground, probes, latch, penetration resolve, and periodic beached hull damage.
+/// </summary>
+public sealed class ShipShoreInteraction
+{
+    /// <summary>
+    /// When the hull center reads as above water (no submergence), apply ground friction and clear controls if settled.
+    /// Call before rudder/throttle smoothing in the ship physics tick.
+    /// </summary>
+    public void ApplyOnLandPhysics(Slave slave, TimeSpan deltaTime)
+    {
+        if (slave.RigidBody == null)
+            return;
+
+        var submergedDepth = Math.Max(0, slave.CachedWaterSurface - slave.RigidBody.Position.Y);
+        var isOnWater = submergedDepth > 0;
+        var isOnLand = !isOnWater && submergedDepth <= 0;
+
+        if (!isOnLand)
+            return;
+
+        const float GroundFriction = 0.4f;
+        var frictionForce = new JVector(-slave.RigidBody.Velocity.X * GroundFriction, 0, -slave.RigidBody.Velocity.Z * GroundFriction);
+        slave.RigidBody.AddForce(frictionForce);
+
+        const float CollisionDamping = 0.5f;
+        slave.RigidBody.Velocity *= CollisionDamping;
+        slave.RigidBody.AngularVelocity *= CollisionDamping;
+
+        if (slave.RigidBody.Velocity.Length() < 0.01f)
+        {
+            slave.RigidBody.Velocity = JVector.Zero;
+            slave.RigidBody.AngularVelocity = JVector.Zero;
+
+            var rollAngle = PhysicsUtil.GetYawPitchRollFromJMatrix(JMatrix.CreateFromQuaternion(slave.RigidBody.Orientation)).Item2;
+            if (Math.Abs(rollAngle) < 0.1f)
+            {
+                var correctionTorque = new JVector(0, 0, -rollAngle * slave.RigidBody.Mass * 0.1f);
+                slave.RigidBody.AddForce(correctionTorque);
+            }
+
+            slave.ThrottleRequest = 0;
+            slave.SteeringRequest = 0;
+            slave.Throttle = 0;
+            slave.Steering = 0;
+            slave.ThrottleSmoothed = 0f;
+            slave.SteeringSmoothed = 0f;
+        }
+    }
+
+    /// <summary>
+    /// Cliff / shore probes, ground latch, vertical resolve, damping. Then hull damage while latched on shore.
+    /// </summary>
+    public void ResolveTerrainContacts(Slave slave, TimeSpan deltaTime, Jitter2.World physWorld)
+    {
+        ResolveLandCollisions(slave, deltaTime, physWorld);
+        slave.TickBeachedHullDamage(deltaTime);
+    }
+
+    /// <summary>
+    /// Visual-only pitch on shoal/ground: aligns replicated nose/stern to local terrain slope (does not move rigidbody).
+    /// </summary>
+    public void UpdateVisualGroundPitch(Slave slave, RigidBody rigidBody, TimeSpan deltaTime)
+    {
+        var dt = Math.Max(0.0001f, (float)deltaTime.TotalSeconds);
+        var rpy = PhysicsUtil.GetYawPitchRollFromMatrix(JMatrix.CreateFromQuaternion(rigidBody.Orientation));
+
+        const float groundPitchMaxDeg = 8.0f;
+        const float groundPitchProbeDistance = 6.0f;
+        const float groundPitchResponse = 2.0f;
+        var targetGroundPitch = 0f;
+        if (slave.ParentWorld != null && (slave.CachedFloorLevel > slave.CachedWaterSurface || slave.GroundContactLatched))
+        {
+            var yaw = rpy.Item1 + 1.57f;
+            var cosYaw = MathF.Cos(yaw);
+            var sinYaw = MathF.Sin(yaw);
+            var cx = rigidBody.Position.X;
+            var cy = rigidBody.Position.Z;
+            var frontX = cx + cosYaw * groundPitchProbeDistance;
+            var frontY = cy + sinYaw * groundPitchProbeDistance;
+            var backX = cx - cosYaw * groundPitchProbeDistance;
+            var backY = cy - sinYaw * groundPitchProbeDistance;
+            var frontH = slave.ParentWorld.GetHeight(frontX, frontY);
+            var backH = slave.ParentWorld.GetHeight(backX, backY);
+
+            const float pitchFloorSmoothResponse = 8.0f;
+            var floorA = 1f - MathF.Exp(-pitchFloorSmoothResponse * dt);
+            if (!slave.GroundPitchFloorSmoothingSeeded)
+            {
+                slave.GroundPitchFrontFloorSmoothed = frontH;
+                slave.GroundPitchBackFloorSmoothed = backH;
+                slave.GroundPitchFloorSmoothingSeeded = true;
+            }
+            else
+            {
+                slave.GroundPitchFrontFloorSmoothed += (frontH - slave.GroundPitchFrontFloorSmoothed) * floorA;
+                slave.GroundPitchBackFloorSmoothed += (backH - slave.GroundPitchBackFloorSmoothed) * floorA;
+            }
+
+            var slopeRad = MathF.Atan2(slave.GroundPitchFrontFloorSmoothed - slave.GroundPitchBackFloorSmoothed, groundPitchProbeDistance * 2f);
+            targetGroundPitch = Math.Clamp(slopeRad, -groundPitchMaxDeg.DegToRad(), groundPitchMaxDeg.DegToRad());
+
+            if (slave.GroundedByStern)
+                targetGroundPitch = -targetGroundPitch;
+        }
+        else
+            slave.GroundPitchFloorSmoothingSeeded = false;
+
+        var pitchA = 1f - MathF.Exp(-groundPitchResponse * dt);
+        slave.GroundPitchAngle += (targetGroundPitch - slave.GroundPitchAngle) * pitchA;
+    }
+
+    private static void ResolveLandCollisions(Slave slave, TimeSpan deltaTime, Jitter2.World physWorld)
+    {
+        if (slave.ShipController?.ShipModel is null || slave.RigidBody == null || slave.ParentWorld == null)
+            return;
+
+        var dt = Math.Max(0.0001f, (float)deltaTime.TotalSeconds);
+
+        var boatBottom = slave.RigidBody.Position.Y;
+
+        var rpy = PhysicsUtil.GetYawPitchRollFromMatrix(JMatrix.CreateFromQuaternion(slave.RigidBody.Orientation));
+        var heading = rpy.Item1 + 1.57f;
+        var dirX = MathF.Cos(heading);
+        var dirZ = MathF.Sin(heading);
+
+        var vX = slave.RigidBody.Velocity.X;
+        var vZ = slave.RigidBody.Velocity.Z;
+        var along = vX * dirX + vZ * dirZ;
+        var movingBackward = along < -0.05f || (MathF.Abs(along) <= 0.05f && slave.ThrottleRequest < 0);
+
+        const float BowProbeMul = 1.5f;
+        const float SternProbeMul = 1.5f;
+        var useSternProbe = slave.GroundContactLatched ? slave.GroundedByStern : movingBackward;
+        var probeMul = useSternProbe ? SternProbeMul : BowProbeMul;
+        var probeDist = MathF.Max(1.0f, slave.ShipController.ShipModel.MassBoxSizeX * probeMul * slave.Scale);
+        var probeSign = useSternProbe ? -1f : 1f;
+        var probeX = slave.RigidBody.Position.X + dirX * probeDist * probeSign;
+        var probeY = slave.RigidBody.Position.Z + dirZ * probeDist * probeSign;
+        var contactFloor = slave.ParentWorld.GetHeight(probeX, probeY);
+
+        const float CliffProbeMul = 1.45f;
+        const float CliffSlopeFracThreshold = 0.57f;
+        var cliffDist = MathF.Max(1.0f, slave.ShipController.ShipModel.MassBoxSizeX * CliffProbeMul * slave.Scale);
+        var cliffX = slave.RigidBody.Position.X + dirX * cliffDist * probeSign;
+        var cliffY = slave.RigidBody.Position.Z + dirZ * cliffDist * probeSign;
+        var cliffFloor = slave.ParentWorld.GetHeight(cliffX, cliffY);
+        const float CliffAboveWaterMargin = 0.20f;
+        if (cliffFloor > slave.CachedWaterSurface + CliffAboveWaterMargin)
+        {
+            var dh = cliffFloor - slave.CachedFloorLevel;
+            var slopeFrac = dh / MathF.Max(0.01f, cliffDist);
+            if (slopeFrac > CliffSlopeFracThreshold)
+            {
+                var v = slave.RigidBody.Velocity;
+                var vAlong = v.X * dirX + v.Z * dirZ;
+                var pushingIntoBarrier = useSternProbe ? (vAlong < 0f) : (vAlong > 0f);
+                if (pushingIntoBarrier)
+                {
+                    slave.Speed = 0f;
+                    var newVX = v.X - vAlong * dirX;
+                    var newVZ = v.Z - vAlong * dirZ;
+                    slave.RigidBody.Velocity = new JVector(newVX * 0.85f, 0f, newVZ * 0.85f);
+                    slave.RigidBody.AngularVelocity *= 0.85f;
+                }
+
+                var pushDirSign = useSternProbe ? 1f : -1f;
+                var pushStep = MathF.Min(0.50f, MathF.Max(0.08f, MathF.Abs(vAlong) * dt * 1.10f));
+                slave.RigidBody.Position += new JVector(dirX * pushStep * pushDirSign, 0f, dirZ * pushStep * pushDirSign);
+
+                return;
+            }
+        }
+
+        const float ShoreEnterHyst = 0.35f;
+        const float ShoreExitHyst = 0.10f;
+
+        const float FloorSmoothResponse = 10.0f;
+        {
+            var a = 1f - MathF.Exp(-FloorSmoothResponse * dt);
+            if (!slave.GroundContactLatched && !slave.GroundContactFloorSmoothingSeeded)
+            {
+                slave.GroundContactFloorSmoothed = contactFloor;
+                slave.GroundContactFloorSmoothingSeeded = true;
+            }
+            else
+                slave.GroundContactFloorSmoothed += (contactFloor - slave.GroundContactFloorSmoothed) * a;
+        }
+        var floorSmoothed = slave.GroundContactFloorSmoothed;
+
+        const float PreShoreBand = 0.25f;
+        var enterDelta = (slave.CachedWaterSurface + ShoreEnterHyst) - floorSmoothed;
+        if (!slave.GroundContactLatched && enterDelta >= 0f && enterDelta <= PreShoreBand)
+        {
+            var v = slave.RigidBody.Velocity;
+            var t = 1f - (enterDelta / PreShoreBand);
+            var damp = 1f - 0.85f * t;
+            slave.RigidBody.Velocity = new JVector(v.X, v.Y * damp, v.Z);
+        }
+
+        if (!slave.GroundContactLatched)
+        {
+            if (slave.CachedWaterSurface + ShoreEnterHyst >= floorSmoothed)
+                return;
+            slave.GroundContactLatched = true;
+            slave.GroundContactLatchedTime = 0f;
+        }
+        else
+        {
+            if (slave.CachedWaterSurface + ShoreExitHyst >= floorSmoothed)
+            {
+                slave.GroundContactLatched = false;
+                slave.GroundContactLatchedTime = 0f;
+                return;
+            }
+        }
+
+        {
+            var v = slave.RigidBody.Velocity;
+            if (MathF.Abs(v.Y) > 0.01f)
+                slave.RigidBody.Velocity = new JVector(v.X, 0f, v.Z);
+        }
+        slave.GroundContactLatchedTime += Math.Max(0f, (float)deltaTime.TotalSeconds);
+
+        var penetration = floorSmoothed - boatBottom;
+        if (penetration <= 0.0f)
+            return;
+
+        const float PenetrationEpsilon = 0.02f;
+        const float PenetrationResponse = 4.5f;
+        var maxUpStepPerTick = slave.GroundContactLatchedTime < 0.30f ? 0.04f : 0.07f;
+        if (penetration > PenetrationEpsilon)
+        {
+            var a = 1f - MathF.Exp(-PenetrationResponse * dt);
+            var step = MathF.Min(penetration * a, maxUpStepPerTick);
+            slave.RigidBody.Position += new JVector(0, step, 0);
+
+            var v = slave.RigidBody.Velocity;
+            if (MathF.Abs(v.Y) > 0.01f)
+                slave.RigidBody.Velocity = new JVector(v.X, 0f, v.Z);
+        }
+        var collisionForce = physWorld.Gravity * -1f;
+        slave.RigidBody.AddForce(collisionForce);
+
+        var escapeThrottleSign = slave.GroundedByStern ? 1 : -1;
+        var isEscapeThrottle = slave.ThrottleRequest != 0 && Math.Sign(slave.ThrottleRequest) == escapeThrottleSign;
+        var deepContact = penetration > 0.25f;
+        var collisionDamping = isEscapeThrottle ? 0.99f : (deepContact ? 0.88f : 0.95f);
+        slave.RigidBody.Velocity *= collisionDamping;
+        slave.RigidBody.AngularVelocity *= collisionDamping;
+    }
+}

--- a/AAEmu.Game/Physics/ShipShoreInteraction.cs
+++ b/AAEmu.Game/Physics/ShipShoreInteraction.cs
@@ -30,13 +30,17 @@ public sealed class ShipShoreInteraction
         if (!isOnLand)
             return;
 
-        const float GroundFriction = 0.4f;
-        var frictionForce = new JVector(-slave.RigidBody.Velocity.X * GroundFriction, 0, -slave.RigidBody.Velocity.Z * GroundFriction);
+        var groundFriction = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.GroundFriction
+            : 0.4f;
+        var frictionForce = new JVector(-slave.RigidBody.Velocity.X * groundFriction, 0, -slave.RigidBody.Velocity.Z * groundFriction);
         slave.RigidBody.AddForce(frictionForce);
 
-        const float CollisionDamping = 0.5f;
-        slave.RigidBody.Velocity *= CollisionDamping;
-        slave.RigidBody.AngularVelocity *= CollisionDamping;
+        var dryDamp = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.DryGroundCollisionDamping
+            : 0.5f;
+        slave.RigidBody.Velocity *= dryDamp;
+        slave.RigidBody.AngularVelocity *= dryDamp;
 
         if (slave.RigidBody.Velocity.Length() < 0.01f)
         {
@@ -44,9 +48,15 @@ public sealed class ShipShoreInteraction
             slave.RigidBody.AngularVelocity = JVector.Zero;
 
             var rollAngle = PhysicsUtil.GetYawPitchRollFromJMatrix(JMatrix.CreateFromQuaternion(slave.RigidBody.Orientation)).Item2;
-            if (Math.Abs(rollAngle) < 0.1f)
+            var rollDeadZone = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+                ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.DryGroundRollDeadZoneRad
+                : 0.1f;
+            if (Math.Abs(rollAngle) < rollDeadZone)
             {
-                var correctionTorque = new JVector(0, 0, -rollAngle * slave.RigidBody.Mass * 0.1f);
+                var rollTorqueMul = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+                    ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.DryGroundRollTorqueMul
+                    : 0.1f;
+                var correctionTorque = new JVector(0, 0, -rollAngle * slave.RigidBody.Mass * rollTorqueMul);
                 slave.RigidBody.AddForce(correctionTorque);
             }
 
@@ -76,9 +86,15 @@ public sealed class ShipShoreInteraction
         var dt = Math.Max(0.0001f, (float)deltaTime.TotalSeconds);
         var rpy = PhysicsUtil.GetYawPitchRollFromMatrix(JMatrix.CreateFromQuaternion(rigidBody.Orientation));
 
-        const float groundPitchMaxDeg = 8.0f;
-        const float groundPitchProbeDistance = 6.0f;
-        const float groundPitchResponse = 2.0f;
+        var groundPitchMaxDeg = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.VisualGroundPitchMaxDeg
+            : 8.0f;
+        var groundPitchProbeDistance = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.VisualGroundPitchProbeDistance
+            : 6.0f;
+        var groundPitchResponse = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.VisualGroundPitchResponse
+            : 2.0f;
         var targetGroundPitch = 0f;
         if (slave.ParentWorld != null && (slave.CachedFloorLevel > slave.CachedWaterSurface || slave.GroundContactLatched))
         {
@@ -94,7 +110,9 @@ public sealed class ShipShoreInteraction
             var frontH = slave.ParentWorld.GetHeight(frontX, frontY);
             var backH = slave.ParentWorld.GetHeight(backX, backY);
 
-            const float pitchFloorSmoothResponse = 8.0f;
+            var pitchFloorSmoothResponse = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+                ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.VisualPitchFloorSmoothResponse
+                : 8.0f;
             var floorA = 1f - MathF.Exp(-pitchFloorSmoothResponse * dt);
             if (!slave.GroundPitchFloorSmoothingSeeded)
             {
@@ -140,28 +158,40 @@ public sealed class ShipShoreInteraction
         var along = vX * dirX + vZ * dirZ;
         var movingBackward = along < -0.05f || (MathF.Abs(along) <= 0.05f && slave.ThrottleRequest < 0);
 
-        const float BowProbeMul = 1.5f;
-        const float SternProbeMul = 1.5f;
+        var bowProbeMul = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.BowProbeMul
+            : 1.5f;
+        var sternProbeMul = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.SternProbeMul
+            : 1.5f;
         var useSternProbe = slave.GroundContactLatched ? slave.GroundedByStern : movingBackward;
-        var probeMul = useSternProbe ? SternProbeMul : BowProbeMul;
-        var probeDist = MathF.Max(1.0f, slave.ShipController.ShipModel.MassBoxSizeX * probeMul * slave.Scale);
+        var probeMul = useSternProbe ? sternProbeMul : bowProbeMul;
+        // MassBoxSizeY is treated as hull length (forward/back).
+        var probeDist = MathF.Max(1.0f, slave.ShipController.ShipModel.MassBoxSizeY * probeMul * slave.Scale);
         var probeSign = useSternProbe ? -1f : 1f;
         var probeX = slave.RigidBody.Position.X + dirX * probeDist * probeSign;
         var probeY = slave.RigidBody.Position.Z + dirZ * probeDist * probeSign;
         var contactFloor = slave.ParentWorld.GetHeight(probeX, probeY);
 
-        const float CliffProbeMul = 1.45f;
-        const float CliffSlopeFracThreshold = 0.57f;
-        var cliffDist = MathF.Max(1.0f, slave.ShipController.ShipModel.MassBoxSizeX * CliffProbeMul * slave.Scale);
+        var cliffProbeMul = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.CliffProbeMul
+            : 1.45f;
+        var cliffSlopeFracThreshold = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.CliffSlopeFracThreshold
+            : 0.57f;
+        // MassBoxSizeY is treated as hull length (forward/back).
+        var cliffDist = MathF.Max(1.0f, slave.ShipController.ShipModel.MassBoxSizeY * cliffProbeMul * slave.Scale);
         var cliffX = slave.RigidBody.Position.X + dirX * cliffDist * probeSign;
         var cliffY = slave.RigidBody.Position.Z + dirZ * cliffDist * probeSign;
         var cliffFloor = slave.ParentWorld.GetHeight(cliffX, cliffY);
-        const float CliffAboveWaterMargin = 0.20f;
-        if (cliffFloor > slave.CachedWaterSurface + CliffAboveWaterMargin)
+        var cliffAboveWaterMargin = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.CliffAboveWaterMargin
+            : 0.20f;
+        if (cliffFloor > slave.CachedWaterSurface + cliffAboveWaterMargin)
         {
             var dh = cliffFloor - slave.CachedFloorLevel;
             var slopeFrac = dh / MathF.Max(0.01f, cliffDist);
-            if (slopeFrac > CliffSlopeFracThreshold)
+            if (slopeFrac > cliffSlopeFracThreshold)
             {
                 var v = slave.RigidBody.Velocity;
                 var vAlong = v.X * dirX + v.Z * dirZ;
@@ -183,12 +213,18 @@ public sealed class ShipShoreInteraction
             }
         }
 
-        const float ShoreEnterHyst = 0.35f;
-        const float ShoreExitHyst = 0.10f;
+        var shoreEnterHyst = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.ShoreEnterHyst
+            : 0.35f;
+        var shoreExitHyst = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.ShoreExitHyst
+            : 0.10f;
 
-        const float FloorSmoothResponse = 10.0f;
+        var floorSmoothResponse = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.FloorSmoothResponse
+            : 10.0f;
         {
-            var a = 1f - MathF.Exp(-FloorSmoothResponse * dt);
+            var a = 1f - MathF.Exp(-floorSmoothResponse * dt);
             if (!slave.GroundContactLatched && !slave.GroundContactFloorSmoothingSeeded)
             {
                 slave.GroundContactFloorSmoothed = contactFloor;
@@ -199,29 +235,33 @@ public sealed class ShipShoreInteraction
         }
         var floorSmoothed = slave.GroundContactFloorSmoothed;
 
-        const float PreShoreBand = 0.25f;
-        var enterDelta = (slave.CachedWaterSurface + ShoreEnterHyst) - floorSmoothed;
-        if (!slave.GroundContactLatched && enterDelta >= 0f && enterDelta <= PreShoreBand)
+        var preShoreBand = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.PreShoreBand
+            : 0.25f;
+        var enterDelta = (slave.CachedWaterSurface + shoreEnterHyst) - floorSmoothed;
+        if (!slave.GroundContactLatched && enterDelta >= 0f && enterDelta <= preShoreBand)
         {
             var v = slave.RigidBody.Velocity;
-            var t = 1f - (enterDelta / PreShoreBand);
+            var t = 1f - (enterDelta / preShoreBand);
             var damp = 1f - 0.85f * t;
             slave.RigidBody.Velocity = new JVector(v.X, v.Y * damp, v.Z);
         }
 
         if (!slave.GroundContactLatched)
         {
-            if (slave.CachedWaterSurface + ShoreEnterHyst >= floorSmoothed)
+            if (slave.CachedWaterSurface + shoreEnterHyst >= floorSmoothed)
                 return;
             slave.GroundContactLatched = true;
             slave.GroundContactLatchedTime = 0f;
+            AAEmu.Game.Physics.Debug.ShipTuningDebug.OnShoreLatchChanged(slave, latched: true);
         }
         else
         {
-            if (slave.CachedWaterSurface + ShoreExitHyst >= floorSmoothed)
+            if (slave.CachedWaterSurface + shoreExitHyst >= floorSmoothed)
             {
                 slave.GroundContactLatched = false;
                 slave.GroundContactLatchedTime = 0f;
+                AAEmu.Game.Physics.Debug.ShipTuningDebug.OnShoreLatchChanged(slave, latched: false);
                 return;
             }
         }
@@ -237,12 +277,18 @@ public sealed class ShipShoreInteraction
         if (penetration <= 0.0f)
             return;
 
-        const float PenetrationEpsilon = 0.02f;
-        const float PenetrationResponse = 4.5f;
-        var maxUpStepPerTick = slave.GroundContactLatchedTime < 0.30f ? 0.04f : 0.07f;
-        if (penetration > PenetrationEpsilon)
+        var penetrationEpsilon = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.PenetrationEpsilon
+            : 0.02f;
+        var penetrationResponse = AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled
+            ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.PenetrationResponse
+            : 4.5f;
+        var maxUpStepPerTick = slave.GroundContactLatchedTime < 0.30f
+            ? (AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.MaxUpStepEarly : 0.04f)
+            : (AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreEnabled ? AAEmu.Game.Physics.Debug.ShipTuningDebug.ShoreTuning.MaxUpStepLate : 0.07f);
+        if (penetration > penetrationEpsilon)
         {
-            var a = 1f - MathF.Exp(-PenetrationResponse * dt);
+            var a = 1f - MathF.Exp(-penetrationResponse * dt);
             var step = MathF.Min(penetration * a, maxUpStepPerTick);
             slave.RigidBody.Position += new JVector(0, step, 0);
 
@@ -259,5 +305,15 @@ public sealed class ShipShoreInteraction
         var collisionDamping = isEscapeThrottle ? 0.99f : (deepContact ? 0.88f : 0.95f);
         slave.RigidBody.Velocity *= collisionDamping;
         slave.RigidBody.AngularVelocity *= collisionDamping;
+
+        AAEmu.Game.Physics.Debug.ShipTuningDebug.OnShoreProbe(
+            slave,
+            probeX, probeY, floorSmoothed,
+            cliffX, cliffY, cliffFloor,
+            boatCenterX: slave.RigidBody.Position.X,
+            boatCenterY: slave.RigidBody.Position.Z,
+            boatBottomZ: boatBottom,
+            waterSurfaceZ: slave.CachedWaterSurface,
+            penetrationMeters: penetration);
     }
 }


### PR DESCRIPTION
https://drive.google.com/file/d/1jVrNCH_DzK3zt4lJJO7ajQV0Zr7uQrHc/view

The ship physics is a server-side simulation layer that moves boats, keeps them aligned to the world (water/shore), detects contacts (ship–ship and ship–shore), resolves penetrations, and converts some contacts into gameplay events (notably hull damage). The implementation is designed to be deterministic enough for multiplayer, fast enough for dozens of ships, and configurable via centralized default blocks.

High-level architecture
ShipController is the core per-ship simulation component. It is responsible for applying forces / motion rules and updating the ship’s rigid body and gameplay-facing transform.
PhysicsManager (world-level) orchestrates physics ticking. It drives per-ship simulation and runs interaction logic where needed.
ShipShipInteraction handles ship–ship contacts: broadphase filtering, narrowphase collision detection, penetration resolution, impulses/push-back, and collision damage.
ShipShoreInteraction handles ship–shore/grounding: probing the seabed/shoreline, detecting “beached” contact, resolving ground penetration, and triggering periodic grounding damage.
Defaults/tuning blocks are centralized in dedicated classes (so tuning isn’t duplicated in debug helpers):
ShipMotionDefaults: how ships accelerate/turn/damp and how environment affects motion.
ShipHullPairDefaults: how ship–ship contacts are resolved and how damage is derived from collision intensity.
ShorePhysicsDefaults: how shore grounding behaves (latching, penetration thresholds, escape behavior).
ShipTuningDebug is a debug-only layer: visualization markers and throttled debug logs. It owns the on/off switches; physics code calls into it but does not own debug toggles.
Coordinate/geometry model
Ship-to-ship collision is treated primarily as a 2D hull interaction in the XZ plane (gameplay “top-down” footprint), using each ship’s “mass box” / hull box geometry projected into world space. The simulation also tracks vertical extents for some checks, but the expensive collision math is focused on XZ where gameplay collisions matter.

Ship–ship collision detection and resolution
Broadphase (cheap reject)
Before doing expensive math, ship pairs are rejected using an AABB overlap check in XZ. This avoids running narrowphase collision for distant ships and is important because pair checks scale as (O(N^2)).

Narrowphase (SAT)
If broadphase overlaps, the system performs Separating Axis Theorem (SAT) tests on the ships’ oriented hull boxes (in XZ). SAT yields whether the shapes overlap and can produce penetration depth and a resolution direction.

Resolution / push-back
When overlap is confirmed, the resolver applies a push/impulse-like correction so that ships separate. The strength and behavior are controlled by ShipHullPairDefaults (e.g., how aggressively ships push apart, how much mass/scale affects resolution).

Damage from collision
When impact conditions are met (relative speed / intensity and cooldown rules), each ship can take hull damage. The interaction code computes an “impact intensity” (e.g., impact speed in m/s) and maps it to damage percentages, with cooldowns to prevent spam.

Ship–shore / grounding behavior
Ground probing
The shore system probes below/around the ship to estimate floor/shore height under the hull.

Penetration and contact latch
If the hull bottom goes below the floor/shore height beyond a threshold, the ship is considered in ground contact. A “latched” state can be used to keep the behavior stable (prevents flicker when right at the threshold).

Resolution and escape behavior
Penetration is resolved by applying constraints / damping / throttling so the ship can “escape” the shore without jitter. Shore behavior is tuned by ShorePhysicsDefaults.

Grounding damage
While grounded/latched, the ship periodically receives hull damage (e.g., once per second as configured), representing scraping/ground impact over time.

Networking: collision damage packets
Collision damage is represented as environmental damage to the client via SCEnvDamagePacket.

Debugging / performance notes
Debug output is centralized in ShipTuningDebug and is designed to be cheap when disabled (no heavy computations beyond a boolean check).
The biggest performance risk is ship–ship pair processing at scale; the broadphase AABB reject is the main optimization already in place. For very large concentrations, spatial partitioning (uniform grid / hash) would further reduce candidate pairs.