### PR TITLE
fix(game): fix MySQL crime id column properties

### DIFF
--- a/SQL/aaemu_game.sql
+++ b/SQL/aaemu_game.sql
@@ -591,7 +591,7 @@ ENGINE=InnoDB
 ;
 
 CREATE TABLE IF NOT EXISTS `crime` (
-	`id` INT UNSIGNED NULL DEFAULT NULL COMMENT 'Crime point Id',
+	`id` INT UNSIGNED NOT NULL DEFAULT '0' COMMENT 'Crime point Id',
 	`criminal` INT UNSIGNED NULL DEFAULT NULL COMMENT 'Player Id of the criminal',
 	`victim` INT UNSIGNED NULL DEFAULT NULL COMMENT 'Player Id of the victim',
 	`reporter` INT UNSIGNED NULL DEFAULT NULL COMMENT 'Player Id of the reporter',

--- a/SQL/updates/2026-03-15_aaemu_game_crime.sql
+++ b/SQL/updates/2026-03-15_aaemu_game_crime.sql
@@ -3,7 +3,7 @@
 -- ------------------------------------------------
 
 CREATE TABLE IF NOT EXISTS `crime` (
-	`id` INT UNSIGNED NULL DEFAULT NULL COMMENT 'Crime point Id',
+	`id` INT UNSIGNED NOT NULL DEFAULT '0' COMMENT 'Crime point Id',
 	`criminal` INT UNSIGNED NULL DEFAULT NULL COMMENT 'Player Id of the criminal',
 	`victim` INT UNSIGNED NULL DEFAULT NULL COMMENT 'Player Id of the victim',
 	`reporter` INT UNSIGNED NULL DEFAULT NULL COMMENT 'Player Id of the reporter',


### PR DESCRIPTION
Update the `crime` table schema in both the main SQL file and the recent update script to make the `id` column non-nullable with a default value of '0'.
