### PR TITLE
fix(game): fixes slave owner tracking to fix a problem with Bloodlust

### DIFF
--- a/AAEmu.Game/Core/Managers/SlaveManager.cs
+++ b/AAEmu.Game/Core/Managers/SlaveManager.cs
@@ -511,6 +511,7 @@ public class SlaveManager(WorldInstance parentWorldInstance)
             Spawner = useSpawner,
             OwnerType = owner != null ? BaseUnitType.Character : BaseUnitType.Invalid,
             OwnerId = owner?.Id ?? 0,
+            OwnerObjId = owner?.ObjId ?? 0,
         };
 
         ApplySlaveBonuses(summonedSlave);

--- a/AAEmu.Game/Models/Game/Units/Slave.cs
+++ b/AAEmu.Game/Models/Game/Units/Slave.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Numerics;
 using AAEmu.Commons.Utils.DB;
 using AAEmu.Game.Core.Managers;
@@ -1062,7 +1061,7 @@ public class Slave : Unit
 
     public override Character GetOwnerCharacter()
     {
-        var ownerObject = OwnerObjId > 0 ? ParentWorld.GetGameObject(OwnerObjId) as BaseUnit : null;
+        var ownerObject = Summoner ?? (OwnerObjId > 0 ? ParentWorld.GetGameObject(OwnerObjId) as BaseUnit : null);
         return ownerObject?.GetOwnerCharacter();
     }
 }


### PR DESCRIPTION
- Populate `OwnerObjId` when summoning a slave in `SlaveManager`.
- Update `GetOwnerCharacter` for `Slave` so that it will correctly resolve the owner for the related functions. This fixed the issues that a Purple can't attack a slave or it's children.
