### PR TITLE
fix(game): fix loading order issues for items, mail and housing data

### DIFF
--- a/AAEmu.Game/Core/Managers/ItemManager.cs
+++ b/AAEmu.Game/Core/Managers/ItemManager.cs
@@ -1416,6 +1416,7 @@ public class ItemManager(ISkillManager skillManager, IItemIdManager itemIdManage
 
         OnItemsLoaded?.Invoke(this, EventArgs.Empty);
         _loaded = true;
+        LoadUserItems();
     }
 
     public Item GetItemByItemId(ulong itemId)

--- a/AAEmu.Game/GameData/HousingGameData.cs
+++ b/AAEmu.Game/GameData/HousingGameData.cs
@@ -78,7 +78,7 @@ public class HousingGameData : Singleton<HousingGameData>, IGameDataLoader
                 while (reader.Read())
                 {
                     var template = new HousingTemplate { Id = reader.GetUInt32("id") };
-                    template.Name = LocalizationManager.Instance.Get("housings", "name", template.Id, reader.GetString("name"));
+                    template.Name = reader.GetString("name");
                     template.CategoryId = reader.GetUInt32("category_id");
                     template.MainModelId = reader.GetUInt32("main_model_id");
                     template.DoorModelId = reader.GetUInt32("door_model_id", 0);
@@ -89,8 +89,7 @@ public class HousingGameData : Singleton<HousingGameData>, IGameDataLoader
                     template.RepairCost = reader.GetUInt32("repair_cost");
                     template.GardenRadius = reader.GetFloat("garden_radius");
                     template.Family = reader.GetString("family");
-                    var taxationId = reader.GetUInt32("taxation_id");
-                    template.Taxation = TaxationsManager.Instance.taxations.GetValueOrDefault(taxationId);
+                    template.TaxationId = reader.GetUInt32("taxation_id");
                     template.GuardTowerSettingId = reader.GetUInt32("guard_tower_setting_id", 0);
                     template.CinemaRadius = reader.GetFloat("cinema_radius");
                     template.AutoZOffsetX = reader.GetFloat("auto_z_offset_x");
@@ -226,7 +225,11 @@ public class HousingGameData : Singleton<HousingGameData>, IGameDataLoader
 
     public void PostLoad()
     {
-        //
+        foreach (var (_, template) in _housingTemplates)
+        {
+            template.Name = LocalizationManager.Instance.Get("housings", "name", template.Id, template.Name);
+            template.Taxation = TaxationsManager.Instance.taxations.GetValueOrDefault(template.TaxationId);
+        }
     }
     
     private List<HousingBindingTemplate> LoadHousingBindings(string dataFolder)

--- a/AAEmu.Game/GameData/HousingGameData.cs
+++ b/AAEmu.Game/GameData/HousingGameData.cs
@@ -77,33 +77,36 @@ public class HousingGameData : Singleton<HousingGameData>, IGameDataLoader
             {
                 while (reader.Read())
                 {
-                    var template = new HousingTemplate { Id = reader.GetUInt32("id") };
-                    template.Name = reader.GetString("name");
-                    template.CategoryId = reader.GetUInt32("category_id");
-                    template.MainModelId = reader.GetUInt32("main_model_id");
-                    template.DoorModelId = reader.GetUInt32("door_model_id", 0);
-                    template.StairModelId = reader.GetUInt32("stair_model_id", 0);
-                    template.AutoZ = reader.GetBoolean("auto_z", true);
-                    template.GateExists = reader.GetBoolean("gate_exists", true);
-                    template.Hp = reader.GetInt32("hp");
-                    template.RepairCost = reader.GetUInt32("repair_cost");
-                    template.GardenRadius = reader.GetFloat("garden_radius");
-                    template.Family = reader.GetString("family");
-                    template.TaxationId = reader.GetUInt32("taxation_id");
-                    template.GuardTowerSettingId = reader.GetUInt32("guard_tower_setting_id", 0);
-                    template.CinemaRadius = reader.GetFloat("cinema_radius");
-                    template.AutoZOffsetX = reader.GetFloat("auto_z_offset_x");
-                    template.AutoZOffsetY = reader.GetFloat("auto_z_offset_y");
-                    template.AutoZOffsetZ = reader.GetFloat("auto_z_offset_z");
-                    template.Alley = reader.GetFloat("alley");
-                    template.ExtraHeightAbove = reader.GetFloat("extra_height_above");
-                    template.ExtraHeightBelow = reader.GetFloat("extra_height_below");
-                    template.DecoLimit = reader.GetUInt32("deco_limit");
-                    template.AbsoluteDecoLimit = reader.GetUInt32("absolute_deco_limit");
-                    template.HousingDecoLimitId = reader.GetUInt32("housing_deco_limit_id", 0);
-                    template.IsSellable = reader.GetBoolean("is_sellable", true);
-                    template.HeavyTax = reader.GetBoolean("heavy_tax", true);
-                    template.AlwaysPublic = reader.GetBoolean("always_public", true);
+                    var template = new HousingTemplate
+                    {
+                        Id = reader.GetUInt32("id"),
+                        Name = reader.GetString("name"),
+                        CategoryId = reader.GetUInt32("category_id"),
+                        MainModelId = reader.GetUInt32("main_model_id"),
+                        DoorModelId = reader.GetUInt32("door_model_id", 0),
+                        StairModelId = reader.GetUInt32("stair_model_id", 0),
+                        AutoZ = reader.GetBoolean("auto_z", true),
+                        GateExists = reader.GetBoolean("gate_exists", true),
+                        Hp = reader.GetInt32("hp"),
+                        RepairCost = reader.GetUInt32("repair_cost"),
+                        GardenRadius = reader.GetFloat("garden_radius"),
+                        Family = reader.GetString("family"),
+                        TaxationId = reader.GetUInt32("taxation_id"),
+                        GuardTowerSettingId = reader.GetUInt32("guard_tower_setting_id", 0),
+                        CinemaRadius = reader.GetFloat("cinema_radius"),
+                        AutoZOffsetX = reader.GetFloat("auto_z_offset_x"),
+                        AutoZOffsetY = reader.GetFloat("auto_z_offset_y"),
+                        AutoZOffsetZ = reader.GetFloat("auto_z_offset_z"),
+                        Alley = reader.GetFloat("alley"),
+                        ExtraHeightAbove = reader.GetFloat("extra_height_above"),
+                        ExtraHeightBelow = reader.GetFloat("extra_height_below"),
+                        DecoLimit = reader.GetUInt32("deco_limit"),
+                        AbsoluteDecoLimit = reader.GetUInt32("absolute_deco_limit"),
+                        HousingDecoLimitId = reader.GetUInt32("housing_deco_limit_id", 0),
+                        IsSellable = reader.GetBoolean("is_sellable", true),
+                        HeavyTax = reader.GetBoolean("heavy_tax", true),
+                        AlwaysPublic = reader.GetBoolean("always_public", true)
+                    };
                     _housingTemplates.Add(template.Id, template);
 
                     var templateBindings = binding.Find(x => x.TemplateId.Contains(template.Id));

--- a/AAEmu.Game/GameService.cs
+++ b/AAEmu.Game/GameService.cs
@@ -77,7 +77,6 @@ public sealed class GameService : IHostedService, IDisposable
 
         // --- Stage 3: Post-load special steps ---
         GameDataManager.Instance.PostLoadGameData();
-        ItemManager.Instance.LoadUserItems();
         CashShopManager.Instance.EnabledShop();
 
         // --- Scripts ---

--- a/AAEmu.Game/Models/Game/Housing/HousingTemplate.cs
+++ b/AAEmu.Game/Models/Game/Housing/HousingTemplate.cs
@@ -4,7 +4,7 @@ namespace AAEmu.Game.Models.Game.Housing;
 
 public class HousingTemplate
 {
-    public uint Id { get; set; }
+    public uint Id { get; init; }
     public string Name { get; set; }
     public uint CategoryId { get; set; }
     public uint MainModelId { get; set; }
@@ -17,6 +17,8 @@ public class HousingTemplate
     public float GardenRadius { get; set; }
     public string Family { get; set; }
     public Taxation Taxation { get; set; }
+    /// <summary>Use Taxation instead of TaxationId for functions in the server</summary>
+    public uint TaxationId { get; set; }
     public uint GuardTowerSettingId { get; set; }
     public float CinemaRadius { get; set; }
     public float AutoZOffsetX { get; set; }

--- a/AAEmu.Game/Models/Game/Housing/HousingTemplate.cs
+++ b/AAEmu.Game/Models/Game/Housing/HousingTemplate.cs
@@ -7,33 +7,33 @@ public class HousingTemplate
     public uint Id { get; init; }
     public string Name { get; set; }
     public uint CategoryId { get; set; }
-    public uint MainModelId { get; set; }
-    public uint DoorModelId { get; set; }
-    public uint StairModelId { get; set; }
-    public bool AutoZ { get; set; }
-    public bool GateExists { get; set; }
-    public int Hp { get; set; }
-    public uint RepairCost { get; set; }
-    public float GardenRadius { get; set; }
-    public string Family { get; set; }
+    public uint MainModelId { get; init; }
+    public uint DoorModelId { get; init; }
+    public uint StairModelId { get; init; }
+    public bool AutoZ { get; init; }
+    public bool GateExists { get; init; }
+    public int Hp { get; init; }
+    public uint RepairCost { get; init; }
+    public float GardenRadius { get; init; }
+    public string Family { get; init; }
     public Taxation Taxation { get; set; }
     /// <summary>Use Taxation instead of TaxationId for functions in the server</summary>
-    public uint TaxationId { get; set; }
-    public uint GuardTowerSettingId { get; set; }
-    public float CinemaRadius { get; set; }
-    public float AutoZOffsetX { get; set; }
-    public float AutoZOffsetY { get; set; }
-    public float AutoZOffsetZ { get; set; }
-    public float Alley { get; set; }
-    public float ExtraHeightAbove { get; set; }
-    public float ExtraHeightBelow { get; set; }
-    public uint DecoLimit { get; set; }
-    public uint AbsoluteDecoLimit { get; set; }
-    public uint HousingDecoLimitId { get; set; }
-    public bool IsSellable { get; set; }
-    public bool HeavyTax { get; set; }
-    public bool AlwaysPublic { get; set; }
+    internal uint TaxationId { get; init; }
+    public uint GuardTowerSettingId { get; init; }
+    public float CinemaRadius { get; init; }
+    public float AutoZOffsetX { get; init; }
+    public float AutoZOffsetY { get; init; }
+    public float AutoZOffsetZ { get; init; }
+    public float Alley { get; init; }
+    public float ExtraHeightAbove { get; init; }
+    public float ExtraHeightBelow { get; init; }
+    public uint DecoLimit { get; init; }
+    public uint AbsoluteDecoLimit { get; init; }
+    public uint HousingDecoLimitId { get; init; }
+    public bool IsSellable { get; init; }
+    public bool HeavyTax { get; init; }
+    public bool AlwaysPublic { get; init; }
 
-    public Dictionary<int, HousingBuildStep> BuildSteps { get; set; } = [];
+    public Dictionary<int, HousingBuildStep> BuildSteps { get; } = [];
     public HousingBindingDoodad[] HousingBindingDoodad { get; set; }
 }


### PR DESCRIPTION
- Move `LoadUserItems` directly into the `ItemManager` loading sequence to ensure user data is initialized immediately after item templates.
- Defer housing localization and taxation lookups to `PostLoad` to prevent circular dependencies or null references when managers are not yet fully initialized during the initial data read.
- Introduce `TaxationId` to `HousingTemplate` to facilitate the deferred lookup.
