### PR TITLE
feat(game): persist housing bound doodads with opt-in config flag

### DIFF
--- a/AAEmu.Game/Configurations/World.json
+++ b/AAEmu.Game/Configurations/World.json
@@ -17,6 +17,7 @@
         "MaxInstances": 32,
         "TargetPhysicsTps": 25.0,
         "WindModel": "Official",
-        "ActabilityRate": 1.0
+        "ActabilityRate": 1.0,
+        "UsePersistentHouseDoodads": false
     }
 }

--- a/AAEmu.Game/Core/Managers/HousingManager.cs
+++ b/AAEmu.Game/Core/Managers/HousingManager.cs
@@ -164,7 +164,9 @@ public class HousingManager(
                         );
                         house.Transform.InstanceId = house.ParentWorld.Id; // Just to be sure
                         house.Transform.ZoneId = worldManager.GetZoneId(house.ParentWorld.Template, house.Transform.World.Position.X, house.Transform.World.Position.Y);
+                        house.IsBeingLoadedFromDb = AppConfiguration.Instance.World.UsePersistentHouseDoodads;
                         house.CurrentStep = reader.GetInt32("current_step");
+                        house.IsBeingLoadedFromDb = false;
                         house.NumAction = reader.GetInt32("current_action");
                         house.Permission = (HousingPermission)reader.GetByte("permission");
                         house.PlaceDate = reader.GetDateTime("place_date");
@@ -239,6 +241,70 @@ public class HousingManager(
             house.Transform.InstanceId = WorldManager.DefaultInstanceId;
             house.Spawn();
         }
+    }
+
+    /// <summary>
+    /// After persistent housing doodads have been loaded from DB, reconcile bound doodads for each completed house.
+    /// Spawns and saves any bound doodads missing from the DB (first-run migration), and removes duplicates.
+    /// </summary>
+    public void ReconcileBoundDoodads()
+    {
+        Logger.Info("Reconciling bound doodads for completed houses...");
+        var addedCount = 0;
+        var removedCount = 0;
+
+        foreach (var house in _houses.Values)
+        {
+            if (house.CurrentStep != -1)
+                continue;
+            if (house.Template.HousingBindingDoodad == null || house.Template.HousingBindingDoodad.Length == 0)
+                continue;
+
+            foreach (var bindingDoodad in house.Template.HousingBindingDoodad)
+            {
+                var matches = house.AttachedDoodads
+                    .Where(d => d.TemplateId == bindingDoodad.DoodadId
+                             && d.AttachPoint == bindingDoodad.AttachPointId)
+                    .ToList();
+
+                if (matches.Count == 0)
+                {
+                    // Missing from DB — spawn fresh and save (first-run migration or data loss recovery)
+                    Logger.Debug($"Reconcile: Spawning missing bound doodad templateId={bindingDoodad.DoodadId} attachPoint={bindingDoodad.AttachPointId} for house {house.Id}");
+                    var doodad = doodadManager.Create(house.ParentWorld, 0, bindingDoodad.DoodadId, house, true);
+                    if (doodad == null)
+                    {
+                        Logger.Error($"Reconcile: Failed to create doodad templateId={bindingDoodad.DoodadId} for house {house.Id} — template not found, skipping.");
+                        continue;
+                    }
+                    doodad.AttachPoint = bindingDoodad.AttachPointId;
+                    doodad.ParentObj = house;
+                    doodad.Transform = house.Transform.CloneDetached(doodad);
+                    doodad.Transform.Parent = house.Transform;
+                    doodad.Transform.Local.ApplyWorldSpawnPositionWithDeg(bindingDoodad.Position);
+                    doodad.IsPersistent = true;
+                    doodad.InitDoodad();
+                    doodad.Save();
+                    house.AttachedDoodads.Add(doodad);
+                    house.ParentWorld.SpawnManager.AddPlayerDoodad(doodad);
+                    addedCount++;
+                }
+                else if (matches.Count > 1)
+                {
+                    // Duplicates — keep the first (earliest loaded = lowest DbId), delete extras
+                    Logger.Warn($"Reconcile: Removing {matches.Count - 1} duplicate(s) for templateId={bindingDoodad.DoodadId} attachPoint={bindingDoodad.AttachPointId} on house {house.Id}");
+                    for (var i = 1; i < matches.Count; i++)
+                    {
+                        var extra = matches[i];
+                        house.AttachedDoodads.Remove(extra);
+                        extra.Delete();
+                        removedCount++;
+                    }
+                }
+            }
+        }
+
+        Logger.Info($"Bound doodad reconciliation complete: {addedCount} added, {removedCount} duplicates removed.");
     }
 
     /// <summary>

--- a/AAEmu.Game/Core/Managers/HousingManager.cs
+++ b/AAEmu.Game/Core/Managers/HousingManager.cs
@@ -284,6 +284,7 @@ public class HousingManager(
                     doodad.Transform.Local.ApplyWorldSpawnPositionWithDeg(bindingDoodad.Position);
                     doodad.IsPersistent = true;
                     doodad.InitDoodad();
+                    doodad.Spawn(); // register in world and make visible
                     doodad.Save();
                     house.AttachedDoodads.Add(doodad);
                     house.ParentWorld.SpawnManager.AddPlayerDoodad(doodad);
@@ -297,6 +298,8 @@ public class HousingManager(
                     {
                         var extra = matches[i];
                         house.AttachedDoodads.Remove(extra);
+                        if (extra.ObjId > 0)
+                            ObjectIdManager.Instance.ReleaseId(extra.ObjId);
                         extra.Delete();
                         removedCount++;
                     }

--- a/AAEmu.Game/Core/Managers/HousingManager.cs
+++ b/AAEmu.Game/Core/Managers/HousingManager.cs
@@ -165,8 +165,14 @@ public class HousingManager(
                         house.Transform.InstanceId = house.ParentWorld.Id; // Just to be sure
                         house.Transform.ZoneId = worldManager.GetZoneId(house.ParentWorld.Template, house.Transform.World.Position.X, house.Transform.World.Position.Y);
                         house.IsBeingLoadedFromDb = AppConfiguration.Instance.World.UsePersistentHouseDoodads;
-                        house.CurrentStep = reader.GetInt32("current_step");
-                        house.IsBeingLoadedFromDb = false;
+                        try
+                        {
+                            house.CurrentStep = reader.GetInt32("current_step");
+                        }
+                        finally
+                        {
+                            house.IsBeingLoadedFromDb = false;
+                        }
                         house.NumAction = reader.GetInt32("current_action");
                         house.Permission = (HousingPermission)reader.GetByte("permission");
                         house.PlaceDate = reader.GetDateTime("place_date");

--- a/AAEmu.Game/Core/Managers/IHousingManager.cs
+++ b/AAEmu.Game/Core/Managers/IHousingManager.cs
@@ -36,4 +36,5 @@ public interface IHousingManager
     House GetHouseAtLocation(float x, float y);
     bool PayWeeklyTax(House house);
     (int, int) Save(MySqlConnection connection, MySqlTransaction transaction);
+    void ReconcileBoundDoodads();
 }

--- a/AAEmu.Game/Core/Managers/World/SpawnManager.cs
+++ b/AAEmu.Game/Core/Managers/World/SpawnManager.cs
@@ -14,6 +14,7 @@ using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Slaves;
 using AAEmu.Game.Models.Game.Transfers;
 using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models;
 using AAEmu.Game.Models.Game.World;
 using AAEmu.Game.Models.Game.World.Transform;
 using AAEmu.Game.Utils;
@@ -301,8 +302,11 @@ public class SpawnManager(WorldInstance parentWorld)
             Logger.Info($"Loading persistent doodads for {World}");
             var doodadsSpawned = 0;
 
-            // Load furniture
+            // Load furniture and bound doodads
             doodadsSpawned += SpawnPersistentDoodads(DoodadOwnerType.Housing);
+            // Reconcile bound doodads: spawn any missing from DB, remove duplicates
+            if (AppConfiguration.Instance.World.UsePersistentHouseDoodads)
+                HousingManager.Instance.ReconcileBoundDoodads();
             // Load plants/packs and everything else that was placed into the world by players
             doodadsSpawned += SpawnPersistentDoodads(DoodadOwnerType.System);
             doodadsSpawned += SpawnPersistentDoodads(DoodadOwnerType.Character);
@@ -776,6 +780,18 @@ public class SpawnManager(WorldInstance parentWorld)
                             doodad.Transform.Parent = owningHouse.Transform;
                             doodad.ParentObj = owningHouse;
                             doodad.ParentObjId = owningHouse.ObjId;
+
+                            // If persistent house doodads are enabled and this doodad matches a binding
+                            // from the house template, register it in AttachedDoodads so
+                            // House.Spawn/Show/Hide/Delete handle it correctly.
+                            if (AppConfiguration.Instance.World.UsePersistentHouseDoodads)
+                            {
+                                var isBoundDoodad = owningHouse.Template?.HousingBindingDoodad != null &&
+                                    owningHouse.Template.HousingBindingDoodad.Any(b =>
+                                        b.DoodadId == templateId && b.AttachPointId == attachPoint);
+                                if (isBoundDoodad)
+                                    owningHouse.AttachedDoodads.Add(doodad);
+                            }
                         }
                     }
 

--- a/AAEmu.Game/Models/Game/Configurations.cs
+++ b/AAEmu.Game/Models/Game/Configurations.cs
@@ -116,6 +116,15 @@ public class WorldConfig
     /// Server-side Actability Points multiplier (on top of buffs)
     /// </summary>
     public double ActabilityRate { get; set; } = 1.0;
+
+    /// <summary>
+    /// When true, housing bound doodads (doors, windows, planters, drills, animals) are saved to the
+    /// database and their state (open/closed, fill level, growth phase) is restored on server restart.
+    /// When false (default), bound doodads are re-created fresh from template data on every restart,
+    /// matching the original behaviour.
+    /// Configure in <c>AAEmu.Game/Configurations/World.json</c> under <c>World.UsePersistentHouseDoodads</c>.
+    /// </summary>
+    public bool UsePersistentHouseDoodads { get; set; } = false;
 }
 
 public class DungeonLoadConfig

--- a/AAEmu.Game/Models/Game/Housing/House.cs
+++ b/AAEmu.Game/Models/Game/Housing/House.cs
@@ -82,6 +82,11 @@ public sealed class House : Unit
                     foreach (var bindingDoodad in Template.HousingBindingDoodad)
                     {
                         var doodad = DoodadManager.Instance.Create(ParentWorld, 0, bindingDoodad.DoodadId, this, true);
+                        if (doodad == null)
+                        {
+                            Logger.Error($"CurrentStep: Failed to create bound doodad templateId={bindingDoodad.DoodadId} for house {Id} — template not found, skipping.");
+                            continue;
+                        }
                         doodad.AttachPoint = bindingDoodad.AttachPointId;
                         doodad.ParentObj = this;
                         doodad.Transform = this.Transform.CloneDetached(doodad);
@@ -197,7 +202,11 @@ public sealed class House : Unit
         foreach (var doodad in AttachedDoodads)
         {
             if (doodad.IsPersistent)
+            {
+                if (doodad.ObjId > 0)
+                    ObjectIdManager.Instance.ReleaseId(doodad.ObjId);
                 doodad.Delete(); // removes from DB and PlayerDoodads
+            }
             else
             {
                 if (doodad.AttachPoint == AttachPointKind.None)

--- a/AAEmu.Game/Models/Game/Housing/House.cs
+++ b/AAEmu.Game/Models/Game/Housing/House.cs
@@ -1,6 +1,7 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Commons.Utils;
 using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models;
 using AAEmu.Game.Core.Managers.Id;
 using AAEmu.Game.Core.Managers.UnitManagers;
 using AAEmu.Game.Core.Managers.World;
@@ -22,6 +23,7 @@ public sealed class House : Unit
     private readonly object _lock = new();
     private HousingTemplate _template;
     private int _currentStep;
+    private bool _isBeingLoadedFromDb;
     private int _allAction;
     private uint _id;
     private uint _accountId;
@@ -42,6 +44,10 @@ public sealed class House : Unit
     /// after it's initial addition to the table, like position/rotation. Therefore it's ok to only set the dirty marker on the other properties
     /// </summary>
     public bool IsDirty { get => _isDirty; set => _isDirty = value; }
+    /// <summary>
+    /// When true, suppresses bound doodad spawning in the CurrentStep setter so they can be loaded from the database instead.
+    /// </summary>
+    public bool IsBeingLoadedFromDb { get => _isBeingLoadedFromDb; set => _isBeingLoadedFromDb = value; }
     public new uint Id { get => _id; set { _id = value; _isDirty = true; } }
     public uint AccountId { get => _accountId; set { _accountId = value; _isDirty = true; } }
     public uint CoOwnerId { get => _coOwnerId; set { _coOwnerId = value; _isDirty = true; } }
@@ -71,25 +77,39 @@ public sealed class House : Unit
             ModelId = _currentStep == -1 ? Template.MainModelId : Template.BuildSteps[_currentStep].ModelId;
             if (_currentStep == -1) // TODO ...
             {
-                foreach (var bindingDoodad in Template.HousingBindingDoodad)
+                if (!_isBeingLoadedFromDb)
                 {
-                    var doodad = DoodadManager.Instance.Create(ParentWorld, 0, bindingDoodad.DoodadId, this, true);
-                    doodad.AttachPoint = bindingDoodad.AttachPointId;
-                    doodad.ParentObj = this;
-                    doodad.Transform = this.Transform.CloneDetached(doodad);
-                    doodad.Transform.Parent = this.Transform;
-                    doodad.Transform.Local.ApplyWorldSpawnPositionWithDeg(bindingDoodad.Position);
-                    doodad.InitDoodad();
-
-                    AttachedDoodads.Add(doodad);
+                    foreach (var bindingDoodad in Template.HousingBindingDoodad)
+                    {
+                        var doodad = DoodadManager.Instance.Create(ParentWorld, 0, bindingDoodad.DoodadId, this, true);
+                        doodad.AttachPoint = bindingDoodad.AttachPointId;
+                        doodad.ParentObj = this;
+                        doodad.Transform = this.Transform.CloneDetached(doodad);
+                        doodad.Transform.Parent = this.Transform;
+                        doodad.Transform.Local.ApplyWorldSpawnPositionWithDeg(bindingDoodad.Position);
+                        if (AppConfiguration.Instance.World.UsePersistentHouseDoodads)
+                        {
+                            doodad.IsPersistent = true;
+                            doodad.InitDoodad();
+                            doodad.Save();
+                        }
+                        else
+                        {
+                            doodad.InitDoodad();
+                        }
+                        AttachedDoodads.Add(doodad);
+                    }
                 }
             }
             else if (AttachedDoodads.Count > 0)
             {
                 foreach (var doodad in AttachedDoodads)
-                    if (doodad.ObjId > 0)
+                {
+                    if (doodad.IsPersistent)
+                        doodad.Delete();
+                    else if (doodad.ObjId > 0)
                         ObjectIdManager.Instance.ReleaseId(doodad.ObjId);
-
+                }
                 AttachedDoodads.Clear();
             }
 
@@ -174,10 +194,18 @@ public sealed class House : Unit
 
     public override void Delete()
     {
-        // Detach children that aren't part of the house itself
         foreach (var doodad in AttachedDoodads)
-            if (doodad.AttachPoint == AttachPointKind.None)
-                doodad.Transform.Parent = null;
+        {
+            if (doodad.IsPersistent)
+                doodad.Delete(); // removes from DB and PlayerDoodads
+            else
+            {
+                if (doodad.AttachPoint == AttachPointKind.None)
+                    doodad.Transform.Parent = null; // detach furniture from transform hierarchy
+                if (doodad.ObjId > 0)
+                    ObjectIdManager.Instance.ReleaseId(doodad.ObjId);
+            }
+        }
         base.Delete();
     }
 

--- a/AAEmu.Game/Models/Game/Housing/House.cs
+++ b/AAEmu.Game/Models/Game/Housing/House.cs
@@ -111,7 +111,11 @@ public sealed class House : Unit
                 foreach (var doodad in AttachedDoodads)
                 {
                     if (doodad.IsPersistent)
+                    {
+                        if (doodad.ObjId > 0)
+                            ObjectIdManager.Instance.ReleaseId(doodad.ObjId);
                         doodad.Delete();
+                    }
                     else if (doodad.ObjId > 0)
                         ObjectIdManager.Instance.ReleaseId(doodad.ObjId);
                 }


### PR DESCRIPTION
Bound doodads (doors, windows, planters, drills, animals) are now saved to the doodads table so their state (open/closed, fill level, growth phase) survives server restarts. The feature is opt-in via a new **World.json** flag, defaulting to the original behaviour.

Changes:
- **House.CurrentStep** setter marks each spawned bound doodad as persistent and saves it to the DB; **IsBeingLoadedFromDb** suppresses re-spawning during load (only active when **UsePersistentHouseDoodads** is true) so doodads are restored from the database instead of recreated from template data
- **House.Delete()** explicitly calls **doodad.Delete()** for persistent **AttachedDoodads** so bound doodad rows are cleaned up on demolition
- **SpawnPersistentDoodads** detects bound doodads by matching against the house template bindings and registers them in **house.AttachedDoodads** for correct Show/Hide/Delete handling alongside **PlayerDoodads**
- **HousingManager.ReconcileBoundDoodads()** runs after the Housing doodad load pass: spawns and saves any bound doodads missing from the DB (automatic first-run migration) and removes duplicates; includes null guard for missing doodad templates
- Adds **World.UsePersistentHouseDoodads** (bool, default false) to **WorldConfig** and **AAEmu.Game/Configurations/World.json**; all new code paths are gated on this flag so the original behaviour is fully preserved when it is not enabled