### PR TITLE
Fix(game): auction house search error when non existant ah page is requested

### DIFF
--- a/AAEmu.Game/Core/Managers/AuctionManager.cs
+++ b/AAEmu.Game/Core/Managers/AuctionManager.cs
@@ -242,6 +242,13 @@ public class AuctionManager(IItemManager itemManager, INameManager nameManager, 
 
         var articles = SortArticles(searchedArticles, AuctionSearchSortKind.Default, AuctionSearchSortOrder.Asc).ToArray();
         var dividedLists = Helpers.SplitArray(articles, 9); // Разделяем массив на массивы по 9 значений
+           
+        if (page >= dividedLists.Length) //Stops client CD when requesting an out-of-bounds page
+        {
+            Logger.Warn($"[AH-BIDS] {player.Name} requested an out-of-bounds page: {page}/{dividedLists.Length - 1}");
+            player.SendPacket(new SCAuctionSearchedPacket(page, 0, [], (short)ErrorMessageType.NoErrorMessage, DateTime.UtcNow));
+            return;
+        }
         player.SendPacket(new SCAuctionSearchedPacket(page, dividedLists[page].Length, dividedLists[page].ToList(), (short)ErrorMessageType.NoErrorMessage, DateTime.UtcNow));
     }
 
@@ -649,6 +656,13 @@ public class AuctionManager(IItemManager itemManager, INameManager nameManager, 
 
         var articles = SortArticles(searchedArticles, search.SortKind, search.SortOrder).ToArray();
         var dividedLists = Helpers.SplitArray(articles, 9); // Разделяем массив на массивы по 9 значений
+
+        if (search.Page >= dividedLists.Length)// //Stops client CD when requesting an out-of-bounds page
+        {
+            Logger.Warn($"[AH] {player.Name} requested an out-of-bounds page: {search.Page}/{dividedLists.Length - 1}");
+            player.SendPacket(new SCAuctionSearchedPacket(search.Page, 0, [], (short)ErrorMessageType.NoErrorMessage, DateTime.UtcNow));
+            return;
+        }
         player.SendPacket(new SCAuctionSearchedPacket(search.Page, dividedLists[search.Page].Length, dividedLists[search.Page].ToList(), (short)ErrorMessageType.NoErrorMessage, DateTime.UtcNow));
     }
 

--- a/AAEmu.Game/Core/Managers/AuctionManager.cs
+++ b/AAEmu.Game/Core/Managers/AuctionManager.cs
@@ -243,11 +243,12 @@ public class AuctionManager(IItemManager itemManager, INameManager nameManager, 
         var articles = SortArticles(searchedArticles, AuctionSearchSortKind.Default, AuctionSearchSortOrder.Asc).ToArray();
         var dividedLists = Helpers.SplitArray(articles, 9); // Разделяем массив на массивы по 9 значений
            
-        if (page >= dividedLists.Length) //Stops client CD when requesting an out-of-bounds page
+        if (page < 0 || page >= dividedLists.Length) //Stops client DC when requesting an out-of-bounds page
         {
             Logger.Warn($"[AH-BIDS] {player.Name} requested an out-of-bounds page: {page}/{dividedLists.Length - 1}");
             player.SendPacket(new SCAuctionSearchedPacket(page, 0, [], (short)ErrorMessageType.NoErrorMessage, DateTime.UtcNow));
             return;
+        }
         }
         player.SendPacket(new SCAuctionSearchedPacket(page, dividedLists[page].Length, dividedLists[page].ToList(), (short)ErrorMessageType.NoErrorMessage, DateTime.UtcNow));
     }

--- a/AAEmu.Game/Core/Managers/AuctionManager.cs
+++ b/AAEmu.Game/Core/Managers/AuctionManager.cs
@@ -249,7 +249,6 @@ public class AuctionManager(IItemManager itemManager, INameManager nameManager, 
             player.SendPacket(new SCAuctionSearchedPacket(page, 0, [], (short)ErrorMessageType.NoErrorMessage, DateTime.UtcNow));
             return;
         }
-        }
         player.SendPacket(new SCAuctionSearchedPacket(page, dividedLists[page].Length, dividedLists[page].ToList(), (short)ErrorMessageType.NoErrorMessage, DateTime.UtcNow));
     }
 

--- a/AAEmu.Game/Core/Managers/AuctionManager.cs
+++ b/AAEmu.Game/Core/Managers/AuctionManager.cs
@@ -663,7 +663,6 @@ public class AuctionManager(IItemManager itemManager, INameManager nameManager, 
             player.SendPacket(new SCAuctionSearchedPacket(search.Page, 0, [], (short)ErrorMessageType.NoErrorMessage, DateTime.UtcNow));
             return;
         }
-        }
         player.SendPacket(new SCAuctionSearchedPacket(search.Page, dividedLists[search.Page].Length, dividedLists[search.Page].ToList(), (short)ErrorMessageType.NoErrorMessage, DateTime.UtcNow));
     }
 

--- a/AAEmu.Game/Core/Managers/AuctionManager.cs
+++ b/AAEmu.Game/Core/Managers/AuctionManager.cs
@@ -658,11 +658,12 @@ public class AuctionManager(IItemManager itemManager, INameManager nameManager, 
         var articles = SortArticles(searchedArticles, search.SortKind, search.SortOrder).ToArray();
         var dividedLists = Helpers.SplitArray(articles, 9); // Разделяем массив на массивы по 9 значений
 
-        if (search.Page >= dividedLists.Length)// //Stops client CD when requesting an out-of-bounds page
+        if (search.Page < 0 || search.Page >= dividedLists.Length) // Stops client DC when requesting an out-of-bounds page
         {
             Logger.Warn($"[AH] {player.Name} requested an out-of-bounds page: {search.Page}/{dividedLists.Length - 1}");
             player.SendPacket(new SCAuctionSearchedPacket(search.Page, 0, [], (short)ErrorMessageType.NoErrorMessage, DateTime.UtcNow));
             return;
+        }
         }
         player.SendPacket(new SCAuctionSearchedPacket(search.Page, dividedLists[search.Page].Length, dividedLists[search.Page].ToList(), (short)ErrorMessageType.NoErrorMessage, DateTime.UtcNow));
     }


### PR DESCRIPTION
client dcs and server gets error when an AH page has 9 items and 0 one the next page. 
client allows you to request the next page even if there's 0. 

this fix handles the error when client tries to request the next page, by giving it an empty page with the last page idx.

basically the client gets DCed if you ever have exactly 9 items and click next and there aren't any items on the next page.

fixed in mybids and AH search

pls feel free to edit or improve the code. 

