### PR TITLE
fix(game): SpawnFishEffect rewritten to correct sports fish no longer spawning

### DIFF
--- a/AAEmu.Game/Models/Game/Skills/Effects/SpawnFishEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpawnFishEffect.cs
@@ -23,63 +23,96 @@ public class SpawnFishEffect : EffectTemplate
         CastAction castObj, EffectSource source, SkillObject skillObject, DateTime time,
         CompressedGamePackets packetBuilder = null)
     {
+        if (caster is not Character player) return;
 
-        if (caster is Character player)
+        var fishSpawnerId = GetFishSpawnerId(player);
+        if (fishSpawnerId == 0)
         {
-            var fishSpawnerId = GetFishSpawnerId(player);
-            if (fishSpawnerId == 0)
+            Logger.Debug($"Fish Spawner ID not found for player {player.Name}.");
+            return;
+        }
+
+        var template = NpcGameData.Instance.GetNpcSpawnerTemplate(fishSpawnerId);
+        if (template?.Npcs == null || template.Npcs.Count == 0)
+        {
+            Logger.Warn($"No NPC templates available for fish spawner {fishSpawnerId}.");
+            return;
+        }
+
+        // Weighted random fish selection
+        NpcSpawnerNpc npcTemplateEntry = template.Npcs.Count == 1
+            ? template.Npcs[0]
+            : SelectWeightedRandom(template.Npcs);
+
+        if (npcTemplateEntry == null)
+        {
+            Logger.Warn($"Failed to select random fish for spawner {fishSpawnerId}");
+            return;
+        }
+
+        Logger.Debug($"Selected fish template {npcTemplateEntry.MemberId} from spawner {fishSpawnerId}");
+
+        // Create temporary spawner with correct position
+        var tempSpawner = new NpcSpawner
+        {
+            ParentWorld = player.ParentWorld,
+            SpawnerId = fishSpawnerId,
+            UnitId = npcTemplateEntry.MemberId,
+            Template = template
+        };
+
+        // Fix for CloneAsSpawnPosition not existing / type mismatch
+        using var spawnPos = target.Transform.Clone();
+        tempSpawner.Position = spawnPos.CloneAsSpawnPosition();
+
+        try
+        {
+            var spawnedList = npcTemplateEntry.Spawn(tempSpawner, player.Id);
+
+            if (spawnedList == null || spawnedList.Count == 0)
             {
-                Logger.Debug($"Fish Spawner ID not found.");
+                Logger.Warn($"npcTemplate.Spawn returned no fish for template {npcTemplateEntry.MemberId}");
                 return;
             }
-            // Process: Spawn the fish, add it to the world at the correct location, then: combat engaged, target, aggro target before starting fish AI.
 
-            // We need to get the spawner at the target location.
-            var npcSpawnerNpc = NpcGameData.Instance.GetNpcSpawnerNpc(fishSpawnerId);
-            var unitId = npcSpawnerNpc.MemberId;
-            var spawner = player.ParentWorld.SpawnManager.GetNpcSpawner(fishSpawnerId);
-            var spawnerId = spawner.Count;
+            var fish = spawnedList.First();
 
-            spawner.Add(new NpcSpawner());
-            spawner[spawnerId].ParentWorld = player.ParentWorld;
-            spawner[spawnerId].UnitId = unitId;
-            spawner[spawnerId].Id = fishSpawnerId;
-            spawner[spawnerId].NpcSpawnerIds = [fishSpawnerId];
-            spawner[spawnerId].Template = NpcGameData.Instance.GetNpcSpawnerTemplate(fishSpawnerId);
-            if (spawner[spawnerId].Template == null) { return; }
+            var spawnTransform = target.Transform.Clone();
 
-            if (spawner[spawnerId].Template.Npcs.Count == 0)
-            {
-                spawner[spawnerId].Template.Npcs = [];
-                var nsn = NpcGameData.Instance.GetNpcSpawnerNpc(fishSpawnerId);
-                if (nsn == null) { return; }
-                spawner[spawnerId].Template.Npcs.Add(nsn);
-            }
-            if (spawner[spawnerId].Template.Npcs == null) { return; }
+            fish.Transform = spawnTransform;
+            fish.ParentWorld = player.ParentWorld;
 
-            spawner[spawnerId].Template.Npcs[0].MemberId = unitId;
-            spawner[spawnerId].Template.Npcs[0].UnitId = unitId;
+            fish.Spawn();
 
-            using var spawnPos = target.Transform.Clone();
+            // Aggro & targeting
+            fish.CurrentTarget = player;
+            fish.AddUnitAggro(AggroKind.Damage, player, 10000);
+            player.CurrentTarget = fish;
+            player.BroadcastPacket(new SCTargetChangedPacket(player.ObjId, fish.ObjId), true);
 
-            spawner[spawnerId].Position = spawnPos.CloneAsSpawnPosition();
-
-            // Spawn the NPC
-            var fish = spawner[spawnerId].DoRandomSpawn(fishSpawnerId, player.Id);
-
-            if (fish != null) // Ensure the fish spawned
-            {
-                fish.CurrentTarget = player;
-                fish.AddUnitAggro(AggroKind.Damage, player, 1);
-                player.CurrentTarget = fish;
-                player.BroadcastPacket(new SCTargetChangedPacket(player.ObjId, fish.ObjId), true);
-                //Fish immediately does Bite skill from its own tree.
-            }
-            else
-            {
-                Logger.Info("No fish to target.");
-            }
+            Logger.Debug($"Successfully spawned fish {npcTemplateEntry.MemberId} (owner {player.Id}) at bobber for {player.Name}");
         }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, $"Error spawning fish from template {npcTemplateEntry.MemberId}");
+        }
+    }
+
+    private NpcSpawnerNpc SelectWeightedRandom(List<NpcSpawnerNpc> npcs)
+    {
+        var totalWeight = npcs.Sum(x => x.Weight);
+        if (totalWeight <= 0) return npcs[0];
+
+        var roll = new Random().NextDouble() * totalWeight;
+        var current = 0.0;
+
+        foreach (var entry in npcs)
+        {
+            current += entry.Weight;
+            if (roll <= current)
+                return entry;
+        }
+        return npcs[0];
     }
 
     private uint GetFishSpawnerId(Character player)
@@ -91,14 +124,12 @@ public class SpawnFishEffect : EffectTemplate
             {
                 foreach (var func in doodad.CurrentPhaseFuncs)
                 {
-                    var template = DoodadManager.Instance.GetPhaseFuncTemplate(func.FuncId, func.FuncType);
-                    if (template is DoodadFuncFishSchool doodadFuncFishSchoolTemplate)
-                    {
-                        return doodadFuncFishSchoolTemplate.NpcSpawnerId;
-                    }
+                    var funcTemplate = DoodadManager.Instance.GetPhaseFuncTemplate(func.FuncId, func.FuncType);
+                    if (funcTemplate is DoodadFuncFishSchool schoolFunc)
+                        return schoolFunc.NpcSpawnerId;
                 }
             }
         }
-        return 0; // not found
+        return 0;
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpawnFishEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpawnFishEffect.cs
@@ -68,28 +68,17 @@ public class SpawnFishEffect : EffectTemplate
         try
         {
             var spawnedList = npcTemplateEntry.Spawn(tempSpawner, player.Id);
-
             if (spawnedList == null || spawnedList.Count == 0)
             {
                 Logger.Warn($"npcTemplate.Spawn returned no fish for template {npcTemplateEntry.MemberId}");
                 return;
             }
-
             var fish = spawnedList.First();
-
-            var spawnTransform = target.Transform.Clone();
-
-            fish.Transform = spawnTransform;
-            fish.ParentWorld = player.ParentWorld;
-
-            fish.Spawn();
-
             // Aggro & targeting
             fish.CurrentTarget = player;
             fish.AddUnitAggro(AggroKind.Damage, player, 10000);
             player.CurrentTarget = fish;
             player.BroadcastPacket(new SCTargetChangedPacket(player.ObjId, fish.ObjId), true);
-
             Logger.Debug($"Successfully spawned fish {npcTemplateEntry.MemberId} (owner {player.Id}) at bobber for {player.Name}");
         }
         catch (Exception ex)
@@ -103,7 +92,7 @@ public class SpawnFishEffect : EffectTemplate
         var totalWeight = npcs.Sum(x => x.Weight);
         if (totalWeight <= 0) return npcs[0];
 
-        var roll = new Random().NextDouble() * totalWeight;
+        var roll = Random.Shared.NextDouble() * totalWeight;
         var current = 0.0;
 
         foreach (var entry in npcs)

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpawnFishEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpawnFishEffect.cs
@@ -73,6 +73,8 @@ public class SpawnFishEffect : EffectTemplate
                 Logger.Warn($"npcTemplate.Spawn returned no fish for template {npcTemplateEntry.MemberId}");
                 return;
             }
+            // Register so that Despawn() -> RemoveNpcFromSpawnedList doesn't log a false warning
+            tempSpawner.SpawnedNpcs.TryAdd(fishSpawnerId, spawnedList);
             var fish = spawnedList.First();
             // Aggro & targeting
             fish.CurrentTarget = player;

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpawnFishEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpawnFishEffect.cs
@@ -100,7 +100,7 @@ public class SpawnFishEffect : EffectTemplate
         foreach (var entry in npcs)
         {
             current += entry.Weight;
-            if (roll <= current)
+            if (roll < current)
                 return entry;
         }
         return npcs[0];


### PR DESCRIPTION
At some point the nature of spawn code changed, and the fish wasn't moving to the correct location. This corrects that, makes the fishing spawners more self-contained within this script, and tidies up the ownership process a little.