### PR TITLE
fix(game): fixed potential labor generation bug

### DIFF
--- a/AAEmu.Game/Core/Managers/TimedRewardsManager.cs
+++ b/AAEmu.Game/Core/Managers/TimedRewardsManager.cs
@@ -51,7 +51,7 @@ public class TimedRewardsManager : Singleton<TimedRewardsManager>, ITimedRewards
 
     public void DoTick()
     {
-        var connections = GameConnectionTable.Instance.GetConnections().ToList();
+        var connections = GameConnectionTable.Instance.GetConnections();
         foreach (var connection in connections)
         {
             //var character = connection.ActiveChar;

--- a/AAEmu.Game/Core/Managers/TimedRewardsManager.cs
+++ b/AAEmu.Game/Core/Managers/TimedRewardsManager.cs
@@ -51,10 +51,7 @@ public class TimedRewardsManager : Singleton<TimedRewardsManager>, ITimedRewards
 
     public void DoTick()
     {
-        if (AppConfiguration.Instance.Credits.TickMinutes <= 0 && AppConfiguration.Instance.Loyalty.TickMinutes <= 0)
-            return;
-
-        var connections = GameConnectionTable.Instance.GetConnections();
+        var connections = GameConnectionTable.Instance.GetConnections().ToList();
         foreach (var connection in connections)
         {
             //var character = connection.ActiveChar;


### PR DESCRIPTION
- Remove the early exit guard that only checked for Credits and Loyalty tick configurations, ensuring Labor ticks can process independently.
- Materialize the connection list to a list before iteration to prevent "collection modified" exceptions if a player disconnects during the tick.
