### PR TITLE
FIX LABOR TICK AND BUFF LINEARS FUNCTIONS

### DIFF
--- a/AAEmu.Game/Core/Managers/ISkillManager.cs
+++ b/AAEmu.Game/Core/Managers/ISkillManager.cs
@@ -11,6 +11,7 @@ public interface ISkillManager : ILoadable
     List<uint> GetBuffsByTagId(uint tagId);
     List<uint> GetBuffTags(uint buffId);
     BuffTemplate GetBuffTemplate(uint id);
+    int ResolveDynamicBonusValue(DynamicBonusTemplate template, uint abLevel);
     List<BuffTriggerTemplate> GetBuffTriggerTemplates(uint buffId);
     List<CombatBuffTemplate> GetCombatBuffs(uint reqBuffId);
     List<DefaultSkill> GetDefaultSkills();

--- a/AAEmu.Game/Core/Managers/SkillManager.cs
+++ b/AAEmu.Game/Core/Managers/SkillManager.cs
@@ -37,6 +37,7 @@ public class SkillManager(IAnimationManager animationManager, IPlotManager plotM
     private Dictionary<uint, List<SkillModifier>> _skillModifiers;
     private Dictionary<uint, List<BuffTriggerTemplate>> _buffTriggers;
     private Dictionary<uint, List<CombatBuffTemplate>> _combatBuffs;
+    private Dictionary<uint, LinearFuncTemplate> _linearFuncs;
     private Dictionary<uint, SkillReagent> _skillReagents;
     private Dictionary<uint, SkillProduct> _skillProducts;
     // private HashSet<ushort> _skillIds = new();
@@ -104,6 +105,26 @@ public class SkillManager(IAnimationManager animationManager, IPlotManager plotM
     public BuffTemplate GetBuffTemplate(uint id)
     {
         return _buffs.GetValueOrDefault(id);
+    }
+
+    public int ResolveDynamicBonusValue(DynamicBonusTemplate template, uint abLevel)
+    {
+        if (template == null)
+            return 0;
+
+        switch (template.FuncType)
+        {
+            case "LinearFunc":
+                if (_linearFuncs != null && _linearFuncs.TryGetValue(template.FuncId, out var linearFunc))
+                    return linearFunc.Evaluate(abLevel);
+
+                Logger.Warn($"Dynamic bonus references missing LinearFunc id={template.FuncId}");
+                return 0;
+
+            default:
+                Logger.Warn($"Unsupported dynamic bonus func type={template.FuncType}, id={template.FuncId}");
+                return 0;
+        }
     }
 
     public List<BuffTriggerTemplate> GetBuffTriggerTemplates(uint buffId)
@@ -299,6 +320,7 @@ public class SkillManager(IAnimationManager animationManager, IPlotManager plotM
         _skillTags = [];
         _taggedSkills = [];
         _combatBuffs = [];
+        _linearFuncs = [];
         _skillReagents = [];
         _skillProducts = [];
 
@@ -728,6 +750,25 @@ public class SkillManager(IAnimationManager animationManager, IPlotManager plotM
                     }
                 }
             }
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT * FROM linear_funcs";
+                command.Prepare();
+                using (var reader = new SQLiteWrapperReader(command.ExecuteReader()))
+                {
+                    while (reader.Read())
+                    {
+                        var template = new LinearFuncTemplate
+                        {
+                            Id = reader.GetUInt32("id"),
+                            StartValue = reader.GetInt32("start_value"),
+                            EndValue = reader.GetInt32("end_value")
+                        };
+                        _linearFuncs[template.Id] = template;
+                    }
+                }
+            }
+
             using (var command = connection.CreateCommand())
             {
                 command.CommandText = "SELECT * FROM dynamic_unit_modifiers";

--- a/AAEmu.Game/Core/Managers/TimedRewardsManager.cs
+++ b/AAEmu.Game/Core/Managers/TimedRewardsManager.cs
@@ -9,14 +9,14 @@ namespace AAEmu.Game.Core.Managers;
 /// <summary>
 /// For timed adding credits and loyalty
 /// </summary>
-public class TimedRewardsManager : Singleton<TimedRewardsManager>, ITimedRewardsManager
+public class TimedRewardsManager(ITaskManager taskManager) : Singleton<TimedRewardsManager>, ITimedRewardsManager
 {
     private const short MaxLabor = 2000;
     private const short MaxLaborPremium = 5000;
 
     public void Initialize()
     {
-        TaskManager.Instance.Schedule(new TimedRewardsTask(), TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
+        taskManager.Schedule(new TimedRewardsTask(), TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
     }
 
     public static short GetMaxLabor(bool isPremium)

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/ManaCost.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/ManaCost.cs
@@ -24,6 +24,15 @@ public class ManaCost : SpecialEffectAction
         // TODO ...
         if (caster is Character) { Logger.Debug("Special effects: ManaCost value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4); }
 
+        // Skills marked as truly free in the `skills` table (e.g. crafting,
+        // vehicle summoning - both mana_cost AND mana_level_md at 0) must not
+        // consume mana through a ManaCost SpecialEffect either. Without this
+        // guard, value1/value2 from special_effects would be deducted from the
+        // caster's Mp on every cast, causing a cascading mana drain on
+        // crafting skills.
+        if (skill?.Template != null && skill.Template.ManaCost <= 0 && skill.Template.ManaLevelMd <= 0f)
+            return;
+
         if (caster is Character character)
         {
             // TODO: Value1 is used by Mana Stars, value2 is used by other skills. They are never used both at once.

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -1468,6 +1468,13 @@ AlwaysHit:
     /// <returns></returns>
     public int ManaCost(Unit caster)
     {
+        // A skill is genuinely free (crafting, vehicle summon, etc.) only when
+        // BOTH `mana_cost` and `mana_level_md` are 0. Most magical skills have
+        // `mana_cost = 0` but rely on `mana_level_md` to scale the cost with
+        // ability level, so we cannot short-circuit on `mana_cost` alone.
+        if (Template.ManaCost <= 0 && Template.ManaLevelMd <= 0f)
+            return 0;
+
         var baseCost = ((caster.GetAbLevel(Template.AbilityId) - 1) * 1.6 + 8) * 3 / 3.65;
         var cost2 = baseCost * Template.ManaLevelMd + Template.ManaCost;
         var manaCost = (int)caster.SkillModifiersCache.ApplyModifiers(this, SkillAttribute.ManaCost, cost2);
@@ -1480,7 +1487,14 @@ AlwaysHit:
             return;
 
         var manaCost = ManaCost(unit);
-        unit.ReduceCurrentMp(null, manaCost);
+
+        // Skip ReduceCurrentMp entirely when the skill costs no mana.
+        // ReduceCurrentMp always broadcasts an SCUnitPointsPacket, which on
+        // truly free skills (crafting, vehicle summon, ...) causes a redundant
+        // client-side re-sync that briefly desyncs the displayed Mp bar even
+        // though the server-side Mp value is unchanged.
+        if (manaCost > 0)
+            unit.ReduceCurrentMp(null, manaCost);
 
         if (caster is not Character character)
             return;

--- a/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
+++ b/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
@@ -219,26 +219,30 @@ public class BuffTemplate
 
         foreach (var template in DynamicBonuses)
         {
+            // Resolve once to avoid duplicate dictionary lookups / log warnings
+            var resolvedValue = SkillManager.Instance.ResolveDynamicBonusValue(template, buff.AbLevel);
             var bonus = new Bonus
             {
                 Template = new BonusTemplate
                 {
                     Attribute = template.Attribute,
                     ModifierType = template.ModifierType,
-                    Value = SkillManager.Instance.ResolveDynamicBonusValue(template, buff.AbLevel),
+                    Value = resolvedValue,
                     LinearLevelBonus = 0
                 },
-                Value = SkillManager.Instance.ResolveDynamicBonusValue(template, buff.AbLevel)
+                Value = resolvedValue
             };
             owner.AddBonus(buff.Index, bonus);
         }
 
+        var hpDelta = 0;
+        var mpDelta = 0;
         if (ownerUnit != null)
         {
             var newMaxHp = ownerUnit.MaxHp;
             var newMaxMp = ownerUnit.MaxMp;
-            var hpDelta = newMaxHp - oldMaxHp;
-            var mpDelta = newMaxMp - oldMaxMp;
+            hpDelta = newMaxHp - oldMaxHp;
+            mpDelta = newMaxMp - oldMaxMp;
 
             if (hpDelta > 0 && ownerUnit.Hp >= oldMaxHp)
                 ownerUnit.Hp = Math.Min(ownerUnit.Hp + hpDelta, newMaxHp);
@@ -257,7 +261,10 @@ public class BuffTemplate
         if (!buff.Passive)
             owner.BroadcastPacket(new SCBuffCreatedPacket(buff), true);
 
-        if (ownerUnit != null)
+        // Only broadcast unit points when MaxHp/MaxMp actually changed.
+        // Buffs that don't touch HP/MP (speed, stealth, silence, ...) shouldn't
+        // trigger redundant network traffic.
+        if (ownerUnit != null && (hpDelta != 0 || mpDelta != 0))
             owner.BroadcastPacket(new SCUnitPointsPacket(ownerUnit.ObjId, ownerUnit.Hp, ownerUnit.Mp), true);
 
         // Special properties handling
@@ -361,9 +368,17 @@ public class BuffTemplate
 
         if (owner is Unit ownerUnit)
         {
-            ownerUnit.Hp = Math.Min(ownerUnit.Hp, ownerUnit.MaxHp);
-            ownerUnit.Mp = Math.Min(ownerUnit.Mp, ownerUnit.MaxMp);
-            owner.BroadcastPacket(new SCUnitPointsPacket(ownerUnit.ObjId, ownerUnit.Hp, ownerUnit.Mp), true);
+            var newHp = Math.Min(ownerUnit.Hp, ownerUnit.MaxHp);
+            var newMp = Math.Min(ownerUnit.Mp, ownerUnit.MaxMp);
+            // Only broadcast when the buff actually changed MaxHp/MaxMp enough
+            // to clamp current Hp/Mp. Avoids redundant packets for movement,
+            // silence, stealth and other buffs that don't affect HP/MP.
+            if (newHp != ownerUnit.Hp || newMp != ownerUnit.Mp)
+            {
+                ownerUnit.Hp = newHp;
+                ownerUnit.Mp = newMp;
+                owner.BroadcastPacket(new SCUnitPointsPacket(ownerUnit.ObjId, ownerUnit.Hp, ownerUnit.Mp), true);
+            }
         }
 
         var requiringBuffs = owner.Buffs.GetBuffsRequiring(buff.Template.Id);

--- a/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
+++ b/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
@@ -207,10 +207,48 @@ public class BuffTemplate
 
     public void Start(BaseUnit caster, BaseUnit owner, Buff buff)
     {
+        var ownerUnit = owner as Unit;
+        var oldMaxHp = ownerUnit?.MaxHp ?? 0;
+        var oldMaxMp = ownerUnit?.MaxMp ?? 0;
+
         foreach (var template in Bonuses)
         {
             var bonus = new Bonus { Template = template, Value = (int)Math.Round(template.Value + template.LinearLevelBonus * (buff.AbLevel / 100f)) };
             owner.AddBonus(buff.Index, bonus);
+        }
+
+        foreach (var template in DynamicBonuses)
+        {
+            var bonus = new Bonus
+            {
+                Template = new BonusTemplate
+                {
+                    Attribute = template.Attribute,
+                    ModifierType = template.ModifierType,
+                    Value = SkillManager.Instance.ResolveDynamicBonusValue(template, buff.AbLevel),
+                    LinearLevelBonus = 0
+                },
+                Value = SkillManager.Instance.ResolveDynamicBonusValue(template, buff.AbLevel)
+            };
+            owner.AddBonus(buff.Index, bonus);
+        }
+
+        if (ownerUnit != null)
+        {
+            var newMaxHp = ownerUnit.MaxHp;
+            var newMaxMp = ownerUnit.MaxMp;
+            var hpDelta = newMaxHp - oldMaxHp;
+            var mpDelta = newMaxMp - oldMaxMp;
+
+            if (hpDelta > 0 && ownerUnit.Hp >= oldMaxHp)
+                ownerUnit.Hp = Math.Min(ownerUnit.Hp + hpDelta, newMaxHp);
+            else
+                ownerUnit.Hp = Math.Min(ownerUnit.Hp, newMaxHp);
+
+            if (mpDelta > 0 && ownerUnit.Mp >= oldMaxMp)
+                ownerUnit.Mp = Math.Min(ownerUnit.Mp + mpDelta, newMaxMp);
+            else
+                ownerUnit.Mp = Math.Min(ownerUnit.Mp, newMaxMp);
         }
 
         if (buff.Charge == 0)
@@ -218,6 +256,9 @@ public class BuffTemplate
 
         if (!buff.Passive)
             owner.BroadcastPacket(new SCBuffCreatedPacket(buff), true);
+
+        if (ownerUnit != null)
+            owner.BroadcastPacket(new SCUnitPointsPacket(ownerUnit.ObjId, ownerUnit.Hp, ownerUnit.Mp), true);
 
         // Special properties handling
         if (owner is Character character)
@@ -314,6 +355,17 @@ public class BuffTemplate
     {
         foreach (var template in Bonuses)
             owner.RemoveBonus(buff.Index, template.Attribute);
+
+        foreach (var template in DynamicBonuses)
+            owner.RemoveBonus(buff.Index, template.Attribute);
+
+        if (owner is Unit ownerUnit)
+        {
+            ownerUnit.Hp = Math.Min(ownerUnit.Hp, ownerUnit.MaxHp);
+            ownerUnit.Mp = Math.Min(ownerUnit.Mp, ownerUnit.MaxMp);
+            owner.BroadcastPacket(new SCUnitPointsPacket(ownerUnit.ObjId, ownerUnit.Hp, ownerUnit.Mp), true);
+        }
+
         var requiringBuffs = owner.Buffs.GetBuffsRequiring(buff.Template.Id);
         foreach (var requiringBuff in requiringBuffs.ToList())
             requiringBuff.Exit();

--- a/AAEmu.Game/Models/Game/Skills/Templates/LinearFuncTemplate.cs
+++ b/AAEmu.Game/Models/Game/Skills/Templates/LinearFuncTemplate.cs
@@ -2,6 +2,21 @@ namespace AAEmu.Game.Models.Game.Skills.Templates;
 
 public class LinearFuncTemplate
 {
+    /// <summary>
+    /// Minimum ability level used for linear interpolation.
+    /// Matches the lower bound of the ArcheAge ability-level range used by buff AbLevel.
+    /// </summary>
+    public const uint MinAbLevel = 1u;
+
+    /// <summary>
+    /// Maximum ability level used for linear interpolation.
+    /// Matches the upper bound of the ArcheAge ability-level range used by buff AbLevel
+    /// (same cap as <c>FeatureSet</c>'s ability cap). If the cap ever changes per game
+    /// version, update this constant (or wire it to <c>FeatureSet</c>) so interpolation
+    /// stays correct.
+    /// </summary>
+    public const uint MaxAbLevel = 55u;
+
     public uint Id { get; init; }
     public int StartValue { get; init; }
     public int EndValue { get; init; }
@@ -14,8 +29,8 @@ public class LinearFuncTemplate
         // Most dynamic_unit_modifiers currently point to constant LinearFunc rows.
         // For non-constant rows, keep a safe linear interpolation across the
         // ArcheAge ability-level range used by buff AbLevel.
-        var clampedLevel = Math.Clamp(abLevel, 1u, 55u);
-        var ratio = (clampedLevel - 1d) / 54d;
+        var clampedLevel = Math.Clamp(abLevel, MinAbLevel, MaxAbLevel);
+        var ratio = (clampedLevel - MinAbLevel) / (double)(MaxAbLevel - MinAbLevel);
         return (int)Math.Round(StartValue + (EndValue - StartValue) * ratio);
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Templates/LinearFuncTemplate.cs
+++ b/AAEmu.Game/Models/Game/Skills/Templates/LinearFuncTemplate.cs
@@ -1,0 +1,21 @@
+namespace AAEmu.Game.Models.Game.Skills.Templates;
+
+public class LinearFuncTemplate
+{
+    public uint Id { get; init; }
+    public int StartValue { get; init; }
+    public int EndValue { get; init; }
+
+    public int Evaluate(uint abLevel)
+    {
+        if (StartValue == EndValue)
+            return StartValue;
+
+        // Most dynamic_unit_modifiers currently point to constant LinearFunc rows.
+        // For non-constant rows, keep a safe linear interpolation across the
+        // ArcheAge ability-level range used by buff AbLevel.
+        var clampedLevel = Math.Clamp(abLevel, 1u, 55u);
+        var ratio = (clampedLevel - 1d) / 54d;
+        return (int)Math.Round(StartValue + (EndValue - StartValue) * ratio);
+    }
+}


### PR DESCRIPTION
First issue identified: the “labor tick”.
The fix mainly consisted of wrapping TimedRewardsManager(ITaskManager taskManager) properly so that the 5-minute tick correctly accounts for updates.

Second issue identified: buffs using the linear_funcs table. Let’s take a concrete example with item ID 17671, Tangy Liquor.

When you consume it, your mana bar increases as expected. However, when you attack a monster and use your first skill, your mana decreases by both:

the normal mana cost of the skill, and
the mana previously gained from the item.

In short, the bonus mana is immediately lost upon using a skill in combat.

Fix implemented:
I introduced a LinearFuncts template and updated several related files to ensure the buff behaves correctly and the mana bonus is preserved during skill usage.