### PR TITLE
FIXED_doodads_housing

### DIFF
--- a/AAEmu.Game/Core/Packets/C2G/CSLootOpenBagPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSLootOpenBagPacket.cs
@@ -3,6 +3,7 @@ using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.Game.World.Interactions;
 using AAEmu.Game.Models.Tasks.Doodads;
 using System.Linq;
 
@@ -20,8 +21,25 @@ public class CSLootOpenBagPacket() : GamePacket(CSOffsets.CSLootOpenBagPacket, 1
         var object2 = Connection.ActiveChar.ParentWorld.GetBaseUnit(obj2Id);
 
         bool IsFuncDrivenLootDoodad(Doodad d) =>
-            // Doodads with these funcs are looted by calling doodad.Use(...) instead of LootingContainer.OpenBag().
-            d.CurrentFuncs.Any(func => Doodad.IsFuncDrivenLootFunc(func.FuncType));
+            // Doodads handled by doodad.Use(...) instead of LootingContainer.OpenBag(). Must match Doodad.Write()'s
+            // hasLootItem semantics exactly: ALL funcs of the current phase must be loot-driven. If a non-loot func
+            // is present (CraftPack, StoreUi, Use, ...), the doodad is a multi-action object (e.g. workshop) and
+            // must keep the interaction wheel, not the gear/loot icon.
+            d.CurrentFuncs.Count > 0 && d.CurrentFuncs.All(func => Doodad.IsFuncDrivenLootFunc(func.FuncType));
+
+        bool IsRecoverItemDoodad(Doodad d) =>
+            // Trade packs / material packs are routed via DoodadFuncRecoverItem only for
+            // the generic world pickup skill. Housing crate recover uses skill 15309 and
+            // must NOT be consumed by CSLootOpenBagPacket, otherwise a right-click store
+            // immediately triggers a recover and cancels the storage visually.
+            d.CurrentFuncs.Any(func =>
+                func.FuncType == "DoodadFuncRecoverItem" &&
+                IsLootPacketRecoverSkill(func.SkillId));
+
+        bool IsLootPacketRecoverSkill(uint skillId) =>
+            // 11361 = generic RecoverItem pickup used by world trade/material packs.
+            // 15309 = housing crate recover; keep it on the normal doodad interaction path.
+            skillId == 11361;
 
         bool TryHandleFuncDrivenLoot(BaseUnit target)
         {
@@ -30,8 +48,19 @@ public class CSLootOpenBagPacket() : GamePacket(CSOffsets.CSLootOpenBagPacket, 1
             if (doodad.LootingContainer.Items.Count > 0 || !IsFuncDrivenLootDoodad(doodad))
                 return false;
 
+            // Pack-style pickup -> route through RecoverItem with backpack guard, same as right-click (skill 11361).
+            // This is the only safe path for DoodadFuncRecoverItem: it refuses to fire if the player already
+            // wears a pack, preventing the duplication / pack-swap parasites observed on housing tradepacks.
+            if (IsRecoverItemDoodad(doodad))
+            {
+                new RecoverItem().Execute(Connection.ActiveChar, null, doodad, null, 0, 0, null);
+                return true;
+            }
+
+            // Other loot-driven doodads (e.g. ship debris with DoodadFuncLootItem/LootPack/Cutdowning):
+            // legacy path is fine.
             doodad.Use(Connection.ActiveChar, 0);
-            // For one-shot loot doodads (ship debris), remove object when it transitions out of loot-capable funcs.
+            // For one-shot loot doodads, remove object when it transitions out of loot-capable funcs.
             if (!IsFuncDrivenLootDoodad(doodad))
                 TaskManager.Instance.Schedule(new DoodadDeleteTask(doodad));
             return true;

--- a/AAEmu.Game/Core/Packets/C2G/CSLootOpenBagPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSLootOpenBagPacket.cs
@@ -11,6 +11,11 @@ namespace AAEmu.Game.Core.Packets.C2G;
 
 public class CSLootOpenBagPacket() : GamePacket(CSOffsets.CSLootOpenBagPacket, 1)
 {
+    // Generic RecoverItem pickup skill used by world trade/material packs (same path as the right-click pickup).
+    // 15309 = housing crate recover; that one is intentionally NOT handled here and stays on the normal doodad
+    // interaction path (see IsLootPacketRecoverSkill).
+    private const uint GenericRecoverItemSkillId = 11361u;
+
     public override void Read(PacketStream stream)
     {
         var objId = stream.ReadBc();
@@ -29,7 +34,7 @@ public class CSLootOpenBagPacket() : GamePacket(CSOffsets.CSLootOpenBagPacket, 1
 
         bool IsRecoverItemDoodad(Doodad d) =>
             // Trade packs / material packs are routed via DoodadFuncRecoverItem only for
-            // the generic world pickup skill. Housing crate recover uses skill 15309 and
+            // the generic world pickup skill (GenericRecoverItemSkillId). Housing crate recover uses skill 15309 and
             // must NOT be consumed by CSLootOpenBagPacket, otherwise a right-click store
             // immediately triggers a recover and cancels the storage visually.
             d.CurrentFuncs.Any(func =>
@@ -37,9 +42,9 @@ public class CSLootOpenBagPacket() : GamePacket(CSOffsets.CSLootOpenBagPacket, 1
                 IsLootPacketRecoverSkill(func.SkillId));
 
         bool IsLootPacketRecoverSkill(uint skillId) =>
-            // 11361 = generic RecoverItem pickup used by world trade/material packs.
+            // GenericRecoverItemSkillId = generic RecoverItem pickup used by world trade/material packs.
             // 15309 = housing crate recover; keep it on the normal doodad interaction path.
-            skillId == 11361;
+            skillId == GenericRecoverItemSkillId;
 
         bool TryHandleFuncDrivenLoot(BaseUnit target)
         {
@@ -48,12 +53,14 @@ public class CSLootOpenBagPacket() : GamePacket(CSOffsets.CSLootOpenBagPacket, 1
             if (doodad.LootingContainer.Items.Count > 0 || !IsFuncDrivenLootDoodad(doodad))
                 return false;
 
-            // Pack-style pickup -> route through RecoverItem with backpack guard, same as right-click (skill 11361).
-            // This is the only safe path for DoodadFuncRecoverItem: it refuses to fire if the player already
-            // wears a pack, preventing the duplication / pack-swap parasites observed on housing tradepacks.
+            // Pack-style pickup -> route through RecoverItem with backpack guard, same as right-click
+            // (GenericRecoverItemSkillId). This is the only safe path for DoodadFuncRecoverItem: it refuses to fire
+            // if the player already wears a pack, preventing the duplication / pack-swap parasites observed on
+            // housing tradepacks. We forward the real recover skillId so the F-key path stays consistent with the
+            // right-click path (DoodadFuncRecoverItem currently only logs it, but later checks/effects may rely on it).
             if (IsRecoverItemDoodad(doodad))
             {
-                new RecoverItem().Execute(Connection.ActiveChar, null, doodad, null, 0, 0, null);
+                new RecoverItem().Execute(Connection.ActiveChar, null, doodad, null, GenericRecoverItemSkillId, 0, null);
                 return true;
             }
 

--- a/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
@@ -446,8 +446,8 @@ public class Doodad : BaseUnit
             {
                 // Iterate over loot-driven funcs handled via skill-less Use() (ship debris and similar).
                 // IMPORTANT: DoodadFuncRecoverItem is intentionally NOT handled here. It is routed by
-                // CSLootOpenBagPacket through RecoverItem.Execute (the same path as the right-click pickup
-                // skill 11361), which enforces the "player must not already wear a pack" guard. Calling it
+                // CSLootOpenBagPacket through RecoverItem.Execute (the same path as the right-click pickup,
+                // GenericRecoverItemSkillId), which enforces the "player must not already wear a pack" guard. Calling it
                 // from Use(0) would bypass that guard and cause the player's current backpack to be silently
                 // swapped into inventory whenever the client sends a stray CSLootOpenBagPacket (observed
                 // right after a F-pickup followed by a re-place via PutDownBackpackEffect).
@@ -474,7 +474,23 @@ public class Doodad : BaseUnit
             // and also not being the owner seems to be a good enough criteria.
             // If somebody finds an edge-case where this would generate a footprint when not needed, we need to adjust this
             var casterOwningCharacter = caster.GetOwnerCharacter();
-            if (OwnerType == DoodadOwnerType.Character && OwnerId != casterOwningCharacter?.Id && startedSkillTemplate?.CrimePoint > 0)
+
+            // Theft happens whenever a player interacts with a doodad directly owned by a *different* character.
+            var isDifferentCharacterOwner =
+                OwnerType == DoodadOwnerType.Character && OwnerId != casterOwningCharacter?.Id;
+
+            // CrimePoint > 0 alone is NOT a sufficient guard: it makes theft evidence 100% dependent on the DB and
+            // silently drops the footprint for legitimate theft paths when:
+            //   - startedSkillId == 0 (skill-less loot/recover, e.g. CSLootOpenBagPacket -> Use(..., 0) on ship debris
+            //     and similar loot-driven doodads), so startedSkillTemplate is null;
+            //   - the skill exists but has CrimePoint == 0 / unset in the DB.
+            // So we keep the historical "owned by another character" fallback for skill-less pickups, and only rely on
+            // CrimePoint > 0 as an *additional* explicit-crime signal when an actual skill is involved.
+            var isExplicitCrimeSkill = startedSkillTemplate?.CrimePoint > 0;
+            var isSkillLessPickup = startedSkillId == 0;
+            var shouldGenerateTheftEvidence = isDifferentCharacterOwner && (isSkillLessPickup || isExplicitCrimeSkill);
+
+            if (shouldGenerateTheftEvidence)
             {
                 // Picking up something from a doodad that isn't owned by the player, need to check permissions
                 // TODO: Enforce theft minimum level

--- a/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
@@ -405,6 +405,7 @@ public class Doodad : BaseUnit
     public void Use(BaseUnit caster, uint startedSkillId = 0, int funcGroupId = 0)
     {
         var skillId = startedSkillId;
+        var startedSkillTemplate = SkillManager.Instance.GetSkillTemplate(startedSkillId);
         if (caster == null)
         {
             return;
@@ -443,6 +444,13 @@ public class Doodad : BaseUnit
 
             if (skillId == 0)
             {
+                // Iterate over loot-driven funcs handled via skill-less Use() (ship debris and similar).
+                // IMPORTANT: DoodadFuncRecoverItem is intentionally NOT handled here. It is routed by
+                // CSLootOpenBagPacket through RecoverItem.Execute (the same path as the right-click pickup
+                // skill 11361), which enforces the "player must not already wear a pack" guard. Calling it
+                // from Use(0) would bypass that guard and cause the player's current backpack to be silently
+                // swapped into inventory whenever the client sends a stray CSLootOpenBagPacket (observed
+                // right after a F-pickup followed by a re-place via PutDownBackpackEffect).
                 foreach (var funcWithoutSkill in allFuncsForGroup.Where(f => f.FuncType is "DoodadFuncLootItem" or "DoodadFuncLootPack" or "DoodadFuncCutdowning"))
                 {
                     if (DoFunc(caster, startedSkillId, funcWithoutSkill))
@@ -466,7 +474,7 @@ public class Doodad : BaseUnit
             // and also not being the owner seems to be a good enough criteria.
             // If somebody finds an edge-case where this would generate a footprint when not needed, we need to adjust this
             var casterOwningCharacter = caster.GetOwnerCharacter();
-            if (OwnerType == DoodadOwnerType.Character && OwnerId != casterOwningCharacter?.Id)
+            if (OwnerType == DoodadOwnerType.Character && OwnerId != casterOwningCharacter?.Id && startedSkillTemplate?.CrimePoint > 0)
             {
                 // Picking up something from a doodad that isn't owned by the player, need to check permissions
                 // TODO: Enforce theft minimum level
@@ -861,8 +869,14 @@ public class Doodad : BaseUnit
         }
 
         stream.Write(Scale); //The size of the object
-        // Mark doodad as lootable for client UI (gear icon) when its current phase has any loot/recover interaction func.
-        var hasLootItem = CurrentFuncs.Any(func => IsFuncDrivenLootFunc(func.FuncType));
+        // Mark doodad as lootable for client UI (gear icon) ONLY when its current phase is exclusively driven by
+        // loot/recover funcs. If the group also contains non-loot interaction funcs (CraftPack, StoreUi, Use, etc.),
+        // the doodad must keep the normal interaction wheel (F/G/H...). Otherwise the client would route every
+        // interaction through CSLootOpenBagPacket -> doodad.Use(skillId=0) and silently break workshops/shops while
+        // accidentally despawning them (RecoverItem with NextPhase=-1 deletes the doodad). This restriction keeps
+        // pickup working for trade packs, chests and crafting tables stored in the world (single-RecoverItem groups)
+        // while preserving multi-action doodads (workshops with CraftPack+StoreUi+RecoverItem).
+        var hasLootItem = CurrentFuncs.Count > 0 && CurrentFuncs.All(func => IsFuncDrivenLootFunc(func.FuncType));
         stream.Write(hasLootItem); // hasLootItem
         stream.Write(FuncGroupId); // doodad_func_group_id
         stream.Write(OwnerId); // characterId (Database relative)


### PR DESCRIPTION
The goal of this patch is to allow shortcut interactions with doodads, such as removing a trade pack from a cart with the “F” key, opening the shop in the farmer’s workshop, or opening a chest.
