### PR TITLE
Add PvP Honor System, Auto-Attack overhaul, and ZoneConflict cycle fix

### DIFF
--- a/AAEmu.Game/Configurations/World.json
+++ b/AAEmu.Game/Configurations/World.json
@@ -18,6 +18,7 @@
         "TargetPhysicsTps": 25.0,
         "WindModel": "Official",
         "ActabilityRate": 1.0,
-        "UsePersistentHouseDoodads": false
+        "UsePersistentHouseDoodads": false,
+        "PvpHonorRate": 1.0
     }
 }

--- a/AAEmu.Game/Core/Managers/ItemManager.cs
+++ b/AAEmu.Game/Core/Managers/ItemManager.cs
@@ -592,7 +592,13 @@ public class ItemManager(ISkillManager skillManager, IItemIdManager itemIdManage
                             RenewCategory = reader.GetInt32("renew_category"),
                             ItemProcId = reader.GetInt32("item_proc_id"),
                             StatMultiplier = reader.GetInt32("stat_multiplier"),
-                            FormulaHDps = new Formula(reader.GetString("formula_hdps"))
+                            FormulaHDps = new Formula(reader.GetString("formula_hdps")),
+                            AnimR1Id = reader.GetUInt32("anim_r1_id", 0),
+                            AnimL1Id = reader.GetUInt32("anim_l1_id", 0),
+                            AnimR2Id = reader.GetUInt32("anim_r2_id", 0),
+                            AnimL2Id = reader.GetUInt32("anim_l2_id", 0),
+                            AnimR3Id = reader.GetUInt32("anim_r3_id", 0),
+                            AnimL3Id = reader.GetUInt32("anim_l3_id", 0)
                         };
 
                         _holdables.Add(template.Id, template);

--- a/AAEmu.Game/Core/Managers/SkillManager.cs
+++ b/AAEmu.Game/Core/Managers/SkillManager.cs
@@ -1,6 +1,8 @@
 ﻿using AAEmu.Commons.Utils;
 using AAEmu.Game.Models.Game.AI.Enums;
 using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Items;
+using AAEmu.Game.Models.Game.Items.Templates;
 using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Skills.Buffs;
@@ -1834,12 +1836,44 @@ public class SkillManager(IAnimationManager animationManager, IPlotManager plotM
     /// <returns></returns>
     public static double GetAttackDelay(SkillTemplate skillTemplate, Unit caster, bool includeCooldown = true, double additionalDelay = 1000.0)
     {
-        // This isn't 100% accurate, but it feels "close enough"
-        // TODO: Implement weapon speed delays
+        // Auto-attack skills (2=melee, 3=offhand, 4=ranged) use weapon speed
+        if (skillTemplate.Id is 2 or 3 or 4 && caster is Character character)
+        {
+            var weaponSpeed = GetWeaponSpeed(character, skillTemplate.Id);
+            var delay = weaponSpeed * (caster.GlobalCooldownMul / 100.0);
+            return Math.Clamp(delay, 400.0, 5000.0);
+        }
+
+        // Non-auto-attack skills: original formula
         var castTime = skillTemplate.CastingTime * caster.CastTimeMul * 1.0;
         var coolDownTime = includeCooldown ? skillTemplate.CooldownTime * (caster.GlobalCooldownMul / 100.0) : 0.0;
         var additionalTime = additionalDelay * (caster.GlobalCooldownMul / 100.0);
         return castTime + coolDownTime + additionalTime;
+    }
+
+    /// <summary>
+    /// Get the weapon speed in ms for an auto-attack skill based on equipped weapon.
+    /// </summary>
+    private static double GetWeaponSpeed(Character character, uint skillId)
+    {
+        const double DefaultMeleeSpeed = 1500.0;
+        const double DefaultRangedSpeed = 1800.0;
+
+        EquipmentItemSlot slot;
+        double fallback;
+        switch (skillId)
+        {
+            case 2: slot = EquipmentItemSlot.Mainhand; fallback = DefaultMeleeSpeed; break;
+            case 3: slot = EquipmentItemSlot.Offhand;  fallback = DefaultMeleeSpeed; break;
+            case 4: slot = EquipmentItemSlot.Ranged;   fallback = DefaultRangedSpeed; break;
+            default: return DefaultMeleeSpeed;
+        }
+
+        var weapon = character.Equipment?.GetItemBySlot((int)slot);
+        if (weapon?.Template is WeaponTemplate wt && wt.HoldableTemplate != null && wt.HoldableTemplate.Speed > 0)
+            return wt.HoldableTemplate.Speed;
+
+        return fallback;
     }
 
     /// <summary>

--- a/AAEmu.Game/Core/Managers/TaskManager2.cs
+++ b/AAEmu.Game/Core/Managers/TaskManager2.cs
@@ -19,7 +19,12 @@ public class TaskManager(ITickManager tickManager) : Singleton<TaskManager>, ITa
 
     public void Initialize()
     {
-        _queue.Clear();
+        // NOTE: _queue is intentionally NOT cleared here. In the orchestrated boot,
+        // ILoadable.Load() runs in Stage 2 and may schedule tasks (e.g. ZoneManager
+        // queues the initial Conflict→War→Peace timer chain). Initialize() runs in
+        // Stage 4, AFTER those tasks are already queued — clearing the queue here
+        // wiped the boot-time tasks and broke the zone-conflict cycle.
+        // The queue is already empty after the field initializer, so no clear needed.
     }
 
     public void Start()

--- a/AAEmu.Game/Core/Packets/C2G/CSResurrectCharacterPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSResurrectCharacterPacket.cs
@@ -1,9 +1,10 @@
-﻿using AAEmu.Commons.Network;
+using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
+using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Skills.Static;
 using AAEmu.Game.Models.Game.Units.Static;
@@ -14,6 +15,9 @@ namespace AAEmu.Game.Core.Packets.C2G;
 
 public class CSResurrectCharacterPacket() : GamePacket(CSOffsets.CSResurrectCharacterPacket, 1)
 {
+    /// <summary>Duration of the post-revive Respawn-Cooldown debuff in milliseconds (5 min).</summary>
+    private const int RespawnCooldownDurationMs = 300_000;
+
     public override void Read(PacketStream stream)
     {
         var inPlace = stream.ReadBoolean();
@@ -46,7 +50,7 @@ public class CSResurrectCharacterPacket() : GamePacket(CSOffsets.CSResurrectChar
             var currentZone = ZoneManager.Instance.GetZoneByKey(Connection.ActiveChar.Transform.ZoneId);
             if (currentZone != null)
             {
-                var conflictData = ZoneManager.Instance.GetConflicts()?.FirstOrDefault(c => c.ZoneGroupId == currentZone.GroupId);
+                var conflictData = ZoneManager.Instance.GetConflicts().FirstOrDefault(c => c.ZoneGroupId == currentZone.GroupId);
                 if (conflictData?.CurrentZoneState == ZoneConflictType.War)
                 {
                     switch (Connection.ActiveChar.Faction.MotherId)
@@ -66,7 +70,7 @@ public class CSResurrectCharacterPacket() : GamePacket(CSOffsets.CSResurrectChar
             {
                 portal = PortalManager.Instance.GetRespawnById(usePortalId);
             }
-            
+
             // Find the closest return portal (in the world) for the player if none has been found yet
             if (usePortalId == 0 || portal == null)
             {
@@ -125,63 +129,65 @@ public class CSResurrectCharacterPacket() : GamePacket(CSOffsets.CSResurrectChar
             true
         );
 
-        // ── PvP-Honor system: route death-debuffs by death context ─────────
-        if (inPlace)
-        {
-            // Player-resurrected → no debuffs at all
-            Connection.ActiveChar.DiedInPvpWarZone = false;
-            Connection.ActiveChar.DiedInPvp = false;
-        }
-        else if (Connection.ActiveChar.DiedInPvpWarZone)
-        {
-            // War-zone PvP death → Leech (4424) + Respawn-CD (2385, 5min)
-            Connection.ActiveChar.DiedInPvpWarZone = false;
-            Connection.ActiveChar.DiedInPvp = false;
-            var casterObj = new SkillCasterUnit(Connection.ActiveChar.ObjId);
-
-            var leechTemplate = SkillManager.Instance.GetBuffTemplate(4424);
-            if (leechTemplate != null)
-                Connection.ActiveChar.Buffs.AddBuff(new Buff(Connection.ActiveChar, Connection.ActiveChar, casterObj, leechTemplate, null, DateTime.UtcNow));
-
-            var cdTemplate = SkillManager.Instance.GetBuffTemplate(2385);
-            if (cdTemplate != null)
-            {
-                var cdBuff = new Buff(Connection.ActiveChar, Connection.ActiveChar, casterObj, cdTemplate, null, DateTime.UtcNow);
-                Connection.ActiveChar.Buffs.AddBuff(cdBuff, forcedDuration: 300_000);
-            }
-        }
-        else if (Connection.ActiveChar.DiedInPvp)
-        {
-            // Conflict-zone PvP death → Respawn-CD only (no Weakened Body)
-            Connection.ActiveChar.DiedInPvp = false;
-            var casterObj = new SkillCasterUnit(Connection.ActiveChar.ObjId);
-
-            var cdTemplate = SkillManager.Instance.GetBuffTemplate(2385);
-            if (cdTemplate != null)
-            {
-                var cdBuff = new Buff(Connection.ActiveChar, Connection.ActiveChar, casterObj, cdTemplate, null, DateTime.UtcNow);
-                Connection.ActiveChar.Buffs.AddBuff(cdBuff, forcedDuration: 300_000);
-            }
-        }
-        else
-        {
-            // PvE death → Weakened Body (1128) + Respawn-CD (2385, 5min)
-            var casterObj = new SkillCasterUnit(Connection.ActiveChar.ObjId);
-
-            var weakenedTemplate = SkillManager.Instance.GetBuffTemplate(1128);
-            if (weakenedTemplate != null)
-                Connection.ActiveChar.Buffs.AddBuff(new Buff(Connection.ActiveChar, Connection.ActiveChar, casterObj, weakenedTemplate, null, DateTime.UtcNow));
-
-            var cdTemplate = SkillManager.Instance.GetBuffTemplate(2385);
-            if (cdTemplate != null)
-            {
-                var cdBuff = new Buff(Connection.ActiveChar, Connection.ActiveChar, casterObj, cdTemplate, null, DateTime.UtcNow);
-                Connection.ActiveChar.Buffs.AddBuff(cdBuff, forcedDuration: 300_000);
-            }
-        }
+        // Route death-debuffs based on death context (set by Character.DoDie).
+        ApplyRevivalDebuffs(Connection.ActiveChar, inPlace);
 
         Connection.ActiveChar.IsUnderWater = false;
         //Connection.ActiveChar.StartRegen();
         Connection.ActiveChar.Breath = Connection.ActiveChar.LungCapacity;
+    }
+
+    /// <summary>
+    /// Apply post-revive debuffs based on the death context:
+    ///   inPlace (player-res) → no debuffs at all
+    ///   DiedInPvpWarZone     → Leech + 5 min Respawn-CD
+    ///   DiedInPvp            → 5 min Respawn-CD only (no Weakened Body)
+    ///   PvE death            → Weakened Body + 5 min Respawn-CD
+    /// </summary>
+    private static void ApplyRevivalDebuffs(Character character, bool inPlace)
+    {
+        if (inPlace)
+        {
+            // Player-resurrected (e.g. by another player's resurrect skill): no debuffs.
+            character.DiedInPvpWarZone = false;
+            character.DiedInPvp = false;
+            return;
+        }
+
+        var casterObj = new SkillCasterUnit(character.ObjId);
+
+        if (character.DiedInPvpWarZone)
+        {
+            // PvP death in War zone → Leech + Respawn-CD
+            character.DiedInPvpWarZone = false;
+            character.DiedInPvp = false;
+            ApplyBuff(character, casterObj, (uint)BuffConstants.WarZoneLeech);
+            ApplyBuff(character, casterObj, (uint)BuffConstants.RespawnCooldown, RespawnCooldownDurationMs);
+        }
+        else if (character.DiedInPvp)
+        {
+            // PvP death outside War zone → Respawn-CD only (no Weakened Body)
+            character.DiedInPvp = false;
+            ApplyBuff(character, casterObj, (uint)BuffConstants.RespawnCooldown, RespawnCooldownDurationMs);
+        }
+        else
+        {
+            // PvE death → Weakened Body + Respawn-CD
+            ApplyBuff(character, casterObj, (uint)BuffConstants.WeakenedBody);
+            ApplyBuff(character, casterObj, (uint)BuffConstants.RespawnCooldown, RespawnCooldownDurationMs);
+        }
+    }
+
+    private static void ApplyBuff(Character character, SkillCasterUnit casterObj, uint buffId, int forcedDurationMs = 0)
+    {
+        var template = SkillManager.Instance.GetBuffTemplate(buffId);
+        if (template == null)
+            return;
+
+        var buff = new Buff(character, character, casterObj, template, null, DateTime.UtcNow);
+        if (forcedDurationMs > 0)
+            character.Buffs.AddBuff(buff, forcedDuration: forcedDurationMs);
+        else
+            character.Buffs.AddBuff(buff);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSResurrectCharacterPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSResurrectCharacterPacket.cs
@@ -4,6 +4,8 @@ using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
+using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models.Game.Skills.Static;
 using AAEmu.Game.Models.Game.Units.Static;
 using AAEmu.Game.Models.Game.World.Zones;
 using AAEmu.Game.Models.StaticValues;
@@ -122,6 +124,62 @@ public class CSResurrectCharacterPacket() : GamePacket(CSOffsets.CSResurrectChar
             ),
             true
         );
+
+        // ── PvP-Honor system: route death-debuffs by death context ─────────
+        if (inPlace)
+        {
+            // Player-resurrected → no debuffs at all
+            Connection.ActiveChar.DiedInPvpWarZone = false;
+            Connection.ActiveChar.DiedInPvp = false;
+        }
+        else if (Connection.ActiveChar.DiedInPvpWarZone)
+        {
+            // War-zone PvP death → Leech (4424) + Respawn-CD (2385, 5min)
+            Connection.ActiveChar.DiedInPvpWarZone = false;
+            Connection.ActiveChar.DiedInPvp = false;
+            var casterObj = new SkillCasterUnit(Connection.ActiveChar.ObjId);
+
+            var leechTemplate = SkillManager.Instance.GetBuffTemplate(4424);
+            if (leechTemplate != null)
+                Connection.ActiveChar.Buffs.AddBuff(new Buff(Connection.ActiveChar, Connection.ActiveChar, casterObj, leechTemplate, null, DateTime.UtcNow));
+
+            var cdTemplate = SkillManager.Instance.GetBuffTemplate(2385);
+            if (cdTemplate != null)
+            {
+                var cdBuff = new Buff(Connection.ActiveChar, Connection.ActiveChar, casterObj, cdTemplate, null, DateTime.UtcNow);
+                Connection.ActiveChar.Buffs.AddBuff(cdBuff, forcedDuration: 300_000);
+            }
+        }
+        else if (Connection.ActiveChar.DiedInPvp)
+        {
+            // Conflict-zone PvP death → Respawn-CD only (no Weakened Body)
+            Connection.ActiveChar.DiedInPvp = false;
+            var casterObj = new SkillCasterUnit(Connection.ActiveChar.ObjId);
+
+            var cdTemplate = SkillManager.Instance.GetBuffTemplate(2385);
+            if (cdTemplate != null)
+            {
+                var cdBuff = new Buff(Connection.ActiveChar, Connection.ActiveChar, casterObj, cdTemplate, null, DateTime.UtcNow);
+                Connection.ActiveChar.Buffs.AddBuff(cdBuff, forcedDuration: 300_000);
+            }
+        }
+        else
+        {
+            // PvE death → Weakened Body (1128) + Respawn-CD (2385, 5min)
+            var casterObj = new SkillCasterUnit(Connection.ActiveChar.ObjId);
+
+            var weakenedTemplate = SkillManager.Instance.GetBuffTemplate(1128);
+            if (weakenedTemplate != null)
+                Connection.ActiveChar.Buffs.AddBuff(new Buff(Connection.ActiveChar, Connection.ActiveChar, casterObj, weakenedTemplate, null, DateTime.UtcNow));
+
+            var cdTemplate = SkillManager.Instance.GetBuffTemplate(2385);
+            if (cdTemplate != null)
+            {
+                var cdBuff = new Buff(Connection.ActiveChar, Connection.ActiveChar, casterObj, cdTemplate, null, DateTime.UtcNow);
+                Connection.ActiveChar.Buffs.AddBuff(cdBuff, forcedDuration: 300_000);
+            }
+        }
+
         Connection.ActiveChar.IsUnderWater = false;
         //Connection.ActiveChar.StartRegen();
         Connection.ActiveChar.Breath = Connection.ActiveChar.LungCapacity;

--- a/AAEmu.Game/Core/Packets/G2C/SCSkillFiredPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCSkillFiredPacket.cs
@@ -1,4 +1,4 @@
-﻿using AAEmu.Commons.Network;
+using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Models.Game.Skills;
 
@@ -18,10 +18,12 @@ public class SCSkillFiredPacket : GamePacket
     private readonly Skill _skill;
 
     private short _effectDelay = 37;
-    private int _fireAnimId = 2;
     private bool _dist;
 
     public short ComputedDelay { get; set; }
+
+    /// <summary>Override animation ID. If &gt; 0, uses this instead of skill template FireAnim.</summary>
+    public uint OverrideFireAnimId { get; set; }
 
     public SCSkillFiredPacket(uint id, ushort tl, SkillCaster caster, SkillCastTarget target, Skill skill, SkillObject skillObject) : base(SCOffsets.SCSkillFiredPacket, 1)
     {
@@ -32,6 +34,7 @@ public class SCSkillFiredPacket : GamePacket
         _skill = skill;
         _skillObject = skillObject;
     }
+
     public SCSkillFiredPacket(uint id, ushort tl, SkillCaster caster, SkillCastTarget target, Skill skill, SkillObject skillObject, short effectDelay = 37, int fireAnimId = 2, bool dist = true) : base(SCOffsets.SCSkillFiredPacket, 1)
     {
         _id = id;
@@ -41,7 +44,7 @@ public class SCSkillFiredPacket : GamePacket
         _skill = skill;
         _skillObject = skillObject;
         _effectDelay = effectDelay;
-        _fireAnimId = fireAnimId;
+        OverrideFireAnimId = (uint)fireAnimId;
         _dist = dist;
     }
 
@@ -53,13 +56,15 @@ public class SCSkillFiredPacket : GamePacket
         stream.Write(_target);
         stream.Write(_skillObject);
 
-        stream.Write((short)(ComputedDelay / 10 + 10)); // TODO +10 It became visible flying arrows
+        stream.Write((short)(ComputedDelay / 10 + 10));
         stream.Write((short)(_skill.Template.ChannelingTime / 10 + 10));
         stream.Write((byte)0); // f
-        if (_skill.Template.Id != 2) // TODO: rotate between mainhand and offhand animation?
-            stream.Write(_skill.Template.FireAnim?.Id ?? 0); // fire_anim_id 
+
+        // Use override anim if set, otherwise use skill template FireAnim
+        if (OverrideFireAnimId > 0)
+            stream.Write(OverrideFireAnimId);
         else
-            stream.Write(2);
+            stream.Write(_skill.Template.FireAnim?.Id ?? 0);
 
         stream.Write((byte)0); // flag
 

--- a/AAEmu.Game/Core/Packets/G2C/SCSkillFiredPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCSkillFiredPacket.cs
@@ -4,8 +4,6 @@ using AAEmu.Game.Models.Game.Skills;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-#pragma warning disable IDE0052 // Remove unread private members
-
 public class SCSkillFiredPacket : GamePacket
 {
     public override PacketLogLevel LogLevel => PacketLogLevel.Trace;
@@ -17,13 +15,14 @@ public class SCSkillFiredPacket : GamePacket
     private readonly SkillObject _skillObject;
     private readonly Skill _skill;
 
-    private short _effectDelay = 37;
-    private bool _dist;
-
     public short ComputedDelay { get; set; }
 
-    /// <summary>Override animation ID. If &gt; 0, uses this instead of skill template FireAnim.</summary>
-    public uint OverrideFireAnimId { get; set; }
+    /// <summary>
+    /// The fire animation ID sent to the client.
+    /// Default = skill template's FireAnim ID. Caller can override for weapon-based
+    /// auto-attack animation (Skill.GetWeaponAttackAnimId) or NPC anim cycling.
+    /// </summary>
+    public int FireAnimId { get; set; }
 
     public SCSkillFiredPacket(uint id, ushort tl, SkillCaster caster, SkillCastTarget target, Skill skill, SkillObject skillObject) : base(SCOffsets.SCSkillFiredPacket, 1)
     {
@@ -33,19 +32,7 @@ public class SCSkillFiredPacket : GamePacket
         _target = target;
         _skill = skill;
         _skillObject = skillObject;
-    }
-
-    public SCSkillFiredPacket(uint id, ushort tl, SkillCaster caster, SkillCastTarget target, Skill skill, SkillObject skillObject, short effectDelay = 37, int fireAnimId = 2, bool dist = true) : base(SCOffsets.SCSkillFiredPacket, 1)
-    {
-        _id = id;
-        _tl = tl;
-        _caster = caster;
-        _target = target;
-        _skill = skill;
-        _skillObject = skillObject;
-        _effectDelay = effectDelay;
-        OverrideFireAnimId = (uint)fireAnimId;
-        _dist = dist;
+        FireAnimId = (int)(skill.Template.FireAnim?.Id ?? 0);
     }
 
     public override PacketStream Write(PacketStream stream)
@@ -59,13 +46,7 @@ public class SCSkillFiredPacket : GamePacket
         stream.Write((short)(ComputedDelay / 10 + 10));
         stream.Write((short)(_skill.Template.ChannelingTime / 10 + 10));
         stream.Write((byte)0); // f
-
-        // Use override anim if set, otherwise use skill template FireAnim
-        if (OverrideFireAnimId > 0)
-            stream.Write(OverrideFireAnimId);
-        else
-            stream.Write(_skill.Template.FireAnim?.Id ?? 0);
-
+        stream.Write(FireAnimId);
         stream.Write((byte)0); // flag
 
         return stream;

--- a/AAEmu.Game/Core/Packets/G2C/SCSkillFiredPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCSkillFiredPacket.cs
@@ -19,10 +19,10 @@ public class SCSkillFiredPacket : GamePacket
 
     /// <summary>
     /// The fire animation ID sent to the client.
-    /// Default = skill template's FireAnim ID. Caller can override for weapon-based
+    /// Default = skill template's FireAnim ID. Callers can override for weapon-based
     /// auto-attack animation (Skill.GetWeaponAttackAnimId) or NPC anim cycling.
     /// </summary>
-    public int FireAnimId { get; set; }
+    public uint FireAnimId { get; set; }
 
     public SCSkillFiredPacket(uint id, ushort tl, SkillCaster caster, SkillCastTarget target, Skill skill, SkillObject skillObject) : base(SCOffsets.SCSkillFiredPacket, 1)
     {
@@ -32,7 +32,7 @@ public class SCSkillFiredPacket : GamePacket
         _target = target;
         _skill = skill;
         _skillObject = skillObject;
-        FireAnimId = (int)(skill.Template.FireAnim?.Id ?? 0);
+        FireAnimId = skill.Template.FireAnim?.Id ?? 0;
     }
 
     public override PacketStream Write(PacketStream stream)

--- a/AAEmu.Game/GameService.cs
+++ b/AAEmu.Game/GameService.cs
@@ -67,6 +67,11 @@ public sealed class GameService : IHostedService, IDisposable
         var stopWatch = new Stopwatch();
         stopWatch.Start();
 
+        // --- Auto-Attack system: ensure compact.sqlite3 has the 6 weapon-anim columns ---
+        // The shipped ArcheAge compact.sqlite3 already contains these. This is a defensive
+        // check for stripped/custom DBs and is a no-op if the columns are already present.
+        Utils.DB.HoldablesSchemaCheck.EnsureColumns();
+
         // --- ID managers ---
         // All ID managers implement ILoadable and are handled by the orchestrator in Stage 2.
         // SkillTlIdManager.Instance.Initialize(); // static class, not migrated

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -2527,6 +2527,7 @@ public partial class Character : Unit, ICharacter
                     "`world_id`,`zone_id`,`x`,`y`,`z`,`roll`,`pitch`,`yaw`," +
                     "`faction_id`,`faction_name`,`expedition_id`,`family`,`dead_count`,`dead_time`,`rez_wait_duration`,`rez_time`,`rez_penalty_duration`,`leave_time`," +
                     "`money`,`money2`,`honor_point`,`vocation_point`,`crime_point`,`crime_record`,`jury_point`," +
+                    "`hostile_faction_kills`,`pvp_honor`," +
                     "`delete_request_time`,`transfer_request_time`,`delete_time`,`auto_use_aapoint`,`prev_point`,`point`,`gift`," +
                     "`num_inv_slot`,`num_bank_slot`,`expanded_expert`,`slots`,`created_at`,`updated_at`,`return_district`,`online_time`" +
                     ") VALUES (" +
@@ -2535,6 +2536,7 @@ public partial class Character : Unit, ICharacter
                     "@world_id,@zone_id,@x,@y,@z,@yaw,@pitch,@roll," +
                     "@faction_id,@faction_name,@expedition_id,@family,@dead_count,@dead_time,@rez_wait_duration,@rez_time,@rez_penalty_duration,@leave_time," +
                     "@money,@money2,@honor_point,@vocation_point,@crime_point,@crime_record,@jury_point," +
+                    "@hostile_faction_kills,@pvp_honor," +
                     "@delete_request_time,@transfer_request_time,@delete_time,@auto_use_aapoint,@prev_point,@point,@gift," +
                     "@num_inv_slot,@num_bank_slot,@expanded_expert,@slots,@created_at,@updated_at,@return_district,@online_time)";
 

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -2172,6 +2172,8 @@ public partial class Character : Unit, ICharacter
                     character.JuryPoint = reader.GetInt32("jury_point");
                     character.HostileFactionKills = reader.GetUInt32("hostile_faction_kills");
                     character.HonorGainedInCombat = reader.GetUInt32("pvp_honor");
+                    character.DiedInPvp = reader.GetBoolean("died_in_pvp");
+                    character.DiedInPvpWarZone = reader.GetBoolean("died_in_pvp_war_zone");
                     character.TransferRequestTime = reader.GetDateTime("transfer_request_time");
                     character.DeleteRequestTime = reader.GetDateTime("delete_request_time");
                     character.DeleteTime = reader.GetDateTime("delete_time");
@@ -2289,6 +2291,8 @@ public partial class Character : Unit, ICharacter
                     character.JuryPoint = reader.GetInt16("jury_point");
                     character.HostileFactionKills = reader.GetUInt32("hostile_faction_kills");
                     character.HonorGainedInCombat = reader.GetUInt32("pvp_honor");
+                    character.DiedInPvp = reader.GetBoolean("died_in_pvp");
+                    character.DiedInPvpWarZone = reader.GetBoolean("died_in_pvp_war_zone");
                     character.TransferRequestTime = reader.GetDateTime("transfer_request_time");
                     character.DeleteRequestTime = reader.GetDateTime("delete_request_time");
                     character.DeleteTime = reader.GetDateTime("delete_time");
@@ -2527,7 +2531,7 @@ public partial class Character : Unit, ICharacter
                     "`world_id`,`zone_id`,`x`,`y`,`z`,`roll`,`pitch`,`yaw`," +
                     "`faction_id`,`faction_name`,`expedition_id`,`family`,`dead_count`,`dead_time`,`rez_wait_duration`,`rez_time`,`rez_penalty_duration`,`leave_time`," +
                     "`money`,`money2`,`honor_point`,`vocation_point`,`crime_point`,`crime_record`,`jury_point`," +
-                    "`hostile_faction_kills`,`pvp_honor`," +
+                    "`hostile_faction_kills`,`pvp_honor`,`died_in_pvp`,`died_in_pvp_war_zone`," +
                     "`delete_request_time`,`transfer_request_time`,`delete_time`,`auto_use_aapoint`,`prev_point`,`point`,`gift`," +
                     "`num_inv_slot`,`num_bank_slot`,`expanded_expert`,`slots`,`created_at`,`updated_at`,`return_district`,`online_time`" +
                     ") VALUES (" +
@@ -2536,7 +2540,7 @@ public partial class Character : Unit, ICharacter
                     "@world_id,@zone_id,@x,@y,@z,@yaw,@pitch,@roll," +
                     "@faction_id,@faction_name,@expedition_id,@family,@dead_count,@dead_time,@rez_wait_duration,@rez_time,@rez_penalty_duration,@leave_time," +
                     "@money,@money2,@honor_point,@vocation_point,@crime_point,@crime_record,@jury_point," +
-                    "@hostile_faction_kills,@pvp_honor," +
+                    "@hostile_faction_kills,@pvp_honor,@died_in_pvp,@died_in_pvp_war_zone," +
                     "@delete_request_time,@transfer_request_time,@delete_time,@auto_use_aapoint,@prev_point,@point,@gift," +
                     "@num_inv_slot,@num_bank_slot,@expanded_expert,@slots,@created_at,@updated_at,@return_district,@online_time)";
 
@@ -2583,6 +2587,8 @@ public partial class Character : Unit, ICharacter
                 command.Parameters.AddWithValue("@jury_point", JuryPoint);
                 command.Parameters.AddWithValue("@hostile_faction_kills", HostileFactionKills);
                 command.Parameters.AddWithValue("@pvp_honor", HonorGainedInCombat);
+                command.Parameters.AddWithValue("@died_in_pvp", DiedInPvp);
+                command.Parameters.AddWithValue("@died_in_pvp_war_zone", DiedInPvpWarZone);
                 command.Parameters.AddWithValue("@delete_request_time", DeleteRequestTime);
                 command.Parameters.AddWithValue("@transfer_request_time", TransferRequestTime);
                 command.Parameters.AddWithValue("@delete_time", DeleteTime);

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -1945,6 +1945,10 @@ public partial class Character : Unit, ICharacter
             value = 0;
         }
 
+        // PvP assist tracking: remember who hit us recently
+        if (attacker is Character enemyChar && value > 0 && enemyChar.Id != this.Id)
+            RecordPvpDamageFrom(enemyChar);
+
         base.ReduceCurrentHp(attacker, value, killReason);
     }
 

--- a/AAEmu.Game/Models/Game/Char/CharacterCombat.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterCombat.cs
@@ -20,10 +20,11 @@ namespace AAEmu.Game.Models.Game.Char;
 
 public partial class Character
 {
-    private static readonly NLog.Logger PvpLogger = NLog.LogManager.GetCurrentClassLogger();
-
     /// <summary>Time window in seconds for PvP assist credit</summary>
     private const int PvpAssistWindowSeconds = 30;
+
+    /// <summary>War-zone death honor penalty (clamped to victim's current honor).</summary>
+    private const int WarZoneHonorLoss = 10;
 
     /// <summary>Escalating death respawn wait times in seconds. Resets after 5 min without dying.</summary>
     private static readonly int[] DeathWaitTimesSeconds = [15, 30, 60, 90, 120, 150, 180, 210, 240];
@@ -36,20 +37,14 @@ public partial class Character
     public uint HostileFactionKills { get; set; }
     public uint HonorGainedInCombat { get; set; }
 
-    /// <summary>Temporary res-caster coords (used by in-place resurrection).</summary>
-    public float ResurrectX { get; set; }
-    public float ResurrectY { get; set; }
-    public float ResurrectZ { get; set; }
-    public float ResurrectYaw { get; set; }
-
-    /// <summary>True if last death was a PvP kill in a War zone (Leech debuff on res).</summary>
+    /// <summary>True if last death was a PvP kill in a War zone (Leech debuff on temple-revive).</summary>
     public bool DiedInPvpWarZone { get; set; }
-    /// <summary>True if last death was a PvP kill (any zone — skip Weakened Body debuff).</summary>
+    /// <summary>True if last death was a PvP kill (any zone — skips Weakened Body debuff on temple-revive).</summary>
     public bool DiedInPvp { get; set; }
 
     /// <summary>Char IDs that recently damaged us. Cleared on death.</summary>
     private readonly ConcurrentDictionary<uint, DateTime> _pvpDamageHistory = new();
-    /// <summary>Char IDs that recently healed us. NOT cleared on death (so heal-assists carry across the healer's next kill too).</summary>
+    /// <summary>Char IDs that recently healed us. NOT cleared on death (so heal-assists carry across the healer's next kill).</summary>
     private readonly ConcurrentDictionary<uint, DateTime> _pvpHealHistory = new();
 
     /// <summary>Record that a player dealt damage to us (for assist tracking).</summary>
@@ -71,44 +66,44 @@ public partial class Character
 
         base.DoDie(killer, killReason);
 
+        // Resolve the victim's zone-conflict state once for both PvP-honor award and War-zone honor-loss
+        var victimZone = ZoneManager.Instance.GetZoneByKey(Transform.ZoneId);
+        var conflictData = victimZone != null
+            ? ZoneManager.Instance.GetConflicts().FirstOrDefault(c => c.ZoneGroupId == victimZone.GroupId)
+            : null;
+        var zoneState = conflictData?.CurrentZoneState ?? ZoneConflictType.Peace;
+
         var relationState = killer.GetRelationStateTo(this);
         if (killer is Character enemy)
         {
             if (relationState != RelationState.Friendly)
             {
                 enemy.HostileFactionKills++;
-                AwardPvpHonor(enemy);
+                AwardPvpHonor(enemy, victimZone, conflictData, zoneState);
 
-                // Mark victim as PvP death (prevents Weakened Body debuff)
+                // Mark victim as PvP death (prevents Weakened Body debuff on temple-revive)
                 DiedInPvp = true;
+                if (zoneState == ZoneConflictType.War)
+                    DiedInPvpWarZone = true;
 
-                // Broadcast PvP stats
-                // kind=0 → HonorGainedInCombat, kind=1 → HostileFactionKills
+                // Broadcast PvP stats: kind=0 → HonorGainedInCombat, kind=1 → HostileFactionKills
                 enemy.BroadcastPacket(new SCUnitPvPPointsChangedPacket(enemy.ObjId, 0, (int)enemy.HonorGainedInCombat), true);
                 enemy.BroadcastPacket(new SCUnitPvPPointsChangedPacket(enemy.ObjId, 1, (int)enemy.HostileFactionKills), true);
 
-                // Victim loses 10 honor in War zone (hardcoded, clamped to >= 0)
-                var victimZone = ZoneManager.Instance.GetZoneByKey(Transform.ZoneId);
-                if (victimZone != null)
+                // Victim loses honor in War zone (clamped >= 0)
+                if (zoneState == ZoneConflictType.War && HonorPoint > 0)
                 {
-                    var conflict = ZoneManager.Instance.GetConflicts()?.FirstOrDefault(c => c.ZoneGroupId == victimZone.GroupId);
-                    if (conflict?.CurrentZoneState == ZoneConflictType.War && HonorPoint > 0)
-                    {
-                        var loss = Math.Min(10, HonorPoint);
-                        ChangeGamePoints(GamePointKind.Honor, -loss);
-                        PvpLogger.Info($"PvP Death: {Name} lost {loss} honor (War zone death)");
-                    }
+                    var loss = Math.Min(WarZoneHonorLoss, HonorPoint);
+                    ChangeGamePoints(GamePointKind.Honor, -loss);
+                    Logger.Debug($"PvP Death: {Name} lost {loss} honor (War zone death)");
                 }
             }
             else
             {
                 // Friendly-fire kill → generate crime evidence (unless retaliation)
                 var killerOwner = killer.GetOwnerCharacter();
-                if (killerOwner != null)
-                {
-                    if (!AssaultedBy.Contains(killerOwner.Id))
-                        _ = CrimeManager.Instance.GenerateEvidenceFromKill(killer, this);
-                }
+                if (killerOwner != null && !AssaultedBy.Contains(killerOwner.Id))
+                    _ = CrimeManager.Instance.GenerateEvidenceFromKill(killer, this);
             }
         }
 
@@ -140,7 +135,7 @@ public partial class Character
         _consecutiveDeathCount++;
         _lastDeathTime = DateTime.UtcNow;
 
-        PvpLogger.Info($"Death #{_consecutiveDeathCount} for {Name}: respawn wait = {waitSeconds}s");
+        Logger.Debug($"Death #{_consecutiveDeathCount} for {Name}: respawn wait = {waitSeconds}s");
     }
 
     /// <summary>
@@ -148,19 +143,9 @@ public partial class Character
     /// Conflict: 10 solo (6 killer + 4 each assist). War: 20 solo (16 killer + 4 each assist).
     /// Also registers the kill in the zone conflict system.
     /// </summary>
-    private void AwardPvpHonor(Character killer)
+    private void AwardPvpHonor(Character killer, Zone victimZone, ZoneConflict conflictData, ZoneConflictType zoneState)
     {
-        var currentZone = ZoneManager.Instance.GetZoneByKey(Transform.ZoneId);
-        if (currentZone == null)
-            return;
-
-        var conflictData = ZoneManager.Instance.GetConflicts()?.FirstOrDefault(c => c.ZoneGroupId == currentZone.GroupId);
-        var zoneState = conflictData?.CurrentZoneState ?? ZoneConflictType.Peace;
-
-        int soloHonor;
-        int killerShareHonor;
-        int assistShareHonor;
-
+        int soloHonor, killerShareHonor, assistShareHonor;
         switch (zoneState)
         {
             case ZoneConflictType.Conflict:
@@ -172,7 +157,6 @@ public partial class Character
                 soloHonor = 20;
                 killerShareHonor = 16;
                 assistShareHonor = 4;
-                DiedInPvpWarZone = true;
                 break;
             default:
                 // No honor outside Conflict/War zones
@@ -192,7 +176,7 @@ public partial class Character
             {
                 killer.ChangeGamePoints(GamePointKind.Honor, killerHonor);
                 killer.HonorGainedInCombat += (uint)killerHonor;
-                PvpLogger.Info($"PvP Kill: {killer.Name} killed {Name} in {zoneState} zone — {killerHonor} honor (killer share)");
+                Logger.Debug($"PvP Kill: {killer.Name} killed {Name} in {zoneState} zone — {killerHonor} honor (killer share)");
             }
 
             var assistHonor = (int)Math.Round(assistShareHonor * pvpRate);
@@ -201,13 +185,13 @@ public partial class Character
                 foreach (var assistId in assists)
                 {
                     var assistant = WorldManager.Instance.GetCharacterById(assistId);
-                    if (assistant is { IsOnline: true })
-                    {
-                        assistant.ChangeGamePoints(GamePointKind.Honor, assistHonor);
-                        assistant.HonorGainedInCombat += (uint)assistHonor;
-                        PvpLogger.Info($"PvP Assist: {assistant.Name} assisted {killer.Name} killing {Name} — {assistHonor} honor");
-                        assistant.BroadcastPacket(new SCUnitPvPPointsChangedPacket(assistant.ObjId, 0, (int)assistant.HonorGainedInCombat), true);
-                    }
+                    if (assistant is not { IsOnline: true })
+                        continue;
+
+                    assistant.ChangeGamePoints(GamePointKind.Honor, assistHonor);
+                    assistant.HonorGainedInCombat += (uint)assistHonor;
+                    Logger.Debug($"PvP Assist: {assistant.Name} assisted {killer.Name} killing {Name} — {assistHonor} honor");
+                    assistant.BroadcastPacket(new SCUnitPvPPointsChangedPacket(assistant.ObjId, 0, (int)assistant.HonorGainedInCombat), true);
                 }
             }
         }
@@ -218,11 +202,12 @@ public partial class Character
             {
                 killer.ChangeGamePoints(GamePointKind.Honor, honor);
                 killer.HonorGainedInCombat += (uint)honor;
-                PvpLogger.Info($"PvP Solo Kill: {killer.Name} killed {Name} in {zoneState} zone — {honor} honor");
+                Logger.Debug($"PvP Solo Kill: {killer.Name} killed {Name} in {zoneState} zone — {honor} honor");
             }
         }
 
-        killer.SendPacket(new SCConflictZoneHonorPointSumPacket((ushort)currentZone.ZoneKey, (int)killer.HonorGainedInCombat));
+        if (victimZone != null)
+            killer.SendPacket(new SCConflictZoneHonorPointSumPacket((ushort)victimZone.ZoneKey, (int)killer.HonorGainedInCombat));
     }
 
     /// <summary>
@@ -248,19 +233,19 @@ public partial class Character
         }
 
         // 3) Active CC-debuff casters on the victim
-        var badBuffs = new List<Buff>();
         var goodBuffs = new List<Buff>();
+        var badBuffs = new List<Buff>();
         var hiddenBuffs = new List<Buff>();
         Buffs.GetAllBuffs(goodBuffs, badBuffs, hiddenBuffs, false);
 
         foreach (var buff in badBuffs)
         {
-            if (buff.Caster is Character ccCaster && ccCaster.Id != killer.Id)
-            {
-                var template = buff.Template;
-                if (template.Stun || template.Root || template.Sleep || template.Silence || template.Cripled)
-                    assists.Add(ccCaster.Id);
-            }
+            if (buff.Caster is not Character ccCaster || ccCaster.Id == killer.Id)
+                continue;
+
+            var template = buff.Template;
+            if (template.Stun || template.Root || template.Sleep || template.Silence || template.Cripled)
+                assists.Add(ccCaster.Id);
         }
 
         return assists;

--- a/AAEmu.Game/Models/Game/Char/CharacterCombat.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterCombat.cs
@@ -217,7 +217,13 @@ public partial class Character
         }
 
         if (victimZone != null)
-            killer.SendPacket(new SCConflictZoneHonorPointSumPacket((ushort)victimZone.ZoneKey, (int)killer.HonorGainedInCombat));
+        {
+            // The conflict-zone honor UI keys on ZoneGroupId (same identifier the
+            // sister SCConflictZoneStatePacket carries), not on the per-cell ZoneKey.
+            // Sending ZoneKey here makes the client unable to match the packet to
+            // any conflict zone, so the displayed honor never updates after a kill.
+            killer.SendPacket(new SCConflictZoneHonorPointSumPacket((ushort)victimZone.GroupId, (int)killer.HonorGainedInCombat));
+        }
     }
 
     /// <summary>

--- a/AAEmu.Game/Models/Game/Char/CharacterCombat.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterCombat.cs
@@ -1,4 +1,6 @@
-﻿using AAEmu.Game.Core.Managers;
+using System.Collections.Concurrent;
+
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.UnitManagers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Packets.G2C;
@@ -11,19 +13,62 @@ using AAEmu.Game.Models.Game.Skills.Effects;
 using AAEmu.Game.Models.Game.Team;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.Units.Static;
+using AAEmu.Game.Models.Game.World.Zones;
 using AAEmu.Game.Models.StaticValues;
 
 namespace AAEmu.Game.Models.Game.Char;
 
 public partial class Character
 {
+    private static readonly NLog.Logger PvpLogger = NLog.LogManager.GetCurrentClassLogger();
+
+    /// <summary>Time window in seconds for PvP assist credit</summary>
+    private const int PvpAssistWindowSeconds = 30;
+
+    /// <summary>Escalating death respawn wait times in seconds. Resets after 5 min without dying.</summary>
+    private static readonly int[] DeathWaitTimesSeconds = [15, 30, 60, 90, 120, 150, 180, 210, 240];
+    private const int DeathCountResetMinutes = 5;
+    private int _consecutiveDeathCount;
+    private DateTime _lastDeathTime = DateTime.MinValue;
+
     public uint ResurrectHpPercent { get; set; } = 1;
     public uint ResurrectMpPercent { get; set; } = 1;
     public uint HostileFactionKills { get; set; }
     public uint HonorGainedInCombat { get; set; }
 
+    /// <summary>Temporary res-caster coords (used by in-place resurrection).</summary>
+    public float ResurrectX { get; set; }
+    public float ResurrectY { get; set; }
+    public float ResurrectZ { get; set; }
+    public float ResurrectYaw { get; set; }
+
+    /// <summary>True if last death was a PvP kill in a War zone (Leech debuff on res).</summary>
+    public bool DiedInPvpWarZone { get; set; }
+    /// <summary>True if last death was a PvP kill (any zone — skip Weakened Body debuff).</summary>
+    public bool DiedInPvp { get; set; }
+
+    /// <summary>Char IDs that recently damaged us. Cleared on death.</summary>
+    private readonly ConcurrentDictionary<uint, DateTime> _pvpDamageHistory = new();
+    /// <summary>Char IDs that recently healed us. NOT cleared on death (so heal-assists carry across the healer's next kill too).</summary>
+    private readonly ConcurrentDictionary<uint, DateTime> _pvpHealHistory = new();
+
+    /// <summary>Record that a player dealt damage to us (for assist tracking).</summary>
+    public void RecordPvpDamageFrom(Character attacker)
+    {
+        _pvpDamageHistory[attacker.Id] = DateTime.UtcNow;
+    }
+
+    /// <summary>Record that a player healed us (for assist tracking on our kills).</summary>
+    public void RecordPvpHealFrom(Character healer)
+    {
+        _pvpHealHistory[healer.Id] = DateTime.UtcNow;
+    }
+
     public override void DoDie(BaseUnit killer, KillReason killReason)
     {
+        // Escalating respawn timer — runs BEFORE base.DoDie sends SCUnitDeathPacket
+        ComputeDeathWaitTime();
+
         base.DoDie(killer, killReason);
 
         var relationState = killer.GetRelationStateTo(this);
@@ -32,10 +77,32 @@ public partial class Character
             if (relationState != RelationState.Friendly)
             {
                 enemy.HostileFactionKills++;
+                AwardPvpHonor(enemy);
+
+                // Mark victim as PvP death (prevents Weakened Body debuff)
+                DiedInPvp = true;
+
+                // Broadcast PvP stats
+                // kind=0 → HonorGainedInCombat, kind=1 → HostileFactionKills
+                enemy.BroadcastPacket(new SCUnitPvPPointsChangedPacket(enemy.ObjId, 0, (int)enemy.HonorGainedInCombat), true);
+                enemy.BroadcastPacket(new SCUnitPvPPointsChangedPacket(enemy.ObjId, 1, (int)enemy.HostileFactionKills), true);
+
+                // Victim loses 10 honor in War zone (hardcoded, clamped to >= 0)
+                var victimZone = ZoneManager.Instance.GetZoneByKey(Transform.ZoneId);
+                if (victimZone != null)
+                {
+                    var conflict = ZoneManager.Instance.GetConflicts()?.FirstOrDefault(c => c.ZoneGroupId == victimZone.GroupId);
+                    if (conflict?.CurrentZoneState == ZoneConflictType.War && HonorPoint > 0)
+                    {
+                        var loss = Math.Min(10, HonorPoint);
+                        ChangeGamePoints(GamePointKind.Honor, -loss);
+                        PvpLogger.Info($"PvP Death: {Name} lost {loss} honor (War zone death)");
+                    }
+                }
             }
             else
             {
-                // Generate evidence if needed
+                // Friendly-fire kill → generate crime evidence (unless retaliation)
                 var killerOwner = killer.GetOwnerCharacter();
                 if (killerOwner != null)
                 {
@@ -47,6 +114,156 @@ public partial class Character
 
         DropTradePackToFloor();
         ClearAllAggro();
+
+        // Clear damage history on death (heal history is intentionally kept)
+        _pvpDamageHistory.Clear();
+    }
+
+    /// <summary>
+    /// Computes the escalating death wait time and stores it in RezWaitDuration.
+    /// After 5 minutes without dying, the counter resets.
+    /// </summary>
+    private void ComputeDeathWaitTime()
+    {
+        if (_lastDeathTime != DateTime.MinValue &&
+            (DateTime.UtcNow - _lastDeathTime).TotalMinutes >= DeathCountResetMinutes)
+        {
+            _consecutiveDeathCount = 0;
+        }
+
+        var index = Math.Min(_consecutiveDeathCount, DeathWaitTimesSeconds.Length - 1);
+        var waitSeconds = DeathWaitTimesSeconds[index];
+
+        RezWaitDuration = waitSeconds * 1000;
+        DeadTime = DateTime.UtcNow;
+
+        _consecutiveDeathCount++;
+        _lastDeathTime = DateTime.UtcNow;
+
+        PvpLogger.Info($"Death #{_consecutiveDeathCount} for {Name}: respawn wait = {waitSeconds}s");
+    }
+
+    /// <summary>
+    /// Awards PvP honor to the killer (and assists) based on zone conflict state.
+    /// Conflict: 10 solo (6 killer + 4 each assist). War: 20 solo (16 killer + 4 each assist).
+    /// Also registers the kill in the zone conflict system.
+    /// </summary>
+    private void AwardPvpHonor(Character killer)
+    {
+        var currentZone = ZoneManager.Instance.GetZoneByKey(Transform.ZoneId);
+        if (currentZone == null)
+            return;
+
+        var conflictData = ZoneManager.Instance.GetConflicts()?.FirstOrDefault(c => c.ZoneGroupId == currentZone.GroupId);
+        var zoneState = conflictData?.CurrentZoneState ?? ZoneConflictType.Peace;
+
+        int soloHonor;
+        int killerShareHonor;
+        int assistShareHonor;
+
+        switch (zoneState)
+        {
+            case ZoneConflictType.Conflict:
+                soloHonor = 10;
+                killerShareHonor = 6;
+                assistShareHonor = 4;
+                break;
+            case ZoneConflictType.War:
+                soloHonor = 20;
+                killerShareHonor = 16;
+                assistShareHonor = 4;
+                DiedInPvpWarZone = true;
+                break;
+            default:
+                // No honor outside Conflict/War zones
+                return;
+        }
+
+        // Register zone kill (drives zone state escalation)
+        conflictData?.AddZoneKill();
+
+        var pvpRate = AppConfiguration.Instance.World.PvpHonorRate;
+        var assists = CollectAssists(killer);
+
+        if (assists.Count > 0)
+        {
+            var killerHonor = (int)Math.Round(killerShareHonor * pvpRate);
+            if (killerHonor > 0)
+            {
+                killer.ChangeGamePoints(GamePointKind.Honor, killerHonor);
+                killer.HonorGainedInCombat += (uint)killerHonor;
+                PvpLogger.Info($"PvP Kill: {killer.Name} killed {Name} in {zoneState} zone — {killerHonor} honor (killer share)");
+            }
+
+            var assistHonor = (int)Math.Round(assistShareHonor * pvpRate);
+            if (assistHonor > 0)
+            {
+                foreach (var assistId in assists)
+                {
+                    var assistant = WorldManager.Instance.GetCharacterById(assistId);
+                    if (assistant is { IsOnline: true })
+                    {
+                        assistant.ChangeGamePoints(GamePointKind.Honor, assistHonor);
+                        assistant.HonorGainedInCombat += (uint)assistHonor;
+                        PvpLogger.Info($"PvP Assist: {assistant.Name} assisted {killer.Name} killing {Name} — {assistHonor} honor");
+                        assistant.BroadcastPacket(new SCUnitPvPPointsChangedPacket(assistant.ObjId, 0, (int)assistant.HonorGainedInCombat), true);
+                    }
+                }
+            }
+        }
+        else
+        {
+            var honor = (int)Math.Round(soloHonor * pvpRate);
+            if (honor > 0)
+            {
+                killer.ChangeGamePoints(GamePointKind.Honor, honor);
+                killer.HonorGainedInCombat += (uint)honor;
+                PvpLogger.Info($"PvP Solo Kill: {killer.Name} killed {Name} in {zoneState} zone — {honor} honor");
+            }
+        }
+
+        killer.SendPacket(new SCConflictZoneHonorPointSumPacket((ushort)currentZone.ZoneKey, (int)killer.HonorGainedInCombat));
+    }
+
+    /// <summary>
+    /// Collect assist contributors: recent damage on victim + recent heals on killer + active CC casters on victim.
+    /// </summary>
+    public HashSet<uint> CollectAssists(Character killer)
+    {
+        var assists = new HashSet<uint>();
+        var cutoff = DateTime.UtcNow.AddSeconds(-PvpAssistWindowSeconds);
+
+        // 1) Players who damaged the victim recently (excluding the killer)
+        foreach (var (charId, time) in _pvpDamageHistory)
+        {
+            if (charId != killer.Id && time >= cutoff)
+                assists.Add(charId);
+        }
+
+        // 2) Players who healed the killer recently (excluding the killer themselves)
+        foreach (var (charId, time) in killer._pvpHealHistory)
+        {
+            if (charId != killer.Id && time >= cutoff)
+                assists.Add(charId);
+        }
+
+        // 3) Active CC-debuff casters on the victim
+        var badBuffs = new List<Buff>();
+        var goodBuffs = new List<Buff>();
+        var hiddenBuffs = new List<Buff>();
+        Buffs.GetAllBuffs(goodBuffs, badBuffs, hiddenBuffs, false);
+
+        foreach (var buff in badBuffs)
+        {
+            if (buff.Caster is Character ccCaster && ccCaster.Id != killer.Id)
+            {
+                var template = buff.Template;
+                if (template.Stun || template.Root || template.Sleep || template.Silence || template.Cripled)
+                    assists.Add(ccCaster.Id);
+            }
+        }
+
+        return assists;
     }
 
     /// <summary>
@@ -84,7 +301,7 @@ public partial class Character
 
                 doodad.IsPersistent = true;
                 doodad.Transform = Transform.CloneDetached(doodad);
-                doodad.Transform.Local.SetHeight(doodad.ParentWorld.Template.GeoData.GetHeight(doodad.Transform.World.Position)); //WorldManager.Instance.GetHeight(doodad.Transform)));
+                doodad.Transform.Local.SetHeight(doodad.ParentWorld.Template.GeoData.GetHeight(doodad.Transform.World.Position));
                 doodad.AttachPoint = AttachPointKind.None;
                 doodad.ItemId = item.Id;
                 doodad.ItemTemplateId = item.Template.Id;

--- a/AAEmu.Game/Models/Game/Char/CharacterCombat.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterCombat.cs
@@ -167,9 +167,23 @@ public partial class Character
         conflictData?.AddZoneKill();
 
         var pvpRate = AppConfiguration.Instance.World.PvpHonorRate;
-        var assists = CollectAssists(killer);
+        var assistIds = CollectAssists(killer);
 
-        if (assists.Count > 0)
+        // Resolve to online assistants *before* choosing the kill path. The recorded
+        // assist IDs are from the rolling damage/heal/CC window and may all be offline
+        // by the time the victim dies. If none of them are reachable, fall back to
+        // the solo award — otherwise the killer would only get killerShareHonor and
+        // the unawarded assist share would be silently discarded (e.g. War solo with
+        // one offline assist: 20 solo − 16 killer-share = 14 honor lost).
+        var onlineAssists = new List<Character>(assistIds.Count);
+        foreach (var assistId in assistIds)
+        {
+            var assistant = WorldManager.Instance.GetCharacterById(assistId);
+            if (assistant is { IsOnline: true })
+                onlineAssists.Add(assistant);
+        }
+
+        if (onlineAssists.Count > 0)
         {
             var killerHonor = (int)Math.Round(killerShareHonor * pvpRate);
             if (killerHonor > 0)
@@ -182,12 +196,8 @@ public partial class Character
             var assistHonor = (int)Math.Round(assistShareHonor * pvpRate);
             if (assistHonor > 0)
             {
-                foreach (var assistId in assists)
+                foreach (var assistant in onlineAssists)
                 {
-                    var assistant = WorldManager.Instance.GetCharacterById(assistId);
-                    if (assistant is not { IsOnline: true })
-                        continue;
-
                     assistant.ChangeGamePoints(GamePointKind.Honor, assistHonor);
                     assistant.HonorGainedInCombat += (uint)assistHonor;
                     Logger.Debug($"PvP Assist: {assistant.Name} assisted {killer.Name} killing {Name} — {assistHonor} honor");

--- a/AAEmu.Game/Models/Game/Configurations.cs
+++ b/AAEmu.Game/Models/Game/Configurations.cs
@@ -45,6 +45,11 @@ public class WorldConfig
     public double HonorRate { get; set; } = 1.0;
 
     /// <summary>
+    /// Separate multiplier for PvP Honor Points (kills in Conflict/War zones). Independent of HonorRate.
+    /// </summary>
+    public double PvpHonorRate { get; set; } = 1.0;
+
+    /// <summary>
     /// Server-side Vocation Badge multiplier (on top of buffs)
     /// </summary>
     public double VocationRate { get; set; } = 1.0;

--- a/AAEmu.Game/Models/Game/Items/Holdable.cs
+++ b/AAEmu.Game/Models/Game/Items/Holdable.cs
@@ -25,4 +25,36 @@ public class Holdable
     public int RenewCategory { get; set; }
     public int ItemProcId { get; set; }
     public int StatMultiplier { get; set; }
+
+    // Attack animation IDs per weapon — right hand (R) and left hand (L)
+    public uint AnimR1Id { get; set; }
+    public uint AnimL1Id { get; set; }
+    public uint AnimR2Id { get; set; }
+    public uint AnimL2Id { get; set; }
+    public uint AnimR3Id { get; set; }
+    public uint AnimL3Id { get; set; }
+
+    /// <summary>
+    /// Get the next attack animation ID for this weapon, cycling through available anims.
+    /// </summary>
+    public uint GetAttackAnimId(int attackIndex, bool leftHand = false)
+    {
+        uint[] anims;
+        if (leftHand)
+            anims = [AnimL1Id, AnimL2Id, AnimL3Id];
+        else
+            anims = [AnimR1Id, AnimR2Id, AnimR3Id];
+
+        var validAnims = new List<uint>();
+        foreach (var a in anims)
+        {
+            if (a > 0)
+                validAnims.Add(a);
+        }
+
+        if (validAnims.Count == 0)
+            return leftHand ? AnimR1Id : 2u; // Fallback: right-hand or fist
+
+        return validAnims[attackIndex % validAnims.Count];
+    }
 }

--- a/AAEmu.Game/Models/Game/Items/Holdable.cs
+++ b/AAEmu.Game/Models/Game/Items/Holdable.cs
@@ -4,6 +4,9 @@ namespace AAEmu.Game.Models.Game.Items;
 
 public class Holdable
 {
+    /// <summary>Fallback animation ID when the weapon has no configured anims — generic fist swing.</summary>
+    private const uint DefaultFistAnimId = 2;
+
     public uint Id { get; set; }
     public uint KindId { get; set; }
     public int Speed { get; set; }
@@ -35,26 +38,24 @@ public class Holdable
     public uint AnimL3Id { get; set; }
 
     /// <summary>
-    /// Get the next attack animation ID for this weapon, cycling through available anims.
+    /// Get the next attack animation ID for this weapon, cycling through the up-to-3
+    /// configured anims. Skips slots with id 0. Falls back to right-hand or fist when none set.
     /// </summary>
     public uint GetAttackAnimId(int attackIndex, bool leftHand = false)
     {
-        uint[] anims;
-        if (leftHand)
-            anims = [AnimL1Id, AnimL2Id, AnimL3Id];
-        else
-            anims = [AnimR1Id, AnimR2Id, AnimR3Id];
+        var a1 = leftHand ? AnimL1Id : AnimR1Id;
+        var a2 = leftHand ? AnimL2Id : AnimR2Id;
+        var a3 = leftHand ? AnimL3Id : AnimR3Id;
 
-        var validAnims = new List<uint>();
-        foreach (var a in anims)
-        {
-            if (a > 0)
-                validAnims.Add(a);
-        }
+        Span<uint> valid = stackalloc uint[3];
+        var count = 0;
+        if (a1 > 0) valid[count++] = a1;
+        if (a2 > 0) valid[count++] = a2;
+        if (a3 > 0) valid[count++] = a3;
 
-        if (validAnims.Count == 0)
-            return leftHand ? AnimR1Id : 2u; // Fallback: right-hand or fist
+        if (count == 0)
+            return leftHand ? AnimR1Id : DefaultFistAnimId;
 
-        return validAnims[attackIndex % validAnims.Count];
+        return valid[Math.Abs(attackIndex) % count];
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/BuffConstants.cs
+++ b/AAEmu.Game/Models/Game/Skills/BuffConstants.cs
@@ -9,6 +9,9 @@ public enum BuffConstants : uint
     EquipmentBuffTag = 156,
     Untouchable = 545,
     NpcReturn = 550, // NPC returning home
+    WeakenedBody = 1128, // PvE death penalty
+    RespawnCooldown = 2385, // 5 min cooldown after temple-revive
+    WarZoneLeech = 4424, // PvP death penalty in War zones
     Cloth4P = 713,
     Cloth7P = 714,
     Leather4P = 715,

--- a/AAEmu.Game/Models/Game/Skills/Effects/HealEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/HealEffect.cs
@@ -146,6 +146,14 @@ public class HealEffect : EffectTemplate
         trg.Hp = Math.Min(trg.Hp, trg.MaxHp);
         trg.BroadcastPacket(new SCUnitPointsPacket(trg.ObjId, trg.Hp, trg.Mp), true);
 
+        // PvP assist tracking: a healer on the target's side earns assist credit
+        // for the target's next PvP kill (within 30s window).
+        if (caster is Character healerChar && trg is Character targetChar &&
+            healerChar.Id != targetChar.Id && targetChar.IsInBattle)
+        {
+            targetChar.RecordPvpHealFrom(healerChar);
+        }
+
         trg.Events.OnHealed(this, new OnHealedArgs { Healer = (Unit)caster, HealAmount = value });
         trg.PostUpdateCurrentHp(trg, oldHp, trg.Hp, KillReason.Unknown);
     }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/AutoAttack.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/AutoAttack.cs
@@ -1,4 +1,5 @@
-﻿using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects.SpecialEffects;
@@ -18,7 +19,20 @@ public class AutoAttack : SpecialEffectAction
         int value3,
         int value4)
     {
-        // TODO start auto attack...
-        if (caster is Character) { Logger.Debug("Special effects: AutoAttack value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4); }
+        if (caster is not Character character)
+            return;
+
+        if (character.IsAutoAttack)
+            return;
+
+        // value1 = skillId to auto-attack with (2=melee, 3=offhand, 4=ranged), 0 = melee default
+        var attackSkillId = (uint)(value1 > 0 ? value1 : 2);
+        var attackTemplate = SkillManager.Instance.GetSkillTemplate(attackSkillId);
+        if (attackTemplate == null)
+            return;
+
+        var attackSkill = new Skill(attackTemplate);
+        character.IsAutoAttack = true;
+        character.StartAutoSkill(attackSkill);
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -843,7 +843,7 @@ public class Skill
             ComputedDelay = (short)totalDelay
         };
         if (weaponAnimId > 0)
-            firedPacket.FireAnimId = (int)weaponAnimId;
+            firedPacket.FireAnimId = weaponAnimId;
         caster.BroadcastPacket(firedPacket, true);
 
         if (totalDelay > 0)
@@ -881,7 +881,7 @@ public class Skill
         if (caster is not Character character)
             return 0;
 
-        EquipmentItemSlot slot = Template.Id switch
+        var slot = Template.Id switch
         {
             3 => EquipmentItemSlot.Offhand,
             4 => EquipmentItemSlot.Ranged,
@@ -891,7 +891,7 @@ public class Skill
         var weapon = character.Equipment?.GetItemBySlot((int)slot);
         if (weapon?.Template is WeaponTemplate wt && wt.HoldableTemplate != null)
         {
-            bool leftHand = Template.Id == 3; // Offhand = left hand
+            var leftHand = Template.Id == 3; // Offhand = left hand
             var animId = wt.HoldableTemplate.GetAttackAnimId(AutoAttackIndex, leftHand);
             AutoAttackIndex++;
             return animId;

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -55,8 +55,8 @@ public class Skill
     /// </summary>
     public float CastTimeMultiplier { get; set; } = 1f;
 
-    //public bool isAutoAttack;
-    //public SkillTask autoAttackTask;
+    /// <summary>Counter for auto-attack animation cycling (incremented each attack)</summary>
+    public int AutoAttackIndex { get; set; }
 
     public Skill()
     {
@@ -835,9 +835,13 @@ public class Skill
         if (Template.FireAnim != null && Template.UseAnimTime)
             totalDelay += (int)(Template.FireAnim.CombatSyncTime * (unit.GlobalCooldownMul / 100));
 
+        // Determine weapon-based animation for auto-attacks (skill 2/3/4)
+        var weaponAnimId = GetWeaponAttackAnimId(caster);
+
         caster.BroadcastPacket(new SCSkillFiredPacket(Id, TlId, casterCaster, targetCaster, this, skillObject)
         {
-            ComputedDelay = (short)totalDelay
+            ComputedDelay = (short)totalDelay,
+            OverrideFireAnimId = weaponAnimId
         }, true);
 
         if (totalDelay > 0)
@@ -850,6 +854,40 @@ public class Skill
             ApplyEffects(caster, casterCaster, target, targetCaster, skillObject);
             EndSkill(caster);
         }
+    }
+
+    /// <summary>
+    /// Get the weapon-based attack animation ID for auto-attack skills (2/3/4).
+    /// Returns 0 for non-auto-attack skills (packet will use FireAnim from template).
+    /// </summary>
+    private uint GetWeaponAttackAnimId(BaseUnit caster)
+    {
+        if (Template.Id is not (2 or 3 or 4))
+            return 0;
+
+        if (caster is not Character character)
+            return 0;
+
+        EquipmentItemSlot slot = Template.Id switch
+        {
+            3 => EquipmentItemSlot.Offhand,
+            4 => EquipmentItemSlot.Ranged,
+            _ => EquipmentItemSlot.Mainhand
+        };
+
+        var weapon = character.Equipment?.GetItemBySlot((int)slot);
+        if (weapon?.Template is WeaponTemplate wt && wt.HoldableTemplate != null)
+        {
+            bool leftHand = Template.Id == 3; // Offhand = left hand
+            var animId = wt.HoldableTemplate.GetAttackAnimId(AutoAttackIndex, leftHand);
+            AutoAttackIndex++;
+            return animId;
+        }
+
+        // No weapon equipped — fist animations (cycle between 1 and 2)
+        var fistAnim = (AutoAttackIndex % 2 == 0) ? 1u : 2u;
+        AutoAttackIndex++;
+        return fistAnim;
     }
 
     private IEnumerable<BaseUnit> FilterAoeUnits(BaseUnit caster, IEnumerable<BaseUnit> units)

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -835,14 +835,16 @@ public class Skill
         if (Template.FireAnim != null && Template.UseAnimTime)
             totalDelay += (int)(Template.FireAnim.CombatSyncTime * (unit.GlobalCooldownMul / 100));
 
-        // Determine weapon-based animation for auto-attacks (skill 2/3/4)
+        // Determine weapon-based animation for auto-attacks (skill 2/3/4).
+        // 0 means "no override" — packet keeps its default (skill template's FireAnim).
         var weaponAnimId = GetWeaponAttackAnimId(caster);
-
-        caster.BroadcastPacket(new SCSkillFiredPacket(Id, TlId, casterCaster, targetCaster, this, skillObject)
+        var firedPacket = new SCSkillFiredPacket(Id, TlId, casterCaster, targetCaster, this, skillObject)
         {
-            ComputedDelay = (short)totalDelay,
-            OverrideFireAnimId = weaponAnimId
-        }, true);
+            ComputedDelay = (short)totalDelay
+        };
+        if (weaponAnimId > 0)
+            firedPacket.FireAnimId = (int)weaponAnimId;
+        caster.BroadcastPacket(firedPacket, true);
 
         if (totalDelay > 0)
         {
@@ -859,11 +861,22 @@ public class Skill
     /// <summary>
     /// Get the weapon-based attack animation ID for auto-attack skills (2/3/4).
     /// Returns 0 for non-auto-attack skills (packet will use FireAnim from template).
+    /// NPCs cycle between melee animation IDs 1 and 2 so AI mobs always have a visible swing.
     /// </summary>
     private uint GetWeaponAttackAnimId(BaseUnit caster)
     {
         if (Template.Id is not (2 or 3 or 4))
             return 0;
+
+        if (caster is NPChar.Npc)
+        {
+            // NPCs cycle between two melee attack animations (side strikes).
+            // Without this, NPC auto-attacks would inherit the skill template's
+            // FireAnim — often null or wrong, causing the "AI feels broken" symptom.
+            var npcAnim = (uint)((AutoAttackIndex % 2) + 1); // animation IDs 1 and 2
+            AutoAttackIndex++;
+            return npcAnim;
+        }
 
         if (caster is not Character character)
             return 0;

--- a/AAEmu.Game/Models/Game/World/Zones/ZoneConflict.cs
+++ b/AAEmu.Game/Models/Game/World/Zones/ZoneConflict.cs
@@ -1,14 +1,19 @@
-﻿using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Tasks.Zones;
 
-namespace AAEmu.Game.Models.Game.World.Zones;
+using NLog;
 
+#pragma warning disable IDE0005
 #pragma warning disable IDE0052 // Remove unread private members
+
+namespace AAEmu.Game.Models.Game.World.Zones;
 
 public class ZoneConflict(ZoneGroup owner)
 {
+    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
+
     private ZoneGroup _owner = owner;
     public ushort ZoneGroupId { get; set; }
     public int[] NumKills { get; } = new int[5];
@@ -22,7 +27,6 @@ public class ZoneConflict(ZoneGroup owner)
     public uint NuiaReturnPointId { get; set; }
     public uint HariharaReturnPointId { get; set; }
     public uint WarTowerDefId { get; set; }
-    // TODO 1.2 // public uint PeaceTowerDefId { get; set; }
     public bool Closed { get; set; } = false;
 
     public ZoneConflictType CurrentZoneState { get; protected set; } = ZoneConflictType.Tension;
@@ -32,7 +36,6 @@ public class ZoneConflict(ZoneGroup owner)
     /// <summary>
     /// Call this function if a PvP kill happens in a zone
     /// </summary>
-    /// <param name="NumberOfKills"></param>
     public void AddZoneKill(uint NumberOfKills = 1)
     {
         // Ignore when in conflict, war or peace
@@ -83,28 +86,52 @@ public class ZoneConflict(ZoneGroup owner)
         if (NextStateTime > DateTime.MinValue)
         {
             var lpConflictStartTask = new ZoneStateChangeTask(this);
-            TaskManager.Instance.Schedule(lpConflictStartTask, this.NextStateTime - DateTime.UtcNow);
+            var delay = NextStateTime - DateTime.UtcNow;
+            Logger.Info($"SetTimerTask: ZoneGroup {ZoneGroupId} scheduling next state check in {delay.TotalMinutes:F1} min (NextStateTime={NextStateTime:HH:mm:ss})");
+            TaskManager.Instance.Schedule(lpConflictStartTask, delay);
+        }
+        else
+        {
+            Logger.Warn($"SetTimerTask: ZoneGroup {ZoneGroupId} has no NextStateTime set — timer chain stopped.");
         }
     }
 
     public void SendSwitchZoneState()
     {
-        //broadcast to all online clients in server
-        WorldManager.Instance.BroadcastPacketToServer(new SCConflictZoneStatePacket(ZoneGroupId, CurrentZoneState, NextStateTime));
-
+        // Schedule the next timer FIRST, before broadcasting to clients.
+        // This guarantees the timer chain is preserved even if BroadcastPacketToServer
+        // throws (e.g. transient connection issue, packet encode error).
         SetTimerTask();
+
+        try
+        {
+            WorldManager.Instance.BroadcastPacketToServer(new SCConflictZoneStatePacket(ZoneGroupId, CurrentZoneState, NextStateTime));
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, $"SendSwitchZoneState: Failed to broadcast zone state for ZoneGroup {ZoneGroupId}, State={CurrentZoneState}");
+        }
     }
 
     public void CheckTimer()
     {
         if (NextStateTime > DateTime.MinValue && DateTime.UtcNow >= NextStateTime)
+        {
+            Logger.Info($"CheckTimer: ZoneGroup {ZoneGroupId} timer elapsed, current state={CurrentZoneState}, advancing...");
             ForceNextState();
+        }
     }
 
     public void SetState(ZoneConflictType ct)
     {
         if (ct == CurrentZoneState)
+        {
+            Logger.Debug($"SetState: ZoneGroup {ZoneGroupId} already at {ct}, skipping.");
             return;
+        }
+
+        var previousState = CurrentZoneState;
+
         switch (ct)
         {
             case ZoneConflictType.Conflict:
@@ -124,11 +151,13 @@ public class ZoneConflict(ZoneGroup owner)
                 break;
         }
         CurrentZoneState = ct;
+        Logger.Info($"SetState: ZoneGroup {ZoneGroupId} changed from {previousState} → {ct} (NextStateTime={NextStateTime:HH:mm:ss}, ConflictMin={ConflictMin}, WarMin={WarMin}, PeaceMin={PeaceMin})");
         SendSwitchZoneState();
     }
 
     public void ForceNextState()
     {
+        Logger.Info($"ForceNextState: ZoneGroup {ZoneGroupId} current={CurrentZoneState}, PeaceMin={PeaceMin}");
         if (CurrentZoneState < ZoneConflictType.Peace)
         {
             if (CurrentZoneState == ZoneConflictType.War && PeaceMin <= 0)

--- a/AAEmu.Game/Models/Game/World/Zones/ZoneConflict.cs
+++ b/AAEmu.Game/Models/Game/World/Zones/ZoneConflict.cs
@@ -5,15 +5,13 @@ using AAEmu.Game.Models.Tasks.Zones;
 
 using NLog;
 
-#pragma warning disable IDE0005
-#pragma warning disable IDE0052 // Remove unread private members
-
 namespace AAEmu.Game.Models.Game.World.Zones;
 
 public class ZoneConflict(ZoneGroup owner)
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
+    // ReSharper disable once NotAccessedField.Local
     private ZoneGroup _owner = owner;
     public ushort ZoneGroupId { get; set; }
     public int[] NumKills { get; } = new int[5];
@@ -87,12 +85,12 @@ public class ZoneConflict(ZoneGroup owner)
         {
             var lpConflictStartTask = new ZoneStateChangeTask(this);
             var delay = NextStateTime - DateTime.UtcNow;
-            Logger.Info($"SetTimerTask: ZoneGroup {ZoneGroupId} scheduling next state check in {delay.TotalMinutes:F1} min (NextStateTime={NextStateTime:HH:mm:ss})");
+            Logger.Debug($"ZoneGroup {ZoneGroupId}: scheduling next state check in {delay.TotalMinutes:F1} min (NextStateTime={NextStateTime:HH:mm:ss})");
             TaskManager.Instance.Schedule(lpConflictStartTask, delay);
         }
         else
         {
-            Logger.Warn($"SetTimerTask: ZoneGroup {ZoneGroupId} has no NextStateTime set — timer chain stopped.");
+            Logger.Debug($"ZoneGroup {ZoneGroupId}: no NextStateTime set — timer chain stopped.");
         }
     }
 
@@ -117,7 +115,7 @@ public class ZoneConflict(ZoneGroup owner)
     {
         if (NextStateTime > DateTime.MinValue && DateTime.UtcNow >= NextStateTime)
         {
-            Logger.Info($"CheckTimer: ZoneGroup {ZoneGroupId} timer elapsed, current state={CurrentZoneState}, advancing...");
+            Logger.Debug($"ZoneGroup {ZoneGroupId}: timer elapsed, current state={CurrentZoneState}, advancing...");
             ForceNextState();
         }
     }
@@ -125,10 +123,7 @@ public class ZoneConflict(ZoneGroup owner)
     public void SetState(ZoneConflictType ct)
     {
         if (ct == CurrentZoneState)
-        {
-            Logger.Debug($"SetState: ZoneGroup {ZoneGroupId} already at {ct}, skipping.");
             return;
-        }
 
         var previousState = CurrentZoneState;
 
@@ -151,13 +146,12 @@ public class ZoneConflict(ZoneGroup owner)
                 break;
         }
         CurrentZoneState = ct;
-        Logger.Info($"SetState: ZoneGroup {ZoneGroupId} changed from {previousState} → {ct} (NextStateTime={NextStateTime:HH:mm:ss}, ConflictMin={ConflictMin}, WarMin={WarMin}, PeaceMin={PeaceMin})");
+        Logger.Info($"ZoneGroup {ZoneGroupId} changed from {previousState} → {ct} (next state at {NextStateTime:HH:mm:ss})");
         SendSwitchZoneState();
     }
 
     public void ForceNextState()
     {
-        Logger.Info($"ForceNextState: ZoneGroup {ZoneGroupId} current={CurrentZoneState}, PeaceMin={PeaceMin}");
         if (CurrentZoneState < ZoneConflictType.Peace)
         {
             if (CurrentZoneState == ZoneConflictType.War && PeaceMin <= 0)

--- a/AAEmu.Game/Models/Tasks/Skills/UseAutoAttackSkillTask.cs
+++ b/AAEmu.Game/Models/Tasks/Skills/UseAutoAttackSkillTask.cs
@@ -3,6 +3,7 @@ using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Items.Templates;
 using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models.Game.Skills.Templates;
 using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Models.Tasks.Skills;
@@ -12,16 +13,19 @@ public class UseAutoAttackSkillTask : SkillTask
     private readonly Character _caster;
     private readonly Skill _mainhandSkill;
 
-    // Offhand skill — only set when dual-wielding (two 1H weapons in mainhand + offhand)
+    /// <summary>
+    /// Cached offhand auto-attack skill instance. Template never changes, so we build
+    /// it on demand once and reuse. Whether it actually FIRES per tick is decided
+    /// fresh in Execute() based on current offhand equipment — see ResolveOffhandSkill().
+    /// </summary>
     private Skill _offhandSkill;
+    private SkillTemplate _offhandSkillTemplate;
 
     public UseAutoAttackSkillTask(Skill skill, Character caster) : base(skill)
     {
         _mainhandSkill = skill;
         _caster = caster;
         Cancelled = false;
-
-        DetectDualWield();
     }
 
     public override void Execute()
@@ -58,13 +62,16 @@ public class UseAutoAttackSkillTask : SkillTask
         // Fire mainhand attack
         _mainhandSkill.Use(_caster, casterCaster, targetCaster, skillObject, true, out _);
 
-        // Dual-wield: fire offhand attack on the same swing
-        if (_offhandSkill != null)
+        // Dual-wield: check the current equipment on every tick (not just at task
+        // construction). If the player swaps weapons mid-fight, the offhand swing
+        // appears / disappears immediately on the next tick.
+        var offhandSkill = ResolveOffhandSkill();
+        if (offhandSkill != null)
         {
             var offCaster = new SkillCasterUnit(_caster.ObjId);
             var offTarget = new SkillCastUnitTarget(target.ObjId);
             var offSkillObject = SkillObject.GetByType(SkillObjectType.None);
-            _offhandSkill.Use(_caster, offCaster, offTarget, offSkillObject, true, out _);
+            offhandSkill.Use(_caster, offCaster, offTarget, offSkillObject, true, out _);
         }
 
         // Adjust delay if attack speed changed (buff/debuff/weapon swap)
@@ -74,24 +81,30 @@ public class UseAutoAttackSkillTask : SkillTask
     }
 
     /// <summary>
-    /// If we wield a melee weapon mainhand AND another weapon (not shield) offhand,
-    /// queue the offhand auto-attack skill (id 3) on the same swing as mainhand (id 2).
+    /// Decide per tick whether an offhand auto-attack should fire alongside the
+    /// mainhand. Returns the offhand Skill if and only if:
+    ///   • mainhand task is the melee skill (id 2)
+    ///   • offhand currently holds a weapon (anything that's not a shield / empty)
+    /// The Skill instance itself is cached lazily on first hit.
     /// </summary>
-    private void DetectDualWield()
+    private Skill ResolveOffhandSkill()
     {
-        // Only for melee mainhand (skill 2)
         if (_mainhandSkill.Template.Id != 2)
-            return;
+            return null;
 
         var offhandItem = _caster.Equipment?.GetItemBySlot((int)EquipmentItemSlot.Offhand);
         if (offhandItem?.Template is not WeaponTemplate)
-            return; // Shield, empty, or non-weapon — not dual-wield
+            return null;
 
-        var offhandTemplate = SkillManager.Instance.GetSkillTemplate(3);
-        if (offhandTemplate == null)
-            return;
+        if (_offhandSkill != null)
+            return _offhandSkill;
 
-        _offhandSkill = new Skill(offhandTemplate);
+        _offhandSkillTemplate ??= SkillManager.Instance.GetSkillTemplate(3);
+        if (_offhandSkillTemplate == null)
+            return null;
+
+        _offhandSkill = new Skill(_offhandSkillTemplate);
+        return _offhandSkill;
     }
 
     private void StopAutoAttack()

--- a/AAEmu.Game/Models/Tasks/Skills/UseAutoAttackSkillTask.cs
+++ b/AAEmu.Game/Models/Tasks/Skills/UseAutoAttackSkillTask.cs
@@ -1,5 +1,7 @@
-﻿using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Items;
+using AAEmu.Game.Models.Game.Items.Templates;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Units;
 
@@ -15,47 +17,72 @@ public class UseAutoAttackSkillTask : SkillTask
         _skill = skill;
         _caster = caster;
         Cancelled = false;
-        // _caster.SendMessage($"[UseAutoAttackSkillTask] Created");
     }
 
     public override void Execute()
     {
         var target = _caster.CurrentTarget as Unit;
+
+        // Stop conditions: dead, no target, target dead, self-target, cancelled
         if (_caster.Hp <= 0 || target == null || target.Hp <= 0 || target.ObjId == _caster.ObjId || Cancelled)
         {
-            Cancelled = true;
-            _caster.IsAutoAttack = false;
-            _caster.AutoAttackTask = null;
-            // _caster.SendMessage($"[UseAutoAttackSkillTask] Cancelled");
-            Cancel();
+            StopAutoAttack();
+            return;
         }
 
-        if (Cancelled)
+        // Skill-pause: while another skill is casting or during GCD, skip this tick.
+        // We don't cancel — auto-attack will resume on the next tick after skill ends.
+        if (_caster.SkillTask != null)
+            return;
+        if (_caster.GlobalCooldown >= DateTime.UtcNow)
             return;
 
-        if (target == null)
+        if (!_caster.CanAttack(target))
             return;
 
-        if (_caster.CanAttack(target))
+        // Range check using weapon max range or skill max range — pause (don't cancel)
+        // if target moved out of range, so player walking back into range resumes attacks.
+        var maxRange = GetEffectiveMaxRange();
+        var distance = _caster.GetDistanceTo(target);
+        if (distance > maxRange)
+            return;
+
+        var casterCaster = new SkillCasterUnit(_caster.ObjId);
+        var targetCaster = new SkillCastUnitTarget(target.ObjId);
+        var skillObject = SkillObject.GetByType(SkillObjectType.None);
+
+        _skill.Use(_caster, casterCaster, targetCaster, skillObject, true, out _);
+
+        // Dynamically adjust delay if attack speed changed (buff/debuff)
+        var newDelay = TimeSpan.FromMilliseconds(SkillManager.GetAttackDelay(_skill.Template, _caster));
+        if (newDelay != RepeatInterval)
+            RepeatInterval = newDelay;
+    }
+
+    private void StopAutoAttack()
+    {
+        Cancelled = true;
+        _caster.IsAutoAttack = false;
+        _caster.AutoAttackTask = null;
+        Cancel();
+    }
+
+    /// <summary>Get max attack range from equipped weapon or fall back to skill template.</summary>
+    private float GetEffectiveMaxRange()
+    {
+        EquipmentItemSlot slot = _skill.Template.Id switch
         {
+            2 => EquipmentItemSlot.Mainhand,
+            3 => EquipmentItemSlot.Offhand,
+            4 => EquipmentItemSlot.Ranged,
+            _ => EquipmentItemSlot.Mainhand
+        };
 
-            var casterCaster = new SkillCasterUnit(_caster.ObjId);
-            var targetCaster = new SkillCastUnitTarget(_caster.CurrentTarget.ObjId);
-            var skillObject = SkillObject.GetByType(SkillObjectType.None);
+        var weapon = _caster.Equipment?.GetItemBySlot((int)slot);
+        if (weapon?.Template is WeaponTemplate wt && wt.HoldableTemplate != null && wt.HoldableTemplate.MaxRange > 0)
+            return wt.HoldableTemplate.MaxRange;
 
-            // _caster.SendMessage($"[UseAutoAttackSkillTask] Using {_skill.Template.Id} on {target.ObjId}");
-            _skill.Use(_caster, casterCaster, targetCaster, skillObject, true, out _);
-
-            var newDelay = TimeSpan.FromMilliseconds(SkillManager.GetAttackDelay(_skill.Template, _caster));
-            if (newDelay != RepeatInterval)
-            {
-                _caster.SendDebugMessage($"[AutoAttack] Delay changed {RepeatInterval.TotalMilliseconds} -> {newDelay.TotalMilliseconds}");
-                RepeatInterval = newDelay;
-            }
-        }
-        else
-        {
-            _caster.SendDebugMessage($"[UseAutoAttackSkillTask] Cannot attack with {_skill.Template.Id} on {target.ObjId}");
-        }
+        // Fallback to skill template max range
+        return _skill.Template.MaxRange > 0 ? _skill.Template.MaxRange : 4f;
     }
 }

--- a/AAEmu.Game/Models/Tasks/Skills/UseAutoAttackSkillTask.cs
+++ b/AAEmu.Game/Models/Tasks/Skills/UseAutoAttackSkillTask.cs
@@ -105,16 +105,14 @@ public class UseAutoAttackSkillTask : SkillTask
     /// <summary>Get max attack range from equipped weapon or fall back to skill template.</summary>
     private float GetEffectiveMaxRange()
     {
-        EquipmentItemSlot slot = _mainhandSkill.Template.Id switch
-        {
-            4 => EquipmentItemSlot.Ranged,
-            _ => EquipmentItemSlot.Mainhand
-        };
+        var slot = _mainhandSkill.Template.Id == 4
+            ? EquipmentItemSlot.Ranged
+            : EquipmentItemSlot.Mainhand;
 
         var weapon = _caster.Equipment?.GetItemBySlot((int)slot);
         if (weapon?.Template is WeaponTemplate wt && wt.HoldableTemplate != null && wt.HoldableTemplate.MaxRange > 0)
             return wt.HoldableTemplate.MaxRange;
 
-        return _mainhandSkill.Template.MaxRange > 0 ? _mainhandSkill.Template.MaxRange : 4f;
+        return _mainhandSkill.Template.MaxRange > 0 ? _mainhandSkill.Template.MaxRange : 3f;
     }
 }

--- a/AAEmu.Game/Models/Tasks/Skills/UseAutoAttackSkillTask.cs
+++ b/AAEmu.Game/Models/Tasks/Skills/UseAutoAttackSkillTask.cs
@@ -9,14 +9,19 @@ namespace AAEmu.Game.Models.Tasks.Skills;
 
 public class UseAutoAttackSkillTask : SkillTask
 {
-    private readonly Skill _skill;
     private readonly Character _caster;
+    private readonly Skill _mainhandSkill;
+
+    // Offhand skill — only set when dual-wielding (two 1H weapons in mainhand + offhand)
+    private Skill _offhandSkill;
 
     public UseAutoAttackSkillTask(Skill skill, Character caster) : base(skill)
     {
-        _skill = skill;
+        _mainhandSkill = skill;
         _caster = caster;
         Cancelled = false;
+
+        DetectDualWield();
     }
 
     public override void Execute()
@@ -40,8 +45,7 @@ public class UseAutoAttackSkillTask : SkillTask
         if (!_caster.CanAttack(target))
             return;
 
-        // Range check using weapon max range or skill max range — pause (don't cancel)
-        // if target moved out of range, so player walking back into range resumes attacks.
+        // Range check — pause (don't cancel) if target moved out of range
         var maxRange = GetEffectiveMaxRange();
         var distance = _caster.GetDistanceTo(target);
         if (distance > maxRange)
@@ -51,12 +55,43 @@ public class UseAutoAttackSkillTask : SkillTask
         var targetCaster = new SkillCastUnitTarget(target.ObjId);
         var skillObject = SkillObject.GetByType(SkillObjectType.None);
 
-        _skill.Use(_caster, casterCaster, targetCaster, skillObject, true, out _);
+        // Fire mainhand attack
+        _mainhandSkill.Use(_caster, casterCaster, targetCaster, skillObject, true, out _);
 
-        // Dynamically adjust delay if attack speed changed (buff/debuff)
-        var newDelay = TimeSpan.FromMilliseconds(SkillManager.GetAttackDelay(_skill.Template, _caster));
+        // Dual-wield: fire offhand attack on the same swing
+        if (_offhandSkill != null)
+        {
+            var offCaster = new SkillCasterUnit(_caster.ObjId);
+            var offTarget = new SkillCastUnitTarget(target.ObjId);
+            var offSkillObject = SkillObject.GetByType(SkillObjectType.None);
+            _offhandSkill.Use(_caster, offCaster, offTarget, offSkillObject, true, out _);
+        }
+
+        // Adjust delay if attack speed changed (buff/debuff/weapon swap)
+        var newDelay = TimeSpan.FromMilliseconds(SkillManager.GetAttackDelay(_mainhandSkill.Template, _caster));
         if (newDelay != RepeatInterval)
             RepeatInterval = newDelay;
+    }
+
+    /// <summary>
+    /// If we wield a melee weapon mainhand AND another weapon (not shield) offhand,
+    /// queue the offhand auto-attack skill (id 3) on the same swing as mainhand (id 2).
+    /// </summary>
+    private void DetectDualWield()
+    {
+        // Only for melee mainhand (skill 2)
+        if (_mainhandSkill.Template.Id != 2)
+            return;
+
+        var offhandItem = _caster.Equipment?.GetItemBySlot((int)EquipmentItemSlot.Offhand);
+        if (offhandItem?.Template is not WeaponTemplate)
+            return; // Shield, empty, or non-weapon — not dual-wield
+
+        var offhandTemplate = SkillManager.Instance.GetSkillTemplate(3);
+        if (offhandTemplate == null)
+            return;
+
+        _offhandSkill = new Skill(offhandTemplate);
     }
 
     private void StopAutoAttack()
@@ -70,10 +105,8 @@ public class UseAutoAttackSkillTask : SkillTask
     /// <summary>Get max attack range from equipped weapon or fall back to skill template.</summary>
     private float GetEffectiveMaxRange()
     {
-        EquipmentItemSlot slot = _skill.Template.Id switch
+        EquipmentItemSlot slot = _mainhandSkill.Template.Id switch
         {
-            2 => EquipmentItemSlot.Mainhand,
-            3 => EquipmentItemSlot.Offhand,
             4 => EquipmentItemSlot.Ranged,
             _ => EquipmentItemSlot.Mainhand
         };
@@ -82,7 +115,6 @@ public class UseAutoAttackSkillTask : SkillTask
         if (weapon?.Template is WeaponTemplate wt && wt.HoldableTemplate != null && wt.HoldableTemplate.MaxRange > 0)
             return wt.HoldableTemplate.MaxRange;
 
-        // Fallback to skill template max range
-        return _skill.Template.MaxRange > 0 ? _skill.Template.MaxRange : 4f;
+        return _mainhandSkill.Template.MaxRange > 0 ? _mainhandSkill.Template.MaxRange : 4f;
     }
 }

--- a/AAEmu.Game/Utils/DB/HoldablesSchemaCheck.cs
+++ b/AAEmu.Game/Utils/DB/HoldablesSchemaCheck.cs
@@ -1,0 +1,98 @@
+using AAEmu.Commons.IO;
+using Microsoft.Data.Sqlite;
+using NLog;
+
+namespace AAEmu.Game.Utils.DB;
+
+/// <summary>
+/// Defensive boot-time check that the `holdables` table in compact.sqlite3 has the
+/// six attack-animation columns (anim_r1_id, anim_l1_id, anim_r2_id, anim_l2_id,
+/// anim_r3_id, anim_l3_id) required by the Auto-Attack system.
+///
+/// The shipped ArcheAge compact.sqlite3 already contains these columns with real
+/// data. This helper only matters if the user is running with a stripped/custom
+/// SQLite that lacks them — in that case it adds them as INT NULL columns.
+///
+/// All ops are best-effort; failures are logged but never throw the server.
+/// </summary>
+public static class HoldablesSchemaCheck
+{
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+    private static readonly string[] RequiredColumns =
+    [
+        "anim_r1_id", "anim_l1_id",
+        "anim_r2_id", "anim_l2_id",
+        "anim_r3_id", "anim_l3_id"
+    ];
+
+    public static void EnsureColumns(string directory = "Data", string sqlite = "compact.sqlite3")
+    {
+        var dbPath = Path.Combine(FileManager.AppPath, directory, sqlite);
+        if (!File.Exists(dbPath))
+        {
+            Logger.Warn("HoldablesSchemaCheck: {0} not found — skipping.", dbPath);
+            return;
+        }
+
+        try
+        {
+            // Phase 1: open ReadOnly to scan columns
+            var existing = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            using (var roConn = new SqliteConnection($"Data Source=file:{dbPath}; Mode=ReadOnly"))
+            {
+                roConn.Open();
+                using var pragma = roConn.CreateCommand();
+                pragma.CommandText = "PRAGMA table_info(holdables);";
+                using var rdr = pragma.ExecuteReader();
+                while (rdr.Read())
+                {
+                    // column 1 is the name in PRAGMA table_info
+                    existing.Add(rdr.GetString(1));
+                }
+            }
+
+            // Identify missing animation columns
+            var missing = new List<string>();
+            foreach (var col in RequiredColumns)
+            {
+                if (!existing.Contains(col))
+                    missing.Add(col);
+            }
+
+            if (missing.Count == 0)
+            {
+                Logger.Info("HoldablesSchemaCheck: all 6 anim columns present, no migration needed.");
+                return;
+            }
+
+            Logger.Warn("HoldablesSchemaCheck: {0} missing column(s) — adding: {1}",
+                missing.Count, string.Join(", ", missing));
+
+            // Phase 2: reopen ReadWrite to ALTER TABLE
+            using var rwConn = new SqliteConnection($"Data Source=file:{dbPath}; Mode=ReadWrite");
+            rwConn.Open();
+            foreach (var col in missing)
+            {
+                using var alter = rwConn.CreateCommand();
+                alter.CommandText = $"ALTER TABLE holdables ADD COLUMN {col} INT DEFAULT 0;";
+                try
+                {
+                    alter.ExecuteNonQuery();
+                    Logger.Info("  + added column {0}", col);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warn(ex, "  ! failed to add {0}", col);
+                }
+            }
+
+            Logger.Info("HoldablesSchemaCheck: migration complete. Anim IDs default to 0 — " +
+                        "auto-attack will fall back to fist animations until real values are set.");
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "HoldablesSchemaCheck failed — server will continue without migration");
+        }
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/TaskManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/TaskManagerTests.cs
@@ -430,22 +430,25 @@ public class TaskManagerTests
     #region Restart/Initialize Tests
 
     [Test]
-    public async Task Initialize_ClearsQueue()
+    public async Task Initialize_PreservesQueue()
     {
         var mockTick = Mock.Of<ITickManager>();
         mockTick.OnTick.Returns(new TickManager.TickEventHandler());
 
         var manager = new TaskManager(mockTick.Object);
 
-        // Add some tasks first
         var task = new TestTask();
         manager.Schedule(task, TimeSpan.FromSeconds(60));
         await Assert.That(manager.GetQueueCount()).IsEqualTo(1);
 
-        // Initialize should clear the queue
+        // Initialize() is intentionally a no-op for the queue: in the orchestrated
+        // boot, ILoadable.Load() runs in Stage 2 and may schedule tasks (e.g.
+        // ZoneManager queues the initial Conflict→War→Peace timer chain) before
+        // Initialize() runs in Stage 4. Clearing the queue here used to wipe those
+        // boot-time tasks and break the zone-conflict cycle.
         manager.Initialize();
 
-        await Assert.That(manager.GetQueueCount()).IsEqualTo(0);
+        await Assert.That(manager.GetQueueCount()).IsEqualTo(1);
     }
 
     [Test]

--- a/SQL/aaemu_game.sql
+++ b/SQL/aaemu_game.sql
@@ -154,6 +154,8 @@ CREATE TABLE IF NOT EXISTS `characters` (
   `jury_point` int NOT NULL DEFAULT '0',
   `hostile_faction_kills` int NOT NULL DEFAULT '0',
   `pvp_honor` int NOT NULL DEFAULT '0',
+  `died_in_pvp` tinyint(1) NOT NULL DEFAULT '0',
+  `died_in_pvp_war_zone` tinyint(1) NOT NULL DEFAULT '0',
   `delete_request_time` datetime NOT NULL DEFAULT '0001-01-01 00:00:00',
   `transfer_request_time` datetime NOT NULL DEFAULT '0001-01-01 00:00:00',
   `delete_time` datetime NOT NULL DEFAULT '0001-01-01 00:00:00',

--- a/SQL/updates/2026-05-20_aaemu_game_died_in_pvp_flags.sql
+++ b/SQL/updates/2026-05-20_aaemu_game_died_in_pvp_flags.sql
@@ -1,0 +1,8 @@
+USE aaemu_game;
+
+-- Persist the PvP-death flags across server restarts so post-revive debuffs
+-- routing in CSResurrectCharacterPacket can recover the correct death context
+-- when a player happens to be dead at restart time.
+ALTER TABLE `characters`
+  ADD COLUMN `died_in_pvp` tinyint(1) NOT NULL DEFAULT '0' AFTER `pvp_honor`,
+  ADD COLUMN `died_in_pvp_war_zone` tinyint(1) NOT NULL DEFAULT '0' AFTER `died_in_pvp`;


### PR DESCRIPTION
# PvP Honor System, Auto-Attack overhaul, and ZoneConflict cycle fix

This PR ships three features that have been running on a server build for a while, plus three follow-up bug-fixes that were found during integration into the current `develop` branch. Everything is gated behind existing config / DB conventions; the only new tunable is `WorldConfig.PvpHonorRate` (defaults to `1.0`, identical to current behaviour for non-PvP servers).

All seven commits build cleanly against the current `develop` head (zero new errors, no new warnings introduced).

---

## 1. PvP Honor System

The current `Character.DoDie` only increments `HostileFactionKills`. This PR turns that into a full kill / assist / honor pipeline:

### Honor distribution (zone-aware)

| Zone state | Solo kill | Killer share (with assists) | Per assist |
| --- | --- | --- | --- |
| **War** | 20 | 16 | 4 |
| **Conflict** | 10 | 6 | 4 |
| Anything else | 0 | 0 | 0 |

All values are multiplied by the new `WorldConfig.PvpHonorRate` (default `1.0`). On a War-zone death the victim also loses up to 10 honor (clamped to their current honor — never goes negative).

### Assist tracking (30s rolling window)

* **Damage assists** — recorded via a 2-line hook in `Character.ReduceCurrentHp` (only when `attacker is Character`).
* **Heal assists** — recorded in `HealEffect.Apply` after the heal lands, only when the target is `IsInBattle`.
* **CC assists** — read live from the victim's active bad-buffs when the kill happens. Any caster of a `Stun / Root / Sleep / Silence / Cripled` buff qualifies.

Both damage- and heal-history use `ConcurrentDictionary<uint, DateTime>`; the damage history is cleared on death, the heal history is intentionally kept so a healer that boosted a teammate still gets assist credit on the teammate's next kill within the window.

### Escalating respawn timer

Consecutive deaths now use a growing wait time stored in `Character.RezWaitDuration` before `SCUnitDeathPacket` ships:

`15, 30, 60, 90, 120, 150, 180, 210, 240` seconds.

Counter resets after 5 minutes without dying.

### Death-debuff routing on revive

`CSResurrectCharacterPacket` now applies post-revive debuffs based on the death context (set by `Character.DoDie`):

| Death context | Debuffs applied |
| --- | --- |
| `inPlace` (skill-revive) | _none_ |
| `DiedInPvpWarZone` | `WarZoneLeech` (4424) + 5-min `RespawnCooldown` (2385) |
| `DiedInPvp` | 5-min `RespawnCooldown` only (no Weakened Body) |
| PvE death | `WeakenedBody` (1128) + 5-min `RespawnCooldown` (vanilla behaviour preserved) |

The three buff IDs are added to `BuffConstants` so no magic numbers leak into packet code. The duplicated buff-application code was collapsed into a single `ApplyRevivalDebuffs()` + `ApplyBuff()` helper pair.

### Live broadcast

`SCUnitPvPPointsChangedPacket` is sent twice on every PvP kill (`kind=0` honor, `kind=1` kills). `SCConflictZoneHonorPointSumPacket` is sent to the killer to update the zone-honor UI.

### Persistence fix

The existing `Character.Save()` had `Parameters.AddWithValue("@hostile_faction_kills", …)` and `@pvp_honor` set, **but the `REPLACE INTO characters` statement listed neither column nor placeholder**. The DB columns were silently overwritten with `DEFAULT 0` on every auto-save, throwing away every accumulated kill/honor on the next save tick. Both columns + placeholders are now part of the `REPLACE INTO` statement (matching the `AddWithValue` order). Load paths already handled both columns correctly.

---

## 2. Auto-Attack overhaul

The previous auto-attack code used a flat 1000 ms tick and hard-coded `fire_anim_id = 2` (fist) for every weapon. This PR plugs the existing `holdables` data into the auto-attack flow.

### Weapon-based attack speed

`SkillManager.GetAttackDelay` is rewritten so that auto-attack skills (ids 2 = melee, 3 = offhand, 4 = ranged) read `holdables.speed`, multiply by `Unit.GlobalCooldownMul / 100` (so attack-speed buffs still apply), and clamp to `[400ms, 5000ms]`. Other skills keep the original formula untouched.

### Weapon animations + cycling

* Six new fields on `Holdable`: `AnimR1Id`, `AnimL1Id`, `AnimR2Id`, `AnimL2Id`, `AnimR3Id`, `AnimL3Id`. These columns already exist in the shipped `compact.sqlite3` with the correct vanilla values.
* `Holdable.GetAttackAnimId(index, leftHand)` cycles through whichever of the three configured anims are non-zero. Allocates nothing (`stackalloc Span<uint>[3]`).
* `Skill.GetWeaponAttackAnimId(caster)` picks the per-weapon anim for the player on each auto-attack tick, and falls back to a 1↔2 melee cycle for NPCs (otherwise NPC swings would resolve to the skill template's often-null `FireAnim` and look invisible).
* `SCSkillFiredPacket.FireAnimId` is now a single overridable `uint` property defaulted from the skill template's `FireAnim?.Id ?? 0` in the constructor — the previous "8-arg ctor + hardcoded fist" path is gone.

### Range check

`UseAutoAttackSkillTask.GetEffectiveMaxRange` reads `holdables.max_range` (bow `20m`, melee `4m`, fist `3m`). When the target moves out of range the tick is **skipped** rather than cancelled — walking back into range resumes the swing without re-engaging.

### Skill-pause

Inside `UseAutoAttackSkillTask.Execute`, two new short-circuit checks pause the swing:

```csharp
if (_caster.SkillTask != null) return;            // a skill is mid-cast
if (_caster.GlobalCooldown >= DateTime.UtcNow)    // GCD active
    return;
```

The task keeps ticking; once cast/GCD ends, the next tick fires the auto-attack normally. No overlapping animations.

### Dual-wield

When mainhand is melee (skill 2) and offhand has any weapon (anything that's not a shield or empty), the task fires both `_mainhandSkill` and a second `Skill(template 3)` on the same tick. Mainhand weapon speed still governs the interval — offhand piggy-backs.

### `AutoAttack` special effect

Replaces the previous `// TODO start auto attack...` stub with a real implementation that starts the matching `StartAutoSkill` once, respecting `value1` as an optional skillId override (default = melee `2`).

### Defensive DB-schema guard

A small `Utils/DB/HoldablesSchemaCheck.cs` runs once at boot: it opens `compact.sqlite3` read-only, scans `PRAGMA table_info(holdables)` for the six `anim_*_id` columns, and if any are missing it reopens read-write and adds them as `INT DEFAULT 0`. The shipped vanilla SQLite already has all six — this is purely defensive against stripped or custom builds and is a complete no-op for them.

---

## 3. ZoneConflict cycle never advanced (bugfix)

Two issues with the same symptom (zones freeze on their current state forever):

### `TaskManager.Initialize()` wiped the boot-time queue

Vanilla boot order:

```
Stage 2   _orchestrator.RunLoadAsync()        ← ZoneManager.Load() runs here,
                                                schedules the first conflict timer
Line 100  TaskManager.Instance.Start()        ← subscribes Tick to TickManager
Stage 4   _orchestrator.RunInitializeAsync()  ← runs TaskManager.Initialize(),
                                                which called _queue.Clear()
```

The `_queue.Clear()` in Stage 4 wiped every task that Stage 2 had queued — including the zone-conflict timers — so zone state machines silently froze.

Fix: remove the `_queue.Clear()` from `TaskManager.Initialize()`. The queue is empty from the field initializer anyway; clearing it during `Initialize()` was only safe under the old "manual Initialize first, then Load" order. The method is left in place with a comment explaining why it's intentionally empty.

### `SetTimerTask` was called after the broadcast

`SendSwitchZoneState()` previously did `BroadcastPacketToServer` first and `SetTimerTask` second. Any transient broadcast failure (e.g. an encoder hiccup mid-zone-switch) broke the timer chain. Order is reversed and the broadcast is now wrapped in a `try/catch` that logs but never swallows the timer setup.

`SetState` now also collapses to a single informative log line on real state transitions; the timer scheduling / "no NextStateTime" lines were dropped down to `Debug` to keep the steady-state log quiet.

---

## Files changed (16)

| File | Change | Why |
| --- | --- | --- |
| `Models/Game/Configurations.cs` | `+PvpHonorRate` | New config tunable |
| `Configurations/World.json` | `+default 1.0` | Match config schema |
| `Models/Game/Char/CharacterCombat.cs` | `+AwardPvpHonor / CollectAssists / ComputeDeathWaitTime / DoDie` | Core of the honor system |
| `Models/Game/Char/Character.cs` | damage-hook + SQL columns | PvP-damage tracking + fix unsaved stats |
| `Models/Game/Skills/Effects/HealEffect.cs` | heal-hook | Heal-assist tracking |
| `Core/Packets/C2G/CSResurrectCharacterPacket.cs` | 4-way debuff routing | Death-context-aware revive |
| `Models/Game/Skills/BuffConstants.cs` | `+WeakenedBody / RespawnCooldown / WarZoneLeech` | Replace magic IDs |
| `Models/Game/World/Zones/ZoneConflict.cs` | timer-first + try/catch + log levels | Zone cycle bugfix |
| `Core/Managers/TaskManager2.cs` | drop `_queue.Clear()` in Initialize | Don't wipe boot-time queue |
| `Models/Game/Items/Holdable.cs` | `+anim fields + GetAttackAnimId` | Per-weapon anim cycling |
| `Core/Managers/ItemManager.cs` | load anim columns | Wire DB → Holdable |
| `Core/Managers/SkillManager.cs` | `GetAttackDelay` rewrite + `GetWeaponSpeed` helper | Weapon-based speed |
| `Core/Packets/G2C/SCSkillFiredPacket.cs` | `FireAnimId` property | Single override point |
| `Models/Game/Skills/Skill.cs` | `AutoAttackIndex + GetWeaponAttackAnimId` | NPC + character anim picker |
| `Models/Tasks/Skills/UseAutoAttackSkillTask.cs` | range + skill-pause + dual-wield | Combat behaviour |
| `Models/Game/Skills/Effects/SpecialEffects/AutoAttack.cs` | implement TODO stub | Trigger auto-attack from skill effect |
| `Utils/DB/HoldablesSchemaCheck.cs` (new) | boot-time anim-column probe | Defensive against stripped DBs |
| `GameService.cs` | wire schema check into boot | One-line hook |

---

## Configuration

A single new key in `World.json`:

```json
"PvpHonorRate": 1.0
```

Server admins can scale all PvP honor (Conflict + War, solo + assist + killer-share) with this independently of the existing `HonorRate`. Default is `1.0` — identical behaviour to the current Vanilla for any server that doesn't change it.

---

## Test plan

Builds cleanly on a fresh `develop` checkout (`dotnet build AAEmu.Game/AAEmu.Game.csproj` → `Build succeeded. 0 Error(s)`).

PvP-honor live-tested on a private build:

* Solo kill in Conflict zone → `+10` honor on killer, `HonorGainedInCombat` increments
* Solo kill in War zone → `+20` honor on killer, victim `-10` honor (if > 0)
* Kill with 1 damage-assist + 1 heal-assist → killer `+6`, both assistants `+4` (Conflict) / killer `+16`, assistants `+4` each (War)
* Stat values survive `logout → server restart → relogin` (this was previously broken; see Persistence fix above)

Auto-attack live-tested:

* Bow → 1000 ms tick + ranged anim (id 9)
* 2H Sword → 2000 ms tick + cycle between anims 7 and 95
* Dagger mainhand + dagger offhand → both hands swing on each tick
* Casting a 2 s skill mid-auto-attack → swing pauses, resumes immediately after GCD

ZoneConflict timer chain: live-verified that `Tension → Danger → … → Conflict → War → Peace → Tension` advances on the configured timers after the `TaskManager.Initialize()` fix. Logs trace each transition at `Info`, scheduling at `Debug`.

---

Co-Authored-By: Evenstone &lt;evenstone@noreply.users.github.com&gt;
