### PR TITLE
Party/Raid remote-member sync + ObjId refresh + optional Tag Share toggle

### DIFF
--- a/AAEmu.Game/Configurations/World.json
+++ b/AAEmu.Game/Configurations/World.json
@@ -19,6 +19,7 @@
         "WindModel": "Official",
         "ActabilityRate": 1.0,
         "UsePersistentHouseDoodads": false,
-        "PvpHonorRate": 1.0
+        "PvpHonorRate": 1.0,
+        "TagShareEnabled": false
     }
 }

--- a/AAEmu.Game/Core/Managers/TeamManager.cs
+++ b/AAEmu.Game/Core/Managers/TeamManager.cs
@@ -453,26 +453,20 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
         activeTeam.IsParty = false;
         activeTeam.BroadcastPacket(new SCTeamBecameRaidTeamPacket(activeTeam.Id));
 
-        var onlineMembers = new List<Character>();
         foreach (var m in activeTeam.Members)
         {
-            if (m?.Character == null) continue;
-            chatManager.GetRaidChat(activeTeam).JoinChannel(m.Character);
-            if (m.Character.IsOnline)
-                onlineMembers.Add(m.Character);
+            if (m?.Character != null)
+                chatManager.GetRaidChat(activeTeam).JoinChannel(m.Character);
         }
 
-        // Pairwise ObjId-refresh — once the party becomes a raid, members spread out
-        // across the world, so the client must know everyone's ObjId for the raid UI.
-        for (var i = 0; i < onlineMembers.Count; i++)
+        // Once the party becomes a raid, members spread out across the world, so the
+        // client must know everyone's ObjId for the raid UI even when out of render.
+        // Refresh each member's view against every other — RefreshTeamMemberObjIds
+        // already skips pairs that are still in render distance.
+        foreach (var m in activeTeam.Members)
         {
-            for (var j = i + 1; j < onlineMembers.Count; j++)
-            {
-                if (AreInRenderDistance(onlineMembers[i], onlineMembers[j]))
-                    continue;
-                onlineMembers[i].SendPacket(new SCRefreshTeamMemberPacket(activeTeam.Id, onlineMembers[j].Id, onlineMembers[j].ObjId));
-                onlineMembers[j].SendPacket(new SCRefreshTeamMemberPacket(activeTeam.Id, onlineMembers[i].Id, onlineMembers[i].ObjId));
-            }
+            if (m?.Character?.IsOnline == true)
+                RefreshTeamMemberObjIds(activeTeam, m.Character);
         }
         // TODO: Handle raids in dungeons
     }
@@ -618,14 +612,9 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
         // re-joining client gets all current HP/MP/positions in one shot, AND refresh
         // ObjIds for out-of-range pairs. Avoids the "Member XYZ joined" chat spam
         // that SCTeamMemberJoinedPacket would otherwise produce on a real reconnect.
-        var allMembers = new List<TeamMember>();
-        foreach (var m in activeTeam.Members)
-        {
-            if (m?.Character != null)
-                allMembers.Add(m);
-        }
-        if (allMembers.Count > 0)
-            activeTeam.BroadcastPacket(new SCTeamRemoteMembersExPacket(allMembers.ToArray()));
+        var allMembers = activeTeam.Members.Where(m => m?.Character != null).ToArray();
+        if (allMembers.Length > 0)
+            activeTeam.BroadcastPacket(new SCTeamRemoteMembersExPacket(allMembers));
 
         RefreshTeamMemberObjIds(activeTeam, unit);
 
@@ -636,13 +625,20 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
 
     public void Load()
     {
-        TickManager.Instance.OnTick.Subscribe(UpdateAllTeams, TimeSpan.FromMilliseconds(TeamSyncIntervalMs), true);
-        Logger.Info("TeamManager initialised with {0}ms remote-sync interval", TeamSyncIntervalMs);
+        // Synchronous tick (useAsync: false). UpdateAllTeams iterates _activeTeams +
+        // _lastSyncState, which are mutated by game-handler threads on player join/
+        // leave/disband. Running synchronously on the tick thread keeps these
+        // reads simple and consistent with the rest of the manager.
+        TickManager.Instance.OnTick.Subscribe(UpdateAllTeams, TimeSpan.FromMilliseconds(TeamSyncIntervalMs), false);
+        Logger.Info("TeamManager loaded with {0}ms remote-sync interval", TeamSyncIntervalMs);
     }
 
     // ──────────────────────────────────────────────────────────────────────
     //  Remote-member sync
     // ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>Reusable scratch list to avoid per-tick allocations inside <see cref="UpdateAllTeams"/>.</summary>
+    private readonly List<TeamMember> _onlineMembersScratch = [];
 
     /// <summary>
     /// 500ms tick: walk every active team and broadcast HP/MP/position to members
@@ -655,20 +651,31 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
     {
         var now = DateTime.UtcNow;
 
-        foreach (var team in _activeTeams.Values)
+        // Snapshot the team list so a parallel Add/Remove on _activeTeams can't
+        // invalidate the enumerator while we tick (defence-in-depth even with
+        // useAsync: false — disband/join handlers may still run on other threads).
+        Team[] teams;
+        lock (_activeTeams)
         {
-            var onlineMembers = new List<TeamMember>();
+            if (_activeTeams.Count == 0) return;
+            teams = new Team[_activeTeams.Count];
+            _activeTeams.Values.CopyTo(teams, 0);
+        }
+
+        foreach (var team in teams)
+        {
+            _onlineMembersScratch.Clear();
             foreach (var m in team.Members)
             {
                 if (m?.Character?.IsOnline == true)
-                    onlineMembers.Add(m);
+                    _onlineMembersScratch.Add(m);
             }
-            if (onlineMembers.Count <= 1)
+            if (_onlineMembersScratch.Count <= 1)
                 continue;
 
-            foreach (var recipient in onlineMembers)
+            foreach (var recipient in _onlineMembersScratch)
             {
-                foreach (var source in onlineMembers)
+                foreach (var source in _onlineMembersScratch)
                 {
                     if (source.Character.Id == recipient.Character.Id)
                         continue;
@@ -688,15 +695,18 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
                         source.Character.ObjId,
                         now);
 
-                    if (_lastSyncState.TryGetValue(key, out var prev) &&
-                        prev.HasSameSnapshotAs(nextState) &&
-                        (now - prev.LastSyncTime).TotalMilliseconds < ForcedResyncIntervalMs)
+                    lock (_lastSyncState)
                     {
-                        continue;
+                        if (_lastSyncState.TryGetValue(key, out var prev) &&
+                            prev.HasSameSnapshotAs(nextState) &&
+                            (now - prev.LastSyncTime).TotalMilliseconds < ForcedResyncIntervalMs)
+                        {
+                            continue;
+                        }
+                        _lastSyncState[key] = nextState;
                     }
 
                     recipient.Character.SendPacket(new SCTeamRemoteMembersExPacket([source]));
-                    _lastSyncState[key] = nextState;
                 }
             }
         }
@@ -707,16 +717,21 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
     /// as either recipient or source. Called whenever a character leaves the team
     /// (offline / leave / kick / disband) so the cache cannot leak.
     /// </summary>
-    public void ClearSyncState(uint characterId)
+    internal void ClearSyncState(uint characterId)
     {
-        var toRemove = new List<(uint, uint)>();
-        foreach (var key in _lastSyncState.Keys)
+        lock (_lastSyncState)
         {
-            if (key.recipientId == characterId || key.sourceId == characterId)
-                toRemove.Add(key);
+            if (_lastSyncState.Count == 0) return;
+
+            var toRemove = new List<(uint, uint)>();
+            foreach (var key in _lastSyncState.Keys)
+            {
+                if (key.recipientId == characterId || key.sourceId == characterId)
+                    toRemove.Add(key);
+            }
+            foreach (var key in toRemove)
+                _lastSyncState.Remove(key);
         }
-        foreach (var key in toRemove)
-            _lastSyncState.Remove(key);
     }
 
     /// <summary>
@@ -742,9 +757,10 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
     }
 
     /// <summary>
-    /// Returns true if <paramref name="a"/> and <paramref name="b"/> live in the
-    /// same world Region or in any of its 8 neighbours. Region-based check is the
-    /// same coarse "render-distance" definition the world streaming uses.
+    /// Symmetric region-based render-distance check: returns true if <paramref name="a"/>
+    /// and <paramref name="b"/> share a Region or are listed as neighbours from either
+    /// side. The bidirectional test guards against edge-of-world Regions whose
+    /// <c>GetNeighbors()</c> set may not be symmetric.
     /// </summary>
     private static bool AreInRenderDistance(Character a, Character b)
     {
@@ -753,8 +769,11 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
 
         foreach (var neighbour in a.Region.GetNeighbors())
         {
-            if (neighbour == b.Region)
-                return true;
+            if (neighbour == b.Region) return true;
+        }
+        foreach (var neighbour in b.Region.GetNeighbors())
+        {
+            if (neighbour == a.Region) return true;
         }
         return false;
     }

--- a/AAEmu.Game/Core/Managers/TeamManager.cs
+++ b/AAEmu.Game/Core/Managers/TeamManager.cs
@@ -566,6 +566,13 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
 
         activeTeam.BroadcastPacket(new SCTeamMemberDisconnectedPacket(activeTeam.Id, unit.Id, memberInfo));
 
+        // Tell every team-mate's client-side world cache that this ObjId is gone so
+        // raid-frame click-routing can't keep firing CSMoveUnitPacket(target=oldObjId)
+        // after the character was Deleted from the world. Without this we'd see
+        // "Invalid target {old objId} from X" warnings every time someone tried to
+        // follow an offline raid mate, until the team-mate's client restarts.
+        activeTeam.BroadcastPacket(new SCUnitsRemovedPacket([unit.ObjId]), unit.Id);
+
         // Drop any cached remote-sync state about this character so it doesn't leak.
         ClearSyncState(unit.Id);
     }
@@ -630,7 +637,13 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
             activeTeam.BroadcastPacket(new SCTeamRemoteMembersExPacket([reconnectingMember]), unit.Id);
         }
 
-        RefreshTeamMemberObjIds(activeTeam, unit);
+        // Reconnect: force the ObjId refresh on EVERY online team-mate, not just
+        // the out-of-render ones. The reconnecting player gets a fresh ObjId from
+        // the pool (the old one is preserved but never re-allocated), and team-mates'
+        // raid frames still have the stale ObjId cached — without an explicit
+        // SCRefreshTeamMemberPacket the next click-to-follow on either side fires
+        // CSMoveUnitPacket(target=old objId) and the server logs "Invalid target".
+        RefreshTeamMemberObjIds(activeTeam, unit, force: true);
 
         if (!activeTeam.IsParty)
             chatManager.GetRaidChat(activeTeam).JoinChannel(unit);
@@ -779,10 +792,12 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
 
     /// <summary>
     /// Send <see cref="SCRefreshTeamMemberPacket"/> in both directions so every
-    /// existing team-mate learns the new member's ObjId — but only for mate-pairs
-    /// that are NOT already in render distance (those already know each other).
+    /// existing team-mate learns the new member's ObjId. By default skips pairs
+    /// already in render distance (those learn the ObjId via the world spawn
+    /// flow); pass <paramref name="force"/> = <c>true</c> on reconnect, where the
+    /// in-range world flow doesn't reliably overwrite cached raid-frame ObjIds.
     /// </summary>
-    private static void RefreshTeamMemberObjIds(Team team, Character newMember)
+    private static void RefreshTeamMemberObjIds(Team team, Character newMember, bool force = false)
     {
         if (team == null || newMember == null) return;
 
@@ -791,7 +806,7 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
             if (m?.Character == null || m.Character.Id == newMember.Id || !m.Character.IsOnline)
                 continue;
 
-            if (AreInRenderDistance(m.Character, newMember))
+            if (!force && AreInRenderDistance(m.Character, newMember))
                 continue;
 
             m.Character.SendPacket(new SCRefreshTeamMemberPacket(team.Id, newMember.Id, newMember.ObjId));

--- a/AAEmu.Game/Core/Managers/TeamManager.cs
+++ b/AAEmu.Game/Core/Managers/TeamManager.cs
@@ -573,12 +573,19 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
 
         activeTeam.BroadcastPacket(new SCTeamMemberDisconnectedPacket(activeTeam.Id, unit.Id, memberInfo));
 
-        // Tell every team-mate's client-side world cache that this ObjId is gone so
-        // raid-frame click-routing can't keep firing CSMoveUnitPacket(target=oldObjId)
-        // after the character was Deleted from the world. Without this we'd see
-        // "Invalid target {old objId} from X" warnings every time someone tried to
-        // follow an offline raid mate, until the team-mate's client restarts.
-        activeTeam.BroadcastPacket(new SCUnitsRemovedPacket([unit.ObjId]), unit.Id);
+        // Tell every OUT-OF-RENDER team-mate's client-side world cache that this
+        // ObjId is gone so raid-frame click-routing stops firing
+        // CSMoveUnitPacket(target=oldObjId) after the character was Deleted from
+        // the world. Mates in the same region already receive SCUnitsRemovedPacket
+        // via Region.RemoveObject when activeChar.Delete() runs later in the
+        // disconnect path — sending again would just be a duplicate.
+        foreach (var member in activeTeam.Members)
+        {
+            if (member?.Character == null || !member.Character.IsOnline) continue;
+            if (member.Character.Id == unit.Id) continue;
+            if (AreInRenderDistance(member.Character, unit)) continue;
+            member.Character.SendPacket(new SCUnitsRemovedPacket([unit.ObjId]));
+        }
 
         // Drop any cached remote-sync state about this character so it doesn't leak.
         ClearSyncState(unit.Id);
@@ -628,12 +635,25 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
         var activeTeam = GetActiveTeamByUnit(unit.Id);
         if (activeTeam == null) return;
 
-        activeTeam.ChangeStatus(unit);
+        // Lock against a concurrent DisbandOfflineTeam: it holds team.SyncLock
+        // across its re-verify + member-wipe + TryRemove. Once we hold the lock,
+        // re-check that the team is still in _activeTeams — if a disband ran to
+        // completion between GetActiveTeamByUnit and the lock acquisition, we'd
+        // otherwise reconnect against a dead team and end up with
+        // InParty = true on a Character that has no live team backing it.
+        lock (activeTeam.SyncLock)
+        {
+            if (!_activeTeams.ContainsKey(activeTeam.Id))
+                return;
+
+            // Cancel the zombie-team disband timer — at least one member is back online.
+            activeTeam.AllOfflineSince = DateTime.MinValue;
+
+            activeTeam.ChangeStatus(unit);
+        }
+
         unit.SendPacket(new SCJoinedTeamPacket(activeTeam));
         unit.InParty = true;
-
-        // Cancel the zombie-team disband timer — at least one member is back online.
-        activeTeam.AllOfflineSince = DateTime.MinValue;
 
         // 1) Reconnecting player gets a single bulk snapshot of every team-mate's
         //    current HP/MP/position/ObjId so the raid UI is fully populated.
@@ -810,29 +830,37 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
     /// </summary>
     private void DisbandOfflineTeam(Team team)
     {
-        // Re-verify under the latest member state before wiping anything. The tick
-        // is decoupled from SetOffline / UpdateAtLogin by a multi-minute grace
-        // window, and the SetOffline check/write pair (MembersOnlineCount() ≤ 0,
-        // then assign AllOfflineSince) is not atomic — a concurrent UpdateAtLogin
-        // landing in between can leave AllOfflineSince armed with a stale "now"
-        // even though a member is currently online. Without this re-check the
-        // tick would silently set InParty = false on a live online player and
-        // pull the team out of _activeTeams while their raid UI still pointed
-        // at it.
-        if (team.MembersOnlineCount() > 0)
+        // Hold the team's SyncLock across the re-verify check AND the member-wipe
+        // loop so a concurrent UpdateAtLogin cannot land in the gap between them
+        // (it would otherwise mark a member online after our check, then receive
+        // InParty = false from the wipe). UpdateAtLogin takes the same lock and
+        // additionally re-checks _activeTeams membership, so it gracefully bails
+        // when this disband has already pulled the team out.
+        lock (team.SyncLock)
         {
-            team.AllOfflineSince = DateTime.MinValue;
-            return;
+            // Re-verify under the latest member state before wiping anything. The
+            // tick is decoupled from SetOffline / UpdateAtLogin by a multi-minute
+            // grace window, and the SetOffline check/write pair
+            // (MembersOnlineCount() ≤ 0, then assign AllOfflineSince) is not
+            // atomic — a concurrent UpdateAtLogin landing in between can leave
+            // AllOfflineSince armed with a stale "now" even though a member is
+            // currently online.
+            if (team.MembersOnlineCount() > 0)
+            {
+                team.AllOfflineSince = DateTime.MinValue;
+                return;
+            }
+
+            foreach (var member in team.Members)
+            {
+                if (member?.Character == null) continue;
+                member.Character.InParty = false;
+                ClearSyncState(member.Character.Id);
+            }
+
+            _activeTeams.TryRemove(team.Id, out _);
         }
 
-        foreach (var member in team.Members)
-        {
-            if (member?.Character == null) continue;
-            member.Character.InParty = false;
-            ClearSyncState(member.Character.Id);
-        }
-
-        _activeTeams.TryRemove(team.Id, out _);
         chatManager.CleanUpChannels();
         Logger.Info("Disbanded zombie team {0} after {1} of all-offline", team.Id, OfflineTeamDisbandGrace);
     }

--- a/AAEmu.Game/Core/Managers/TeamManager.cs
+++ b/AAEmu.Game/Core/Managers/TeamManager.cs
@@ -680,11 +680,15 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
         }
 
         // Reconnect: force the ObjId refresh on EVERY online team-mate, not just
-        // the out-of-render ones. The reconnecting player gets a fresh ObjId from
-        // the pool (the old one is preserved but never re-allocated), and team-mates'
-        // raid frames still have the stale ObjId cached — without an explicit
-        // SCRefreshTeamMemberPacket the next click-to-follow on either side fires
-        // CSMoveUnitPacket(target=old objId) and the server logs "Invalid target".
+        // the out-of-render ones. SetOffline's SCTeamMemberDisconnectedPacket
+        // carries WritePerson(IsOnline ? ObjId : 0) — i.e. ObjId = 0 after the
+        // P1 setter-order fix — so each team-mate's raid-frame slot for this
+        // player is currently keyed to 0. The reconnecting player gets the
+        // SAME ObjId back via Character.UsedCharacterObjIds, but the in-range
+        // world Spawn flow does not push the raid-frame re-mapping on its own;
+        // without an explicit SCRefreshTeamMemberPacket the next click-to-
+        // follow fires CSMoveUnitPacket(target=0) and the server logs
+        // "Invalid target".
         RefreshTeamMemberObjIds(activeTeam, unit, force: true);
 
         if (!activeTeam.IsParty)

--- a/AAEmu.Game/Core/Managers/TeamManager.cs
+++ b/AAEmu.Game/Core/Managers/TeamManager.cs
@@ -798,19 +798,23 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
 
     /// <summary>
     /// Auto-disband a team that has been fully offline past the grace window.
-    /// Mirrors the cleanup that <see cref="AskRiskyTeam"/> does on its auto-disband
-    /// branch, but without broadcasting <c>SCTeamDismissedPacket</c> (nobody online
-    /// to receive it; on next reconnect <see cref="UpdateAtLogin"/> sees no team
-    /// and the client lands without raid UI, which is the desired end state).
+    /// Mirrors the per-member cleanup that <see cref="AskRiskyTeam"/> does on its
+    /// auto-disband branch — most importantly resetting <c>Character.InParty</c>
+    /// so a Character object that survives the disband (e.g. cached across a fast
+    /// reconnect) cannot leave <c>InParty = true</c> with no backing team, which
+    /// would break null-unchecked call sites like
+    /// <c>Tagging.AddTagger → TeamManager.GetTeamByObjId</c>.
+    /// <c>SCTeamDismissedPacket</c> is skipped because nobody is online to receive
+    /// it; on next reconnect <see cref="UpdateAtLogin"/> sees no team and the
+    /// client lands without raid UI, which is the desired end state.
     /// </summary>
     private void DisbandOfflineTeam(Team team)
     {
         foreach (var member in team.Members)
         {
             if (member?.Character == null) continue;
+            member.Character.InParty = false;
             ClearSyncState(member.Character.Id);
-            // Character.InParty is already false on offline members (handled by the
-            // logout path / setter); no further per-member packets needed.
         }
 
         _activeTeams.TryRemove(team.Id, out _);

--- a/AAEmu.Game/Core/Managers/TeamManager.cs
+++ b/AAEmu.Game/Core/Managers/TeamManager.cs
@@ -655,9 +655,13 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
         unit.SendPacket(new SCJoinedTeamPacket(activeTeam));
         unit.InParty = true;
 
-        // 1) Reconnecting player gets a single bulk snapshot of every team-mate's
-        //    current HP/MP/position/ObjId so the raid UI is fully populated.
-        var allMembers = activeTeam.Members.Where(m => m?.Character != null).ToArray();
+        // 1) Reconnecting player gets a single bulk snapshot of every OTHER team-
+        //    mate's current HP/MP/position/ObjId so the raid UI is fully populated.
+        //    Self is excluded — the client already knows its own state and a
+        //    self-entry in SCTeamRemoteMembersExPacket would just be wasted bytes.
+        var allMembers = activeTeam.Members
+            .Where(m => m?.Character != null && m.Character.Id != unit.Id)
+            .ToArray();
         if (allMembers.Length > 0)
             unit.SendPacket(new SCTeamRemoteMembersExPacket(allMembers));
 

--- a/AAEmu.Game/Core/Managers/TeamManager.cs
+++ b/AAEmu.Game/Core/Managers/TeamManager.cs
@@ -31,6 +31,13 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
     private const int TeamSyncIntervalMs = 500;
     /// <summary>Force a fresh broadcast even if state didn't change (paranoia against packet loss).</summary>
     private const int ForcedResyncIntervalMs = 5000;
+    /// <summary>
+    /// Grace window after the last online member of a team goes offline before the
+    /// team is auto-disbanded. Lets brief crash-then-reconnect cycles preserve the
+    /// team while keeping <c>_activeTeams</c> from accumulating zombie entries on
+    /// long-running servers.
+    /// </summary>
+    private static readonly TimeSpan OfflineTeamDisbandGrace = TimeSpan.FromMinutes(5);
 
     /// <summary>
     /// Per-(recipient,source) snapshot of the last values broadcast to that recipient.
@@ -575,6 +582,14 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
 
         // Drop any cached remote-sync state about this character so it doesn't leak.
         ClearSyncState(unit.Id);
+
+        // Arm the zombie-team disband timer once the last online member goes offline.
+        // The 500ms UpdateAllTeams tick checks the grace window and removes the team
+        // from _activeTeams if it stays fully offline — otherwise the entry would
+        // live forever because LeaveWorldTask no longer calls MemberRemoveFromTeam
+        // (which used to be the only path that hit AskRiskyTeam's auto-disband).
+        if (activeTeam.MembersOnlineCount() <= 0)
+            activeTeam.AllOfflineSince = DateTime.UtcNow;
     }
 
     public void MemberRemoveFromTeam(Character unit, Character source, RiskyAction leaveType)
@@ -616,6 +631,9 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
         activeTeam.ChangeStatus(unit);
         unit.SendPacket(new SCJoinedTeamPacket(activeTeam));
         unit.InParty = true;
+
+        // Cancel the zombie-team disband timer — at least one member is back online.
+        activeTeam.AllOfflineSince = DateTime.MinValue;
 
         // 1) Reconnecting player gets a single bulk snapshot of every team-mate's
         //    current HP/MP/position/ObjId so the raid UI is fully populated.
@@ -693,6 +711,16 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
         // cannot be invalidated by a parallel Add/Remove during the tick.
         foreach (var team in _activeTeams.Values)
         {
+            // Zombie-team cleanup: every member offline for longer than the grace
+            // window → disband and free the slot. Done before the per-member walk so
+            // the tick doesn't pay the snapshot cost on a doomed team.
+            if (team.AllOfflineSince != DateTime.MinValue &&
+                now - team.AllOfflineSince >= OfflineTeamDisbandGrace)
+            {
+                DisbandOfflineTeam(team);
+                continue;
+            }
+
             _onlineMembersScratch.Clear();
             foreach (var m in team.Members)
             {
@@ -766,6 +794,28 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
         if (!_perRecipientScratch.TryGetValue(recipient, out var list))
             _perRecipientScratch[recipient] = list = [];
         list.Add(source);
+    }
+
+    /// <summary>
+    /// Auto-disband a team that has been fully offline past the grace window.
+    /// Mirrors the cleanup that <see cref="AskRiskyTeam"/> does on its auto-disband
+    /// branch, but without broadcasting <c>SCTeamDismissedPacket</c> (nobody online
+    /// to receive it; on next reconnect <see cref="UpdateAtLogin"/> sees no team
+    /// and the client lands without raid UI, which is the desired end state).
+    /// </summary>
+    private void DisbandOfflineTeam(Team team)
+    {
+        foreach (var member in team.Members)
+        {
+            if (member?.Character == null) continue;
+            ClearSyncState(member.Character.Id);
+            // Character.InParty is already false on offline members (handled by the
+            // logout path / setter); no further per-member packets needed.
+        }
+
+        _activeTeams.TryRemove(team.Id, out _);
+        chatManager.CleanUpChannels();
+        Logger.Info("Disbanded zombie team {0} after {1} of all-offline", team.Id, OfflineTeamDisbandGrace);
     }
 
     /// <summary>

--- a/AAEmu.Game/Core/Managers/TeamManager.cs
+++ b/AAEmu.Game/Core/Managers/TeamManager.cs
@@ -1,4 +1,6 @@
-﻿using AAEmu.Commons.Utils;
+﻿using System.Collections.Concurrent;
+
+using AAEmu.Commons.Utils;
 using AAEmu.Game.Core.Managers.Id;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Packets.G2C;
@@ -37,7 +39,10 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
     /// </summary>
     private readonly Dictionary<(uint recipientId, uint sourceId), MemberSyncState> _lastSyncState = [];
 
-    private readonly Dictionary<uint, Team> _activeTeams = []; // teamId, Team
+    // ConcurrentDictionary so the 500ms UpdateAllTeams tick can enumerate the team
+    // set while game-handler threads concurrently join/disband. Reads (TryGetValue,
+    // Values) are lock-free; mutations (TryAdd, TryRemove) are internally synced.
+    private readonly ConcurrentDictionary<uint, Team> _activeTeams = new(); // teamId, Team
     private readonly Dictionary<uint, InvitationTemplate> _activeInvitations = []; // targetId, InvitationTemplate
 
     public Team GetActiveTeamByUnit(uint unitId)
@@ -292,10 +297,7 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
         };
         if (newTeam.AddMember(activeInvitation.Owner).Item1 == null || newTeam.AddMember(activeInvitation.Target).Item1 == null) return;
 
-        lock (_activeTeams)
-        {
-            _activeTeams.Add(newTeam.Id, newTeam);
-        }
+        _activeTeams.TryAdd(newTeam.Id, newTeam);
 
         activeInvitation.Owner.SendPacket(new SCJoinedTeamPacket(newTeam));
         activeInvitation.Owner.InParty = true;
@@ -334,10 +336,7 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
         };
         if (newTeam.AddMember(character).Item1 == null) return;
 
-        lock (_activeTeams)
-        {
-            _activeTeams.Add(newTeam.Id, newTeam);
-        }
+        _activeTeams.TryAdd(newTeam.Id, newTeam);
 
         character.SendPacket(new SCJoinedTeamPacket(newTeam));
         character.InParty = asParty;
@@ -435,10 +434,7 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
                 }
             }
 
-            lock (_activeTeams)
-            {
-                _activeTeams.Remove(teamId);
-            }
+            _activeTeams.TryRemove(teamId, out _);
         }
         // TODO: Add this to a timer or trigger instead of calling on a party/raid disband. But is good enough and functional for now
         chatManager.CleanUpChannels();
@@ -669,18 +665,11 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
     {
         var now = DateTime.UtcNow;
 
-        // Snapshot the team list so a parallel Add/Remove on _activeTeams can't
-        // invalidate the enumerator while we tick (defence-in-depth even with
-        // useAsync: false — disband/join handlers may still run on other threads).
-        Team[] teams;
-        lock (_activeTeams)
-        {
-            if (_activeTeams.Count == 0) return;
-            teams = new Team[_activeTeams.Count];
-            _activeTeams.Values.CopyTo(teams, 0);
-        }
+        if (_activeTeams.IsEmpty) return;
 
-        foreach (var team in teams)
+        // ConcurrentDictionary.Values returns a snapshot, so the enumeration
+        // cannot be invalidated by a parallel Add/Remove during the tick.
+        foreach (var team in _activeTeams.Values)
         {
             _onlineMembersScratch.Clear();
             foreach (var m in team.Members)

--- a/AAEmu.Game/Core/Managers/TeamManager.cs
+++ b/AAEmu.Game/Core/Managers/TeamManager.cs
@@ -654,6 +654,9 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
     /// <summary>Reusable scratch list to avoid per-tick allocations inside <see cref="UpdateAllTeams"/>.</summary>
     private readonly List<TeamMember> _onlineMembersScratch = [];
 
+    /// <summary>Reusable per-recipient buffer of source members whose snapshots changed this tick.</summary>
+    private readonly Dictionary<TeamMember, List<TeamMember>> _perRecipientScratch = [];
+
     /// <summary>
     /// 500ms tick: walk every active team and broadcast HP/MP/position to members
     /// that are NOT in render distance of each other. Members in render distance
@@ -661,6 +664,12 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
     /// skipped. Delta-cache (<see cref="_lastSyncState"/>) skips identical
     /// packets so a stationary raid produces no traffic.
     /// </summary>
+    /// <remarks>
+    /// Pair-walk is upper-triangle (i &lt; j) — <see cref="AreInRenderDistance"/> is
+    /// symmetric so each pair only needs one neighbour check, not two. Sends are
+    /// coalesced per recipient into one <see cref="SCTeamRemoteMembersExPacket"/>:
+    /// a spread-out 50-man raid produces ~50 packets/tick instead of ~2,450.
+    /// </remarks>
     private void UpdateAllTeams(TimeSpan delta)
     {
         var now = DateTime.UtcNow;
@@ -680,43 +689,70 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
             if (_onlineMembersScratch.Count <= 1)
                 continue;
 
-            foreach (var recipient in _onlineMembersScratch)
+            _perRecipientScratch.Clear();
+
+            for (var i = 0; i < _onlineMembersScratch.Count; i++)
             {
-                foreach (var source in _onlineMembersScratch)
+                var a = _onlineMembersScratch[i];
+                for (var j = i + 1; j < _onlineMembersScratch.Count; j++)
                 {
-                    if (source.Character.Id == recipient.Character.Id)
-                        continue;
+                    var b = _onlineMembersScratch[j];
 
                     // Same/neighbouring region — normal broadcast already covers them
-                    if (AreInRenderDistance(recipient.Character, source.Character))
+                    if (AreInRenderDistance(a.Character, b.Character))
                         continue;
 
-                    var key = (recipient.Character.Id, source.Character.Id);
-                    var pos = source.Character.Transform.World.Position;
-                    var nextState = new MemberSyncState(
-                        source.Character.Hp,
-                        source.Character.MaxHp,
-                        source.Character.Mp,
-                        source.Character.MaxMp,
-                        pos.X, pos.Y, pos.Z,
-                        source.Character.ObjId,
-                        now);
-
-                    lock (_lastSyncState)
-                    {
-                        if (_lastSyncState.TryGetValue(key, out var prev) &&
-                            prev.HasSameSnapshotAs(nextState) &&
-                            (now - prev.LastSyncTime).TotalMilliseconds < ForcedResyncIntervalMs)
-                        {
-                            continue;
-                        }
-                        _lastSyncState[key] = nextState;
-                    }
-
-                    recipient.Character.SendPacket(new SCTeamRemoteMembersExPacket([source]));
+                    // Each direction has its own (recipient, source) cache entry; check
+                    // both, but the expensive region walk above only runs once per pair.
+                    if (TryClaimSnapshot(a, b, now)) AddSnapshotTarget(a, b);
+                    if (TryClaimSnapshot(b, a, now)) AddSnapshotTarget(b, a);
                 }
             }
+
+            foreach (var (recipient, sources) in _perRecipientScratch)
+            {
+                recipient.Character.SendPacket(new SCTeamRemoteMembersExPacket(sources.ToArray()));
+            }
         }
+    }
+
+    /// <summary>
+    /// Per-(recipient, source) delta-cache check. Returns true when the source's
+    /// current snapshot differs from the cached one (or the forced-resync window
+    /// has elapsed), and atomically updates the cache so subsequent ticks see the
+    /// new state.
+    /// </summary>
+    private bool TryClaimSnapshot(TeamMember recipient, TeamMember source, DateTime now)
+    {
+        var key = (recipient.Character.Id, source.Character.Id);
+        var pos = source.Character.Transform.World.Position;
+        var nextState = new MemberSyncState(
+            source.Character.Hp,
+            source.Character.MaxHp,
+            source.Character.Mp,
+            source.Character.MaxMp,
+            pos.X, pos.Y, pos.Z,
+            source.Character.ObjId,
+            now);
+
+        lock (_lastSyncState)
+        {
+            if (_lastSyncState.TryGetValue(key, out var prev) &&
+                prev.HasSameSnapshotAs(nextState) &&
+                (now - prev.LastSyncTime).TotalMilliseconds < ForcedResyncIntervalMs)
+            {
+                return false;
+            }
+            _lastSyncState[key] = nextState;
+            return true;
+        }
+    }
+
+    private void AddSnapshotTarget(TeamMember recipient, TeamMember source)
+    {
+        if (!_perRecipientScratch.TryGetValue(recipient, out var list))
+            _perRecipientScratch[recipient] = list = [];
+        list.Add(source);
     }
 
     /// <summary>

--- a/AAEmu.Game/Core/Managers/TeamManager.cs
+++ b/AAEmu.Game/Core/Managers/TeamManager.cs
@@ -292,7 +292,10 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
         };
         if (newTeam.AddMember(activeInvitation.Owner).Item1 == null || newTeam.AddMember(activeInvitation.Target).Item1 == null) return;
 
-        _activeTeams.Add(newTeam.Id, newTeam);
+        lock (_activeTeams)
+        {
+            _activeTeams.Add(newTeam.Id, newTeam);
+        }
 
         activeInvitation.Owner.SendPacket(new SCJoinedTeamPacket(newTeam));
         activeInvitation.Owner.InParty = true;
@@ -331,7 +334,10 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
         };
         if (newTeam.AddMember(character).Item1 == null) return;
 
-        _activeTeams.Add(newTeam.Id, newTeam);
+        lock (_activeTeams)
+        {
+            _activeTeams.Add(newTeam.Id, newTeam);
+        }
 
         character.SendPacket(new SCJoinedTeamPacket(newTeam));
         character.InParty = asParty;
@@ -429,7 +435,10 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
                 }
             }
 
-            _activeTeams.Remove(teamId);
+            lock (_activeTeams)
+            {
+                _activeTeams.Remove(teamId);
+            }
         }
         // TODO: Add this to a timer or trigger instead of calling on a party/raid disband. But is good enough and functional for now
         chatManager.CleanUpChannels();
@@ -461,13 +470,10 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
 
         // Once the party becomes a raid, members spread out across the world, so the
         // client must know everyone's ObjId for the raid UI even when out of render.
-        // Refresh each member's view against every other — RefreshTeamMemberObjIds
-        // already skips pairs that are still in render distance.
-        foreach (var m in activeTeam.Members)
-        {
-            if (m?.Character?.IsOnline == true)
-                RefreshTeamMemberObjIds(activeTeam, m.Character);
-        }
+        // Walk the upper-triangle pairs so each (a,b) pair is refreshed exactly once
+        // (avoids the O(N²) duplicate-send problem of calling RefreshTeamMemberObjIds
+        // per member, which would send both directions for every pair twice).
+        RefreshAllTeamMemberObjIds(activeTeam);
         // TODO: Handle raids in dungeons
     }
 
@@ -608,13 +614,25 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
         unit.SendPacket(new SCJoinedTeamPacket(activeTeam));
         unit.InParty = true;
 
-        // Reconnect: send a bulk Remote-Members update to everyone in the team so the
-        // re-joining client gets all current HP/MP/positions in one shot, AND refresh
-        // ObjIds for out-of-range pairs. Avoids the "Member XYZ joined" chat spam
-        // that SCTeamMemberJoinedPacket would otherwise produce on a real reconnect.
+        // 1) Reconnecting player gets a single bulk snapshot of every team-mate's
+        //    current HP/MP/position/ObjId so the raid UI is fully populated.
         var allMembers = activeTeam.Members.Where(m => m?.Character != null).ToArray();
         if (allMembers.Length > 0)
-            activeTeam.BroadcastPacket(new SCTeamRemoteMembersExPacket(allMembers));
+            unit.SendPacket(new SCTeamRemoteMembersExPacket(allMembers));
+
+        // 2) Existing team-mates get the explicit "back online" signal
+        //    (SCTeamMemberJoinedPacket — counterpart to SCTeamMemberDisconnectedPacket
+        //    sent in SetOffline) plus *only* the reconnecting player's snapshot,
+        //    not all 50 frames. Without the JoinedPacket the client party-frame
+        //    stays stuck on the offline indicator even though HP/MP keep updating.
+        var idx = activeTeam.GetIndex(unit.Id);
+        if (idx >= 0)
+        {
+            var reconnectingMember = activeTeam.Members[idx];
+            var partyIndex = Team.GetParty(idx);
+            activeTeam.BroadcastPacket(new SCTeamMemberJoinedPacket(activeTeam.Id, reconnectingMember, partyIndex), unit.Id);
+            activeTeam.BroadcastPacket(new SCTeamRemoteMembersExPacket([reconnectingMember]), unit.Id);
+        }
 
         RefreshTeamMemberObjIds(activeTeam, unit);
 
@@ -753,6 +771,36 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
 
             m.Character.SendPacket(new SCRefreshTeamMemberPacket(team.Id, newMember.Id, newMember.ObjId));
             newMember.SendPacket(new SCRefreshTeamMemberPacket(team.Id, m.Character.Id, m.Character.ObjId));
+        }
+    }
+
+    /// <summary>
+    /// Refresh ObjIds for every out-of-render-distance pair in the team exactly once.
+    /// Used by <see cref="ConvertToRaid"/> where the whole team needs to learn each
+    /// other's ObjIds; iterating with <see cref="RefreshTeamMemberObjIds"/> per member
+    /// would double every pair (O(N²) duplicates — ~4,900 redundant packets for a
+    /// 50-member raid). Upper-triangle traversal (i &lt; j) avoids that.
+    /// </summary>
+    private static void RefreshAllTeamMemberObjIds(Team team)
+    {
+        if (team == null) return;
+
+        var online = new List<Character>();
+        foreach (var m in team.Members)
+        {
+            if (m?.Character != null && m.Character.IsOnline)
+                online.Add(m.Character);
+        }
+
+        for (var i = 0; i < online.Count; i++)
+        {
+            for (var j = i + 1; j < online.Count; j++)
+            {
+                if (AreInRenderDistance(online[i], online[j]))
+                    continue;
+                online[i].SendPacket(new SCRefreshTeamMemberPacket(team.Id, online[j].Id, online[j].ObjId));
+                online[j].SendPacket(new SCRefreshTeamMemberPacket(team.Id, online[i].Id, online[i].ObjId));
+            }
         }
     }
 

--- a/AAEmu.Game/Core/Managers/TeamManager.cs
+++ b/AAEmu.Game/Core/Managers/TeamManager.cs
@@ -7,7 +7,10 @@ using AAEmu.Game.Models.Game.Faction;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Team;
+using AAEmu.Game.Models.Game.World;
 using AAEmu.Game.Models.Game.World.Transform;
+
+using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
@@ -18,6 +21,21 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
      *
      * RE-DO LEAVE / KICK / DISMISS
      */
+
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+    // ── Remote-member sync (see Party/Raid remote sync design) ────────────
+    /// <summary>Tick interval for the periodic remote-member sync.</summary>
+    private const int TeamSyncIntervalMs = 500;
+    /// <summary>Force a fresh broadcast even if state didn't change (paranoia against packet loss).</summary>
+    private const int ForcedResyncIntervalMs = 5000;
+
+    /// <summary>
+    /// Per-(recipient,source) snapshot of the last values broadcast to that recipient.
+    /// Used to skip identical packets ("delta-update") so a stationary raid produces zero
+    /// remote-sync traffic.
+    /// </summary>
+    private readonly Dictionary<(uint recipientId, uint sourceId), MemberSyncState> _lastSyncState = [];
 
     private readonly Dictionary<uint, Team> _activeTeams = []; // teamId, Team
     private readonly Dictionary<uint, InvitationTemplate> _activeInvitations = []; // targetId, InvitationTemplate
@@ -190,6 +208,9 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
                 target.InParty = true;
                 target.SendPacket(new SCTeamPingPosPacket(true, activeTeam.PingPosition, 0));
                 activeTeam.BroadcastPacket(new SCTeamMemberJoinedPacket(activeTeam.Id, newTeamMember, party), target.Id);
+
+                // Make sure team-mates outside render distance learn each other's ObjId
+                RefreshTeamMemberObjIds(activeTeam, target);
             }
         }
 
@@ -288,6 +309,10 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
         // Trigger events
         activeInvitation.Owner.Events?.OnTeamJoin(activeInvitation, new OnTeamJoinArgs { Team = newTeam, Player = activeInvitation.Owner });
         activeInvitation.Target.Events?.OnTeamJoin(activeInvitation, new OnTeamJoinArgs { Team = newTeam, Player = activeInvitation.Target });
+
+        // Owner and target may be out of each other's render distance — make sure
+        // both clients know each other's ObjId.
+        RefreshTeamMemberObjIds(newTeam, activeInvitation.Target);
     }
 
     public void CreateSoloTeam(Character character, bool asParty)
@@ -364,6 +389,9 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
                 target.SendPacket(new SCLeavedTeamPacket(teamId, riskyAction == RiskyAction.Kick, false));
                 target.Events?.OnTeamLeave(target, new OnTeamLeaveArgs { Id = activeTeam.Id, Team = activeTeam, Player = target });
             }
+
+            // Drop cached remote-sync state for the leaver
+            ClearSyncState(targetId);
         }
 
         // Disband if only one member left in Party (not raid)
@@ -395,6 +423,9 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
                         // trigger event
                         member.Character.Events?.OnTeamLeave(member.Character, new OnTeamLeaveArgs { Id = activeTeam.Id, Team = activeTeam, Player = member.Character });
                     }
+
+                    // Drop cached remote-sync state per disbanded member
+                    ClearSyncState(member.Character.Id);
                 }
             }
 
@@ -421,9 +452,28 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
 
         activeTeam.IsParty = false;
         activeTeam.BroadcastPacket(new SCTeamBecameRaidTeamPacket(activeTeam.Id));
+
+        var onlineMembers = new List<Character>();
         foreach (var m in activeTeam.Members)
-            if (m != null && m.Character != null)
-                chatManager.GetRaidChat(activeTeam).JoinChannel(m.Character);
+        {
+            if (m?.Character == null) continue;
+            chatManager.GetRaidChat(activeTeam).JoinChannel(m.Character);
+            if (m.Character.IsOnline)
+                onlineMembers.Add(m.Character);
+        }
+
+        // Pairwise ObjId-refresh — once the party becomes a raid, members spread out
+        // across the world, so the client must know everyone's ObjId for the raid UI.
+        for (var i = 0; i < onlineMembers.Count; i++)
+        {
+            for (var j = i + 1; j < onlineMembers.Count; j++)
+            {
+                if (AreInRenderDistance(onlineMembers[i], onlineMembers[j]))
+                    continue;
+                onlineMembers[i].SendPacket(new SCRefreshTeamMemberPacket(activeTeam.Id, onlineMembers[j].Id, onlineMembers[j].ObjId));
+                onlineMembers[j].SendPacket(new SCRefreshTeamMemberPacket(activeTeam.Id, onlineMembers[i].Id, onlineMembers[i].ObjId));
+            }
+        }
         // TODO: Handle raids in dungeons
     }
 
@@ -519,6 +569,9 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
         }
 
         activeTeam.BroadcastPacket(new SCTeamMemberDisconnectedPacket(activeTeam.Id, unit.Id, memberInfo));
+
+        // Drop any cached remote-sync state about this character so it doesn't leak.
+        ClearSyncState(unit.Id);
     }
 
     public void MemberRemoveFromTeam(Character unit, Character source, RiskyAction leaveType)
@@ -557,11 +610,25 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
         var activeTeam = GetActiveTeamByUnit(unit.Id);
         if (activeTeam == null) return;
 
-        var newInfo = activeTeam.ChangeStatus(unit);
+        activeTeam.ChangeStatus(unit);
         unit.SendPacket(new SCJoinedTeamPacket(activeTeam));
         unit.InParty = true;
-        activeTeam.BroadcastPacket(new SCTeamMemberJoinedPacket(activeTeam.Id, newInfo, Team.GetParty(activeTeam.GetIndex(unit.Id))));
-        //activeTeam.BroadcastPacket(new SCRefreshTeamMemberPacket(activeTeam.Id, unit.Id, unit.ObjId));
+
+        // Reconnect: send a bulk Remote-Members update to everyone in the team so the
+        // re-joining client gets all current HP/MP/positions in one shot, AND refresh
+        // ObjIds for out-of-range pairs. Avoids the "Member XYZ joined" chat spam
+        // that SCTeamMemberJoinedPacket would otherwise produce on a real reconnect.
+        var allMembers = new List<TeamMember>();
+        foreach (var m in activeTeam.Members)
+        {
+            if (m?.Character != null)
+                allMembers.Add(m);
+        }
+        if (allMembers.Count > 0)
+            activeTeam.BroadcastPacket(new SCTeamRemoteMembersExPacket(allMembers.ToArray()));
+
+        RefreshTeamMemberObjIds(activeTeam, unit);
+
         if (!activeTeam.IsParty)
             chatManager.GetRaidChat(activeTeam).JoinChannel(unit);
         chatManager.GetPartyChat(activeTeam, unit).JoinChannel(unit);
@@ -569,8 +636,151 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
 
     public void Load()
     {
-        // Nothing special to do here
+        TickManager.Instance.OnTick.Subscribe(UpdateAllTeams, TimeSpan.FromMilliseconds(TeamSyncIntervalMs), true);
+        Logger.Info("TeamManager initialised with {0}ms remote-sync interval", TeamSyncIntervalMs);
     }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Remote-member sync
+    // ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 500ms tick: walk every active team and broadcast HP/MP/position to members
+    /// that are NOT in render distance of each other. Members in render distance
+    /// already receive that data via the normal Broadcast* pipeline, so they are
+    /// skipped. Delta-cache (<see cref="_lastSyncState"/>) skips identical
+    /// packets so a stationary raid produces no traffic.
+    /// </summary>
+    private void UpdateAllTeams(TimeSpan delta)
+    {
+        var now = DateTime.UtcNow;
+
+        foreach (var team in _activeTeams.Values)
+        {
+            var onlineMembers = new List<TeamMember>();
+            foreach (var m in team.Members)
+            {
+                if (m?.Character?.IsOnline == true)
+                    onlineMembers.Add(m);
+            }
+            if (onlineMembers.Count <= 1)
+                continue;
+
+            foreach (var recipient in onlineMembers)
+            {
+                foreach (var source in onlineMembers)
+                {
+                    if (source.Character.Id == recipient.Character.Id)
+                        continue;
+
+                    // Same/neighbouring region — normal broadcast already covers them
+                    if (AreInRenderDistance(recipient.Character, source.Character))
+                        continue;
+
+                    var key = (recipient.Character.Id, source.Character.Id);
+                    var pos = source.Character.Transform.World.Position;
+                    var nextState = new MemberSyncState(
+                        source.Character.Hp,
+                        source.Character.MaxHp,
+                        source.Character.Mp,
+                        source.Character.MaxMp,
+                        pos.X, pos.Y, pos.Z,
+                        source.Character.ObjId,
+                        now);
+
+                    if (_lastSyncState.TryGetValue(key, out var prev) &&
+                        prev.HasSameSnapshotAs(nextState) &&
+                        (now - prev.LastSyncTime).TotalMilliseconds < ForcedResyncIntervalMs)
+                    {
+                        continue;
+                    }
+
+                    recipient.Character.SendPacket(new SCTeamRemoteMembersExPacket([source]));
+                    _lastSyncState[key] = nextState;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Drop every cached sync-state entry mentioning <paramref name="characterId"/>
+    /// as either recipient or source. Called whenever a character leaves the team
+    /// (offline / leave / kick / disband) so the cache cannot leak.
+    /// </summary>
+    public void ClearSyncState(uint characterId)
+    {
+        var toRemove = new List<(uint, uint)>();
+        foreach (var key in _lastSyncState.Keys)
+        {
+            if (key.recipientId == characterId || key.sourceId == characterId)
+                toRemove.Add(key);
+        }
+        foreach (var key in toRemove)
+            _lastSyncState.Remove(key);
+    }
+
+    /// <summary>
+    /// Send <see cref="SCRefreshTeamMemberPacket"/> in both directions so every
+    /// existing team-mate learns the new member's ObjId — but only for mate-pairs
+    /// that are NOT already in render distance (those already know each other).
+    /// </summary>
+    private static void RefreshTeamMemberObjIds(Team team, Character newMember)
+    {
+        if (team == null || newMember == null) return;
+
+        foreach (var m in team.Members)
+        {
+            if (m?.Character == null || m.Character.Id == newMember.Id || !m.Character.IsOnline)
+                continue;
+
+            if (AreInRenderDistance(m.Character, newMember))
+                continue;
+
+            m.Character.SendPacket(new SCRefreshTeamMemberPacket(team.Id, newMember.Id, newMember.ObjId));
+            newMember.SendPacket(new SCRefreshTeamMemberPacket(team.Id, m.Character.Id, m.Character.ObjId));
+        }
+    }
+
+    /// <summary>
+    /// Returns true if <paramref name="a"/> and <paramref name="b"/> live in the
+    /// same world Region or in any of its 8 neighbours. Region-based check is the
+    /// same coarse "render-distance" definition the world streaming uses.
+    /// </summary>
+    private static bool AreInRenderDistance(Character a, Character b)
+    {
+        if (a?.Region == null || b?.Region == null) return false;
+        if (a.Region == b.Region) return true;
+
+        foreach (var neighbour in a.Region.GetNeighbors())
+        {
+            if (neighbour == b.Region)
+                return true;
+        }
+        return false;
+    }
+}
+
+/// <summary>
+/// Snapshot of a team-member's last broadcast state, keyed by (recipientId, sourceId).
+/// Used by the delta-cache to suppress identical remote-member sync packets.
+/// </summary>
+public sealed record MemberSyncState(
+    int Hp,
+    int MaxHp,
+    int Mp,
+    int MaxMp,
+    float X,
+    float Y,
+    float Z,
+    uint ObjId,
+    DateTime LastSyncTime)
+{
+    /// <summary>True when every field except <see cref="LastSyncTime"/> matches.</summary>
+    public bool HasSameSnapshotAs(MemberSyncState other) =>
+        Hp == other.Hp && MaxHp == other.MaxHp &&
+        Mp == other.Mp && MaxMp == other.MaxMp &&
+        X == other.X && Y == other.Y && Z == other.Z &&
+        ObjId == other.ObjId;
 }
 
 public class InvitationTemplate

--- a/AAEmu.Game/Core/Managers/TeamManager.cs
+++ b/AAEmu.Game/Core/Managers/TeamManager.cs
@@ -831,11 +831,22 @@ public sealed record MemberSyncState(
     uint ObjId,
     DateTime LastSyncTime)
 {
-    /// <summary>True when every field except <see cref="LastSyncTime"/> matches.</summary>
+    /// <summary>
+    /// Position-equality tolerance for the delta-cache comparison. Anything below
+    /// this is sub-centimetre physics jitter that wouldn't be visible on the raid
+    /// UI; using strict <c>==</c> here would defeat the delta cache for stationary
+    /// raid mates whose solver still produces tiny floating-point wobble each tick.
+    /// </summary>
+    private const float PositionEpsilon = 0.01f;
+
+    /// <summary>True when every field except <see cref="LastSyncTime"/> matches
+    /// (position fields compared with <see cref="PositionEpsilon"/> tolerance).</summary>
     public bool HasSameSnapshotAs(MemberSyncState other) =>
         Hp == other.Hp && MaxHp == other.MaxHp &&
         Mp == other.Mp && MaxMp == other.MaxMp &&
-        X == other.X && Y == other.Y && Z == other.Z &&
+        MathF.Abs(X - other.X) < PositionEpsilon &&
+        MathF.Abs(Y - other.Y) < PositionEpsilon &&
+        MathF.Abs(Z - other.Z) < PositionEpsilon &&
         ObjId == other.ObjId;
 }
 

--- a/AAEmu.Game/Core/Managers/TeamManager.cs
+++ b/AAEmu.Game/Core/Managers/TeamManager.cs
@@ -810,6 +810,21 @@ public class TeamManager(IWorldManager worldManager, IChatManager chatManager, I
     /// </summary>
     private void DisbandOfflineTeam(Team team)
     {
+        // Re-verify under the latest member state before wiping anything. The tick
+        // is decoupled from SetOffline / UpdateAtLogin by a multi-minute grace
+        // window, and the SetOffline check/write pair (MembersOnlineCount() ≤ 0,
+        // then assign AllOfflineSince) is not atomic — a concurrent UpdateAtLogin
+        // landing in between can leave AllOfflineSince armed with a stale "now"
+        // even though a member is currently online. Without this re-check the
+        // tick would silently set InParty = false on a live online player and
+        // pull the team out of _activeTeams while their raid UI still pointed
+        // at it.
+        if (team.MembersOnlineCount() > 0)
+        {
+            team.AllOfflineSince = DateTime.MinValue;
+            return;
+        }
+
         foreach (var member in team.Members)
         {
             if (member?.Character == null) continue;

--- a/AAEmu.Game/Core/Managers/World/EnterWorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/EnterWorldManager.cs
@@ -19,7 +19,6 @@ public class EnterWorldManager(
     IAccountManager accountManager,
     IStreamManager streamManager,
     IQuestManager questManager,
-    ITeamManager teamManager,
     IChatManager chatManager,
     IFamilyManager familyManager,
     IWorldManager worldManager) : Singleton<EnterWorldManager>, IEnterWorldManager
@@ -179,8 +178,13 @@ public class EnterWorldManager(
             // Check if still mounted on somebody else's mount and dismount that if needed
             activeChar.ForceDismount(/*AttachUnitReason.PrefabChanged*/); // Dismounting a mount because of unsummoning sends "10" for this
 
-            // Remove from Team (raid/party)
-            teamManager.MemberRemoveFromTeam(activeChar, activeChar, RiskyAction.Leave);
+            // NOTE: do NOT MemberRemoveFromTeam here. Setting IsOnline = false above
+            // already routed through TeamManager.SetOffline, which broadcasts
+            // SCTeamMemberDisconnectedPacket so team-mates see the player as offline
+            // while the TeamMember entry stays in Team.Members[] for a clean reconnect
+            // via UpdateAtLogin. Calling MemberRemoveFromTeam here used to immediately
+            // overwrite the offline indicator with a "left the team" broadcast and
+            // wipe the slot — which is what made every disconnect look like a kick.
 
             // Remove from all Chat
             chatManager.LeaveAllChannels(activeChar);

--- a/AAEmu.Game/Core/Network/Connections/GameConnection.cs
+++ b/AAEmu.Game/Core/Network/Connections/GameConnection.cs
@@ -209,7 +209,13 @@ public class GameConnection
         // mirror it here or the next reconnect will TryAddCharacter on a stale slot
         // and end up with a divergent _characters[id] = OLD vs _baseUnits[id] = NEW,
         // so any later operation on the ghost reference Deletes the live character.
-        WorldManager.Instance.TryRemoveCharacter(activeChar.ObjId);
+        //
+        // Guard with an identity check so the cleanup stays safe if ObjId recycling
+        // is ever re-enabled: only remove the slot if _characters still maps this
+        // ObjId to OUR character — never evict a freshly-spawned entity that
+        // happened to inherit the recycled ObjId.
+        if (WorldManager.Instance.GetCharacterByObjId(activeChar.ObjId) == activeChar)
+            WorldManager.Instance.TryRemoveCharacter(activeChar.ObjId);
 
         // Do a manual save here as it's no longer in _characters at this point
         // TODO: might need a better option like saving this transaction for later to be used by the SaveManager

--- a/AAEmu.Game/Core/Network/Connections/GameConnection.cs
+++ b/AAEmu.Game/Core/Network/Connections/GameConnection.cs
@@ -4,6 +4,7 @@ using AAEmu.Commons.Network.Core;
 using AAEmu.Commons.Utils.DB;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.UnitManagers;
+using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Models;
 using AAEmu.Game.Models.Game.Char;
@@ -77,6 +78,13 @@ public class GameConnection
 
         if (ActiveChar != null)
         {
+            // Hard DC / crash path: LeaveWorldTask never runs here, so nothing else
+            // would set IsOnline = false and team-mates would keep seeing the player
+            // as online with a frozen HP bar. Toggling the setter fires
+            // TeamManager.SetOffline + FriendMananger status broadcast for us.
+            if (ActiveChar.IsOnline)
+                ActiveChar.IsOnline = false;
+
             foreach (var subscriber in ActiveChar.Subscribers)
                 subscriber.Dispose();
 
@@ -194,6 +202,14 @@ public class GameConnection
         activeChar.Delete();
         // Removed ReleaseId here to try and fix party/raid disconnect and reconnect issues. Replaced with saving the data
         //ObjectIdManager.Instance.ReleaseId(ActiveChar.ObjId);
+
+        // Also drop the entry from WorldManager._characters. Without this, hard-DC
+        // / crash paths leak a ghost reference at that ObjId (LeaveWorldTask does
+        // the same TryRemoveCharacter explicitly on graceful logout — we have to
+        // mirror it here or the next reconnect will TryAddCharacter on a stale slot
+        // and end up with a divergent _characters[id] = OLD vs _baseUnits[id] = NEW,
+        // so any later operation on the ghost reference Deletes the live character.
+        WorldManager.Instance.TryRemoveCharacter(activeChar.ObjId);
 
         // Do a manual save here as it's no longer in _characters at this point
         // TODO: might need a better option like saving this transaction for later to be used by the SaveManager

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -262,8 +262,13 @@ public partial class Character : Unit, ICharacter
             if (_isOnline == value) return;
             // TODO - GUILD STATUS CHANGE
             FriendMananger.Instance.SendStatusChange(this, true, value);
-            if (!value) TeamManager.Instance.SetOffline(this);
+            // Set _isOnline BEFORE the SetOffline side-effect so anything it triggers
+            // (SetOffline → SCTeamMemberDisconnectedPacket → TeamMember.WritePerson)
+            // observes the new state. Otherwise WritePerson's "ObjId or 0 if offline"
+            // ternary would still see IsOnline = true on disconnect and write the live
+            // ObjId into a packet that is supposed to carry the explicit offline marker.
             _isOnline = value;
+            if (!value) TeamManager.Instance.SetOffline(this);
         }
     }
     // public FishSchool FishSchool { get; set; }

--- a/AAEmu.Game/Models/Game/Configurations.cs
+++ b/AAEmu.Game/Models/Game/Configurations.cs
@@ -123,6 +123,14 @@ public class WorldConfig
     public double ActabilityRate { get; set; } = 1.0;
 
     /// <summary>
+    /// When true, monster kill credits and quest progress are shared across every
+    /// player that dealt damage to the mob plus their party / raid mates that are
+    /// within 200m at time of death. When false (default = vanilla behaviour), only
+    /// the killer (and the killer's team for tagged kills) earns the credit.
+    /// </summary>
+    public bool TagShareEnabled { get; set; } = false;
+
+    /// <summary>
     /// When true, housing bound doodads (doors, windows, planters, drills, animals) are saved to the
     /// database and their state (open/closed, fill level, growth phase) is restored on server restart.
     /// When false (default), bound doodads are re-created fresh from template data on every restart,

--- a/AAEmu.Game/Models/Game/NPChar/Npc.cs
+++ b/AAEmu.Game/Models/Game/NPChar/Npc.cs
@@ -982,6 +982,28 @@ public partial class Npc : Unit
                 QuestManager.Instance.DoOnMonsterHuntEvents(pl, this);
             }
         }
+
+        // ── Tag Share toggle ──────────────────────────────────────────────
+        // When enabled, fan out monster-hunt quest events to every player
+        // that dealt damage (plus their party / raid mates in range). This
+        // runs AFTER both branches above (eligible-players loop AND the
+        // killer-only fallback) so two parties or two raids hitting the
+        // same mob can both progress kill quests, even when neither broke
+        // the 50% HP tag threshold. XP and loot are NOT affected — only
+        // quest progress fans out.
+        if (AppConfiguration.Instance.World.TagShareEnabled)
+        {
+            var alreadyCredited = new HashSet<Character>(eligiblePlayers);
+            if (killer is Character ck) alreadyCredited.Add(ck);
+
+            var contributors = CharacterTagging.GetAllContributors(Items.Containers.LootingContainer.MaxLootingRange);
+            foreach (var contributor in contributors)
+            {
+                if (!alreadyCredited.Add(contributor)) continue;
+                QuestManager.Instance.DoOnMonsterHuntEvents(contributor, this);
+            }
+        }
+
         base.DoDie(killer, killReason);
         ClearAllAggroTargetsAndCheckCombatState();
         // AggroTable.Clear();

--- a/AAEmu.Game/Models/Game/NPChar/Npc.cs
+++ b/AAEmu.Game/Models/Game/NPChar/Npc.cs
@@ -994,8 +994,14 @@ public partial class Npc : Unit
         // quest progress fans out.
         if (AppConfiguration.Instance.World.TagShareEnabled)
         {
+            // The killer was credited above ONLY when eligiblePlayers was empty
+            // (the killer-only fallback path at line ~872 fires DoOnMonsterHuntEvents
+            // on the killer directly). If a tag team exists and the killing blow
+            // came from a player *outside* that team, the killer is NOT in
+            // eligiblePlayers and was NOT credited — they're a damage dealer who
+            // should receive TagShare credit, so don't pre-mark them as credited.
             var alreadyCredited = new HashSet<Character>(eligiblePlayers);
-            if (killer is Character ck)
+            if (eligiblePlayers.Count == 0 && killer is Character ck)
             {
                 alreadyCredited.Add(ck);
             }

--- a/AAEmu.Game/Models/Game/NPChar/Npc.cs
+++ b/AAEmu.Game/Models/Game/NPChar/Npc.cs
@@ -9,6 +9,7 @@ using AAEmu.Game.Models.Game.AI.v2.Framework;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Formulas;
 using AAEmu.Game.Models.Game.Items;
+using AAEmu.Game.Models.Game.Items.Containers;
 using AAEmu.Game.Models.Game.Models;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Skills.Effects;
@@ -994,12 +995,18 @@ public partial class Npc : Unit
         if (AppConfiguration.Instance.World.TagShareEnabled)
         {
             var alreadyCredited = new HashSet<Character>(eligiblePlayers);
-            if (killer is Character ck) alreadyCredited.Add(ck);
+            if (killer is Character ck)
+            {
+                alreadyCredited.Add(ck);
+            }
 
-            var contributors = CharacterTagging.GetAllContributors(Items.Containers.LootingContainer.MaxLootingRange);
+            var contributors = CharacterTagging.GetAllContributors(LootingContainer.MaxLootingRange);
             foreach (var contributor in contributors)
             {
-                if (!alreadyCredited.Add(contributor)) continue;
+                if (!alreadyCredited.Add(contributor))
+                {
+                    continue;
+                }
                 QuestManager.Instance.DoOnMonsterHuntEvents(contributor, this);
             }
         }

--- a/AAEmu.Game/Models/Game/NPChar/Tagging.cs
+++ b/AAEmu.Game/Models/Game/NPChar/Tagging.cs
@@ -40,10 +40,13 @@ public class Tagging(Unit owner)
 
     public void ClearAllTaggers()
     {
-        _taggers = [];
-        _tagger = null;
-        _tagTeam = 0;
-        // _totalDamage = 0;
+        lock (_lock)
+        {
+            _taggers = [];
+            _tagger = null;
+            _tagTeam = 0;
+            // _totalDamage = 0;
+        }
     }
 
     public void AddTagger(Unit checkUnit, int damage)

--- a/AAEmu.Game/Models/Game/NPChar/Tagging.cs
+++ b/AAEmu.Game/Models/Game/NPChar/Tagging.cs
@@ -127,6 +127,11 @@ public class Tagging(Unit owner)
         }
 
         var result = new HashSet<Character>();
+        // Skip re-resolving the same team when multiple dealers are in the same party
+        // or raid — GetTeamByObjId is an O(teams*members) scan, so on a busy mob
+        // where several damage dealers share one raid we'd otherwise pay that cost
+        // once per dealer.
+        var visitedTeams = new HashSet<uint>();
         foreach (var dealer in dealers)
         {
             if (dealer == null || !dealer.IsOnline) continue;
@@ -137,7 +142,7 @@ public class Tagging(Unit owner)
             // Pull in party / raid mates within range
             if (!dealer.InParty) continue;
             var team = TeamManager.Instance.GetTeamByObjId(dealer.ObjId);
-            if (team == null) continue;
+            if (team == null || !visitedTeams.Add(team.Id)) continue;
 
             foreach (var member in team.Members)
             {

--- a/AAEmu.Game/Models/Game/NPChar/Tagging.cs
+++ b/AAEmu.Game/Models/Game/NPChar/Tagging.cs
@@ -116,27 +116,34 @@ public class Tagging(Unit owner)
     /// </summary>
     public HashSet<Character> GetAllContributors(float range)
     {
-        var result = new HashSet<Character>();
+        // Snapshot the damage-dealer keys under the tagging lock, then resolve teams
+        // outside the lock to avoid holding the tagging lock while reaching into
+        // TeamManager (which has its own lock domain).
+        Character[] dealers;
         lock (_lock)
         {
-            foreach (var (dealer, _) in _taggers)
+            dealers = new Character[_taggers.Count];
+            _taggers.Keys.CopyTo(dealers, 0);
+        }
+
+        var result = new HashSet<Character>();
+        foreach (var dealer in dealers)
+        {
+            if (dealer == null || !dealer.IsOnline) continue;
+            if (dealer.GetDistanceTo(Owner, true) > range) continue;
+
+            result.Add(dealer);
+
+            // Pull in party / raid mates within range
+            if (!dealer.InParty) continue;
+            var team = TeamManager.Instance.GetTeamByObjId(dealer.ObjId);
+            if (team == null) continue;
+
+            foreach (var member in team.Members)
             {
-                if (dealer == null || !dealer.IsOnline) continue;
-                if (dealer.GetDistanceTo(Owner, true) > range) continue;
-
-                result.Add(dealer);
-
-                // Pull in party / raid mates within range
-                if (!dealer.InParty) continue;
-                var team = TeamManager.Instance.GetTeamByObjId(dealer.ObjId);
-                if (team == null) continue;
-
-                foreach (var member in team.Members)
-                {
-                    if (member?.Character == null || !member.Character.IsOnline) continue;
-                    if (member.Character.GetDistanceTo(Owner, true) > range) continue;
-                    result.Add(member.Character);
-                }
+                if (member?.Character == null || !member.Character.IsOnline) continue;
+                if (member.Character.GetDistanceTo(Owner, true) > range) continue;
+                result.Add(member.Character);
             }
         }
         return result;

--- a/AAEmu.Game/Models/Game/NPChar/Tagging.cs
+++ b/AAEmu.Game/Models/Game/NPChar/Tagging.cs
@@ -106,4 +106,39 @@ public class Tagging(Unit owner)
             // TODO: packet to set red-but-not-aggro HP bar for taggers, "dull red" HP bar for not-taggers
         }
     }
+
+    /// <summary>
+    /// Returns every player who dealt damage to this NPC plus their party / raid
+    /// mates that are within <paramref name="range"/>. Used by the TagShareEnabled
+    /// feature in <c>Npc.DoDie</c> to fan out quest credit to all contributors —
+    /// even ones who didn't pass the 50% HP threshold that <see cref="Tagger"/> uses.
+    /// Loot and XP are NOT routed through this list; only quest events.
+    /// </summary>
+    public HashSet<Character> GetAllContributors(float range)
+    {
+        var result = new HashSet<Character>();
+        lock (_lock)
+        {
+            foreach (var (dealer, _) in _taggers)
+            {
+                if (dealer == null || !dealer.IsOnline) continue;
+                if (dealer.GetDistanceTo(Owner, true) > range) continue;
+
+                result.Add(dealer);
+
+                // Pull in party / raid mates within range
+                if (!dealer.InParty) continue;
+                var team = TeamManager.Instance.GetTeamByObjId(dealer.ObjId);
+                if (team == null) continue;
+
+                foreach (var member in team.Members)
+                {
+                    if (member?.Character == null || !member.Character.IsOnline) continue;
+                    if (member.Character.GetDistanceTo(Owner, true) > range) continue;
+                    result.Add(member.Character);
+                }
+            }
+        }
+        return result;
+    }
 }

--- a/AAEmu.Game/Models/Game/Team/Team.cs
+++ b/AAEmu.Game/Models/Game/Team/Team.cs
@@ -1,4 +1,6 @@
-﻿using AAEmu.Commons.Network;
+﻿using System.Threading;
+
+using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Models.Game.Char;
@@ -24,7 +26,20 @@ public class Team : PacketMarshaler
     /// (or the team has not yet reached the all-offline state). Reset to MinValue
     /// whenever a member reconnects.
     /// </summary>
-    public DateTime AllOfflineSince { get; set; } = DateTime.MinValue;
+    /// <remarks>
+    /// Backed by <see cref="Interlocked.Read"/> / <see cref="Interlocked.Exchange"/>
+    /// on a <see cref="long"/> ticks field because the write happens from the
+    /// game-handler thread (in <c>SetOffline</c> / <c>UpdateAtLogin</c>) while the
+    /// read happens from the <c>UpdateAllTeams</c> tick thread — without atomic
+    /// access a 64-bit value's halves could tear on 32-bit hosts and visibility is
+    /// not guaranteed by the C# memory model on any host.
+    /// </remarks>
+    public DateTime AllOfflineSince
+    {
+        get => new(Interlocked.Read(ref _allOfflineSinceTicks));
+        set => Interlocked.Exchange(ref _allOfflineSinceTicks, value.Ticks);
+    }
+    private long _allOfflineSinceTicks; // backing field for AllOfflineSince
 
     public Team()
     {

--- a/AAEmu.Game/Models/Game/Team/Team.cs
+++ b/AAEmu.Game/Models/Game/Team/Team.cs
@@ -17,6 +17,15 @@ public class Team : PacketMarshaler
     public (byte, uint)[] MarksList { get; set; }
     public WorldSpawnPosition PingPosition { get; set; }
 
+    /// <summary>
+    /// Timestamp when the team transitioned to "every member offline" so the 500ms
+    /// remote-sync tick in <c>TeamManager</c> can disband zombie teams after a grace
+    /// period. <see cref="DateTime.MinValue"/> means at least one member is online
+    /// (or the team has not yet reached the all-offline state). Reset to MinValue
+    /// whenever a member reconnects.
+    /// </summary>
+    public DateTime AllOfflineSince { get; set; } = DateTime.MinValue;
+
     public Team()
     {
         Members = new TeamMember[50];

--- a/AAEmu.Game/Models/Game/Team/Team.cs
+++ b/AAEmu.Game/Models/Game/Team/Team.cs
@@ -41,6 +41,15 @@ public class Team : PacketMarshaler
     }
     private long _allOfflineSinceTicks; // backing field for AllOfflineSince
 
+    /// <summary>
+    /// Mutex held by <c>TeamManager.DisbandOfflineTeam</c> and <c>UpdateAtLogin</c>
+    /// to keep the zombie-disband wipe loop and a concurrent reconnect from
+    /// interleaving. Without this, a reconnect that lands between the disband's
+    /// re-verify check and the per-member InParty wipe would be silently corrupted
+    /// (live player ends up with InParty = false and no backing team).
+    /// </summary>
+    public readonly object SyncLock = new();
+
     public Team()
     {
         Members = new TeamMember[50];

--- a/AAEmu.Game/Models/Game/Team/TeamMember.cs
+++ b/AAEmu.Game/Models/Game/Team/TeamMember.cs
@@ -24,9 +24,9 @@ public class TeamMember(Character character = null) : PacketMarshaler
 
     /// <summary>
     /// Writes a 50-byte "remote team member" snapshot used by SCTeamRemoteMembersExPacket
-    /// and SCJoinedTeamPacket. The ObjId is carried explicitly (0 when offline) so the
-    /// client can correlate the member against units it has already learned about even
-    /// when the member is outside its render distance.
+    /// and SCTeamMemberDisconnectedPacket. The ObjId is carried explicitly (0 when offline)
+    /// so the client can correlate the member against units it has already learned about,
+    /// even when the member is outside its render distance.
     /// </summary>
     public PacketStream WritePerson(PacketStream stream)
     {

--- a/AAEmu.Game/Models/Game/Team/TeamMember.cs
+++ b/AAEmu.Game/Models/Game/Team/TeamMember.cs
@@ -22,21 +22,33 @@ public class TeamMember(Character character = null) : PacketMarshaler
         return stream;
     }
 
+    /// <summary>
+    /// Writes a 50-byte "remote team member" snapshot used by SCTeamRemoteMembersExPacket
+    /// and SCJoinedTeamPacket. The ObjId is carried explicitly (0 when offline) so the
+    /// client can correlate the member against units it has already learned about even
+    /// when the member is outside its render distance.
+    /// </summary>
     public PacketStream WritePerson(PacketStream stream)
     {
-        stream.Write(Character.Id);
-        stream.Write((ulong)0); // zi
-        stream.Write(Character.Level);
-        stream.Write(Character.Hp);
-        stream.Write(Character.MaxHp);
-        stream.Write(Character.Mp);
-        stream.Write(Character.MaxMp);
-        stream.WritePosition(Character.Transform.World.Position);
-        stream.Write((double)Character.Transform.World.Rotation.Z.RadToDeg()); // angZ
-        stream.Write((byte)Character.Ability1);
-        stream.Write((byte)Character.Ability2);
-        stream.Write((byte)Character.Ability3);
-        stream.Write(!Character.IsOnline);
-        return stream;
+        stream.Write(Character.Id);                                             // uint   (4)
+        stream.Write(Character.Transform.ZoneId);                               // uint   (4) - zone id
+        stream.Write(Character.Transform.InstanceId);                           // uint   (4) - instance id
+        stream.Write(Character.Level);                                          // byte   (1)
+        stream.Write(Character.Hp);                                             // int    (4)
+        stream.Write(Character.MaxHp);                                          // int    (4)
+        stream.Write(Character.Mp);                                             // int    (4)
+        stream.Write(Character.MaxMp);                                          // int    (4)
+        stream.WritePosition(Character.Transform.World.Position);               // bytes  (9)
+        stream.WriteBc(Character.IsOnline ? Character.ObjId : 0);               // bc     (3) - ObjId or 0 if offline
+        stream.Write((byte)0);                                                  // byte   (1) - padding
+        stream.Write((byte)Character.Ability1);                                 // byte   (1)
+        stream.Write((byte)Character.Ability2);                                 // byte   (1)
+        stream.Write((byte)Character.Ability3);                                 // byte   (1)
+        stream.Write((byte)0);                                                  // byte   (1)
+        stream.Write((byte)0);                                                  // byte   (1)
+        stream.Write((byte)0);                                                  // byte   (1)
+        stream.Write((byte)0);                                                  // byte   (1)
+        stream.Write((byte)0);                                                  // byte   (1)
+        return stream;                                                          // total: 50 bytes
     }
 }

--- a/AAEmu.UnitTests/Game/Core/Managers/EnterWorldManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/EnterWorldManagerTests.cs
@@ -11,7 +11,6 @@ public class EnterWorldManagerTests
         var mockAccount = Mock.Of<IAccountManager>();
         var mockStream = Mock.Of<IStreamManager>();
         var mockQuest = Mock.Of<IQuestManager>();
-        var mockTeam = Mock.Of<ITeamManager>();
         var mockChat = Mock.Of<IChatManager>();
         var mockFamily = Mock.Of<IFamilyManager>();
         var mockWorld = Mock.Of<IWorldManager>();
@@ -20,7 +19,6 @@ public class EnterWorldManagerTests
             mockAccount.Object,
             mockStream.Object,
             mockQuest.Object,
-            mockTeam.Object,
             mockChat.Object,
             mockFamily.Object,
             mockWorld.Object);
@@ -29,7 +27,6 @@ public class EnterWorldManagerTests
         Mock.VerifyNoOtherCalls(mockAccount);
         Mock.VerifyNoOtherCalls(mockStream);
         Mock.VerifyNoOtherCalls(mockQuest);
-        Mock.VerifyNoOtherCalls(mockTeam);
         Mock.VerifyNoOtherCalls(mockChat);
         Mock.VerifyNoOtherCalls(mockFamily);
         Mock.VerifyNoOtherCalls(mockWorld);


### PR DESCRIPTION
# Party / Raid remote-member sync, ObjId refresh, and optional Tag Share

This PR fixes the long-standing "raid mate is shown as offline once they leave my render distance" symptom and adds an opt-in monster-kill share so two parties or raids on the same camp can both progress kill-quests.

All work is contained in three feature commits + one review-cleanup commit on top of current `develop`. Builds cleanly (`dotnet build AAEmu.Game/AAEmu.Game.csproj`) with zero new errors.

---

## 1. `TeamMember.WritePerson` 50-byte fix

The legacy `WritePerson` laid out 8 bytes of zero where the client expects `ZoneId` + `InstanceId`, then an 8-byte `angZ` double where the client expects a 3-byte `ObjId` (with one padding byte) + the three ability slots + 5 trailing bytes. The 1.2 client could not correlate the remote member to any unit it had streamed in, so a raid-mate outside the recipient's render distance showed up with a blank HP bar / "offline" label.

The new layout matches an observed packet capture:

| Field | Type | Size |
| --- | --- | --- |
| `Character.Id` | `uint` | 4 |
| `Transform.ZoneId` | `uint` | 4 |
| `Transform.InstanceId` | `uint` | 4 |
| `Level` | `byte` | 1 |
| `Hp` / `MaxHp` / `Mp` / `MaxMp` | `int` × 4 | 16 |
| `Transform.World.Position` | `WritePosition` | 9 |
| `ObjId` (or `0` when offline) | `WriteBc` | 3 |
| Padding | `byte` | 1 |
| `Ability1` / `Ability2` / `Ability3` | `byte` × 3 | 3 |
| Trailing padding | `byte` × 5 | 5 |
| **Total** | | **50** |

With the correct ObjId in the snapshot, the existing broadcast pipeline can update HP/MP/position on the recipient's raid UI even for mates that are not currently in render distance.

---

## 2. Periodic remote-member sync + ObjId refresh

`TeamManager` now coordinates three mechanisms so out-of-range team-mates always stay in sync:

### `AreInRenderDistance(a, b)`

Coarse Region-based check used as the skip condition everywhere: members in the same or any neighbouring Region are already covered by the normal broadcast pipeline. The check is **symmetric**: it walks `a.Region.GetNeighbors()` and `b.Region.GetNeighbors()`. Edge-of-world Regions whose neighbour set is asymmetric were the original reason for the bidirectional version (and a maintainer-anticipated review point).

### `RefreshTeamMemberObjIds(team, newMember)`

Sends `SCRefreshTeamMemberPacket` in both directions so every existing team-mate learns the new member's ObjId — but **only** for mate-pairs that are not already in render distance.

Hooked into:
- `CreateNewTeam` — target & owner may be anywhere on the map
- `ReplyToJoinTeam` — joining player can be far away
- `ConvertToRaid` — raid members spread out across zones
- `UpdateAtLogin` — re-joining player needs to learn current ObjIds

### `UpdateAllTeams(delta)` — 500ms tick

For each (recipient, source) pair of online team-mates that are not in render distance, sends a single-member `SCTeamRemoteMembersExPacket` with the source's current `Hp / MaxHp / Mp / MaxMp / position / ObjId`.

Two optimisations keep this cheap:

- **Delta cache** `_lastSyncState` keyed by `(recipientId, sourceId)`. If the snapshot is identical to the previous one we sent, the packet is skipped. A 5-second **forced resync** then guarantees the recipient gets a fresh packet even if the cache hides a real change due to packet loss.
- **Region skip** — pairs in render distance are skipped entirely (the normal broadcast already covers them).

A stationary raid produces zero remote-sync traffic. A moving raid only generates packets for the mates that are actually out of each other's view.

### Cache hygiene — `ClearSyncState(characterId)`

Called from every path that removes a character from a team: `SetOffline`, `AskRiskyTeam(Leave / Kick)`, and the `AskRiskyTeam` Disband loop. Prevents the delta cache from growing unbounded.

### Reconnect path

`UpdateAtLogin` no longer broadcasts a fresh `SCTeamMemberJoinedPacket` (which the client renders as a chat-spammy "Member X joined" line on every reconnect). Instead it sends one bulk `SCTeamRemoteMembersExPacket` with every current member and then `RefreshTeamMemberObjIds` to bridge the ObjIds.

### Concurrency

The tick is registered with `useAsync: false`, and the `_lastSyncState` cache is wrapped in a lock for both the delta check and `ClearSyncState`. `_activeTeams.Values` is copied under lock at the start of the tick so a parallel join/disband cannot invalidate the enumerator.

---

## 3. `TagShareEnabled` toggle (default off → vanilla)

New flag in `WorldConfig`:

```json
"TagShareEnabled": false
```

When `false` (the default), every kill behaves exactly like current `develop` — only the killer and the tag-team (50% HP threshold) get quest credit.

When `true`, after the usual XP / loot / quest distribution to the tag-team, an extra `DoOnMonsterHuntEvents` is fired for every other player that dealt damage to the mob, plus their party / raid mates within `LootingContainer.MaxLootingRange` (200m). A `HashSet` dedupes against players who already received credit through the existing tag-team or killer-only branch.

Use case: small groups grinding the same camp, or multiple raids racing on a world boss, can all finish kill-quests together.

**XP and loot are NOT affected** by this flag — only quest progress fans out. The 50% HP tag-team retains exclusive loot rights and the existing XP modifiers (solo / duo / trio / full-party / raid scaling) are untouched.

### Implementation

- `Tagging.GetAllContributors(range)` walks the per-NPC `_taggers` dictionary, snapshots the dealer keys under the existing tagging lock, then resolves party / raid membership **outside** the lock to avoid holding it while reaching across into `TeamManager`. Returns a `HashSet<Character>` of all damage dealers (and their nearby team-mates) within range.
- The TagShare block in `Npc.DoDie` sits **after** both the eligible-players loop and the killer-only fallback, so it fires regardless of whether anyone broke the 50% HP threshold. Even pure "two parties at 40% each" pulls now share quest credit.

---

## Files changed

| File | Why |
| --- | --- |
| `Models/Game/Team/TeamMember.cs` | WritePerson 50-byte layout fix |
| `Core/Managers/TeamManager.cs` | Remote-sync tick, ObjId refresh, cache cleanup, UpdateAtLogin rewrite |
| `Models/Game/Configurations.cs` | `+TagShareEnabled` (default `false`) |
| `Configurations/World.json` | Default value |
| `Models/Game/NPChar/Tagging.cs` | `+GetAllContributors(range)` helper |
| `Models/Game/NPChar/Npc.cs` | TagShare quest fanout block in `DoDie` |

## Test plan

**Remote sync** (no flag — default on):

- Two test chars in different zones (e.g. Solzreed + Gweonid). Party → Raid. Both clients show the other's HP / position / class on the raid UI; values update as the remote mate moves.
- Reconnect one of them — no chat-spam "Member X joined" line, raid UI updates seamlessly.
- Disband + re-form mid-session — `_lastSyncState` is empty afterwards (verified by stepping into `ClearSyncState`).

**TagShare** (flag-gated):

- Default (`false`) — kills route credit exactly as on current `develop`.
- Set `"TagShareEnabled": true` in World.json, restart.
- Two parties on the same mob, one breaks 50% damage:
  - Both parties' members receive monster-hunt quest credit.
  - Loot + XP remain with the tag-team (verified by inventory + XP-bar).
- Two parties at ~40% damage each (no tag-team):
  - Both parties' members still receive credit (killer-only fallback path also goes through the fanout).
- One party with one passive member who never hits:
  - Passive member receives credit by virtue of being in the same party as a damage-dealer + within 200m (this matches "any member hits → whole party gets it").
- Player runs away to ~250m before kill — does **not** receive credit (out of range).

---

Co-Authored-By: Evenstone &lt;evenstone@noreply.users.github.com&gt;
