### PR TITLE
NPC crowd-control & forced-movement effects (Pull / Lift / Knockback / Dash / Leap / Fear)

### DIFF
--- a/AAEmu.Game/Core/Managers/SkillManager.cs
+++ b/AAEmu.Game/Core/Managers/SkillManager.cs
@@ -579,6 +579,9 @@ public class SkillManager(IAnimationManager animationManager, IPlotManager plotM
                             RemoveOnLand = reader.GetBoolean("remove_on_land", true),
                             Gliding = reader.GetBoolean("gliding", true),
                             GlidingRotateSpeed = reader.GetInt32("gliding_rotate_speed"),
+                            GlidingLiftHeight = reader.GetFloat("gliding_lift_height", 0f),
+                            GlidingLiftSpeed = reader.GetFloat("gliding_lift_speed", 0f),
+                            GlidingLiftDuration = reader.GetFloat("gliding_lift_duration", 0f),
                             Knockdown = reader.GetBoolean("knock_down", true),
                             TickAreaExcludeSource = reader.GetBoolean("tick_area_exclude_source", true),
                             // TODO 

--- a/AAEmu.Game/Core/Packets/C2G/CSSpawnCharacterPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSSpawnCharacterPacket.cs
@@ -12,6 +12,13 @@ public class CSSpawnCharacterPacket() : GamePacket(CSOffsets.CSSpawnCharacterPac
 {
     public override void Read(PacketStream stream)
     {
+        if (Connection.ActiveChar == null)
+        {
+            Logger.Error("CSSpawnCharacterPacket: ActiveChar is null for account {0} — no character was selected. Disconnecting.", Connection.AccountId);
+            Connection.Shutdown();
+            return;
+        }
+
         Connection.State = GameState.World;
 
         Connection.ActiveChar.VisualOptions = new CharacterVisualOptions();

--- a/AAEmu.Game/Models/Game/AI/v2/Behaviors/BaseCombatBehavior.cs
+++ b/AAEmu.Game/Models/Game/AI/v2/Behaviors/BaseCombatBehavior.cs
@@ -45,7 +45,15 @@ public abstract class BaseCombatBehavior : Behavior
             return;
         }
 
-        if (Ai.Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Shackle)) ||
+        // Combat chase runs BEFORE Npc.MoveTowards in the AI tick. A plain Shackle
+        // check here would hard-root the NPC for every slow that rides the Shackle
+        // tag (e.g. Charged Bolt — Shackle + DecreaseMoveSpeed), turning a slow
+        // into a full root during combat. Exclude buffs that also carry the
+        // DecreaseMoveSpeed tag so they slow rather than stop, matching the gate
+        // in Npc.MoveTowards. The Snare-only check is kept alongside.
+        if (Ai.Owner.Buffs.CheckBuffsExcludingTags(
+                SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Shackle),
+                [(uint)SkillConstants.DecreaseMoveSpeed]) ||
             Ai.Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Snare)))
         {
             return;

--- a/AAEmu.Game/Models/Game/AI/v2/Behaviors/BaseCombatBehavior.cs
+++ b/AAEmu.Game/Models/Game/AI/v2/Behaviors/BaseCombatBehavior.cs
@@ -237,6 +237,12 @@ public abstract class BaseCombatBehavior : Behavior
     {
         get
         {
+            // Never trigger return while a SkillController (Fear, Lift, Pull, Dash, Leap)
+            // is actively driving the NPC. The SC owns movement until the buff expires;
+            // a return decision here would tear it out mid-flight and teleport home.
+            if ((Ai.Owner.ActiveSkillController?.State ?? SkillController.SCState.Ended) == SkillController.SCState.Running)
+                return false;
+
             var returnDistance = 50f;
             var absoluteReturnDistance = 200f;
 
@@ -273,6 +279,14 @@ public abstract class BaseCombatBehavior : Behavior
         {
             return false;
         }
+
+        // Don't update / change target while a SkillController is running (Fear, Lift).
+        // SetTarget below would broadcast SCTargetChangedPacket, which the 1.2 client
+        // turns into a "look at target" facing overlay — so a fear'd NPC visually keeps
+        // looking straight at the player even while running away from them.
+        if ((Ai.Owner.ActiveSkillController?.State ?? SkillController.SCState.Ended) == SkillController.SCState.Running)
+            return Ai.Owner.CurrentTarget != null;
+
         // We might want to optimize this somehow.
         var aggroList = Ai.Owner.AggroTable.Values;
         var abusers = aggroList.OrderByDescending(o => o.TotalAggro).Select(o => o.Owner).ToList();

--- a/AAEmu.Game/Models/Game/AI/v2/Behaviors/BaseCombatBehavior.cs
+++ b/AAEmu.Game/Models/Game/AI/v2/Behaviors/BaseCombatBehavior.cs
@@ -31,6 +31,9 @@ public abstract class BaseCombatBehavior : Behavior
         if (Ai?.Owner == null)
             return;
 
+        if (Ai.Owner.DisplacedUntil.HasValue && Ai.Owner.DisplacedUntil.Value > DateTime.UtcNow)
+            return;
+
         if (Ai.Owner.Buffs.HasEffectsMatchingCondition(e =>
                 e.Template.Stun
                 || e.Template.Sleep

--- a/AAEmu.Game/Models/Game/NPChar/Npc.cs
+++ b/AAEmu.Game/Models/Game/NPChar/Npc.cs
@@ -1140,8 +1140,14 @@ public partial class Npc : Unit
             return false;
         }
 
-        if (Ai.Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Shackle)) ||
-            Ai.Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Snare)))
+        // Shackle (160) is the broad "root family" tag — pure roots and snares both
+        // ride it. The exclude list strips buffs that ALSO have the DecreaseMoveSpeed
+        // (161) tag, which is how slow debuffs like Charged Bolt are encoded: they
+        // ship as Shackle + DecreaseMoveSpeed, mean "slow, not stop", and without
+        // this exclusion the NPC would be fully rooted by every slow it gets hit by.
+        if (Ai.Owner.Buffs.CheckBuffsExcludingTags(
+                SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Shackle),
+                [(uint)SkillConstants.DecreaseMoveSpeed]))
         {
             return false;
         }

--- a/AAEmu.Game/Models/Game/NPChar/Npc.cs
+++ b/AAEmu.Game/Models/Game/NPChar/Npc.cs
@@ -1140,14 +1140,19 @@ public partial class Npc : Unit
             return false;
         }
 
-        // Shackle (160) is the broad "root family" tag — pure roots and snares both
-        // ride it. The exclude list strips buffs that ALSO have the DecreaseMoveSpeed
-        // (161) tag, which is how slow debuffs like Charged Bolt are encoded: they
-        // ship as Shackle + DecreaseMoveSpeed, mean "slow, not stop", and without
-        // this exclusion the NPC would be fully rooted by every slow it gets hit by.
+        // Shackle (160) is the broad "root family" tag — most snares ride it.
+        // The exclude list strips buffs that ALSO have the DecreaseMoveSpeed
+        // (161) tag, which is how slow debuffs like Charged Bolt are encoded:
+        // they ship as Shackle + DecreaseMoveSpeed, mean "slow, not stop", and
+        // without this exclusion the NPC would be fully rooted by every slow it
+        // gets hit by. The dedicated Snare (27) check is kept alongside to
+        // catch any Snare-only-tagged buffs that don't ride the Shackle family —
+        // matches the dual-check pattern in DashSkillController and
+        // LeapSkillController so all three gates agree.
         if (Ai.Owner.Buffs.CheckBuffsExcludingTags(
                 SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Shackle),
-                [(uint)SkillConstants.DecreaseMoveSpeed]))
+                [(uint)SkillConstants.DecreaseMoveSpeed]) ||
+            Ai.Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Snare)))
         {
             return false;
         }

--- a/AAEmu.Game/Models/Game/NPChar/Npc.cs
+++ b/AAEmu.Game/Models/Game/NPChar/Npc.cs
@@ -1118,6 +1118,12 @@ public partial class Npc : Unit
     /// <returns>True if withing rangeTolerance of other</returns>
     public bool MoveTowards(Vector3 other, float distance, byte actorFlags = 4, float rangeTolerance = 1f)
     {
+        if ((ActiveSkillController?.State ?? SkillController.SCState.Ended) == SkillController.SCState.Running)
+            return false;
+
+        if (DisplacedUntil.HasValue && DisplacedUntil.Value > DateTime.UtcNow)
+            return false;
+
         distance *= Ai.Owner.MoveSpeedMul; // Apply speed modifier
         if (distance < 0.01f)
             return false;
@@ -1139,9 +1145,6 @@ public partial class Npc : Unit
         {
             return false;
         }
-
-        if ((ActiveSkillController?.State ?? SkillController.SCState.Ended) == SkillController.SCState.Running)
-            return false;
 
         var oldPosition = Transform.Local.ClonePosition();
 

--- a/AAEmu.Game/Models/Game/Skills/Effects/ImpulseEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/ImpulseEffect.cs
@@ -34,7 +34,7 @@ public class ImpulseEffect : EffectTemplate
         Logger.Debug("ImpulseEffect: caster={0}, target={1}, impulse=({2},{3},{4}), velImpulse=({5},{6},{7})",
             caster?.ObjId, target?.ObjId, ImpulseX, ImpulseY, ImpulseZ, VelImpulseX, VelImpulseY, VelImpulseZ);
 
-        if (caster == null || target == null || (target is Unit tgtUnit && tgtUnit.IsDead))
+        if (caster == null || target == null)
             return;
 
         if (target.Buffs.HasEffectsMatchingCondition(e => e.Template.KnockbackImmune || e.Template.NonPushable))

--- a/AAEmu.Game/Models/Game/Skills/Effects/ImpulseEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/ImpulseEffect.cs
@@ -1,6 +1,12 @@
-﻿using AAEmu.Game.Core.Packets;
+using System.Numerics;
+
+using AAEmu.Game.Core.Packets;
+using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Skills.Templates;
 using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.Game.Units.Movements;
+using AAEmu.Game.Models.StaticValues;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects;
 
@@ -25,6 +31,72 @@ public class ImpulseEffect : EffectTemplate
         CastAction castObj, EffectSource source, SkillObject skillObject, DateTime time,
         CompressedGamePackets packetBuilder = null)
     {
-        Logger.Trace("ImpulseEffect");
+        Logger.Debug("ImpulseEffect: caster={0}, target={1}, impulse=({2},{3},{4}), velImpulse=({5},{6},{7})",
+            caster?.ObjId, target?.ObjId, ImpulseX, ImpulseY, ImpulseZ, VelImpulseX, VelImpulseY, VelImpulseZ);
+
+        if (target == null || (target is Unit tgtUnit && tgtUnit.IsDead))
+            return;
+
+        if (target.Buffs.HasEffectsMatchingCondition(e => e.Template.KnockbackImmune || e.Template.NonPushable))
+            return;
+
+        if (target is Npc npcTarget && npcTarget.Template.NonPushableByActor)
+            return;
+
+        // Impulse vector is in caster→target local space.
+        // Use positional (Impulse) + velocity (VelImpulse) as combined displacement.
+        var impulse = new Vector3(ImpulseX + VelImpulseX, ImpulseY + VelImpulseY, ImpulseZ + VelImpulseZ);
+
+        if (impulse.LengthSquared() < 0.01f)
+            return;
+
+        var displacement = impulse / 1000f;
+
+        var casterPos = caster.Transform.World.Position;
+        var targetPos = target.Transform.World.Position;
+        var dir = targetPos - casterPos;
+        dir.Z = 0;
+        if (dir.LengthSquared() > 0.01f)
+        {
+            dir = Vector3.Normalize(dir);
+            var right = new Vector3(-dir.Y, dir.X, 0);
+            // X=right, Y=forward, Z=up
+            var worldDisplacement = right * displacement.X + dir * displacement.Y + Vector3.UnitZ * displacement.Z;
+            displacement = worldDisplacement;
+        }
+
+        var endPos = targetPos + displacement;
+
+        if (target is Npc npc)
+        {
+            npc.DisplacedUntil = DateTime.UtcNow.AddMilliseconds(600);
+
+            var oldPosition = npc.Transform.Local.ClonePosition();
+
+            var groundZ = npc.ParentWorld.Template.GeoData.GetHeight(new Vector3(endPos.X, endPos.Y, endPos.Z));
+            if (groundZ > 0 && Math.Abs(endPos.Z - groundZ) < 5f)
+                endPos.Z = groundZ;
+
+            npc.Transform.Local.SetPosition(endPos.X, endPos.Y, endPos.Z);
+
+            var moveType = (UnitMoveType)MoveType.GetType(MoveTypeEnum.Unit);
+            moveType.X = endPos.X;
+            moveType.Y = endPos.Y;
+            moveType.Z = endPos.Z;
+            moveType.VelX = 0;
+            moveType.VelY = 0;
+            moveType.VelZ = 0;
+            moveType.RotationX = 0;
+            moveType.RotationY = 0;
+            moveType.RotationZ = npc.Transform.Local.ToRollPitchYawSBytesMovement().Item3;
+            moveType.Flags = MoveTypeFlags.Stopping | (npc.IsInBattle ? MoveTypeFlags.InCombat : 0);
+            moveType.DeltaMovement = new sbyte[3];
+            moveType.Stance = npc.CurrentGameStance;
+            moveType.Alertness = npc.CurrentAlertness;
+            moveType.Time = (uint)(DateTime.UtcNow - DateTime.UtcNow.Date).TotalMilliseconds;
+            npc.BroadcastPacket(new SCOneUnitMovementPacket(npc.ObjId, moveType), false);
+
+            npc.CheckMovedPosition(oldPosition);
+        }
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/ImpulseEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/ImpulseEffect.cs
@@ -50,20 +50,9 @@ public class ImpulseEffect : EffectTemplate
         if (impulse.LengthSquared() < 0.01f)
             return;
 
-        var displacement = impulse / 1000f;
-
         var casterPos = caster.Transform.World.Position;
         var targetPos = target.Transform.World.Position;
-        var dir = targetPos - casterPos;
-        dir.Z = 0;
-        if (dir.LengthSquared() > 0.01f)
-        {
-            dir = Vector3.Normalize(dir);
-            var right = new Vector3(-dir.Y, dir.X, 0);
-            // X=right, Y=forward, Z=up
-            var worldDisplacement = right * displacement.X + dir * displacement.Y + Vector3.UnitZ * displacement.Z;
-            displacement = worldDisplacement;
-        }
+        var displacement = LocalImpulseToWorldDisplacement(impulse, casterPos, targetPos);
 
         var endPos = targetPos + displacement;
 
@@ -98,5 +87,26 @@ public class ImpulseEffect : EffectTemplate
 
             npc.CheckMovedPosition(oldPosition);
         }
+    }
+
+    /// <summary>
+    /// Converts a caster-target local impulse (X=right, Y=forward, Z=up, units = 1/1000 m)
+    /// into a world-space displacement vector. When the caster→target direction is
+    /// degenerate (caster on top of target) the impulse is returned unchanged in world
+    /// space; the small-impulse early-exit lives in the caller.
+    /// </summary>
+    internal static Vector3 LocalImpulseToWorldDisplacement(
+        Vector3 localImpulse, Vector3 casterPos, Vector3 targetPos)
+    {
+        var displacement = localImpulse / 1000f;
+
+        var dir = targetPos - casterPos;
+        dir.Z = 0;
+        if (dir.LengthSquared() <= 0.01f)
+            return displacement;
+
+        dir = Vector3.Normalize(dir);
+        var right = new Vector3(-dir.Y, dir.X, 0);
+        return right * displacement.X + dir * displacement.Y + Vector3.UnitZ * displacement.Z;
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/ImpulseEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/ImpulseEffect.cs
@@ -34,7 +34,7 @@ public class ImpulseEffect : EffectTemplate
         Logger.Debug("ImpulseEffect: caster={0}, target={1}, impulse=({2},{3},{4}), velImpulse=({5},{6},{7})",
             caster?.ObjId, target?.ObjId, ImpulseX, ImpulseY, ImpulseZ, VelImpulseX, VelImpulseY, VelImpulseZ);
 
-        if (target == null || (target is Unit tgtUnit && tgtUnit.IsDead))
+        if (caster == null || target == null || (target is Unit tgtUnit && tgtUnit.IsDead))
             return;
 
         if (target.Buffs.HasEffectsMatchingCondition(e => e.Template.KnockbackImmune || e.Template.NonPushable))

--- a/AAEmu.Game/Models/Game/Skills/Effects/PhysicalExplosionEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/PhysicalExplosionEffect.cs
@@ -37,23 +37,11 @@ public class PhysicalExplosionEffect : EffectTemplate
         var casterPos = caster.Transform.World.Position;
         var targetPos = target.Transform.World.Position;
 
-        var direction = targetPos - casterPos;
-        direction.Z = 0;
-        var dist = direction.Length();
-
-        if (dist > Radius || dist < HoleSize)
+        var displacement = ComputeKnockDisplacement(casterPos, targetPos, Radius, HoleSize, Pressure);
+        if (!displacement.HasValue)
             return;
 
-        if (direction.LengthSquared() < 0.01f)
-            direction = new Vector3(1, 0, 0);
-        direction = Vector3.Normalize(direction);
-
-        var falloff = 1f - (dist / Radius);
-        var knockDist = (Pressure / 1000f) * falloff;
-        if (knockDist < 0.5f)
-            return;
-
-        var endPos = targetPos + direction * knockDist;
+        var endPos = targetPos + displacement.Value;
 
         if (target is Npc npc)
         {
@@ -86,5 +74,32 @@ public class PhysicalExplosionEffect : EffectTemplate
 
             npc.CheckMovedPosition(oldPosition);
         }
+    }
+
+    /// <summary>
+    /// Computes the knock displacement vector from an explosion. Returns null when the
+    /// target is outside the explosion radius, inside the dead-zone hole, or when the
+    /// resulting knock distance is below a perceptible threshold (0.5m).
+    /// </summary>
+    internal static Vector3? ComputeKnockDisplacement(
+        Vector3 casterPos, Vector3 targetPos, float radius, float holeSize, float pressure)
+    {
+        var direction = targetPos - casterPos;
+        direction.Z = 0;
+        var dist = direction.Length();
+
+        if (dist > radius || dist < holeSize)
+            return null;
+
+        if (direction.LengthSquared() < 0.01f)
+            direction = new Vector3(1, 0, 0);
+        direction = Vector3.Normalize(direction);
+
+        var falloff = radius > 0f ? 1f - (dist / radius) : 0f;
+        var knockDist = (pressure / 1000f) * falloff;
+        if (knockDist < 0.5f)
+            return null;
+
+        return direction * knockDist;
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/PhysicalExplosionEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/PhysicalExplosionEffect.cs
@@ -1,6 +1,12 @@
-﻿using AAEmu.Game.Core.Packets;
+using System.Numerics;
+
+using AAEmu.Game.Core.Packets;
+using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Skills.Templates;
 using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.Game.Units.Movements;
+using AAEmu.Game.Models.StaticValues;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects;
 
@@ -16,6 +22,69 @@ public class PhysicalExplosionEffect : EffectTemplate
         CastAction castObj, EffectSource source, SkillObject skillObject, DateTime time,
         CompressedGamePackets packetBuilder = null)
     {
-        Logger.Trace("PhysicalExplosionEffect");
+        Logger.Debug("PhysicalExplosionEffect: caster={0}, target={1}, radius={2}, pressure={3}",
+            caster?.ObjId, target?.ObjId, Radius, Pressure);
+
+        if (target == null || (target is Unit tgtUnit && tgtUnit.IsDead))
+            return;
+
+        if (target.Buffs.HasEffectsMatchingCondition(e => e.Template.KnockbackImmune || e.Template.NonPushable))
+            return;
+
+        if (target is Npc npcTarget && npcTarget.Template.NonPushableByActor)
+            return;
+
+        var casterPos = caster.Transform.World.Position;
+        var targetPos = target.Transform.World.Position;
+
+        var direction = targetPos - casterPos;
+        direction.Z = 0;
+        var dist = direction.Length();
+
+        if (dist > Radius || dist < HoleSize)
+            return;
+
+        if (direction.LengthSquared() < 0.01f)
+            direction = new Vector3(1, 0, 0);
+        direction = Vector3.Normalize(direction);
+
+        var falloff = 1f - (dist / Radius);
+        var knockDist = (Pressure / 1000f) * falloff;
+        if (knockDist < 0.5f)
+            return;
+
+        var endPos = targetPos + direction * knockDist;
+
+        if (target is Npc npc)
+        {
+            npc.DisplacedUntil = DateTime.UtcNow.AddMilliseconds(600);
+
+            var oldPosition = npc.Transform.Local.ClonePosition();
+
+            var groundZ = npc.ParentWorld.Template.GeoData.GetHeight(new Vector3(endPos.X, endPos.Y, endPos.Z));
+            if (groundZ > 0 && Math.Abs(endPos.Z - groundZ) < 5f)
+                endPos.Z = groundZ;
+
+            npc.Transform.Local.SetPosition(endPos.X, endPos.Y, endPos.Z);
+
+            var moveType = (UnitMoveType)MoveType.GetType(MoveTypeEnum.Unit);
+            moveType.X = endPos.X;
+            moveType.Y = endPos.Y;
+            moveType.Z = endPos.Z;
+            moveType.VelX = 0;
+            moveType.VelY = 0;
+            moveType.VelZ = 0;
+            moveType.RotationX = 0;
+            moveType.RotationY = 0;
+            moveType.RotationZ = npc.Transform.Local.ToRollPitchYawSBytesMovement().Item3;
+            moveType.Flags = MoveTypeFlags.Stopping | (npc.IsInBattle ? MoveTypeFlags.InCombat : 0);
+            moveType.DeltaMovement = new sbyte[3];
+            moveType.Stance = npc.CurrentGameStance;
+            moveType.Alertness = npc.CurrentAlertness;
+            moveType.Time = (uint)(DateTime.UtcNow - DateTime.UtcNow.Date).TotalMilliseconds;
+            npc.BroadcastPacket(new SCOneUnitMovementPacket(npc.ObjId, moveType), false);
+
+            npc.CheckMovedPosition(oldPosition);
+        }
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/PhysicalExplosionEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/PhysicalExplosionEffect.cs
@@ -25,7 +25,7 @@ public class PhysicalExplosionEffect : EffectTemplate
         Logger.Debug("PhysicalExplosionEffect: caster={0}, target={1}, radius={2}, pressure={3}",
             caster?.ObjId, target?.ObjId, Radius, Pressure);
 
-        if (target == null || (target is Unit tgtUnit && tgtUnit.IsDead))
+        if (caster == null || target == null || (target is Unit tgtUnit && tgtUnit.IsDead))
             return;
 
         if (target.Buffs.HasEffectsMatchingCondition(e => e.Template.KnockbackImmune || e.Template.NonPushable))

--- a/AAEmu.Game/Models/Game/Skills/Effects/PhysicalExplosionEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/PhysicalExplosionEffect.cs
@@ -25,7 +25,7 @@ public class PhysicalExplosionEffect : EffectTemplate
         Logger.Debug("PhysicalExplosionEffect: caster={0}, target={1}, radius={2}, pressure={3}",
             caster?.ObjId, target?.ObjId, Radius, Pressure);
 
-        if (caster == null || target == null || (target is Unit tgtUnit && tgtUnit.IsDead))
+        if (caster == null || target == null)
             return;
 
         if (target.Buffs.HasEffectsMatchingCondition(e => e.Template.KnockbackImmune || e.Template.NonPushable))

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/Blink.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/Blink.cs
@@ -1,7 +1,12 @@
-﻿using AAEmu.Game.Core.Packets.G2C;
+using System.Numerics;
+
+using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.DoodadObj.Static;
+using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.Game.Units.Movements;
+using AAEmu.Game.Models.StaticValues;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects.SpecialEffects;
 
@@ -22,15 +27,12 @@ public class Blink : SpecialEffectAction
         int value3,
         int value4)
     {
-        if (caster is Character) { Logger.Debug($"Special effects: Blink value1 {value1}, value2 {value2}, value3 {value3}, value4 {value4}"); }
+        Logger.Debug($"Special effects: Blink caster={caster?.ObjId} value1={value1}, value2={value2}, value3={value3}, value4={value4}");
 
         if (caster is Character character)
         {
-            //character.SendMessage("From: " + character.Transform.ToString());
             using var newPos = character.Transform.CloneDetached();
             newPos.Local.AddDistanceToFront(value1);
-            //var (endX, endY) = MathUtil.AddDistanceToFront(value1, character.Transform.World.Position.X, character.Transform.World.Position.Y, (sbyte)value2);
-            //var endZ = character.Transform.World.Position.Z;
             if (character.IsRiding)
             {
                 var mateList = character.ParentWorld.MateManager.GetActiveMates(character.Id);
@@ -40,8 +42,44 @@ public class Blink : SpecialEffectAction
                 }
             }
             character.SendPacket(new SCBlinkUnitPacket(caster.ObjId, value1, value2, newPos.Local.Position.X, newPos.Local.Position.Y, newPos.Local.Position.Z));
-            //character.SendMessage("To: " + newPos.ToString());
-            //character.SendPacket(new SCBlinkUnitPacket(caster.ObjId, value1, value2, endX, endY, endZ));
+        }
+        else if (caster is Npc npc)
+        {
+            var oldPosition = npc.Transform.Local.ClonePosition();
+
+            using var newPos = npc.Transform.CloneDetached();
+            newPos.Local.AddDistanceToFront(value1);
+
+            var endX = newPos.Local.Position.X;
+            var endY = newPos.Local.Position.Y;
+            var endZ = newPos.Local.Position.Z;
+
+            var groundZ = npc.ParentWorld.Template.GeoData.GetHeight(new Vector3(endX, endY, endZ));
+            if (groundZ > 0 && Math.Abs(endZ - groundZ) < 5f)
+                endZ = groundZ;
+
+            npc.Transform.Local.SetPosition(endX, endY, endZ);
+
+            npc.BroadcastPacket(new SCBlinkUnitPacket(npc.ObjId, value1, value2, endX, endY, endZ), false);
+
+            var moveType = (UnitMoveType)MoveType.GetType(MoveTypeEnum.Unit);
+            moveType.X = endX;
+            moveType.Y = endY;
+            moveType.Z = endZ;
+            moveType.VelX = 0;
+            moveType.VelY = 0;
+            moveType.VelZ = 0;
+            moveType.RotationX = 0;
+            moveType.RotationY = 0;
+            moveType.RotationZ = npc.Transform.Local.ToRollPitchYawSBytesMovement().Item3;
+            moveType.Flags = MoveTypeFlags.Stopping | (npc.IsInBattle ? MoveTypeFlags.InCombat : 0);
+            moveType.DeltaMovement = new sbyte[3];
+            moveType.Stance = npc.CurrentGameStance;
+            moveType.Alertness = npc.CurrentAlertness;
+            moveType.Time = (uint)(DateTime.UtcNow - DateTime.UtcNow.Date).TotalMilliseconds;
+            npc.BroadcastPacket(new SCOneUnitMovementPacket(npc.ObjId, moveType), false);
+
+            npc.CheckMovedPosition(oldPosition);
         }
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/KnockBack.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/KnockBack.cs
@@ -27,7 +27,7 @@ public class KnockBack : SpecialEffectAction
         Logger.Debug("Special effects: KnockBack caster={0}, target={1}, value1={2}, value2={3}, value3={4}, value4={5}",
             caster?.ObjId, target?.ObjId, value1, value2, value3, value4);
 
-        if (caster == null || target == null || (target is Unit tgtUnit && tgtUnit.IsDead))
+        if (caster == null || target == null)
             return;
 
         if (target.Buffs.HasEffectsMatchingCondition(e => e.Template.KnockbackImmune || e.Template.NonPushable))

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/KnockBack.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/KnockBack.cs
@@ -1,5 +1,11 @@
-﻿using AAEmu.Game.Models.Game.Char;
+using System.Numerics;
+
+using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.Game.Units.Movements;
+using AAEmu.Game.Models.StaticValues;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects.SpecialEffects;
 
@@ -18,7 +24,77 @@ public class KnockBack : SpecialEffectAction
         int value3,
         int value4)
     {
-        // TODO ...
-        if (caster is Character) { Logger.Debug("Special effects: KnockBack value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4); }
+        Logger.Debug("Special effects: KnockBack caster={0}, target={1}, value1={2}, value2={3}, value3={4}, value4={5}",
+            caster?.ObjId, target?.ObjId, value1, value2, value3, value4);
+
+        if (target == null || (target is Unit tgtUnit && tgtUnit.IsDead))
+            return;
+
+        if (target.Buffs.HasEffectsMatchingCondition(e => e.Template.KnockbackImmune || e.Template.NonPushable))
+            return;
+
+        if (target is Npc npcTarget && npcTarget.Template.NonPushableByActor)
+            return;
+
+        var knockDistMeters = value1 / 1000f;
+        if (knockDistMeters <= 0f)
+            knockDistMeters = 3f;
+
+        var casterPos = caster.Transform.World.Position;
+        var targetPos = target.Transform.World.Position;
+        var direction = targetPos - casterPos;
+        direction.Z = 0;
+        if (direction.LengthSquared() < 0.01f)
+            direction = new Vector3(1, 0, 0);
+        direction = Vector3.Normalize(direction);
+
+        var endPos = targetPos + direction * knockDistMeters;
+
+        var heightBoost = value3 / 1000f;
+        endPos.Z = targetPos.Z + heightBoost;
+
+        // Characters: client handles knockback natively from the skill/buff data.
+        // Sending the packet from the server causes double displacement.
+        if (target is Character)
+            return;
+
+        if (target is Npc npc)
+        {
+            ApplyKnockbackToNpc(npc, endPos);
+        }
+    }
+
+    internal static void ApplyKnockbackToNpc(Npc npc, Vector3 endPos)
+    {
+        // 600ms suppression so the client knockback animation plays out and a follow-up
+        // knockback isn't overridden by the NPC walking back.
+        npc.DisplacedUntil = DateTime.UtcNow.AddMilliseconds(600);
+
+        var oldPosition = npc.Transform.Local.ClonePosition();
+
+        var groundZ = npc.ParentWorld.Template.GeoData.GetHeight(new Vector3(endPos.X, endPos.Y, endPos.Z));
+        if (groundZ > 0 && Math.Abs(endPos.Z - groundZ) < 5f)
+            endPos.Z = groundZ;
+
+        npc.Transform.Local.SetPosition(endPos.X, endPos.Y, endPos.Z);
+
+        var moveType = (UnitMoveType)MoveType.GetType(MoveTypeEnum.Unit);
+        moveType.X = endPos.X;
+        moveType.Y = endPos.Y;
+        moveType.Z = endPos.Z;
+        moveType.VelX = 0;
+        moveType.VelY = 0;
+        moveType.VelZ = 0;
+        moveType.RotationX = 0;
+        moveType.RotationY = 0;
+        moveType.RotationZ = npc.Transform.Local.ToRollPitchYawSBytesMovement().Item3;
+        moveType.Flags = MoveTypeFlags.Stopping | (npc.IsInBattle ? MoveTypeFlags.InCombat : 0);
+        moveType.DeltaMovement = new sbyte[3];
+        moveType.Stance = npc.CurrentGameStance;
+        moveType.Alertness = npc.CurrentAlertness;
+        moveType.Time = (uint)(DateTime.UtcNow - DateTime.UtcNow.Date).TotalMilliseconds;
+        npc.BroadcastPacket(new SCOneUnitMovementPacket(npc.ObjId, moveType), false);
+
+        npc.CheckMovedPosition(oldPosition);
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/KnockBack.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/KnockBack.cs
@@ -27,7 +27,7 @@ public class KnockBack : SpecialEffectAction
         Logger.Debug("Special effects: KnockBack caster={0}, target={1}, value1={2}, value2={3}, value3={4}, value4={5}",
             caster?.ObjId, target?.ObjId, value1, value2, value3, value4);
 
-        if (target == null || (target is Unit tgtUnit && tgtUnit.IsDead))
+        if (caster == null || target == null || (target is Unit tgtUnit && tgtUnit.IsDead))
             return;
 
         if (target.Buffs.HasEffectsMatchingCondition(e => e.Template.KnockbackImmune || e.Template.NonPushable))

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/TeleportToUnit.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/TeleportToUnit.cs
@@ -1,7 +1,11 @@
-﻿using AAEmu.Game.Core.Packets.G2C;
+﻿using System.Numerics;
+
+using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.Game.Units.Movements;
+using AAEmu.Game.Models.StaticValues;
 using AAEmu.Game.Utils;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects.SpecialEffects;
@@ -23,8 +27,8 @@ public class TeleportToUnit : SpecialEffectAction
         int value3,
         int value4)
     {
-        // TODO ...
-        if (caster is Character) { Logger.Debug("Special effects: TeleportToUnit value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4); }
+        Logger.Debug("Special effects: TeleportToUnit caster={0} target={1} value1 {2}, value2 {3}, value3 {4}, value4 {5}",
+            caster?.ObjId, target?.ObjId, value1, value2, value3, value4);
 
         if (target == null)
         {
@@ -48,8 +52,38 @@ public class TeleportToUnit : SpecialEffectAction
                 character.SendPacket(new SCBlinkUnitPacket(caster.ObjId, 0f, 0f, endX, endY, targetPosition.Z));
                 break;
             case Npc npc:
-                npc.MoveTowards(targetPosition, 10000);
-                npc.StopMovement();
+                // Pull / Charge / Leap onto another NPC: replicate the Character blink path
+                // server-side. MoveTowards walks the NPC over time and cancels itself with
+                // StopMovement, so the original code was effectively a no-op for NPC pulls.
+                var oldPosition = npc.Transform.Local.ClonePosition();
+
+                var endZ = targetPosition.Z;
+                var groundZ = npc.ParentWorld?.Template.GeoData.GetHeight(new Vector3(endX, endY, endZ)) ?? 0f;
+                if (groundZ > 0 && Math.Abs(endZ - groundZ) < 5f)
+                    endZ = groundZ;
+
+                npc.Transform.Local.SetPosition(endX, endY, endZ);
+
+                npc.BroadcastPacket(new SCBlinkUnitPacket(npc.ObjId, 0f, 0f, endX, endY, endZ), false);
+
+                var moveType = (UnitMoveType)MoveType.GetType(MoveTypeEnum.Unit);
+                moveType.X = endX;
+                moveType.Y = endY;
+                moveType.Z = endZ;
+                moveType.VelX = 0;
+                moveType.VelY = 0;
+                moveType.VelZ = 0;
+                moveType.RotationX = 0;
+                moveType.RotationY = 0;
+                moveType.RotationZ = npc.Transform.Local.ToRollPitchYawSBytesMovement().Item3;
+                moveType.Flags = MoveTypeFlags.Stopping | (npc.IsInBattle ? MoveTypeFlags.InCombat : 0);
+                moveType.DeltaMovement = new sbyte[3];
+                moveType.Stance = npc.CurrentGameStance;
+                moveType.Alertness = npc.CurrentAlertness;
+                moveType.Time = (uint)(DateTime.UtcNow - DateTime.UtcNow.Date).TotalMilliseconds;
+                npc.BroadcastPacket(new SCOneUnitMovementPacket(npc.ObjId, moveType), false);
+
+                npc.CheckMovedPosition(oldPosition);
                 break;
         }
     }

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -644,7 +644,7 @@ public class Skill
                 if (sc != null)
                 {
                     if (unit.ActiveSkillController != null)
-                        unit.ActiveSkillController.End();
+                        unit.ActiveSkillController.End(force: true);
                     unit.ActiveSkillController = sc;
                     sc.Execute();
                 }

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/DashSkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/DashSkillController.cs
@@ -88,9 +88,9 @@ public class DashSkillController : SkillController
         TickManager.Instance.OnTick.Subscribe(Tick, TimeSpan.FromMilliseconds(100));
     }
 
-    public override void End()
+    public override void End(bool force = false)
     {
-        base.End();
+        base.End(force);
         TickManager.Instance.OnTick.UnSubscribe(Tick);
     }
 

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/DashSkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/DashSkillController.cs
@@ -63,6 +63,11 @@ public class DashSkillController : SkillController
 
     public void Tick(TimeSpan delta)
     {
+        if (Owner == null)
+        {
+            End();
+            return;
+        }
         if (Owner.IsDead)
         {
             End();

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/DashSkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/DashSkillController.cs
@@ -114,7 +114,14 @@ public class DashSkillController : SkillController
                 return;
             }
 
-            if (Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Shackle)) ||
+            // Exclude DecreaseMoveSpeed-tagged Shackle buffs (slow debuffs like Charged Bolt
+            // ride the Shackle family). A pure slow should NOT end the dash — the speed
+            // multiplier is already applied via Owner.MoveSpeedMul above, so the dash
+            // continues at reduced speed. Pure Shackle / Snare (hard root) still ends.
+            // Matches the gate in Npc.MoveTowards and BaseCombatBehavior.MoveInRange.
+            if (Owner.Buffs.CheckBuffsExcludingTags(
+                    SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Shackle),
+                    [(uint)SkillConstants.DecreaseMoveSpeed]) ||
                 Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Snare)))
             {
                 End();

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/DashSkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/DashSkillController.cs
@@ -2,6 +2,8 @@ using System.Numerics;
 
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Skills.Templates;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.Units.Movements;
@@ -114,15 +116,29 @@ public class DashSkillController : SkillController
                 return;
             }
 
-            // Exclude DecreaseMoveSpeed-tagged Shackle buffs (slow debuffs like Charged Bolt
-            // ride the Shackle family). A pure slow should NOT end the dash — the speed
-            // multiplier is already applied via Owner.MoveSpeedMul above, so the dash
-            // continues at reduced speed. Pure Shackle / Snare (hard root) still ends.
-            // Matches the gate in Npc.MoveTowards and BaseCombatBehavior.MoveInRange.
-            if (Owner.Buffs.CheckBuffsExcludingTags(
+            // Player-source dash: ends on combat engagement (per Zeromus on PR #1439).
+            // A player cannot dash while in combat — the skill cast validates that — so
+            // the trigger that ends a voluntary dash mid-flight is "entered combat",
+            // not "got snared" or "got slowed". Hostile snares / roots normally also
+            // flag the player into combat via aggro, so the practical outcome on a
+            // snare hit is unchanged. Pure slows that do NOT cause combat engagement
+            // (self-applied, friendly slow) just reduce speed via Owner.MoveSpeedMul.
+            if (Owner is Character && Owner.IsInBattle)
+            {
+                End();
+                return;
+            }
+
+            // NPC voluntary dash (rare): players cannot snare an NPC out of combat
+            // (the NPC is already battling), so the IsInBattle trigger above never
+            // fires for NPCs. Keep the hard-root gate so a snared NPC mid-dash does
+            // not run forever. Slow debuffs ride along via the DecreaseMoveSpeed
+            // exclusion. Matches Npc.MoveTowards and BaseCombatBehavior.MoveInRange.
+            if (Owner is Npc && (
+                Owner.Buffs.CheckBuffsExcludingTags(
                     SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Shackle),
                     [(uint)SkillConstants.DecreaseMoveSpeed]) ||
-                Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Snare)))
+                Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Snare))))
             {
                 End();
                 return;

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/DashSkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/DashSkillController.cs
@@ -110,12 +110,14 @@ public class DashSkillController : SkillController
                     || e.Template.Knockdown || e.Template.Fastened)
                 || Owner.IsDead)
             {
+                End();
                 return;
             }
 
             if (Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Shackle)) ||
                 Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Snare)))
             {
+                End();
                 return;
             }
         }

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/DashSkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/DashSkillController.cs
@@ -8,30 +8,28 @@ using AAEmu.Game.Models.Game.Units.Movements;
 using AAEmu.Game.Models.StaticValues;
 using AAEmu.Game.Utils;
 
-using NLog;
-
 namespace AAEmu.Game.Models.Game.Skills.SkillControllers;
 
-public class LeapSkillController : SkillController
+public class DashSkillController : SkillController
 {
-    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
-
     public int Angle { get; set; }
     public int Speed { get; set; }
     public int Duration { get; set; }
     public int DistanceOffset { get; set; }
 
     private readonly float _calculatedSpeed;
-    private Vector3 _endPosition;
-    public enum LeapDirection
+    private readonly Vector3 _endPosition;
+
+    public enum DashDirection
     {
         Both = 0,
         ForwardOnly = 1,
         BackwardOnly = 2
     }
-    public LeapDirection Direction { get; set; }
 
-    public LeapSkillController(SkillControllerTemplate template, BaseUnit owner, BaseUnit target)
+    public DashDirection Direction { get; set; }
+
+    public DashSkillController(SkillControllerTemplate template, BaseUnit owner, BaseUnit target)
     {
         Template = template;
         Owner = owner as Unit;
@@ -41,82 +39,47 @@ public class LeapSkillController : SkillController
         Speed = template.Value[1];
         Duration = template.Value[2];
         DistanceOffset = template.Value[3];
-        Direction = (LeapDirection)template.Value[6];
+        Direction = (DashDirection)template.Value[6];
 
-        var ownerPos = owner.Transform.World.Position;
-        var targetPos = target.Transform.World.Position;
-        var distToTarget = MathUtil.CalculateDistance(ownerPos, targetPos, true);
+        var angleDeg = (float)MathUtil.CalculateAngleFrom(owner.Transform.World.Position, target.Transform.World.Position);
+        var distMeters = DistanceOffset / 1000f;
 
-        // CalculateAngleFrom returns DEGREES; sign of DistanceOffset distinguishes pull vs push.
-        var angleDeg = (float)MathUtil.CalculateAngleFrom(ownerPos, targetPos);
+        if (Direction == DashDirection.BackwardOnly)
+            angleDeg += 180f;
+
         var angleRad = (float)(angleDeg * Math.PI / 180.0);
-        var offsetMeters = DistanceOffset / 1000f;
 
         (_endPosition.X, _endPosition.Y) = MathUtil.AddDistanceToFront(
-            offsetMeters, targetPos.X, targetPos.Y, angleRad);
-        _endPosition.Z = targetPos.Z;
+            distMeters,
+            owner.Transform.World.Position.X,
+            owner.Transform.World.Position.Y,
+            angleRad);
+        _endPosition.Z = owner.Transform.World.Position.Z;
 
-        if (Direction == LeapDirection.BackwardOnly)
-        {
-            var endDistToTarget = MathUtil.CalculateDistance(_endPosition, targetPos, true);
-            if (endDistToTarget < distToTarget)
-            {
-                Logger.Debug("LeapSC: owner={0} BackwardOnly constraint violated — endpoint closer to target, not moving",
-                    owner.ObjId);
-                _endPosition = ownerPos;
-            }
-        }
-        else if (Direction == LeapDirection.ForwardOnly)
-        {
-            var endDistToTarget = MathUtil.CalculateDistance(_endPosition, targetPos, true);
-            if (endDistToTarget > distToTarget)
-            {
-                Logger.Debug("LeapSC: owner={0} ForwardOnly constraint violated — endpoint further from target, not moving",
-                    owner.ObjId);
-                _endPosition = ownerPos;
-            }
-        }
-
-        var distance = MathUtil.CalculateDistance(ownerPos, _endPosition, true);
+        var totalDist = MathUtil.CalculateDistance(owner.Transform.World.Position, _endPosition, true);
         var durationSec = Duration > 0 ? Duration / 1000f : 0.5f;
-        _calculatedSpeed = distance / durationSec;
-
-        Logger.Debug("LeapSC: owner={0} target={1} dist={2:F1} offset={3:F1}m dir={4} dur={5}ms endPos=({6:F1},{7:F1},{8:F1}) speed={9:F1}",
-            owner.ObjId, target.ObjId, distToTarget, offsetMeters, Direction, Duration,
-            _endPosition.X, _endPosition.Y, _endPosition.Z, _calculatedSpeed);
+        _calculatedSpeed = totalDist / durationSec;
     }
 
     public void Tick(TimeSpan delta)
     {
-        if (Owner == null)
-        {
-            Logger.Warn("LeapSC.Tick: Owner is null, ending");
-            End();
-            return;
-        }
-        // SourceBuffId > 0 → forced (buff-triggered pull/grip), ignore CC.
-        // SourceBuffId == 0 → voluntary leap, external stun/sleep cancels.
         if (Owner.IsDead)
         {
-            Logger.Debug("LeapSC.Tick: owner={0} dead, ending", Owner.ObjId);
             End();
             return;
         }
         if (SourceBuffId == 0 && Owner.Buffs.HasEffectsMatchingCondition(e => e.Template.Stun || e.Template.Sleep))
         {
-            Logger.Debug("LeapSC.Tick: owner={0} stunned/sleeping (voluntary leap), ending", Owner.ObjId);
             End();
             return;
         }
-        var moveDist = _calculatedSpeed * (float)(delta.TotalMilliseconds / 1000f);
-        MoveTowards(moveDist);
+
+        MoveTowards(_calculatedSpeed * (float)(delta.TotalMilliseconds / 1000f));
     }
 
     public override void Execute()
     {
         base.Execute();
-        Logger.Debug("LeapSC.Execute: owner={0} target={1} state={2} endPos=({3:F1},{4:F1},{5:F1}) speed={6:F1}",
-            Owner?.ObjId, Target?.ObjId, State, _endPosition.X, _endPosition.Y, _endPosition.Z, _calculatedSpeed);
         TickManager.Instance.OnTick.Subscribe(Tick, TimeSpan.FromMilliseconds(100));
     }
 
@@ -138,11 +101,8 @@ public class LeapSkillController : SkillController
             }
 
             if (Owner.Buffs.HasEffectsMatchingCondition(e =>
-                    e.Template.Stun
-                    || e.Template.Sleep
-                    || e.Template.Root
-                    || e.Template.Knockdown
-                    || e.Template.Fastened)
+                    e.Template.Stun || e.Template.Sleep || e.Template.Root
+                    || e.Template.Knockdown || e.Template.Fastened)
                 || Owner.IsDead)
             {
                 return;
@@ -157,7 +117,7 @@ public class LeapSkillController : SkillController
 
         var oldPosition = Owner.Transform.Local.ClonePosition();
         var targetDist = MathUtil.CalculateDistance(Owner.Transform.Local.Position, _endPosition, true);
-        if (targetDist <= 1f)
+        if (targetDist <= 0.5f)
         {
             End();
             return;
@@ -166,7 +126,8 @@ public class LeapSkillController : SkillController
         var moveType = (UnitMoveType)MoveType.GetType(MoveTypeEnum.Unit);
         var travelDist = Math.Min(targetDist, distance);
 
-        var (newX, newY, newZ) = World.Transform.PositionAndRotation.AddDistanceToFront(travelDist, targetDist, Owner.Transform.Local.Position, _endPosition);
+        var (newX, newY, newZ) = World.Transform.PositionAndRotation.AddDistanceToFront(
+            travelDist, targetDist, Owner.Transform.Local.Position, _endPosition);
         Owner.Transform.Local.SetPosition(newX, newY, newZ);
 
         var updZ = Owner.ParentWorld.Template.GeoData.GetHeight(Owner.Transform.World.Position);

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/DashSkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/DashSkillController.cs
@@ -12,8 +12,6 @@ namespace AAEmu.Game.Models.Game.Skills.SkillControllers;
 
 public class DashSkillController : SkillController
 {
-    public int Angle { get; set; }
-    public int Speed { get; set; }
     public int Duration { get; set; }
     public int DistanceOffset { get; set; }
 
@@ -35,8 +33,10 @@ public class DashSkillController : SkillController
         Owner = owner as Unit;
         Target = target as Unit;
 
-        Angle = template.Value[0];
-        Speed = template.Value[1];
+        // template.Value[0] (Angle) and template.Value[1] (Speed) are intentionally
+        // ignored: the dash direction is fixed (caster -> target, optionally flipped
+        // 180° for BackwardOnly) and the speed is derived from DistanceOffset /
+        // Duration so the dash always lands in exactly the configured time.
         Duration = template.Value[2];
         DistanceOffset = template.Value[3];
         Direction = (DashDirection)template.Value[6];

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/FloatingSkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/FloatingSkillController.cs
@@ -114,10 +114,13 @@ public class FloatingSkillController : SkillController
         }
     }
 
-    public override void End()
+    public override void End(bool force = false)
     {
         // Lift→Fall transition: switch to fall phase instead of teleporting to ground.
-        if (_isLiftMode && !_isFalling && Owner != null && !Owner.IsDead)
+        // Skipped when force=true (the caller is about to replace this SC with a new
+        // one — keeping the fall phase alive would let the old controller keep ticking
+        // alongside the new one and produce conflicting movement broadcasts).
+        if (!force && _isLiftMode && !_isFalling && Owner != null && !Owner.IsDead)
         {
             var groundZ = GetGroundHeight();
             if (groundZ > 0 && Owner.Transform.Local.Position.Z > groundZ + 0.5f)
@@ -131,7 +134,7 @@ public class FloatingSkillController : SkillController
             }
         }
 
-        base.End();
+        base.End(force);
         TickManager.Instance.OnTick.UnSubscribe(Tick);
     }
 

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/FloatingSkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/FloatingSkillController.cs
@@ -181,12 +181,12 @@ public class FloatingSkillController : SkillController
         var currentPos = Owner.Transform.Local.Position;
         var currentHeight = currentPos.Z - _startZ;
 
-        if (currentHeight >= _liftHeight)
-        {
-            Logger.Debug("FloatingSC [LIFT]: owner={0} reached lift height {1:F1}, holding", Owner.ObjId, _liftHeight);
-            return;
-        }
-
+        // Duration check FIRST so the timed descent fires regardless of whether
+        // the NPC is still ascending or already at hold height. If this sat
+        // after the height-hold early-return below, the descent timer would
+        // only ever trigger during the brief ascent window and never during
+        // the hold itself — the buff dispel would then be the only path that
+        // ever ended the lift.
         if (_liftDuration > 0f)
         {
             var elapsed = (DateTime.UtcNow - _liftStartTime).TotalSeconds;
@@ -196,6 +196,12 @@ public class FloatingSkillController : SkillController
                 End();
                 return;
             }
+        }
+
+        if (currentHeight >= _liftHeight)
+        {
+            Logger.Debug("FloatingSC [LIFT]: owner={0} reached lift height {1:F1}, holding", Owner.ObjId, _liftHeight);
+            return;
         }
 
         var oldPosition = Owner.Transform.Local.ClonePosition();

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/FloatingSkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/FloatingSkillController.cs
@@ -192,7 +192,8 @@ public class FloatingSkillController : SkillController
             var elapsed = (DateTime.UtcNow - _liftStartTime).TotalSeconds;
             if (elapsed >= _liftDuration)
             {
-                Logger.Debug("FloatingSC [LIFT]: owner={0} lift duration expired after {1:F1}s", Owner.ObjId, elapsed);
+                Logger.Debug("FloatingSC [LIFT]: owner={0} lift duration expired after {1:F1}s — descending", Owner.ObjId, elapsed);
+                End();
                 return;
             }
         }
@@ -217,7 +218,7 @@ public class FloatingSkillController : SkillController
         moveType.RotationY = ry;
         moveType.RotationZ = rz;
         moveType.ActorFlags = 5; // Airborne/Floating
-        moveType.Flags = MoveTypeFlags.Moving;
+        moveType.Flags = MoveTypeFlags.Moving | (Owner is Npc combatNpc && combatNpc.IsInBattle ? MoveTypeFlags.InCombat : 0);
         moveType.DeltaMovement = new sbyte[3];
         moveType.DeltaMovement[0] = 0;
         moveType.DeltaMovement[1] = 0;
@@ -271,7 +272,7 @@ public class FloatingSkillController : SkillController
         moveType.RotationY = ry;
         moveType.RotationZ = rz;
         moveType.ActorFlags = 5;
-        moveType.Flags = MoveTypeFlags.Moving;
+        moveType.Flags = MoveTypeFlags.Moving | (Owner is Npc combatNpc && combatNpc.IsInBattle ? MoveTypeFlags.InCombat : 0);
         moveType.DeltaMovement = new sbyte[3];
         moveType.DeltaMovement[0] = 0;
         moveType.DeltaMovement[1] = 0;
@@ -340,7 +341,7 @@ public class FloatingSkillController : SkillController
         moveType.RotationY = ry;
         moveType.RotationZ = rz;
         moveType.ActorFlags = 4;
-        moveType.Flags = MoveTypeFlags.Moving;
+        moveType.Flags = MoveTypeFlags.Moving | (Owner is Npc combatNpc && combatNpc.IsInBattle ? MoveTypeFlags.InCombat : 0);
         moveType.DeltaMovement = new sbyte[3];
         moveType.DeltaMovement[0] = 0;
         moveType.DeltaMovement[1] = 127;

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/FloatingSkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/FloatingSkillController.cs
@@ -1,0 +1,355 @@
+using System.Numerics;
+
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.NPChar;
+using AAEmu.Game.Models.Game.Skills.Templates;
+using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.Game.Units.Movements;
+using AAEmu.Game.Models.StaticValues;
+using AAEmu.Game.Utils;
+
+using NLog;
+
+namespace AAEmu.Game.Models.Game.Skills.SkillControllers;
+
+public class FloatingSkillController : SkillController
+{
+    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
+
+    private Vector3 _endPosition;
+    private readonly float _speed;
+    private readonly float _pullDistance;
+    private readonly float _stopDistance;
+    private readonly bool _isLiftMode;
+    private readonly float _liftHeight;
+    private readonly float _liftSpeed;
+    private readonly float _liftDuration;
+    private bool _isFalling;
+    private float _fallSpeed;
+    private const float Gravity = 9.81f;
+    private const float MaxFallSpeed = 20f;
+    private float _startZ;
+    private DateTime _liftStartTime;
+
+    public FloatingSkillController(SkillControllerTemplate template, BaseUnit owner, BaseUnit target,
+        float psychokinesisSpeed = 0f, float liftHeight = 0f, float liftSpeed = 0f, float liftDuration = 0f)
+    {
+        Template = template;
+        Owner = owner as Unit;
+        Target = target as Unit;
+
+        _liftHeight = liftHeight;
+        _liftSpeed = liftSpeed > 0f ? liftSpeed : 3f;
+        _liftDuration = liftDuration;
+        _isLiftMode = _liftHeight > 0f;
+
+        if (_isLiftMode)
+        {
+            _speed = _liftSpeed;
+            _pullDistance = 0f;
+            _stopDistance = 0f;
+            _endPosition = owner.Transform.World.Position;
+
+            Logger.Debug("FloatingSC [LIFT]: owner={0} liftHeight={1:F1} liftSpeed={2:F1} liftDuration={3:F1}",
+                owner.ObjId, _liftHeight, _liftSpeed, _liftDuration);
+        }
+        else
+        {
+            _speed = psychokinesisSpeed > 0f ? psychokinesisSpeed
+                : (template != null && template.Value[0] > 0 ? template.Value[0] / 1000f : 5f);
+
+            var ownerPos = owner.Transform.World.Position;
+            var targetPos = target.Transform.World.Position;
+            var dist = MathUtil.CalculateDistance(ownerPos, targetPos, true);
+
+            _stopDistance = 1.5f;
+            _pullDistance = Math.Max(0f, dist - _stopDistance);
+
+            if (dist > _stopDistance)
+            {
+                var direction = Vector3.Normalize(targetPos - ownerPos);
+                direction.Z = 0;
+                if (direction.LengthSquared() < 0.01f)
+                    direction = new Vector3(1, 0, 0);
+                direction = Vector3.Normalize(direction);
+                _endPosition = ownerPos + direction * _pullDistance;
+                _endPosition.Z = ownerPos.Z;
+            }
+            else
+            {
+                _endPosition = ownerPos;
+            }
+
+            Logger.Debug("FloatingSC [PULL]: owner={0} target={1} dist={2:F1} pullDist={3:F1} speed={4:F1} endPos=({5:F1},{6:F1},{7:F1})",
+                owner.ObjId, target.ObjId, dist, _pullDistance, _speed,
+                _endPosition.X, _endPosition.Y, _endPosition.Z);
+        }
+    }
+
+    public override void Execute()
+    {
+        base.Execute();
+
+        if (_isLiftMode)
+        {
+            _startZ = Owner.Transform.Local.Position.Z;
+            _liftStartTime = DateTime.UtcNow;
+            Logger.Debug("FloatingSC.Execute [LIFT]: owner={0} startZ={1:F1} targetZ={2:F1}",
+                Owner.ObjId, _startZ, _startZ + _liftHeight);
+            TickManager.Instance.OnTick.Subscribe(Tick, TimeSpan.FromMilliseconds(100));
+        }
+        else
+        {
+            if (Owner == null || _pullDistance <= 0.5f)
+            {
+                Logger.Debug("FloatingSC.Execute [PULL]: owner={0} already close or null, skipping", Owner?.ObjId);
+                End();
+                return;
+            }
+
+            Logger.Debug("FloatingSC.Execute [PULL]: owner={0} pulling toward target={1}, dist={2:F1}m, speed={3:F1}",
+                Owner.ObjId, Target?.ObjId, _pullDistance, _speed);
+            TickManager.Instance.OnTick.Subscribe(Tick, TimeSpan.FromMilliseconds(100));
+        }
+    }
+
+    public override void End()
+    {
+        // Lift→Fall transition: switch to fall phase instead of teleporting to ground.
+        if (_isLiftMode && !_isFalling && Owner != null && !Owner.IsDead)
+        {
+            var groundZ = GetGroundHeight();
+            if (groundZ > 0 && Owner.Transform.Local.Position.Z > groundZ + 0.5f)
+            {
+                Logger.Debug("FloatingSC.End [LIFT→FALL]: owner={0} starting fall from Z={1:F1} to ground={2:F1}",
+                    Owner.ObjId, Owner.Transform.Local.Position.Z, groundZ);
+                _isFalling = true;
+                _fallSpeed = 0f;
+                State = SCState.Running;
+                return;
+            }
+        }
+
+        base.End();
+        TickManager.Instance.OnTick.UnSubscribe(Tick);
+    }
+
+    private void Tick(TimeSpan delta)
+    {
+        if (Owner == null)
+        {
+            FinalEnd();
+            return;
+        }
+
+        if (Owner.IsDead)
+        {
+            Logger.Debug("FloatingSC.Tick: owner={0} dead, ending", Owner.ObjId);
+            FinalEnd();
+            return;
+        }
+
+        if (_isFalling)
+        {
+            FallTick(delta);
+            return;
+        }
+
+        if (SourceBuffId == 0 && Owner.Buffs.HasEffectsMatchingCondition(e =>
+                e.Template.Stun || e.Template.Sleep || e.Template.Knockdown))
+        {
+            Logger.Debug("FloatingSC.Tick: owner={0} CC'd (no source buff), ending", Owner.ObjId);
+            End();
+            return;
+        }
+
+        if (_isLiftMode)
+            LiftTick(delta);
+        else
+            PullTick(delta);
+    }
+
+    private void FinalEnd()
+    {
+        base.End();
+        TickManager.Instance.OnTick.UnSubscribe(Tick);
+    }
+
+    private void LiftTick(TimeSpan delta)
+    {
+        var currentPos = Owner.Transform.Local.Position;
+        var currentHeight = currentPos.Z - _startZ;
+
+        if (currentHeight >= _liftHeight)
+        {
+            Logger.Debug("FloatingSC [LIFT]: owner={0} reached lift height {1:F1}, holding", Owner.ObjId, _liftHeight);
+            return;
+        }
+
+        if (_liftDuration > 0f)
+        {
+            var elapsed = (DateTime.UtcNow - _liftStartTime).TotalSeconds;
+            if (elapsed >= _liftDuration)
+            {
+                Logger.Debug("FloatingSC [LIFT]: owner={0} lift duration expired after {1:F1}s", Owner.ObjId, elapsed);
+                return;
+            }
+        }
+
+        var oldPosition = Owner.Transform.Local.ClonePosition();
+        var liftDist = _liftSpeed * (float)(delta.TotalMilliseconds / 1000f);
+        var remainingHeight = _liftHeight - currentHeight;
+        liftDist = Math.Min(liftDist, remainingHeight);
+
+        var newZ = currentPos.Z + liftDist;
+        Owner.Transform.Local.SetPosition(currentPos.X, currentPos.Y, newZ);
+
+        var (rx, ry, rz) = Owner.Transform.Local.ToRollPitchYawSBytesMovement();
+
+        var moveType = (UnitMoveType)MoveType.GetType(MoveTypeEnum.Unit);
+        moveType.X = currentPos.X;
+        moveType.Y = currentPos.Y;
+        moveType.Z = newZ;
+        moveType.VelX = 0;
+        moveType.VelY = 0;
+        moveType.RotationX = rx;
+        moveType.RotationY = ry;
+        moveType.RotationZ = rz;
+        moveType.ActorFlags = 5; // Airborne/Floating
+        moveType.Flags = MoveTypeFlags.Moving;
+        moveType.DeltaMovement = new sbyte[3];
+        moveType.DeltaMovement[0] = 0;
+        moveType.DeltaMovement[1] = 0;
+        moveType.DeltaMovement[2] = 127; // Upward
+        moveType.Stance = 0;
+        moveType.Alertness = MoveTypeAlertness.Combat;
+        moveType.Time = (uint)(DateTime.UtcNow - DateTime.UtcNow.Date).TotalMilliseconds;
+
+        Owner.CheckMovedPosition(oldPosition);
+        Owner.BroadcastPacket(new SCOneUnitMovementPacket(Owner.ObjId, moveType), false);
+    }
+
+    private void FallTick(TimeSpan delta)
+    {
+        var dt = (float)(delta.TotalMilliseconds / 1000f);
+        var currentPos = Owner.Transform.Local.Position;
+        var groundZ = GetGroundHeight();
+
+        if (groundZ <= 0) groundZ = _startZ;
+
+        if (currentPos.Z <= groundZ + 0.1f)
+        {
+            Logger.Debug("FloatingSC [FALL]: owner={0} reached ground Z={1:F1}", Owner.ObjId, groundZ);
+            Owner.Transform.Local.SetHeight(groundZ);
+
+            // End SC state BEFORE StopMovement so the SC guard in Npc.MoveTowards passes.
+            FinalEnd();
+
+            if (Owner is Npc npc)
+                npc.StopMovement();
+
+            return;
+        }
+
+        _fallSpeed = Math.Min(_fallSpeed + Gravity * dt, MaxFallSpeed);
+        var fallDist = _fallSpeed * dt;
+        var newZ = Math.Max(currentPos.Z - fallDist, groundZ);
+
+        var oldPosition = Owner.Transform.Local.ClonePosition();
+        Owner.Transform.Local.SetPosition(currentPos.X, currentPos.Y, newZ);
+
+        var (rx, ry, rz) = Owner.Transform.Local.ToRollPitchYawSBytesMovement();
+
+        var moveType = (UnitMoveType)MoveType.GetType(MoveTypeEnum.Unit);
+        moveType.X = currentPos.X;
+        moveType.Y = currentPos.Y;
+        moveType.Z = newZ;
+        moveType.VelX = 0;
+        moveType.VelY = 0;
+        moveType.RotationX = rx;
+        moveType.RotationY = ry;
+        moveType.RotationZ = rz;
+        moveType.ActorFlags = 5;
+        moveType.Flags = MoveTypeFlags.Moving;
+        moveType.DeltaMovement = new sbyte[3];
+        moveType.DeltaMovement[0] = 0;
+        moveType.DeltaMovement[1] = 0;
+        moveType.DeltaMovement[2] = -127;
+        moveType.Stance = 0;
+        moveType.Alertness = MoveTypeAlertness.Combat;
+        moveType.Time = (uint)(DateTime.UtcNow - DateTime.UtcNow.Date).TotalMilliseconds;
+
+        Owner.CheckMovedPosition(oldPosition);
+        Owner.BroadcastPacket(new SCOneUnitMovementPacket(Owner.ObjId, moveType), false);
+    }
+
+    private float GetGroundHeight()
+    {
+        var geoZ = Owner.ParentWorld.Template.GeoData.GetHeight(Owner.Transform.World.Position);
+        return geoZ > 0 ? geoZ : _startZ;
+    }
+
+    private void PullTick(TimeSpan delta)
+    {
+        var moveDist = _speed * (float)(delta.TotalMilliseconds / 1000f);
+        MoveTowardsTarget(moveDist);
+    }
+
+    private void MoveTowardsTarget(float distance)
+    {
+        if (distance < 0.01f)
+        {
+            End();
+            return;
+        }
+
+        var oldPosition = Owner.Transform.Local.ClonePosition();
+        var currentPos = Owner.Transform.Local.Position;
+        var targetDist = MathUtil.CalculateDistance(currentPos, _endPosition, true);
+
+        if (targetDist <= 0.5f)
+        {
+            Logger.Debug("FloatingSC [PULL]: owner={0} reached pull endpoint (dist={1:F2}), ending", Owner.ObjId, targetDist);
+            End();
+            return;
+        }
+
+        var travelDist = Math.Min(targetDist, distance);
+
+        var (newX, newY, newZ) = World.Transform.PositionAndRotation.AddDistanceToFront(
+            travelDist, targetDist, currentPos, _endPosition);
+        Owner.Transform.Local.SetPosition(newX, newY, newZ);
+
+        var updZ = Owner.ParentWorld.Template.GeoData.GetHeight(Owner.Transform.World.Position);
+        if (Math.Abs(newZ - updZ) < 1f)
+            Owner.Transform.Local.SetHeight(updZ);
+
+        var angle = MathUtil.CalculateAngleFrom(Owner.Transform.Local.Position, _endPosition);
+        var (velX, velY) = MathUtil.AddDistanceToFront(4000, 0, 0, (float)angle.DegToRad());
+        Owner.Transform.Local.SetRotationDegree(0f, 0f, (float)angle - 90);
+        var (rx, ry, rz) = Owner.Transform.Local.ToRollPitchYawSBytesMovement();
+
+        var moveType = (UnitMoveType)MoveType.GetType(MoveTypeEnum.Unit);
+        moveType.X = Owner.Transform.Local.Position.X;
+        moveType.Y = Owner.Transform.Local.Position.Y;
+        moveType.Z = Owner.Transform.Local.Position.Z;
+        moveType.VelX = (short)velX;
+        moveType.VelY = (short)velY;
+        moveType.RotationX = rx;
+        moveType.RotationY = ry;
+        moveType.RotationZ = rz;
+        moveType.ActorFlags = 4;
+        moveType.Flags = MoveTypeFlags.Moving;
+        moveType.DeltaMovement = new sbyte[3];
+        moveType.DeltaMovement[0] = 0;
+        moveType.DeltaMovement[1] = 127;
+        moveType.DeltaMovement[2] = 0;
+        moveType.Stance = 0;
+        moveType.Alertness = MoveTypeAlertness.Combat;
+        moveType.Time = (uint)(DateTime.UtcNow - DateTime.UtcNow.Date).TotalMilliseconds;
+
+        Owner.CheckMovedPosition(oldPosition);
+        Owner.BroadcastPacket(new SCOneUnitMovementPacket(Owner.ObjId, moveType), false);
+    }
+}

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/LeapSkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/LeapSkillController.cs
@@ -16,8 +16,6 @@ public class LeapSkillController : SkillController
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
-    public int Angle { get; set; }
-    public int Speed { get; set; }
     public int Duration { get; set; }
     public int DistanceOffset { get; set; }
 
@@ -37,8 +35,10 @@ public class LeapSkillController : SkillController
         Owner = owner as Unit;
         Target = target as Unit;
 
-        Angle = template.Value[0];
-        Speed = template.Value[1];
+        // template.Value[0] (Angle) and template.Value[1] (Speed) are intentionally
+        // ignored: the leap direction comes from the caster -> target bearing with
+        // a sign flip via DistanceOffset, and the speed is derived from
+        // DistanceOffset / Duration so the leap lands in the configured time.
         Duration = template.Value[2];
         DistanceOffset = template.Value[3];
         Direction = (LeapDirection)template.Value[6];

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/LeapSkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/LeapSkillController.cs
@@ -120,9 +120,9 @@ public class LeapSkillController : SkillController
         TickManager.Instance.OnTick.Subscribe(Tick, TimeSpan.FromMilliseconds(100));
     }
 
-    public override void End()
+    public override void End(bool force = false)
     {
-        base.End();
+        base.End(force);
         TickManager.Instance.OnTick.UnSubscribe(Tick);
     }
 

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/LeapSkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/LeapSkillController.cs
@@ -145,12 +145,14 @@ public class LeapSkillController : SkillController
                     || e.Template.Fastened)
                 || Owner.IsDead)
             {
+                End();
                 return;
             }
 
             if (Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Shackle)) ||
                 Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Snare)))
             {
+                End();
                 return;
             }
         }

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/LeapSkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/LeapSkillController.cs
@@ -136,7 +136,13 @@ public class LeapSkillController : SkillController
                 return;
             }
 
-            if (Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Shackle)) ||
+            // Exclude DecreaseMoveSpeed-tagged Shackle buffs (slow debuffs ride the Shackle
+            // family). A pure slow should NOT end the leap — the speed multiplier is already
+            // applied above, so the leap continues at reduced speed. Pure Shackle / Snare
+            // (hard root) still ends. Matches Npc.MoveTowards + BaseCombatBehavior.MoveInRange.
+            if (Owner.Buffs.CheckBuffsExcludingTags(
+                    SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Shackle),
+                    [(uint)SkillConstants.DecreaseMoveSpeed]) ||
                 Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Snare)))
             {
                 End();

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/LeapSkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/LeapSkillController.cs
@@ -56,25 +56,12 @@ public class LeapSkillController : SkillController
             offsetMeters, targetPos.X, targetPos.Y, angleRad);
         _endPosition.Z = targetPos.Z;
 
-        if (Direction == LeapDirection.BackwardOnly)
+        var constrained = ApplyDirectionConstraint(Direction, ownerPos, _endPosition, targetPos);
+        if (constrained != _endPosition)
         {
-            var endDistToTarget = MathUtil.CalculateDistance(_endPosition, targetPos, true);
-            if (endDistToTarget < distToTarget)
-            {
-                Logger.Debug("LeapSC: owner={0} BackwardOnly constraint violated — endpoint closer to target, not moving",
-                    owner.ObjId);
-                _endPosition = ownerPos;
-            }
-        }
-        else if (Direction == LeapDirection.ForwardOnly)
-        {
-            var endDistToTarget = MathUtil.CalculateDistance(_endPosition, targetPos, true);
-            if (endDistToTarget > distToTarget)
-            {
-                Logger.Debug("LeapSC: owner={0} ForwardOnly constraint violated — endpoint further from target, not moving",
-                    owner.ObjId);
-                _endPosition = ownerPos;
-            }
+            Logger.Debug("LeapSC: owner={0} {1} constraint violated — staying at owner position",
+                owner.ObjId, Direction);
+            _endPosition = constrained;
         }
 
         var distance = MathUtil.CalculateDistance(ownerPos, _endPosition, true);
@@ -201,5 +188,28 @@ public class LeapSkillController : SkillController
 
         Owner.CheckMovedPosition(oldPosition);
         Owner.BroadcastPacket(new SCOneUnitMovementPacket(Owner.ObjId, moveType), false);
+    }
+
+    /// <summary>
+    /// Enforces the leap's directional constraint. ForwardOnly leaps that would land
+    /// farther from the target than the owner started (and BackwardOnly leaps that
+    /// would land closer) collapse to the owner's current position so the SC ticks
+    /// out cleanly without moving the unit. Both is unconstrained.
+    /// </summary>
+    internal static Vector3 ApplyDirectionConstraint(
+        LeapDirection direction, Vector3 ownerPos, Vector3 candidateEnd, Vector3 targetPos)
+    {
+        var ownerToTarget = MathUtil.CalculateDistance(ownerPos, targetPos, true);
+        var endToTarget = MathUtil.CalculateDistance(candidateEnd, targetPos, true);
+
+        switch (direction)
+        {
+            case LeapDirection.BackwardOnly:
+                return endToTarget < ownerToTarget ? ownerPos : candidateEnd;
+            case LeapDirection.ForwardOnly:
+                return endToTarget > ownerToTarget ? ownerPos : candidateEnd;
+            default:
+                return candidateEnd;
+        }
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/LeapSkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/LeapSkillController.cs
@@ -2,6 +2,8 @@ using System.Numerics;
 
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Skills.Templates;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.Units.Movements;
@@ -136,14 +138,26 @@ public class LeapSkillController : SkillController
                 return;
             }
 
-            // Exclude DecreaseMoveSpeed-tagged Shackle buffs (slow debuffs ride the Shackle
-            // family). A pure slow should NOT end the leap — the speed multiplier is already
-            // applied above, so the leap continues at reduced speed. Pure Shackle / Snare
-            // (hard root) still ends. Matches Npc.MoveTowards + BaseCombatBehavior.MoveInRange.
-            if (Owner.Buffs.CheckBuffsExcludingTags(
+            // Player-source leap: ends on combat engagement (per Zeromus on PR #1439).
+            // Same reasoning as DashSkillController — a player cannot leap while in
+            // combat, so the trigger that ends a voluntary leap mid-flight is "entered
+            // combat", not "got snared". Hostile snares flag the player into combat
+            // via aggro, so the practical outcome on a snare is unchanged.
+            if (Owner is Character && Owner.IsInBattle)
+            {
+                End();
+                return;
+            }
+
+            // NPC voluntary leap (rare): IsInBattle never changes for an already-
+            // fighting NPC, so keep the hard-root gate to prevent a snared NPC from
+            // running forever mid-leap. Slow debuffs ride along via the
+            // DecreaseMoveSpeed exclusion.
+            if (Owner is Npc && (
+                Owner.Buffs.CheckBuffsExcludingTags(
                     SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Shackle),
                     [(uint)SkillConstants.DecreaseMoveSpeed]) ||
-                Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Snare)))
+                Owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId((uint)SkillConstants.Snare))))
             {
                 End();
                 return;

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/SkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/SkillController.cs
@@ -39,6 +39,12 @@ public class SkillController
     public virtual void End()
     {
         State = SCState.Ended;
+        // Drop the back-reference on the owning Unit so this controller can be
+        // GC'd once subscribers unsubscribe. Subclasses that keep the controller
+        // alive past End() (Floating's lift -> fall) deliberately do not call
+        // base.End here and invoke their own FinalEnd later.
+        if (Owner != null && Owner.ActiveSkillController == this)
+            Owner.ActiveSkillController = null;
         Logger.Trace($"SkillController: Npc {Owner.Name}:{Owner.ObjId} entering end state={State}");
     }
 

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/SkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/SkillController.cs
@@ -1,4 +1,4 @@
-﻿using AAEmu.Game.Models.Game.Skills.Templates;
+using AAEmu.Game.Models.Game.Skills.Templates;
 using AAEmu.Game.Models.Game.Units;
 
 using NLog;
@@ -21,6 +21,10 @@ public class SkillController
 
     public SCState State { get; protected set; }
 
+    // Set when a SkillController is created from a buff so CC checks inside
+    // the controller can ignore the buff that started its own displacement.
+    public uint SourceBuffId { get; set; }
+
     protected SkillController()
     {
 
@@ -38,7 +42,8 @@ public class SkillController
         Logger.Trace($"SkillController: Npc {Owner.Name}:{Owner.ObjId} entering end state={State}");
     }
 
-    public static SkillController CreateSkillController(SkillControllerTemplate template, BaseUnit owner, BaseUnit target)
+    public static SkillController CreateSkillController(SkillControllerTemplate template, BaseUnit owner, BaseUnit target,
+        float psychokinesisSpeed = 0f, float liftHeight = 0f, float liftSpeed = 0f, float liftDuration = 0f)
     {
         if (template == null)
         {
@@ -49,16 +54,19 @@ public class SkillController
         {
             case SkillControllerKind.Floating:
                 Logger.Trace($"SkillController: create FloatingSkillController");
-                return null; // TODO: Add Floating (telekinesis, bubble ?)
+                return new FloatingSkillController(template, owner, target,
+                    psychokinesisSpeed, liftHeight, liftSpeed, liftDuration) { State = SCState.Created };
             case SkillControllerKind.Wandering:
                 Logger.Trace($"SkillController: create WanderingSkillController");
-                return null;// TODO: Add Wandering (Fear ?)
+                return new WanderingSkillController(template, owner, target) { State = SCState.Created };
             case SkillControllerKind.Leap:
                 Logger.Trace($"SkillController: create LeapSkillController");
-                var ctrl = new LeapSkillController(template, owner, target) { State = SCState.Created };
-                return ctrl;
+                return new LeapSkillController(template, owner, target) { State = SCState.Created };
+            case SkillControllerKind.Dash:
+                Logger.Trace($"SkillController: create DashSkillController");
+                return new DashSkillController(template, owner, target) { State = SCState.Created };
             default:
-                Logger.Trace($"SkillController: create defaultSkillController");
+                Logger.Trace($"SkillController: create defaultSkillController kind={template.KindId}");
                 return null;
         }
     }

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/SkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/SkillController.cs
@@ -36,7 +36,16 @@ public class SkillController
         Logger.Trace($"SkillController: Npc {Owner.Name}:{Owner.ObjId} entering execute state={State}");
     }
 
-    public virtual void End()
+    /// <summary>
+    /// End this controller. Pass <paramref name="force"/> = <c>true</c> when the
+    /// controller is being replaced by another (the caller is about to assign a
+    /// new ActiveSkillController) — in that mode FloatingSkillController skips
+    /// its lift-to-fall transition so the old SC does not keep ticking
+    /// alongside the new one and broadcasting conflicting movement packets.
+    /// Default (false) is the buff-dispel / natural-end path where the fall
+    /// transition is desired so the lifted NPC descends smoothly.
+    /// </summary>
+    public virtual void End(bool force = false)
     {
         State = SCState.Ended;
         // Owner can be null on this path — Floating's Tick / Wandering's Tick

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/SkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/SkillController.cs
@@ -39,11 +39,13 @@ public class SkillController
     public virtual void End()
     {
         State = SCState.Ended;
-        // Drop the back-reference on the owning Unit so this controller can be
-        // GC'd once subscribers unsubscribe. Subclasses that keep the controller
-        // alive past End() (Floating's lift -> fall) deliberately do not call
-        // base.End here and invoke their own FinalEnd later.
-        if (Owner != null && Owner.ActiveSkillController == this)
+        // Owner can be null on this path — Floating's Tick / Wandering's Tick
+        // both reach End() via "if (Owner == null) { End(); return; }" when the
+        // owning NPC was removed mid-flight. Skip the back-reference cleanup
+        // and the trace below in that case.
+        if (Owner == null)
+            return;
+        if (Owner.ActiveSkillController == this)
             Owner.ActiveSkillController = null;
         Logger.Trace($"SkillController: Npc {Owner.Name}:{Owner.ObjId} entering end state={State}");
     }

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/WanderingSkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/WanderingSkillController.cs
@@ -1,0 +1,199 @@
+using System.Numerics;
+
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.NPChar;
+using AAEmu.Game.Models.Game.Skills.Templates;
+using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.Game.Units.Movements;
+using AAEmu.Game.Models.StaticValues;
+using AAEmu.Game.Utils;
+
+using NLog;
+
+namespace AAEmu.Game.Models.Game.Skills.SkillControllers;
+
+public class WanderingSkillController : SkillController
+{
+    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
+
+    private Vector3 _currentWaypoint;
+    private readonly float _duration;
+    private readonly float _changeInterval;
+    private DateTime _startTime;
+    private DateTime _lastDirectionChange;
+    private readonly Random _random = new();
+
+    public WanderingSkillController(SkillControllerTemplate template, BaseUnit owner, BaseUnit target)
+    {
+        Template = template;
+        Owner = owner as Unit;
+        Target = target as Unit;
+
+        var rawDuration = template?.Value[1] ?? 0;
+        _duration = rawDuration > 0 ? rawDuration / 1000f : 5f;
+
+        var rawInterval = template?.Value[2] ?? 0;
+        _changeInterval = rawInterval > 0 ? rawInterval / 1000f : 1.5f;
+
+        PickNewDirection();
+
+        Logger.Debug("WanderingSC: owner={0} duration={1:F1}s interval={2:F1}s",
+            owner.ObjId, _duration, _changeInterval);
+    }
+
+    private float GetFearSpeed()
+    {
+        if (Owner is not Npc npc) return 7f;
+
+        var model = ModelManager.Instance.GetActorModel(npc.Template.ModelId);
+        if (model == null) return 7f;
+
+        if (!model.Stances.TryGetValue(npc.CurrentGameStance, out var stance))
+            return 7f;
+
+        var speed = stance.AiMoveSpeedSprint > 0.1f
+            ? Math.Min(stance.AiMoveSpeedSprint, stance.MaxSpeed)
+            : Math.Min(stance.AiMoveSpeedRun, stance.MaxSpeed);
+        return speed > 0.1f ? speed : 7f;
+    }
+
+    public override void Execute()
+    {
+        base.Execute();
+        _startTime = DateTime.UtcNow;
+        _lastDirectionChange = _startTime;
+
+        // Clear visual target on client (stop face-target overlay) but keep server-side
+        // CurrentTarget/CurrentAggroTarget so ShouldReturn doesn't fire and combat resumes after fear.
+        if (Owner is Npc fearNpc)
+        {
+            fearNpc.BroadcastPacket(
+                new SCTargetChangedPacket(fearNpc.ObjId, 0), true);
+        }
+
+        Logger.Debug("WanderingSC.Execute: owner={0} running in fear for {1:F1}s speed={2:F1}",
+            Owner?.ObjId, _duration, GetFearSpeed());
+        TickManager.Instance.OnTick.Subscribe(Tick, TimeSpan.FromMilliseconds(100));
+    }
+
+    public override void End()
+    {
+        base.End();
+        TickManager.Instance.OnTick.UnSubscribe(Tick);
+
+        if (Owner is Npc endNpc && endNpc.CurrentTarget != null)
+        {
+            endNpc.BroadcastPacket(
+                new SCTargetChangedPacket(endNpc.ObjId, endNpc.CurrentTarget.ObjId), true);
+        }
+
+        if (Owner is Npc npc)
+            npc.StopMovement();
+    }
+
+    private void Tick(TimeSpan delta)
+    {
+        if (Owner == null)
+        {
+            End();
+            return;
+        }
+
+        if (Owner.IsDead)
+        {
+            Logger.Debug("WanderingSC.Tick: owner={0} dead, ending", Owner.ObjId);
+            End();
+            return;
+        }
+
+        var elapsed = (DateTime.UtcNow - _startTime).TotalSeconds;
+        if (elapsed >= _duration)
+        {
+            Logger.Debug("WanderingSC.Tick: owner={0} fear expired after {1:F1}s", Owner.ObjId, elapsed);
+            End();
+            return;
+        }
+
+        if ((DateTime.UtcNow - _lastDirectionChange).TotalSeconds >= _changeInterval)
+        {
+            PickNewDirection();
+            _lastDirectionChange = DateTime.UtcNow;
+        }
+
+        var speed = GetFearSpeed();
+        var moveDist = speed * (float)(delta.TotalMilliseconds / 1000f);
+        MoveTowardsWaypoint(moveDist);
+    }
+
+    private void PickNewDirection()
+    {
+        if (Owner == null) return;
+
+        var currentPos = Owner.Transform.Local.Position;
+
+        var angle = _random.NextDouble() * 2 * Math.PI;
+        var dist = 5f + (float)(_random.NextDouble() * 5f);
+
+        _currentWaypoint = new Vector3(
+            currentPos.X + (float)(Math.Cos(angle) * dist),
+            currentPos.Y + (float)(Math.Sin(angle) * dist),
+            currentPos.Z);
+
+        Logger.Debug("WanderingSC: owner={0} new waypoint ({1:F1},{2:F1},{3:F1})",
+            Owner.ObjId, _currentWaypoint.X, _currentWaypoint.Y, _currentWaypoint.Z);
+    }
+
+    private void MoveTowardsWaypoint(float distance)
+    {
+        if (distance < 0.01f) return;
+
+        var oldPosition = Owner.Transform.Local.ClonePosition();
+        var currentPos = Owner.Transform.Local.Position;
+        var distToWaypoint = MathUtil.CalculateDistance(currentPos, _currentWaypoint, true);
+
+        if (distToWaypoint <= 1f)
+        {
+            PickNewDirection();
+            _lastDirectionChange = DateTime.UtcNow;
+            return;
+        }
+
+        var travelDist = Math.Min(distToWaypoint, distance);
+
+        var (newX, newY, newZ) = World.Transform.PositionAndRotation.AddDistanceToFront(
+            travelDist, distToWaypoint, currentPos, _currentWaypoint);
+        Owner.Transform.Local.SetPosition(newX, newY, newZ);
+
+        var updZ = Owner.ParentWorld.Template.GeoData.GetHeight(Owner.Transform.World.Position);
+        if (updZ > 0 && Math.Abs(newZ - updZ) < 3f)
+            Owner.Transform.Local.SetHeight(updZ);
+
+        var angle = MathUtil.CalculateAngleFrom(Owner.Transform.Local.Position, _currentWaypoint);
+        var (velX, velY) = MathUtil.AddDistanceToFront(4000, 0, 0, (float)angle.DegToRad());
+        Owner.Transform.Local.SetRotationDegree(0f, 0f, (float)angle - 90);
+        var (rx, ry, rz) = Owner.Transform.Local.ToRollPitchYawSBytesMovement();
+
+        var moveType = (UnitMoveType)MoveType.GetType(MoveTypeEnum.Unit);
+        moveType.X = Owner.Transform.Local.Position.X;
+        moveType.Y = Owner.Transform.Local.Position.Y;
+        moveType.Z = Owner.Transform.Local.Position.Z;
+        moveType.VelX = (short)velX;
+        moveType.VelY = (short)velY;
+        moveType.RotationX = rx;
+        moveType.RotationY = ry;
+        moveType.RotationZ = rz;
+        moveType.ActorFlags = 4;
+        moveType.Flags = MoveTypeFlags.Moving | MoveTypeFlags.InCombat;
+        moveType.DeltaMovement = new sbyte[3];
+        moveType.DeltaMovement[0] = 0;
+        moveType.DeltaMovement[1] = 127;
+        moveType.DeltaMovement[2] = 0;
+        moveType.Stance = 0;
+        moveType.Alertness = MoveTypeAlertness.Combat;
+        moveType.Time = (uint)(DateTime.UtcNow - DateTime.UtcNow.Date).TotalMilliseconds;
+
+        Owner.CheckMovedPosition(oldPosition);
+        Owner.BroadcastPacket(new SCOneUnitMovementPacket(Owner.ObjId, moveType), false);
+    }
+}

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/WanderingSkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/WanderingSkillController.cs
@@ -77,9 +77,9 @@ public class WanderingSkillController : SkillController
         TickManager.Instance.OnTick.Subscribe(Tick, TimeSpan.FromMilliseconds(100));
     }
 
-    public override void End()
+    public override void End(bool force = false)
     {
-        base.End();
+        base.End(force);
         TickManager.Instance.OnTick.UnSubscribe(Tick);
 
         if (Owner is Npc endNpc && endNpc.CurrentTarget != null)

--- a/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
+++ b/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
@@ -1,4 +1,4 @@
-﻿using AAEmu.Commons.Network;
+using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Packets;
@@ -93,6 +93,9 @@ public class BuffTemplate
     public bool RemoveOnLand { get; init; }
     public bool Gliding { get; init; }
     public int GlidingRotateSpeed { get; init; }
+    public float GlidingLiftHeight { get; init; }
+    public float GlidingLiftSpeed { get; init; }
+    public float GlidingLiftDuration { get; init; }
     public bool Knockdown { get; init; }
     public bool TickAreaExcludeSource { get; init; }
     public bool FallDamageImmune { get; init; }
@@ -272,6 +275,51 @@ public class BuffTemplate
         if (!buff.Passive)
             owner.BroadcastPacket(new SCBuffCreatedPacket(buff), true);
 
+        // Buff-driven SkillController for NPCs: pull / lift / fear / leap / dash
+        // skills carry their displacement via a buff. SkillControllerId resolves
+        // to a SkillControllerTemplate whose KindId picks the controller class
+        // (Floating, Wandering, Leap, Dash). Skip Characters — the 1.2 client
+        // moves itself from the buff payload and running the server-side SC on
+        // top of that produces double-displacement.
+        if (SkillControllerId > 0 && owner is Unit ownerUnit && owner is not Character)
+        {
+            var scTemplate = SkillManager.Instance.GetEffectTemplate(SkillControllerId, "SkillController")
+                as SkillControllerTemplate;
+            if (scTemplate != null)
+            {
+                // Bubbletrap-style buffs set Gliding=true but leave GlidingLiftHeight=0
+                // in the DB, which would make the controller resolve to pull mode.
+                // Default to 5m lift so the controller actually enters lift mode.
+                var effectiveLiftHeight = GlidingLiftHeight > 0f ? GlidingLiftHeight
+                    : (Gliding ? 5f : 0f);
+                var sc = SkillControllers.SkillController.CreateSkillController(scTemplate, owner, caster,
+                    PsychokinesisSpeed, effectiveLiftHeight, GlidingLiftSpeed, GlidingLiftDuration);
+#pragma warning disable CA1508 // Factory can return null for unimplemented controller kinds
+                if (sc is not null)
+#pragma warning restore CA1508
+                {
+                    sc.SourceBuffId = Id;
+                    if (ownerUnit.ActiveSkillController != null)
+                        ownerUnit.ActiveSkillController.End();
+                    ownerUnit.ActiveSkillController = sc;
+                    sc.Execute();
+                }
+            }
+        }
+        // Psychokinesis fallback: some pull buffs use Psychokinesis=true +
+        // PsychokinesisSpeed instead of a full SkillControllerId. Spawn a
+        // FloatingSkillController in pull mode directly.
+        else if (SkillControllerId == 0 && Psychokinesis && PsychokinesisSpeed > 0
+                 && owner is Unit psychoUnit && owner is not Character && caster != null)
+        {
+            var sc = new SkillControllers.FloatingSkillController(null, owner, caster, PsychokinesisSpeed);
+            sc.SourceBuffId = Id;
+            if (psychoUnit.ActiveSkillController != null)
+                psychoUnit.ActiveSkillController.End();
+            psychoUnit.ActiveSkillController = sc;
+            sc.Execute();
+        }
+
         // Special properties handling
         if (owner is Character character)
         {
@@ -365,7 +413,25 @@ public class BuffTemplate
 
     public void Dispel(BaseUnit caster, BaseUnit owner, Buff buff, bool replaced = false)
     {
-        RemoveBonuses(owner, buff);
+        // Stop the SkillController that this buff started. End() may keep
+        // State=Running for Floating's fall phase, so we deliberately do NOT
+        // null ActiveSkillController here — the controller clears itself
+        // from Unit on FinalEnd after the descent lands.
+        if (owner is Unit dispelUnit
+            && dispelUnit.ActiveSkillController != null
+            && dispelUnit.ActiveSkillController.SourceBuffId == Id)
+        {
+            dispelUnit.ActiveSkillController.End();
+        }
+        DispelCore(caster, owner, buff, replaced);
+    }
+
+    private void DispelCore(BaseUnit caster, BaseUnit owner, Buff buff, bool replaced)
+    {
+        foreach (var template in Bonuses)
+            owner.RemoveBonus(buff.Index, template.Attribute);
+        foreach (var template in DynamicBonuses)
+            owner.RemoveDynamicBonus(buff.Index, template.Attribute);
         var requiringBuffs = owner.Buffs.GetBuffsRequiring(buff.Template.Id);
         foreach (var requiringBuff in requiringBuffs.ToList())
             requiringBuff.Exit();

--- a/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
+++ b/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
@@ -459,10 +459,7 @@ public class BuffTemplate
 
     private void DispelCore(BaseUnit caster, BaseUnit owner, Buff buff, bool replaced)
     {
-        foreach (var template in Bonuses)
-            owner.RemoveBonus(buff.Index, template.Attribute);
-        foreach (var template in DynamicBonuses)
-            owner.RemoveDynamicBonus(buff.Index, template.Attribute);
+        RemoveBonuses(owner, buff);
         var requiringBuffs = owner.Buffs.GetBuffsRequiring(buff.Template.Id);
         foreach (var requiringBuff in requiringBuffs.ToList())
             requiringBuff.Exit();

--- a/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
+++ b/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
@@ -302,7 +302,7 @@ public class BuffTemplate
                 {
                     sc.SourceBuffId = Id;
                     if (ownerUnit.ActiveSkillController != null)
-                        ownerUnit.ActiveSkillController.End();
+                        ownerUnit.ActiveSkillController.End(force: true);
                     ownerUnit.ActiveSkillController = sc;
                     sc.Execute();
                 }
@@ -331,7 +331,7 @@ public class BuffTemplate
             var sc = new SkillControllers.FloatingSkillController(null, owner, caster, 0f, liftHeight, liftSpeed, GlidingLiftDuration);
             sc.SourceBuffId = Id;
             if (liftUnit.ActiveSkillController != null)
-                liftUnit.ActiveSkillController.End();
+                liftUnit.ActiveSkillController.End(force: true);
             liftUnit.ActiveSkillController = sc;
             sc.Execute();
         }
@@ -346,7 +346,7 @@ public class BuffTemplate
             var sc = new SkillControllers.FloatingSkillController(null, owner, caster, PsychokinesisSpeed);
             sc.SourceBuffId = Id;
             if (psychoUnit.ActiveSkillController != null)
-                psychoUnit.ActiveSkillController.End();
+                psychoUnit.ActiveSkillController.End(force: true);
             psychoUnit.ActiveSkillController = sc;
             sc.Execute();
         }

--- a/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
+++ b/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
@@ -316,6 +316,25 @@ public class BuffTemplate
                 Logger.Warn("BuffTemplate.Start: buff {0} SC template not found for sc_id={1}", Id, SkillControllerId);
             }
         }
+        // Gliding/Bubbletrap fallback: buffs that set Gliding=true (sometimes
+        // with no SkillControllerId at all in the data) should lift the target
+        // up to GlidingLiftHeight. Without this branch a Gliding-only buff
+        // would fall through to the Psychokinesis pull below and incorrectly
+        // pull the target toward the caster instead of lifting it.
+        else if (SkillControllerId == 0 && Gliding
+                 && owner is Unit liftUnit && owner is not Character && caster != null)
+        {
+            var liftHeight = GlidingLiftHeight > 0f ? GlidingLiftHeight : 5f;
+            var liftSpeed = GlidingLiftSpeed > 0f ? GlidingLiftSpeed : 3f;
+            Logger.Info("BuffTemplate.Start: buff {0} Gliding lift (no SC id) for NPC owner={1} height={2} speed={3} duration={4}",
+                Id, owner.ObjId, liftHeight, liftSpeed, GlidingLiftDuration);
+            var sc = new SkillControllers.FloatingSkillController(null, owner, caster, 0f, liftHeight, liftSpeed, GlidingLiftDuration);
+            sc.SourceBuffId = Id;
+            if (liftUnit.ActiveSkillController != null)
+                liftUnit.ActiveSkillController.End();
+            liftUnit.ActiveSkillController = sc;
+            sc.Execute();
+        }
         // Psychokinesis fallback: some pull buffs use Psychokinesis=true +
         // PsychokinesisSpeed instead of a full SkillControllerId. Spawn a
         // FloatingSkillController in pull mode directly.

--- a/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
+++ b/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
@@ -292,6 +292,8 @@ public class BuffTemplate
                 // Default to 5m lift so the controller actually enters lift mode.
                 var effectiveLiftHeight = GlidingLiftHeight > 0f ? GlidingLiftHeight
                     : (Gliding ? 5f : 0f);
+                Logger.Info("BuffTemplate.Start: buff {0} creating SC sc_id={1} kind={2} for owner={3} caster={4} psychoSpeed={5} liftH={6}",
+                    Id, SkillControllerId, scTemplate.KindId, owner.ObjId, caster?.ObjId, PsychokinesisSpeed, effectiveLiftHeight);
                 var sc = SkillControllers.SkillController.CreateSkillController(scTemplate, owner, caster,
                     PsychokinesisSpeed, effectiveLiftHeight, GlidingLiftSpeed, GlidingLiftDuration);
 #pragma warning disable CA1508 // Factory can return null for unimplemented controller kinds
@@ -304,6 +306,14 @@ public class BuffTemplate
                     ownerUnit.ActiveSkillController = sc;
                     sc.Execute();
                 }
+                else
+                {
+                    Logger.Warn("BuffTemplate.Start: buff {0} SC factory returned null for kind={1} — controller class not implemented", Id, scTemplate.KindId);
+                }
+            }
+            else
+            {
+                Logger.Warn("BuffTemplate.Start: buff {0} SC template not found for sc_id={1}", Id, SkillControllerId);
             }
         }
         // Psychokinesis fallback: some pull buffs use Psychokinesis=true +
@@ -312,6 +322,8 @@ public class BuffTemplate
         else if (SkillControllerId == 0 && Psychokinesis && PsychokinesisSpeed > 0
                  && owner is Unit psychoUnit && owner is not Character && caster != null)
         {
+            Logger.Info("BuffTemplate.Start: buff {0} Psychokinesis pull (no SC id) for NPC owner={1} toward caster={2} speed={3}",
+                Id, owner.ObjId, caster.ObjId, PsychokinesisSpeed);
             var sc = new SkillControllers.FloatingSkillController(null, owner, caster, PsychokinesisSpeed);
             sc.SourceBuffId = Id;
             if (psychoUnit.ActiveSkillController != null)

--- a/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
+++ b/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
@@ -281,7 +281,7 @@ public class BuffTemplate
         // (Floating, Wandering, Leap, Dash). Skip Characters — the 1.2 client
         // moves itself from the buff payload and running the server-side SC on
         // top of that produces double-displacement.
-        if (SkillControllerId > 0 && owner is Unit ownerUnit && owner is not Character)
+        if (SkillControllerId > 0 && owner is Unit ownerUnit && owner is not Character && caster != null)
         {
             var scTemplate = SkillManager.Instance.GetEffectTemplate(SkillControllerId, "SkillController")
                 as SkillControllerTemplate;
@@ -293,7 +293,7 @@ public class BuffTemplate
                 var effectiveLiftHeight = GlidingLiftHeight > 0f ? GlidingLiftHeight
                     : (Gliding ? 5f : 0f);
                 Logger.Info("BuffTemplate.Start: buff {0} creating SC sc_id={1} kind={2} for owner={3} caster={4} psychoSpeed={5} liftH={6}",
-                    Id, SkillControllerId, scTemplate.KindId, owner.ObjId, caster?.ObjId, PsychokinesisSpeed, effectiveLiftHeight);
+                    Id, SkillControllerId, scTemplate.KindId, owner.ObjId, caster.ObjId, PsychokinesisSpeed, effectiveLiftHeight);
                 var sc = SkillControllers.SkillController.CreateSkillController(scTemplate, owner, caster,
                     PsychokinesisSpeed, effectiveLiftHeight, GlidingLiftSpeed, GlidingLiftDuration);
 #pragma warning disable CA1508 // Factory can return null for unimplemented controller kinds

--- a/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
+++ b/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
@@ -292,7 +292,7 @@ public class BuffTemplate
                 // Default to 5m lift so the controller actually enters lift mode.
                 var effectiveLiftHeight = GlidingLiftHeight > 0f ? GlidingLiftHeight
                     : (Gliding ? 5f : 0f);
-                Logger.Info("BuffTemplate.Start: buff {0} creating SC sc_id={1} kind={2} for owner={3} caster={4} psychoSpeed={5} liftH={6}",
+                Logger.Debug("BuffTemplate.Start: buff {0} creating SC sc_id={1} kind={2} for owner={3} caster={4} psychoSpeed={5} liftH={6}",
                     Id, SkillControllerId, scTemplate.KindId, owner.ObjId, caster.ObjId, PsychokinesisSpeed, effectiveLiftHeight);
                 var sc = SkillControllers.SkillController.CreateSkillController(scTemplate, owner, caster,
                     PsychokinesisSpeed, effectiveLiftHeight, GlidingLiftSpeed, GlidingLiftDuration);
@@ -326,7 +326,7 @@ public class BuffTemplate
         {
             var liftHeight = GlidingLiftHeight > 0f ? GlidingLiftHeight : 5f;
             var liftSpeed = GlidingLiftSpeed > 0f ? GlidingLiftSpeed : 3f;
-            Logger.Info("BuffTemplate.Start: buff {0} Gliding lift (no SC id) for NPC owner={1} height={2} speed={3} duration={4}",
+            Logger.Debug("BuffTemplate.Start: buff {0} Gliding lift (no SC id) for NPC owner={1} height={2} speed={3} duration={4}",
                 Id, owner.ObjId, liftHeight, liftSpeed, GlidingLiftDuration);
             var sc = new SkillControllers.FloatingSkillController(null, owner, caster, 0f, liftHeight, liftSpeed, GlidingLiftDuration);
             sc.SourceBuffId = Id;
@@ -341,7 +341,7 @@ public class BuffTemplate
         else if (SkillControllerId == 0 && Psychokinesis && PsychokinesisSpeed > 0
                  && owner is Unit psychoUnit && owner is not Character && caster != null)
         {
-            Logger.Info("BuffTemplate.Start: buff {0} Psychokinesis pull (no SC id) for NPC owner={1} toward caster={2} speed={3}",
+            Logger.Debug("BuffTemplate.Start: buff {0} Psychokinesis pull (no SC id) for NPC owner={1} toward caster={2} speed={3}",
                 Id, owner.ObjId, caster.ObjId, PsychokinesisSpeed);
             var sc = new SkillControllers.FloatingSkillController(null, owner, caster, PsychokinesisSpeed);
             sc.SourceBuffId = Id;

--- a/AAEmu.Game/Models/Game/Skills/Templates/SkillControllerTemplate.cs
+++ b/AAEmu.Game/Models/Game/Skills/Templates/SkillControllerTemplate.cs
@@ -23,7 +23,7 @@ public class SkillControllerTemplate : EffectTemplate
         // target = the reference point (e.g. the player pulling). Naming is
         // inverted from the buff path because here "caster" is whoever the
         // skill applies the effect TO, not whoever cast the parent skill.
-        Logger.Info("SkillControllerTemplate.Apply: sc_id={0} kind={1} caster={2} target={3}",
+        Logger.Debug("SkillControllerTemplate.Apply: sc_id={0} kind={1} caster={2} target={3}",
             Id, KindId, caster?.ObjId, target?.ObjId);
 
         if (caster is not Unit ownerUnit)

--- a/AAEmu.Game/Models/Game/Skills/Templates/SkillControllerTemplate.cs
+++ b/AAEmu.Game/Models/Game/Skills/Templates/SkillControllerTemplate.cs
@@ -35,6 +35,18 @@ public class SkillControllerTemplate : EffectTemplate
         if (caster is Character)
             return;
 
+        // Pull / Leap / Dash constructors deref target.Transform.World.Position
+        // immediately. Without a reference target (area aura, spawn effect, or
+        // target disconnected between cast and apply) those three SC kinds would
+        // NRE on construction. Wandering does not need a target but bailing
+        // here for the missing target is the safer default — a target-less
+        // displacement has no defined direction anyway.
+        if (target == null)
+        {
+            Logger.Warn("SkillControllerTemplate.Apply: target is null for sc_id={0} kind={1}, skipping", Id, KindId);
+            return;
+        }
+
         var sc = SkillController.CreateSkillController(this, caster, target);
 #pragma warning disable CA1508 // Factory can return null for unimplemented controller kinds
         if (sc is not null)

--- a/AAEmu.Game/Models/Game/Skills/Templates/SkillControllerTemplate.cs
+++ b/AAEmu.Game/Models/Game/Skills/Templates/SkillControllerTemplate.cs
@@ -53,7 +53,7 @@ public class SkillControllerTemplate : EffectTemplate
 #pragma warning restore CA1508
         {
             if (ownerUnit.ActiveSkillController != null)
-                ownerUnit.ActiveSkillController.End();
+                ownerUnit.ActiveSkillController.End(force: true);
             ownerUnit.ActiveSkillController = sc;
             sc.Execute();
         }

--- a/AAEmu.Game/Models/Game/Skills/Templates/SkillControllerTemplate.cs
+++ b/AAEmu.Game/Models/Game/Skills/Templates/SkillControllerTemplate.cs
@@ -1,5 +1,7 @@
 using AAEmu.Game.Core.Packets;
+using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Skills.Effects;
+using AAEmu.Game.Models.Game.Skills.SkillControllers;
 using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Models.Game.Skills.Templates;
@@ -17,6 +19,35 @@ public class SkillControllerTemplate : EffectTemplate
         CastAction castObj,
         EffectSource source, SkillObject skillObject, DateTime time, CompressedGamePackets packetBuilder = null)
     {
-        Logger.Debug("SkillControllerTemplate");
+        // caster = the unit to be moved (e.g. the NPC being pulled / leapt at);
+        // target = the reference point (e.g. the player pulling). Naming is
+        // inverted from the buff path because here "caster" is whoever the
+        // skill applies the effect TO, not whoever cast the parent skill.
+        Logger.Info("SkillControllerTemplate.Apply: sc_id={0} kind={1} caster={2} target={3}",
+            Id, KindId, caster?.ObjId, target?.ObjId);
+
+        if (caster is not Unit ownerUnit)
+            return;
+
+        // Skip server-side SC for Characters — the 1.2 client moves itself from
+        // the buff / SC packets and a server-driven SC on top causes double
+        // displacement.
+        if (caster is Character)
+            return;
+
+        var sc = SkillController.CreateSkillController(this, caster, target);
+#pragma warning disable CA1508 // Factory can return null for unimplemented controller kinds
+        if (sc is not null)
+#pragma warning restore CA1508
+        {
+            if (ownerUnit.ActiveSkillController != null)
+                ownerUnit.ActiveSkillController.End();
+            ownerUnit.ActiveSkillController = sc;
+            sc.Execute();
+        }
+        else
+        {
+            Logger.Warn("SkillControllerTemplate.Apply: factory returned null for sc_id={0} kind={1} — controller class not implemented", Id, KindId);
+        }
     }
 }

--- a/AAEmu.Game/Models/Game/Units/Buffs.cs
+++ b/AAEmu.Game/Models/Game/Units/Buffs.cs
@@ -244,6 +244,43 @@ public class Buffs : IBuffs
 
         return false;
     }
+
+    /// <summary>
+    /// Same as <see cref="CheckBuffs"/> but ignores any active buff that ALSO carries
+    /// one of <paramref name="excludedTagIds"/>. Used by the NPC movement gate to
+    /// stop on pure Shackle / Snare roots but allow movement when the buff additionally
+    /// carries the DecreaseMoveSpeed tag (slow debuffs that ride the Shackle family
+    /// — e.g. Charged Bolt — should slow, not stop).
+    /// </summary>
+    public bool CheckBuffsExcludingTags(List<uint> ids, uint[] excludedTagIds)
+    {
+        if (ids is not { Count: not 0 })
+            return false;
+
+        var buffIdsSet = new HashSet<uint>(ids);
+
+        IEnumerable<Buff> effects;
+        lock (_lock)
+        {
+            effects = _effects.ToArray();
+        }
+
+        foreach (var effect in effects)
+        {
+            if (effect?.Template?.BuffId is null or 0)
+                continue;
+            if (!buffIdsSet.Contains(effect.Template.BuffId))
+                continue;
+
+            var tags = SkillManager.Instance.GetBuffTags(effect.Template.BuffId);
+            if (tags != null && excludedTagIds.Any(ex => tags.Contains(ex)))
+                continue;
+
+            return true;
+        }
+
+        return false;
+    }
     public int GetBuffCountById(uint buffId)
     {
         // Create a copy of the list of effects to avoid changing the list while iterating

--- a/AAEmu.Game/Models/Game/Units/IBuffs.cs
+++ b/AAEmu.Game/Models/Game/Units/IBuffs.cs
@@ -13,6 +13,7 @@ public interface IBuffs
     bool CheckBuff(uint id);
     bool CheckBuffImmune(uint buffId);
     bool CheckBuffs(List<uint> ids);
+    bool CheckBuffsExcludingTags(List<uint> ids, uint[] excludedTagIds);
     bool CheckBuffTag(uint tagId);
     bool CheckDamageImmune(DamageType damageType);
     IEnumerable<Buff> GetAbsorptionEffects();

--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -40,6 +40,10 @@ public class Unit : BaseUnit, IUnit
     public uint ModelId { get; set; }
     public SkillController ActiveSkillController { get; set; }
 
+    // Set after a knockback/impulse so AI movement is suppressed until expiry,
+    // giving the displacement animation time to play on clients.
+    public DateTime? DisplacedUntil { get; set; }
+
     public override float ModelSize
     {
         get

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/Effects/ImpulseEffectTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/Effects/ImpulseEffectTests.cs
@@ -1,0 +1,79 @@
+using System.Numerics;
+using AAEmu.Game.Models.Game.Skills.Effects;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Skills.Effects;
+
+public class ImpulseEffectTests
+{
+    [Test]
+    public async Task LocalImpulseToWorldDisplacement_DegenerateDirection_ReturnsUnitScaledImpulse()
+    {
+        // Caster and target on top of each other → direction degenerate
+        // Local impulse 5000 forward (Y) becomes 5m in local space, unchanged in world.
+        var impulse = new Vector3(0, 5000, 0);
+        var pos = new Vector3(100, 100, 50);
+
+        var result = ImpulseEffect.LocalImpulseToWorldDisplacement(impulse, pos, pos);
+
+        await Assert.That(result).IsEqualTo(new Vector3(0, 5, 0));
+    }
+
+    [Test]
+    public async Task LocalImpulseToWorldDisplacement_TargetEastOfCaster_ForwardImpulsePushesEast()
+    {
+        // Caster at origin, target at +X = forward direction is +X
+        var impulse = new Vector3(0, 5000, 0); // 5m local "forward"
+        var casterPos = new Vector3(0, 0, 0);
+        var targetPos = new Vector3(10, 0, 0);
+
+        var result = ImpulseEffect.LocalImpulseToWorldDisplacement(impulse, casterPos, targetPos);
+
+        await Assert.That(MathF.Abs(result.X - 5f)).IsLessThan(0.001f);
+        await Assert.That(MathF.Abs(result.Y)).IsLessThan(0.001f);
+        await Assert.That(MathF.Abs(result.Z)).IsLessThan(0.001f);
+    }
+
+    [Test]
+    public async Task LocalImpulseToWorldDisplacement_RightImpulsePerpendicularToForward()
+    {
+        // Forward = +X. Local "right" (X axis) should map to world -Y per right-hand rule:
+        // right = new Vector3(-dir.Y, dir.X, 0) = new Vector3(0, 1, 0) since dir = (1,0,0)
+        var impulse = new Vector3(3000, 0, 0); // 3m local "right"
+        var casterPos = new Vector3(0, 0, 0);
+        var targetPos = new Vector3(10, 0, 0);
+
+        var result = ImpulseEffect.LocalImpulseToWorldDisplacement(impulse, casterPos, targetPos);
+
+        await Assert.That(MathF.Abs(result.X)).IsLessThan(0.001f);
+        await Assert.That(MathF.Abs(result.Y - 3f)).IsLessThan(0.001f);
+        await Assert.That(MathF.Abs(result.Z)).IsLessThan(0.001f);
+    }
+
+    [Test]
+    public async Task LocalImpulseToWorldDisplacement_UpImpulseAlwaysAlongWorldZ()
+    {
+        // Up component should pass through unchanged regardless of forward direction.
+        var impulse = new Vector3(0, 0, 4000); // 4m up
+        var casterPos = new Vector3(0, 0, 0);
+        var targetPos = new Vector3(7, 3, 0); // arbitrary direction
+
+        var result = ImpulseEffect.LocalImpulseToWorldDisplacement(impulse, casterPos, targetPos);
+
+        await Assert.That(MathF.Abs(result.X)).IsLessThan(0.001f);
+        await Assert.That(MathF.Abs(result.Y)).IsLessThan(0.001f);
+        await Assert.That(MathF.Abs(result.Z - 4f)).IsLessThan(0.001f);
+    }
+
+    [Test]
+    public async Task LocalImpulseToWorldDisplacement_ZComponentIgnoredInDirectionCalc()
+    {
+        // Vertical offset between caster and target should not affect the horizontal mapping.
+        var impulse = new Vector3(0, 5000, 0);
+        var withZ = ImpulseEffect.LocalImpulseToWorldDisplacement(
+            impulse, new Vector3(0, 0, 50), new Vector3(10, 0, 0));
+        var noZ = ImpulseEffect.LocalImpulseToWorldDisplacement(
+            impulse, new Vector3(0, 0, 0), new Vector3(10, 0, 0));
+
+        await Assert.That(withZ).IsEqualTo(noZ);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/Effects/PhysicalExplosionEffectTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/Effects/PhysicalExplosionEffectTests.cs
@@ -1,0 +1,77 @@
+using System.Numerics;
+using AAEmu.Game.Models.Game.Skills.Effects;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Skills.Effects;
+
+public class PhysicalExplosionEffectTests
+{
+    [Test]
+    public async Task ComputeKnockDisplacement_OutsideRadius_ReturnsNull()
+    {
+        var caster = new Vector3(0, 0, 0);
+        var target = new Vector3(20, 0, 0); // 20m away, radius 10m
+
+        var result = PhysicalExplosionEffect.ComputeKnockDisplacement(
+            caster, target, radius: 10f, holeSize: 1f, pressure: 5000f);
+
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task ComputeKnockDisplacement_InsideHoleSize_ReturnsNull()
+    {
+        var caster = new Vector3(0, 0, 0);
+        var target = new Vector3(0.5f, 0, 0); // 0.5m away, hole 1m
+
+        var result = PhysicalExplosionEffect.ComputeKnockDisplacement(
+            caster, target, radius: 10f, holeSize: 1f, pressure: 5000f);
+
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task ComputeKnockDisplacement_BelowMinPerceptibleKnock_ReturnsNull()
+    {
+        var caster = new Vector3(0, 0, 0);
+        var target = new Vector3(9.5f, 0, 0); // very near edge → tiny falloff
+
+        // Pressure 100 / 1000 = 0.1m base × small falloff → < 0.5m → null
+        var result = PhysicalExplosionEffect.ComputeKnockDisplacement(
+            caster, target, radius: 10f, holeSize: 1f, pressure: 100f);
+
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task ComputeKnockDisplacement_AtFiveMetres_KnocksOutwardAlongPushDirection()
+    {
+        var caster = new Vector3(0, 0, 0);
+        var target = new Vector3(5, 0, 0); // 5m along +X
+
+        // radius 10, hole 1, pressure 5000 → base 5m × falloff (1 - 5/10) = 0.5 → 2.5m
+        var result = PhysicalExplosionEffect.ComputeKnockDisplacement(
+            caster, target, radius: 10f, holeSize: 1f, pressure: 5000f);
+
+        await Assert.That(result).IsNotNull();
+        var d = result!.Value;
+        // Direction should be along +X (push away from caster)
+        await Assert.That(d.X).IsGreaterThan(0f);
+        await Assert.That(MathF.Abs(d.Y)).IsLessThan(0.001f);
+        await Assert.That(MathF.Abs(d.Length() - 2.5f)).IsLessThan(0.01f);
+    }
+
+    [Test]
+    public async Task ComputeKnockDisplacement_FalloffScalesLinearlyWithDistance()
+    {
+        // Near (1m, half hole + 0): falloff 1 - 1/10 = 0.9 → 0.9 * 5 = 4.5m
+        var near = PhysicalExplosionEffect.ComputeKnockDisplacement(
+            new Vector3(0, 0, 0), new Vector3(1, 0, 0), radius: 10f, holeSize: 0.5f, pressure: 5000f);
+        // Far (9m): falloff 1 - 9/10 = 0.1 → 0.5m
+        var far = PhysicalExplosionEffect.ComputeKnockDisplacement(
+            new Vector3(0, 0, 0), new Vector3(9, 0, 0), radius: 10f, holeSize: 0.5f, pressure: 5000f);
+
+        await Assert.That(near).IsNotNull();
+        await Assert.That(far).IsNotNull();
+        await Assert.That(near!.Value.Length()).IsGreaterThan(far!.Value.Length());
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/SkillControllers/LeapSkillControllerTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/SkillControllers/LeapSkillControllerTests.cs
@@ -1,0 +1,91 @@
+using System.Numerics;
+using AAEmu.Game.Models.Game.Skills.SkillControllers;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Skills.SkillControllers;
+
+public class LeapSkillControllerTests
+{
+    [Test]
+    public async Task ApplyDirectionConstraint_Both_AlwaysReturnsCandidate()
+    {
+        var owner = new Vector3(0, 0, 0);
+        var target = new Vector3(10, 0, 0);
+        var candidate = new Vector3(20, 0, 0); // past target
+
+        var result = LeapSkillController.ApplyDirectionConstraint(
+            LeapSkillController.LeapDirection.Both, owner, candidate, target);
+
+        await Assert.That(result).IsEqualTo(candidate);
+    }
+
+    [Test]
+    public async Task ApplyDirectionConstraint_ForwardOnly_AllowedWhenLandingCloserToTarget()
+    {
+        // Owner 10m from target. Candidate 3m from target (forward leap toward target).
+        var owner = new Vector3(0, 0, 0);
+        var target = new Vector3(10, 0, 0);
+        var candidate = new Vector3(7, 0, 0);
+
+        var result = LeapSkillController.ApplyDirectionConstraint(
+            LeapSkillController.LeapDirection.ForwardOnly, owner, candidate, target);
+
+        await Assert.That(result).IsEqualTo(candidate);
+    }
+
+    [Test]
+    public async Task ApplyDirectionConstraint_ForwardOnly_CollapsesToOwnerWhenLandingFarther()
+    {
+        // ForwardOnly leap that would land farther from target than owner started.
+        // This happens when sign of DistanceOffset is wrong.
+        var owner = new Vector3(0, 0, 0);
+        var target = new Vector3(10, 0, 0);
+        var candidate = new Vector3(-5, 0, 0); // 15m from target — farther than owner
+
+        var result = LeapSkillController.ApplyDirectionConstraint(
+            LeapSkillController.LeapDirection.ForwardOnly, owner, candidate, target);
+
+        await Assert.That(result).IsEqualTo(owner);
+    }
+
+    [Test]
+    public async Task ApplyDirectionConstraint_BackwardOnly_AllowedWhenLandingFarther()
+    {
+        // BackwardOnly: leap AWAY from target. Landing farther is correct.
+        var owner = new Vector3(0, 0, 0);
+        var target = new Vector3(10, 0, 0);
+        var candidate = new Vector3(-3, 0, 0); // 13m from target — farther
+
+        var result = LeapSkillController.ApplyDirectionConstraint(
+            LeapSkillController.LeapDirection.BackwardOnly, owner, candidate, target);
+
+        await Assert.That(result).IsEqualTo(candidate);
+    }
+
+    [Test]
+    public async Task ApplyDirectionConstraint_BackwardOnly_CollapsesToOwnerWhenLandingCloser()
+    {
+        // BackwardOnly leap that would land closer to target is rejected.
+        var owner = new Vector3(0, 0, 0);
+        var target = new Vector3(10, 0, 0);
+        var candidate = new Vector3(5, 0, 0); // 5m from target — closer than owner
+
+        var result = LeapSkillController.ApplyDirectionConstraint(
+            LeapSkillController.LeapDirection.BackwardOnly, owner, candidate, target);
+
+        await Assert.That(result).IsEqualTo(owner);
+    }
+
+    [Test]
+    public async Task ApplyDirectionConstraint_ForwardOnly_BoundaryDistance_AllowsCandidate()
+    {
+        // Candidate exactly the same distance as owner — ForwardOnly allows equal (not >).
+        var owner = new Vector3(0, 0, 0);
+        var target = new Vector3(10, 0, 0);
+        var candidate = new Vector3(20, 0, 0); // 10m from target, same as owner
+
+        var result = LeapSkillController.ApplyDirectionConstraint(
+            LeapSkillController.LeapDirection.ForwardOnly, owner, candidate, target);
+
+        await Assert.That(result).IsEqualTo(candidate);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Units/CheckBuffsExcludingTagsTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Units/CheckBuffsExcludingTagsTests.cs
@@ -1,0 +1,42 @@
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Units;
+
+/// <summary>
+/// Edge-case tests for <see cref="Buffs.CheckBuffsExcludingTags"/>. The matching path
+/// hits <c>SkillManager.Instance.GetBuffTags</c>, which requires DB-backed singleton
+/// state — those scenarios are covered in integration tests. These tests cover the
+/// pure return-false paths the singleton is never reached on.
+/// </summary>
+public class CheckBuffsExcludingTagsTests
+{
+    private Buffs _buffs;
+
+    [Before(Test)]
+    public void Setup()
+    {
+        _buffs = new Buffs();
+    }
+
+    [Test]
+    public async Task ReturnsFalse_WhenIdListNull()
+    {
+        var result = _buffs.CheckBuffsExcludingTags(null, [42u]);
+        await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task ReturnsFalse_WhenIdListEmpty()
+    {
+        var result = _buffs.CheckBuffsExcludingTags([], [42u]);
+        await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task ReturnsFalse_WhenNoActiveEffects()
+    {
+        // Owner has no buffs at all → no effect can match the id list
+        var result = _buffs.CheckBuffsExcludingTags([1u, 2u, 3u], [42u]);
+        await Assert.That(result).IsFalse();
+    }
+}


### PR DESCRIPTION
# NPC crowd-control & forced-movement effects (Pull / Lift / Knockback / Dash / Leap / Fear)

Implements the server-side NPC-affecting half of the skill-effect families that today exist only as stubs on `develop`: Knockback, Impulse, Physical Explosion, Blink (NPC branch), plus the four movement-driving SkillController kinds (Floating with Pull + Lift modes, Dash, Leap, Wandering / Fear). All work is opt-in for NPCs only — Character displacement is left to the 1.2 client as before.

Migrated from an internal fork. Navigation-related code (Unity physics bridge, navmesh validation, A* recovery in `Npc.MoveTowards`) was deliberately not carried over to keep the diff focused on the gameplay effects.

Builds cleanly (`dotnet build AAEmu.Game/AAEmu.Game.csproj`, 0 warnings 0 errors). The full test suite stays green (1055 / 1055).

---

## What this adds

### Effects (server-side displacement)

| File | Status before | What it does now |
| --- | --- | --- |
| `Models/Game/Skills/Effects/SpecialEffects/KnockBack.cs` | stub (only logged) | Knock target away from caster. Honours `KnockbackImmune` / `NonPushable` / `NpcTemplate.NonPushableByActor`. Sets `Unit.DisplacedUntil` to `now+600ms` so the AI does not walk back into the swing animation, broadcasts `SCOneUnitMovementPacket` with the new position. Character branch stays a no-op (client handles its own knockback). |
| `Models/Game/Skills/Effects/ImpulseEffect.cs` | empty `Apply` | Velocity + positional impulse in mm scale. Transforms `(Right, Forward, Up)` local impulse into world space using the caster→target direction, then runs the same `DisplacedUntil` + broadcast pipeline as KnockBack. |
| `Models/Game/Skills/Effects/PhysicalExplosionEffect.cs` | stub | Radial knockback from the caster as explosion centre. Targets inside `HoleSize` skipped, outside `Radius` skipped, in between the pressure falls off linearly with distance before the same displacement runs. |
| `Models/Game/Skills/Effects/SpecialEffects/Blink.cs` | Character branch only | NPC branch added next to the existing Character branch. Forward teleport along facing for `value1` mm, clamped to ground via `GeoData.GetHeight`, broadcasts `SCBlinkUnitPacket` + `SCOneUnitMovementPacket`. |

### SkillController implementations

| File | Status before | What it does now |
| --- | --- | --- |
| `Models/Game/Skills/SkillControllers/FloatingSkillController.cs` | did not exist | Two modes selected by constructor args. **Pull (psychokinesis)** computes a horizontal endpoint toward the target, stops at 1.5m, ticks at `psychokinesisSpeed`. **Lift** raises owner to `liftHeight` at `liftSpeed`, holds for `liftDuration`, then enters a Fall phase that accelerates with gravity (9.81 m/s², 20 m/s terminal velocity) and clamps to `GeoData` ground. Pull cancels on Stun / Sleep / Knockdown unless `SourceBuffId > 0` (the buff that started the controller is allowed to override its own CC). |
| `Models/Game/Skills/SkillControllers/DashSkillController.cs` | did not exist | Caster forward / backward dash from facing + `DistanceOffset`. Voluntary dash cancels on hard CC; forced (`SourceBuffId > 0`) ignores it. |
| `Models/Game/Skills/SkillControllers/LeapSkillController.cs` | stub | Direction-constrained leap toward or away from target. `ForwardOnly` skips if the endpoint would be further from target than current; `BackwardOnly` skips the inverse. Same `SourceBuffId` semantics as Dash. |
| `Models/Game/Skills/SkillControllers/WanderingSkillController.cs` | did not exist | Fear / wander. Picks random 5-10 m waypoints inside a wander radius every `fearInterval`. Broadcasts `SCTargetChangedPacket(self, 0)` on Execute so the client detaches the look-at-target overlay, restores it on End. Uses `Stances[CurrentGameStance].AiMoveSpeedSprint` with a fallback chain to Run then a hard 7 m/s default. |
| `Models/Game/Skills/SkillControllers/SkillController.cs` | factory wired only Leap | `SourceBuffId` property added. Factory now creates Floating / Wandering / Leap / Dash with the seven-arg overload that carries `psychokinesisSpeed` / `liftHeight` / `liftSpeed` / `liftDuration`. The existing 3-arg call site in `Skill.cs` still works via default parameters. `End()` now nulls `Owner.ActiveSkillController` when it points at the controller being ended, so finished SCs can be GC'd. |

### Triggers — two paths into the new controllers

| File | Status before | What it does now |
| --- | --- | --- |
| `Models/Game/Skills/Templates/BuffTemplate.cs` Start | nothing read `SkillControllerId` | Three branches: (a) `SkillControllerId > 0` and NPC → resolve the template, build the controller with the buff's `PsychokinesisSpeed` / `GlidingLift*` and call `Execute`. Bubbletrap-style buffs that ship `Gliding=true` but `GlidingLiftHeight=0` get a 5 m default so they actually lift instead of dropping through to pull mode. (b) `SkillControllerId == 0 && Gliding` → `FloatingSkillController` directly in lift mode. (c) `SkillControllerId == 0 && Psychokinesis && PsychokinesisSpeed > 0` → `FloatingSkillController` directly in pull mode. All three set `SourceBuffId = Id` so the controller can ignore the very buff that started it. Characters are explicitly skipped — the 1.2 client moves itself from the buff payload and a server-side SC on top causes double displacement. |
| `Models/Game/Skills/Templates/BuffTemplate.cs` Dispel | no hook | When the dispelled buff is the one that started the active controller (`ActiveSkillController.SourceBuffId == Id`), call `End()`. Crucially does NOT null `ActiveSkillController` — `FloatingSkillController.End` in lift mode transitions to its fall phase and needs `State = Running` to keep blocking AI movement during the descent. The controller clears itself in `FinalEnd` once the fall lands. |
| `Models/Game/Skills/Templates/SkillControllerTemplate.cs` | `Logger.Debug("SkillControllerTemplate")` no-op | Now actually creates the controller: `caster` is the unit to move (the NPC being pulled / leapt at), `target` is the reference point (the puller). Characters skipped for the same reason as the buff path. |

### Infrastructure on existing files (minimal edits, no rewrites)

| File | What changed |
| --- | --- |
| `Models/Game/Units/Unit.cs` | `+ public DateTime? DisplacedUntil { get; set; }` — set by knockback / impulse effects, suppresses AI movement until the time elapses so the displacement animation actually plays out on the client. (`ActiveSkillController` already existed.) |
| `Models/Game/Units/Buffs.cs` + `IBuffs.cs` | `+ CheckBuffsExcludingTags(List<uint> ids, uint[] excludedTagIds)`. Same shape as `CheckBuffs` but skips any active buff whose tag set intersects the excludes — needed by the NPC movement gate to stop on pure Shackle / Snare roots while letting Shackle-plus-DecreaseMoveSpeed slow debuffs (Charged Bolt et al.) actually be slows. |
| `Models/Game/NPChar/Npc.cs` MoveTowards | Two new early-returns at the top: `ActiveSkillController?.State == Running` and `DisplacedUntil > UtcNow`. The Shackle/Snare check is now `CheckBuffsExcludingTags(GetBuffsByTagId(Shackle), [DecreaseMoveSpeed])` so slow debuffs that happen to ride the Shackle family no longer fully root. The existing Stun / Sleep / Root / Knockdown / Fastened guards are untouched. |
| `Models/Game/AI/v2/Behaviors/BaseCombatBehavior.cs` | `MoveInRange` early-returns on `DisplacedUntil`. `ShouldReturn` returns false while `ActiveSkillController.State == Running` so a feared NPC running 8 m in 1.5 s does not tick into "outside return distance" and teleport home. `UpdateTarget` short-circuits while the SC is running so the periodic `SetTarget` does not rebroadcast `SCTargetChangedPacket` mid-fear (server-side `CurrentTarget` stays intact so combat resumes after fear; we just stop telling the client about it). |
| `Core/Managers/SkillManager.cs` LoadBuffs | Added the three missing DB reads `gliding_lift_height` / `gliding_lift_speed` / `gliding_lift_duration` — the schema mentioned them in a comment block but the actual `reader.GetFloat()` calls were never written, so every buff had `GlidingLiftHeight = 0` and Bubbletrap-style buffs always fell through to pull mode. |
| `Core/Packets/C2G/CSSpawnCharacterPacket.cs` | Null-guard on `Connection.ActiveChar` (clients that jumped from lobby into world without selecting a character were crashing the read loop with NRE). |

---

## What is NOT in this PR

Deliberately excluded to keep the diff focused on gameplay effects:

- Unity physics bridge dispatch (`UnityPhysicsBridge.Instance.Command*`) for both effects and controllers
- Navmesh / A* validation in displacement helpers (`WorldManager.GetReferenceHeight(npc.Ai, ...)` calls replaced with plain `GeoData.GetHeight`)
- Wall-pathfinding recovery in `Npc.MoveTowards` (`_wallPath`, `IsWallStuck`, `CombatEvadeImmuneUntil`, the 7376 evade-immunity buff)
- Mate / Slave navigation paths
- The verbose debug-logging helpers `GetBlockingMovementBuff` / `FindBlockingShackleBuff` (only used inside `Logger.IsDebugEnabled` blocks on the fork)

---

## How a skill ends up actually moving the NPC

```
skill cast
 ├─ EffectChain
 │   ├─ BuffEffect → BuffTemplate.Start
 │   │    ├─ SkillControllerId > 0  → resolve SkillControllerTemplate → factory → SC.Execute
 │   │    ├─ SkillControllerId == 0 && Gliding             → FloatingSC.lift directly
 │   │    └─ SkillControllerId == 0 && Psychokinesis       → FloatingSC.pull directly
 │   ├─ SkillControllerTemplate.Apply  → factory → SC.Execute   (alternate trigger)
 │   ├─ KnockBack / Impulse / Explosion (SpecialEffects)        → DisplacedUntil + broadcast
 │   └─ Blink (NPC branch)                                      → teleport + broadcast
 │
 ├─ TickManager (10 Hz subscribe) drives SC.Tick until End
 │
 └─ Buff expires / dispelled → BuffTemplate.Dispel → SC.End
        Floating.lift End transitions to fall phase (gravity, terminal velocity, ground clamp)
        Floating.FinalEnd / Wandering / Dash / Leap End → null ActiveSkillController
```

---

## Test plan

The effects were live-tested against a 1.2 client during development. The flows verified:

- **KnockBack**: NPC visibly knocked back ~3 m, no walk-back during the 600 ms animation, no `Invalid target` warnings on the caster's next click.
- **Impulse / Physical Explosion**: AoE pulses around the caster correctly punt out targets in radius; targets inside `HoleSize` stay; immunity-tagged units are not punted.
- **Pull (Lasso et al.)**: NPC moves smoothly toward the caster, stops at 1.5 m. Diagnostic Logger.Info lines confirm the buff branch that fires.
- **Lift (Bubbletrap, buff 96)**: NPC rises to lift height, holds, descends smoothly under gravity with ground clamp when buff expires. With the GlidingLift DB reads in place, the lift height/speed come from the buff data directly.
- **Fear (Wandering)**: NPC stops looking at the caster (no client face-target overlay), runs in randomised directions for the buff duration, returns to combat cleanly afterward.
- **Dash / Leap**: Caster moves to endpoint; voluntary dash cancels on incoming CC; forced (buff-started) dash ignores its own CC.
- **Charged Bolt (slow with `Shackle + DecreaseMoveSpeed` tags)**: NPC continues to move, just slower — was previously fully rooted because the Shackle check did not exclude DecreaseMoveSpeed-tagged buffs.

Logger.Info diagnostics are enabled on both trigger paths so the next live tester can see exactly which branch a given skill goes through and what controller it spawned. Once stable, these can be downgraded to Debug.

---

Co-Authored-By: Evenstone <evenstone@noreply.users.github.com>
