### PR TITLE
FIX_GEAR_SLOT_BUFF

### DIFF
--- a/AAEmu.Game/Models/Game/Units/Buffs.cs
+++ b/AAEmu.Game/Models/Game/Units/Buffs.cs
@@ -20,6 +20,13 @@ public class Buffs : IBuffs
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
     private const int MinimumBuffDurationToSave = 60000;
 
+    // [GEAR-SLOT-FIX] Slot reserved in Unit.Bonuses for gear bonuses (see Unit.UpdateGearBonuses,
+    // which does `Bonuses[1] = []`). The buff allocator MUST skip this index, otherwise the first
+    // passive buff applied at character load collides with gear and is wiped at login.
+    // _nextIndex therefore starts at GearBonusesIndex + 1 and wraps back to it after uint.MaxValue.
+    public const uint GearBonusesIndex = 1;
+    private const uint FirstBuffIndex = GearBonusesIndex + 1;
+
     // ReSharper disable once ChangeFieldTypeToSystemThreadingLock
     private readonly object _lock = new();
     private uint _nextIndex;
@@ -30,7 +37,7 @@ public class Buffs : IBuffs
 
     public Buffs()
     {
-        _nextIndex = 1;
+        _nextIndex = FirstBuffIndex; // [GEAR-SLOT-FIX] skip GearBonusesIndex
         _effects = [];
         _toleranceCounters = [];
     }
@@ -38,7 +45,7 @@ public class Buffs : IBuffs
     public Buffs(BaseUnit owner)
     {
         SetOwner(owner);
-        _nextIndex = 1;
+        _nextIndex = FirstBuffIndex; // [GEAR-SLOT-FIX] skip GearBonusesIndex
         _effects = [];
         _toleranceCounters = [];
     }
@@ -308,7 +315,7 @@ public class Buffs : IBuffs
                 buff.Index = _nextIndex; // TODO need safe increment...
 
                 if (++_nextIndex == uint.MaxValue)
-                    _nextIndex = 1;
+                    _nextIndex = FirstBuffIndex; // [GEAR-SLOT-FIX] skip GearBonusesIndex on wrap
             }
             else
             {

--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -27,6 +27,7 @@ using AAEmu.Game.Models.Game.World;
 using AAEmu.Game.Models.StaticValues;
 using AAEmu.Game.Models.Tasks.Skills;
 using AAEmu.Game.Utils;
+using static AAEmu.Game.Models.Game.Units.Buffs;
 
 namespace AAEmu.Game.Models.Game.Units;
 
@@ -1040,7 +1041,7 @@ public class Unit : BaseUnit, IUnit
 
     public void UpdateGearBonuses(Item itemAdded, Item itemRemoved)
     {
-        Bonuses[AAEmu.Game.Models.Game.Units.Buffs.GearBonusesIndex] = [];
+        Bonuses[GearBonusesIndex] = [];
 
         foreach (var item in Equipment.Items)
         {
@@ -1049,12 +1050,12 @@ public class Unit : BaseUnit, IUnit
 
             // Mods on the gear Itself
             foreach (var template in ItemManager.Instance.GetUnitModifiers(item.TemplateId))
-                AddBonus(1, new Bonus { Template = template, Value = template.Value });
+                AddBonus(GearBonusesIndex, new Bonus { Template = template, Value = template.Value });
 
             // Mods from equipped Gems
             foreach (var gem in ei.GemIds)
                 foreach (var template in ItemManager.Instance.GetUnitModifiers(gem))
-                    AddBonus(1, new Bonus { Template = template, Value = template.Value });
+                    AddBonus(GearBonusesIndex, new Bonus { Template = template, Value = template.Value });
         }
 
         // Apply Equipment Effects

--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -1040,8 +1040,7 @@ public class Unit : BaseUnit, IUnit
 
     public void UpdateGearBonuses(Item itemAdded, Item itemRemoved)
     {
-        // We use index 1 for gear bonuses. Will make this a constant later, or do it properly. Right now the expected behavior is to have key == buff id, which doesn't work when you have items.
-        Bonuses[1] = [];
+        Bonuses[AAEmu.Game.Models.Game.Units.Buffs.GearBonusesIndex] = [];
 
         foreach (var item in Equipment.Items)
         {


### PR DESCRIPTION
This fix aims to correctly activate passive buffs. I focused on those coming from player skill trees, such as the passive 15% mana buff or the one that converts 3% of damage.
