### PR TITLE
fix(game): Fix GameException on slave wreck doodad spawn — missing ParentWorld on manual Doodad instantiation in SlaveManager

### DIFF
--- a/AAEmu.Game/Core/Managers/SlaveManager.cs
+++ b/AAEmu.Game/Core/Managers/SlaveManager.cs
@@ -605,6 +605,7 @@ public class SlaveManager(WorldInstance parentWorldInstance)
                 Template = DoodadManager.Instance.GetTemplate(doodadBinding.DoodadId),
                 Data = (byte)doodadBinding.AttachPointId, // copy of AttachPointId
                 ParentObj = summonedSlave,
+                ParentWorld = summonedSlave.ParentWorld, // FIX: Spawn() throws "no owning parent world" without this
                 Faction = summonedSlave.Faction,
                 Type2 = 1u, // Flag: No idea why it's 1 for slave's doodads, seems to be 0 for everything else
                 Spawner = null,
@@ -1009,6 +1010,7 @@ public class SlaveManager(WorldInstance parentWorldInstance)
                     Template = DoodadManager.Instance.GetTemplate(healBinding.DoodadId),
                     Data = (byte)wreckPointLocation, // copy of AttachPointId
                     ParentObj = slave,
+                    ParentWorld = slave.ParentWorld, // FIX: Spawn() throws "no owning parent world" without this
                     Faction = slave.Faction, // FactionManager.Instance.GetFaction(FactionsEnum.Friendly),
                     Type2 = 1u, // Flag: No idea why it's 1 for slave's doodads, seems to be 0 for everything else
                     Spawner = null,


### PR DESCRIPTION
The bug
When a summoned slave (boat, car, cart…) drops below 100% HP, the server crashes with:

GameException: Tried to spawn an object without a owning parent world

The crash originates in SlaveManager.UpdateSlaveRepairPoints: a wreckArea doodad is built with new Doodad { ... } and then Spawn() is called on it — but the initializer never sets ParentWorld, which GameObject.Spawn() requires.
The bug has been dormant in develop because the buggy branch is only reached when a slave is actually damaged; as long as slaves stay at 100% HP, wreckArea.Spawn() is never called.

Why it happens

Everywhere else in the codebase, doodads are created through 
DoodadManager.Instance.Create(...), which wires up ParentWorld for you. SlaveManager is the only place that hand-builds a Doodad via an object initializer and then spawns it — and it forgets that field. Two sites are affected:

      - UpdateSlaveRepairPoints → the one that actually throws on damaged slaves.
      - BindSlaveDoodad → same pattern, currently dormant, fixed preventively.

The fix

Add ParentWorld = <slave>.ParentWorld to both initializers. Two lines, no logic change, aligned with the convention used everywhere else.

ParentObj = slave,
ParentWorld = slave.ParentWorld, // required by Spawn()
Faction = slave.Faction,

Repro

Summon a slave → take it under 100% HP → crash. With this patch, the repair doodad spawns cleanly on the damaged attach point.