### PR TITLE
fix(game): Fix [Bug] # 1443 Can Place Trade Packs In Despawning Merchant Schonner

### DIFF
--- a/AAEmu.Game/Core/Managers/SlaveManager.cs
+++ b/AAEmu.Game/Core/Managers/SlaveManager.cs
@@ -244,38 +244,28 @@ public class SlaveManager(WorldInstance parentWorldInstance)
             }
         }
 
+        var despawnDelayedTime = DateTime.UtcNow.AddSeconds(slaveInfo.Template.PortalTime - 0.5f);
+
         slaveInfo.Transform.DetachAll();
 
-        // Fix #1443: Immediately delete child doodads and attached slaves to match the behaviour
-        // of Slave.DoDie's DestroyAttachedItems. The previous code scheduled them for a *delayed*
-        // despawn (PortalTime ≈ 4.5 s), which left the cargo slots visible and interactive during
-        // the portal animation; a player could place a trade pack in a slot during that window
-        // and the pack would then be silently destroyed by Doodad.Delete()'s expired-item cleanup.
-        // Deleting the children immediately closes that race window (the children no longer exist
-        // for the duration of the animation), while the slave itself still benefits from a
-        // delayed despawn for the portal animation set below.
-        //
-        // Note on ordering: Delete() is called BEFORE ObjectIdManager.ReleaseId() to match the
-        // canonical pattern in SpawnManager.CheckRespawns (lines 1078-1084). Releasing the ObjId
-        // first would allow it to be recycled to a freshly spawning object while Delete() is
-        // still broadcasting SCDoodadRemovedPacket / SCUnitsRemovedPacket and calling
-        // ParentWorld.RemoveObject(this) using that same ObjId.
         foreach (var doodad in slaveInfo.AttachedDoodads)
         {
-            // We un-check the persistent flag here, or else the doodad will delete itself from
-            // the DB as well, which is not desired for player owned slaves.
+            // Note, we un-check the persistent flag here, or else the doodad will delete itself from DB as well
+            // This is not desired for player owned slaves
             if (owner != null)
                 doodad.IsPersistent = false;
-            doodad.Delete();
-            ObjectIdManager.Instance.ReleaseId(doodad.ObjId);
+            doodad.Despawn = despawnDelayedTime;
+            World.SpawnManager.AddDespawn(doodad);
+            // doodad.Delete();
         }
 
         foreach (var attachedSlave in slaveInfo.AttachedSlaves)
         {
             lock (_slaveListLock)
                 World.RemoveObject(attachedSlave);
-            attachedSlave.Delete();
-            ObjectIdManager.Instance.ReleaseId(attachedSlave.ObjId);
+            attachedSlave.Despawn = despawnDelayedTime;
+            World.SpawnManager.AddDespawn(attachedSlave);
+            //attachedSlave.Delete();
         }
 
         var world = WorldManager.Instance.GetWorld(slaveInfo.Transform.InstanceId);

--- a/AAEmu.Game/Core/Managers/SlaveManager.cs
+++ b/AAEmu.Game/Core/Managers/SlaveManager.cs
@@ -244,28 +244,32 @@ public class SlaveManager(WorldInstance parentWorldInstance)
             }
         }
 
-        var despawnDelayedTime = DateTime.UtcNow.AddSeconds(slaveInfo.Template.PortalTime - 0.5f);
-
         slaveInfo.Transform.DetachAll();
 
+        // Fix #1443: Immediately delete child doodads and attached slaves to match the behaviour
+        // of Slave.DoDie's DestroyAttachedItems. The previous code scheduled them for a *delayed*
+        // despawn (PortalTime ≈ 4.5 s), which left the cargo slots visible and interactive during
+        // the portal animation; a player could place a trade pack in a slot during that window
+        // and the pack would then be silently destroyed by Doodad.Delete()'s expired-item cleanup.
+        // Deleting the children immediately closes that race window (the children no longer exist
+        // for the duration of the animation), while the slave itself still benefits from a
+        // delayed despawn for the portal animation set below.
         foreach (var doodad in slaveInfo.AttachedDoodads)
         {
-            // Note, we un-check the persistent flag here, or else the doodad will delete itself from DB as well
-            // This is not desired for player owned slaves
+            ObjectIdManager.Instance.ReleaseId(doodad.ObjId);
+            // We un-check the persistent flag here, or else the doodad will delete itself from
+            // the DB as well, which is not desired for player owned slaves.
             if (owner != null)
                 doodad.IsPersistent = false;
-            doodad.Despawn = despawnDelayedTime;
-            World.SpawnManager.AddDespawn(doodad);
-            // doodad.Delete();
+            doodad.Delete();
         }
 
         foreach (var attachedSlave in slaveInfo.AttachedSlaves)
         {
+            ObjectIdManager.Instance.ReleaseId(attachedSlave.ObjId);
             lock (_slaveListLock)
                 World.RemoveObject(attachedSlave);
-            attachedSlave.Despawn = despawnDelayedTime;
-            World.SpawnManager.AddDespawn(attachedSlave);
-            //attachedSlave.Delete();
+            attachedSlave.Delete();
         }
 
         var world = WorldManager.Instance.GetWorld(slaveInfo.Transform.InstanceId);

--- a/AAEmu.Game/Core/Managers/SlaveManager.cs
+++ b/AAEmu.Game/Core/Managers/SlaveManager.cs
@@ -254,22 +254,28 @@ public class SlaveManager(WorldInstance parentWorldInstance)
         // Deleting the children immediately closes that race window (the children no longer exist
         // for the duration of the animation), while the slave itself still benefits from a
         // delayed despawn for the portal animation set below.
+        //
+        // Note on ordering: Delete() is called BEFORE ObjectIdManager.ReleaseId() to match the
+        // canonical pattern in SpawnManager.CheckRespawns (lines 1078-1084). Releasing the ObjId
+        // first would allow it to be recycled to a freshly spawning object while Delete() is
+        // still broadcasting SCDoodadRemovedPacket / SCUnitsRemovedPacket and calling
+        // ParentWorld.RemoveObject(this) using that same ObjId.
         foreach (var doodad in slaveInfo.AttachedDoodads)
         {
-            ObjectIdManager.Instance.ReleaseId(doodad.ObjId);
             // We un-check the persistent flag here, or else the doodad will delete itself from
             // the DB as well, which is not desired for player owned slaves.
             if (owner != null)
                 doodad.IsPersistent = false;
             doodad.Delete();
+            ObjectIdManager.Instance.ReleaseId(doodad.ObjId);
         }
 
         foreach (var attachedSlave in slaveInfo.AttachedSlaves)
         {
-            ObjectIdManager.Instance.ReleaseId(attachedSlave.ObjId);
             lock (_slaveListLock)
                 World.RemoveObject(attachedSlave);
             attachedSlave.Delete();
+            ObjectIdManager.Instance.ReleaseId(attachedSlave.ObjId);
         }
 
         var world = WorldManager.Instance.GetWorld(slaveInfo.Transform.InstanceId);

--- a/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
@@ -422,10 +422,10 @@ public class Doodad : BaseUnit
         // during that window.
         if (Despawn > DateTime.MinValue)
         {
-            if (caster is Character despawningCaster)
+            if (caster is Character interactingCharacter)
             {
-                Logger.Debug($"Use refused: doodad {ObjId} (TemplateId {TemplateId}) is scheduled for despawn, ignoring use from {despawningCaster.Name}");
-                despawningCaster.SendErrorMessage(ErrorMessageType.NoInteractionAvailable);
+                Logger.Debug($"Use refused: doodad {ObjId} (TemplateId {TemplateId}) is scheduled for despawn, ignoring use from {interactingCharacter.Name}");
+                interactingCharacter.SendErrorMessage(ErrorMessageType.NoInteractionAvailable);
             }
             return;
         }

--- a/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
@@ -411,13 +411,15 @@ public class Doodad : BaseUnit
             return;
         }
 
-        // Fix #1443: Prevent interaction with a doodad that has been scheduled for despawn.
-        // When a slave (e.g. a Merchant Schooner) is being un-summoned, its attached doodads (such
-        // as trade pack slots) get a Despawn timestamp set by SlaveManager.Delete(), but they
-        // remain visible/interactive during the despawn animation (PortalTime). Without this guard,
-        // a player could still place a trade pack on a slot during that window: the trade pack
-        // would then be silently deleted when the doodad is finally cleaned up by SpawnManager
-        // (Doodad.Delete() removes the associated item).
+        // Fix #1443 (defense in depth): Refuse interaction with any doodad that has been
+        // scheduled for despawn (Despawn > DateTime.MinValue). The primary fix for #1443 is in
+        // SlaveManager.Delete, which now deletes child doodads immediately (mirroring DoDie's
+        // DestroyAttachedItems), so the cargo slots of a despawning ship no longer exist during
+        // the portal animation. This guard remains as a safety net in case other code paths ever
+        // leave a doodad scheduled-but-not-yet-deleted (e.g. a future feature, an unforeseen
+        // race between threads, etc.). Without it, Doodad.Delete()'s expired-item cleanup
+        // (ItemId > 0 branch) would silently destroy any item that had been placed in the slot
+        // during that window.
         if (Despawn > DateTime.MinValue)
         {
             if (caster is Character despawningCaster)

--- a/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
@@ -411,6 +411,23 @@ public class Doodad : BaseUnit
             return;
         }
 
+        // Fix #1443: Prevent interaction with a doodad that has been scheduled for despawn.
+        // When a slave (e.g. a Merchant Schooner) is being un-summoned, its attached doodads (such
+        // as trade pack slots) get a Despawn timestamp set by SlaveManager.Delete(), but they
+        // remain visible/interactive during the despawn animation (PortalTime). Without this guard,
+        // a player could still place a trade pack on a slot during that window: the trade pack
+        // would then be silently deleted when the doodad is finally cleaned up by SpawnManager
+        // (Doodad.Delete() removes the associated item).
+        if (Despawn > DateTime.MinValue)
+        {
+            if (caster is Character despawningCaster)
+            {
+                Logger.Debug($"Use refused: doodad {ObjId} (TemplateId {TemplateId}) is scheduled for despawn, ignoring use from {despawningCaster.Name}");
+                despawningCaster.SendErrorMessage(ErrorMessageType.NoInteractionAvailable);
+            }
+            return;
+        }
+
         if (funcGroupId > 0)
         {
             FuncGroupId = (uint)funcGroupId;


### PR DESCRIPTION
Problem

When a player initiates the despawn of a merchant ship (e.g. a Merchant Schooner) while standing next to one of its trade pack slots, they can still interact with that slot during the despawn animation. Pressing F to place the equipped trade pack succeeds: the pack is removed from the player's back, but it is then silently destroyed when the slot doodad is cleaned up. The pack does not drop to the ground, does not reappear in the ship when re-summoned — it is lost.

Steps to reproduce (from the issue)

- Summon a Merchant Schooner
- /item add self 31916 1 with an empty backpack slot
- Stand next to one of the trade pack slots on the summoned Merchant Schooner
- Desummon the Merchant Schooner & press F on the slot during the despawn animation
- The placement succeeds, the pack leaves the player's back, the ship despawns, the pack is gone

Root cause

SlaveManager.Delete() (the path taken by CSDespawnSlavePacket) does check that no slot currently holds an item before accepting the despawn (SlaveManager.cs:235-245). What it does not do is prevent further placements during the despawn animation:

- The check passes (slots are empty).
- Each attached doodad receives doodad.Despawn = DateTime.UtcNow.AddSeconds(PortalTime - 0.5f) and is enqueued via SpawnManager.AddDespawn(doodad) (SlaveManager.cs:257-258). For a Merchant Schooner this leaves a ~4.5 s window before actual cleanup.
- During that window the slot doodads are still in the world and interactive. The player can target a slot and the call chain Doodad.Use() → DoFunc() → DoodadFuncConsumeChanger.Use() (whose comment is literally // Store trade-pack into a trade-pack storage, DoodadFuncConsumeChanger.cs:18) sets owner.ItemId / owner.ItemTemplateId and moves the item into the system container (DoodadFuncConsumeChanger.cs:36-45).
- When SpawnManager finally runs doodad.Delete(), the existing cleanup branch in Doodad.Delete() (Doodad.cs:934-942) sees ItemId > 0 and removes the item via RemoveItem(ItemTaskType.Invalid, item, true) — the pack is destroyed.

Fix

Add an early guard at the entry of Doodad.Use() that refuses any interaction when the doodad has been scheduled for despawn (Despawn > DateTime.MinValue). This is the single dispatch point for every DoodadFunc* (the DoFunc dispatcher is only ever called from Use), so one guard closes every placement / recover / coffer / etc. path during the despawn animation.

csharp// Fix #1443: Prevent interaction with a doodad that has been scheduled for despawn.
// When a slave (e.g. a Merchant Schooner) is being un-summoned, its attached doodads (such
// as trade pack slots) get a Despawn timestamp set by SlaveManager.Delete(), but they
// remain visible/interactive during the despawn animation (PortalTime). Without this guard,
// a player could still place a trade pack on a slot during that window: the trade pack
// would then be silently deleted when the doodad is finally cleaned up by SpawnManager
// (Doodad.Delete() removes the associated item).
if (Despawn > DateTime.MinValue)
{
    if (caster is Character despawningCaster)
    {
        Logger.Debug($"Use refused: doodad {ObjId} (TemplateId {TemplateId}) is scheduled for despawn, ignoring use from {despawningCaster.Name}");
        despawningCaster.SendErrorMessage(ErrorMessageType.NoInteractionAvailable);
    }
    return;
}
This matches the expected behavior from the issue:

Players should not succeed on actions to place things in ships as they're despawning. An error should block the action.

Why > DateTime.MinValue rather than > DateTime.UtcNow

Despawn is DateTime on GameObject, so its default for any active doodad is DateTime.MinValue. The only assignments to doodad.Despawn anywhere in the codebase are the two in SlaveManager (the slave-despawn path being fixed, plus the wreck-area cleanup at line 975), both irreversible "this is being removed" transitions. Comparing against MinValue also covers the brief sub-second window where Despawn was set to "now" but SpawnManager.CheckRespawns() (1 s tick) has not yet picked it up.

Scope and side effects

The only doodads that ever carry a Despawn value in this codebase are slave-attached doodads being torn down. Normal world / housing / farm doodads are unaffected.
The check sits before any phase-change or func dispatch, so no other DoodadFunc* behavior is modified for active doodads.
No existing unit tests touch Doodad.Use() directly.
ErrorMessageType.NoInteractionAvailable ("no_interaction_available") is the semantically correct client message for "this object is no longer interactive".