### PR TITLE
fix: trigger impulse effect packets

### DIFF
--- a/AAEmu.Game/Core/Packets/G2C/SCUnitImpulsePacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCUnitImpulsePacket.cs
@@ -1,0 +1,47 @@
+using System;
+
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Network.Game;
+
+namespace AAEmu.Game.Core.Packets.G2C;
+
+public class SCUnitImpulsePacket(
+    uint unitObjId,
+    float velImpulseX,
+    float velImpulseY,
+    float velImpulseZ,
+    float angvelImpulseX,
+    float angvelImpulseY,
+    float angvelImpulseZ,
+    float impulseX,
+    float impulseY,
+    float impulseZ,
+    float angImpulseX,
+    float angImpulseY,
+    float angImpulseZ)
+    : GamePacket(SCOffsets.SCUnitImpulsePacket, 1)
+{
+    internal static float EncodeUnitObjIdFloat(uint unitObjId)
+    {
+        return BitConverter.Int32BitsToSingle(unchecked((int)(unitObjId << 8)));
+    }
+
+    public override PacketStream Write(PacketStream stream)
+    {
+        stream.WriteBc(unitObjId);
+        stream.Write(EncodeUnitObjIdFloat(unitObjId));
+        stream.Write(velImpulseX);
+        stream.Write(velImpulseY);
+        stream.Write(velImpulseZ);
+        stream.Write(angvelImpulseX);
+        stream.Write(angvelImpulseY);
+        stream.Write(angvelImpulseZ);
+        stream.Write(impulseX);
+        stream.Write(impulseY);
+        stream.Write(impulseZ);
+        stream.Write(angImpulseX);
+        stream.Write(angImpulseY);
+        stream.Write(angImpulseZ);
+        return stream;
+    }
+}

--- a/AAEmu.Game/Models/Game/Skills/Effects/ImpulseEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/ImpulseEffect.cs
@@ -1,4 +1,6 @@
-﻿using AAEmu.Game.Core.Packets;
+using AAEmu.Game.Core.Packets;
+using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Skills.Templates;
 using AAEmu.Game.Models.Game.Units;
 
@@ -26,5 +28,53 @@ public class ImpulseEffect : EffectTemplate
         CompressedGamePackets packetBuilder = null)
     {
         Logger.Trace("ImpulseEffect");
+
+        var impulseTarget = ResolveImpulseTarget(caster, target);
+        if (impulseTarget == null || impulseTarget is Unit { IsDead: true })
+            return;
+
+        var packet = new SCUnitImpulsePacket(
+            impulseTarget.ObjId,
+            VelImpulseX,
+            VelImpulseY,
+            VelImpulseZ,
+            AngvelImpulseX,
+            AngvelImpulseY,
+            AngvelImpulseZ,
+            ImpulseX,
+            ImpulseY,
+            ImpulseZ,
+            AngImpulseX,
+            AngImpulseY,
+            AngImpulseZ);
+
+        impulseTarget.BroadcastPacket(packet, impulseTarget is Character);
+    }
+
+    private static BaseUnit ResolveImpulseTarget(BaseUnit caster, BaseUnit target)
+    {
+        if (target is Slave)
+            return target;
+
+        if (caster is Slave)
+            return caster;
+
+        if (target == caster && caster is Character character)
+        {
+            var slave = GetCharacterSlave(character);
+            if (slave != null)
+                return slave;
+        }
+
+        return target;
+    }
+
+    private static Slave GetCharacterSlave(Character character)
+    {
+        if (character.ParentWorld == null)
+            return null;
+
+        return character.ParentWorld.SlaveManager.GetIsMounted(character.ObjId, out _)
+               ?? character.ParentWorld.SlaveManager.GetActiveSlaveByOwnerObjId(character.ObjId);
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/ImpulseEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/ImpulseEffect.cs
@@ -45,15 +45,19 @@ public class ImpulseEffect : EffectTemplate
         if (target is Npc npcTarget && npcTarget.Template.NonPushableByActor)
             return;
 
-        BroadcastImpulsePacket(impulseTarget);
-
-        if (caster == null || target == null)
-            return;
-
         var impulse = new Vector3(ImpulseX + VelImpulseX, ImpulseY + VelImpulseY, ImpulseZ + VelImpulseZ);
 
         if (impulse.LengthSquared() < 0.01f)
             return;
+
+        if (caster == null || target == null)
+            return;
+
+        impulseTarget.BroadcastPacket(new SCUnitImpulsePacket(impulseTarget.ObjId,
+            VelImpulseX, VelImpulseY, VelImpulseZ,
+            AngvelImpulseX, AngvelImpulseY, AngvelImpulseZ,
+            ImpulseX, ImpulseY, ImpulseZ,
+            AngImpulseX, AngImpulseY, AngImpulseZ), impulseTarget is Character);
 
         var casterPos = caster.Transform.World.Position;
         var targetPos = target.Transform.World.Position;
@@ -92,26 +96,6 @@ public class ImpulseEffect : EffectTemplate
 
             npc.CheckMovedPosition(oldPosition);
         }
-    }
-
-    private void BroadcastImpulsePacket(BaseUnit impulseTarget)
-    {
-        var packet = new SCUnitImpulsePacket(
-            impulseTarget.ObjId,
-            VelImpulseX,
-            VelImpulseY,
-            VelImpulseZ,
-            AngvelImpulseX,
-            AngvelImpulseY,
-            AngvelImpulseZ,
-            ImpulseX,
-            ImpulseY,
-            ImpulseZ,
-            AngImpulseX,
-            AngImpulseY,
-            AngImpulseZ);
-
-        impulseTarget.BroadcastPacket(packet, impulseTarget is Character);
     }
 
     private static BaseUnit ResolveImpulseTarget(BaseUnit caster, BaseUnit target)

--- a/AAEmu.Game/Models/Game/Skills/Effects/ImpulseEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/ImpulseEffect.cs
@@ -32,35 +32,40 @@ public class ImpulseEffect : EffectTemplate
         CastAction castObj, EffectSource source, SkillObject skillObject, DateTime time,
         CompressedGamePackets packetBuilder = null)
     {
+        Logger.Debug("ImpulseEffect: caster={0}, target={1}, impulse=({2},{3},{4}), velImpulse=({5},{6},{7})",
+            caster?.ObjId, target?.ObjId, ImpulseX, ImpulseY, ImpulseZ, VelImpulseX, VelImpulseY, VelImpulseZ);
+
         var impulseTarget = ResolveImpulseTarget(caster, target);
-
-        Logger.Debug("ImpulseEffect: caster={0}, target={1}, impulseTarget={2}, impulse=({3},{4},{5}), velImpulse=({6},{7},{8})",
-            caster?.ObjId, target?.ObjId, impulseTarget?.ObjId, ImpulseX, ImpulseY, ImpulseZ,
-            VelImpulseX, VelImpulseY, VelImpulseZ);
-
         if (impulseTarget == null || impulseTarget is Unit { IsDead: true })
             return;
 
-        if (impulseTarget.Buffs.HasEffectsMatchingCondition(e => e.Template.KnockbackImmune || e.Template.NonPushable))
+        if (target?.Buffs.HasEffectsMatchingCondition(e => e.Template.KnockbackImmune || e.Template.NonPushable) == true)
             return;
 
-        if (impulseTarget is Npc npcTarget && npcTarget.Template.NonPushableByActor)
+        if (target is Npc npcTarget && npcTarget.Template.NonPushableByActor)
+            return;
+
+        BroadcastImpulsePacket(impulseTarget);
+
+        if (caster == null || target == null)
             return;
 
         var impulse = new Vector3(ImpulseX + VelImpulseX, ImpulseY + VelImpulseY, ImpulseZ + VelImpulseZ);
 
-        if (impulseTarget is Npc npc)
-        {
-            if (caster == null || impulse.LengthSquared() < 0.01f)
-                return;
+        if (impulse.LengthSquared() < 0.01f)
+            return;
 
+        var casterPos = caster.Transform.World.Position;
+        var targetPos = target.Transform.World.Position;
+        var displacement = LocalImpulseToWorldDisplacement(impulse, casterPos, targetPos);
+
+        var endPos = targetPos + displacement;
+
+        if (target is Npc npc)
+        {
             npc.DisplacedUntil = DateTime.UtcNow.AddMilliseconds(600);
 
             var oldPosition = npc.Transform.Local.ClonePosition();
-            var targetPos = npc.Transform.World.Position;
-            var casterPos = caster.Transform.World.Position;
-            var displacement = LocalImpulseToWorldDisplacement(impulse, casterPos, targetPos);
-            var endPos = targetPos + displacement;
 
             var groundZ = npc.ParentWorld.Template.GeoData.GetHeight(new Vector3(endPos.X, endPos.Y, endPos.Z));
             if (groundZ > 0 && Math.Abs(endPos.Z - groundZ) < 5f)
@@ -86,9 +91,11 @@ public class ImpulseEffect : EffectTemplate
             npc.BroadcastPacket(new SCOneUnitMovementPacket(npc.ObjId, moveType), false);
 
             npc.CheckMovedPosition(oldPosition);
-            return;
         }
+    }
 
+    private void BroadcastImpulsePacket(BaseUnit impulseTarget)
+    {
         var packet = new SCUnitImpulsePacket(
             impulseTarget.ObjId,
             VelImpulseX,
@@ -135,8 +142,9 @@ public class ImpulseEffect : EffectTemplate
     }
 
     /// <summary>
-    /// Converts a caster-target local impulse (X = right, Y = forward, Z = up, units = 1/1000 m)
-    /// into a world-space displacement vector.
+    /// Converts a caster-target local impulse (X=right, Y=forward, Z=up, units = 1/1000 m)
+    /// into a world-space displacement vector. When the caster-to-target direction is
+    /// degenerate, the impulse is returned unchanged in world space.
     /// </summary>
     internal static Vector3 LocalImpulseToWorldDisplacement(
         Vector3 localImpulse, Vector3 casterPos, Vector3 targetPos)

--- a/AAEmu.UnitTests/Game/Core/Packets/G2C/SCUnitImpulsePacketTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Packets/G2C/SCUnitImpulsePacketTests.cs
@@ -1,0 +1,48 @@
+using System;
+
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Packets.G2C;
+
+namespace AAEmu.UnitTests.Game.Core.Packets.G2C;
+
+public class SCUnitImpulsePacketTests
+{
+    [Test]
+    public async Task Write_WritesObjIdAndCraftedObjIdFloat()
+    {
+        const uint objId = 0x123456;
+        var packet = new SCUnitImpulsePacket(
+            objId,
+            1f,
+            2f,
+            3f,
+            4f,
+            5f,
+            6f,
+            7f,
+            8f,
+            9f,
+            10f,
+            11f,
+            12f);
+
+        var stream = packet.Write(new PacketStream());
+        stream.Rollback();
+
+        await Assert.That(stream.ReadBc()).IsEqualTo(objId);
+        await Assert.That(BitConverter.SingleToInt32Bits(stream.ReadSingle())).IsEqualTo(unchecked((int)(objId << 8)));
+        await Assert.That(stream.ReadSingle()).IsEqualTo(1f);
+        await Assert.That(stream.ReadSingle()).IsEqualTo(2f);
+        await Assert.That(stream.ReadSingle()).IsEqualTo(3f);
+    }
+
+    [Test]
+    public async Task EncodeUnitObjIdFloat_PacksObjIdIntoHighThreeBytes()
+    {
+        const uint objId = 0x123456;
+
+        var bytes = BitConverter.GetBytes(SCUnitImpulsePacket.EncodeUnitObjIdFloat(objId));
+
+        await Assert.That(bytes).IsEquivalentTo(new byte[] { 0x00, 0x56, 0x34, 0x12 });
+    }
+}


### PR DESCRIPTION
This PR intends to add the missing packet for ImpulseEffects handled by the client. It affects vehicles like Timber where the server validate the skill and then sends a impulse effect to client. 