### PR TITLE
update(nuget): Update NuGet dependencies

### DIFF
--- a/AAEmu.Aspire.AppHost/AAEmu.Aspire.AppHost.csproj
+++ b/AAEmu.Aspire.AppHost/AAEmu.Aspire.AppHost.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="Aspire.Hosting.MySql" />
+      <PackageReference Include="MessagePack" />
     </ItemGroup>
   
     <ItemGroup>

--- a/AAEmu.Commons/Utils/DB/MySQL.cs
+++ b/AAEmu.Commons/Utils/DB/MySQL.cs
@@ -53,7 +53,7 @@ public static class MySQL
             AllowZeroDateTime = true,
             ConvertZeroDateTime = true,
             DefaultCommandTimeout = 180,
-            SslMode = MySqlSslMode.Prefered
+            SslMode = MySqlSslMode.Preferred
         };
         s_connectionString = builder.ConnectionString;
     }

--- a/AAEmu.Game/Physics/Forces/Buoyancy.cs
+++ b/AAEmu.Game/Physics/Forces/Buoyancy.cs
@@ -24,7 +24,6 @@ public class Buoyancy : ForceGenerator
     /// </summary>
     public static float ShipWaterDensityMul = 3f;
 
-
     /// <summary>
     /// Returns true if the given point is within the area.
     /// </summary>
@@ -203,7 +202,7 @@ public class Buoyancy : ForceGenerator
     {
         foreach (var body in _bodies.ToArray())
         {
-            if (body.IsStatic || !body.IsActive) continue;
+            if (body.MotionType == MotionType.Static || !body.IsActive) continue;
 
             var slave = (Slave)body.Tag;
             if (slave == null) continue;

--- a/AAEmu.Game/Physics/Forces/OneShotVelocityKick.cs
+++ b/AAEmu.Game/Physics/Forces/OneShotVelocityKick.cs
@@ -1,4 +1,4 @@
-using Jitter2;
+﻿using Jitter2;
 using Jitter2.Dynamics;
 using Jitter2.LinearMath;
 
@@ -23,7 +23,7 @@ public sealed class OneShotVelocityKick : ForceGenerator
             return;
         _applied = true;
 
-        if (_body is { IsStatic: false })
+        if (_body is { MotionType: MotionType.Static })
             _body.Velocity += _deltaV;
 
         RemoveEffect();

--- a/AAEmu.Game/Physics/Forces/OneShotVelocityKick.cs
+++ b/AAEmu.Game/Physics/Forces/OneShotVelocityKick.cs
@@ -23,7 +23,7 @@ public sealed class OneShotVelocityKick : ForceGenerator
             return;
         _applied = true;
 
-        if (_body is { MotionType: MotionType.Static })
+        if (_body is { MotionType: MotionType.Dynamic })
             _body.Velocity += _deltaV;
 
         RemoveEffect();

--- a/AAEmu.Game/Physics/HeightMaps/HeightmapDetection.cs
+++ b/AAEmu.Game/Physics/HeightMaps/HeightmapDetection.cs
@@ -1,5 +1,6 @@
 ﻿using Jitter2.Collision;
 using Jitter2.Collision.Shapes;
+using Jitter2.Dynamics;
 using Jitter2.LinearMath;
 
 namespace AAEmu.Game.Physics.HeightMaps;
@@ -26,7 +27,7 @@ public class HeightmapDetection : IBroadPhaseFilter
 
         var collider = shapeA == _shape ? shapeB : shapeA;
 
-        if (collider is not RigidBodyShape rbs || rbs.RigidBody.Data.IsStaticOrInactive) return false;
+        if (collider is not RigidBodyShape rbs || rbs.RigidBody.Data.MotionType == MotionType.Static || !rbs.RigidBody.Data.IsActive) return false;
 
         ref var body = ref rbs.RigidBody!.Data;
 

--- a/AAEmu.Game/Physics/ShipController.cs
+++ b/AAEmu.Game/Physics/ShipController.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 using System.Numerics;
 
@@ -293,7 +293,7 @@ public class ShipController(World world, ShipModelV1 shipModel)
         // Set Mass
         Hull.SetMassInertia(ShipModel.Mass);
         Hull.DeactivationTime = TimeSpan.MaxValue;
-        Hull.IsStatic = false;
+        Hull.MotionType = MotionType.Dynamic;
         Hull.SetActivationState(true);
     }
 
@@ -498,8 +498,6 @@ public class ShipController(World world, ShipModelV1 shipModel)
             var target = escapeThrottleSignOnGround * targetEscapeSpeed;
             slave.Speed += (target - slave.Speed) * escapeA;
         }
-
-
 
         // When wind bonus disappears (especially Official "hard cutoff"), max speed can drop instantly.
         // Hard-clamping causes a visible speed snap. Instead, smoothly converge back to the new cap unless

--- a/AAEmu.UnitTests/Game/Core/Managers/UnitManagers/DoodadManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/UnitManagers/DoodadManagerTests.cs
@@ -195,7 +195,7 @@ public class DoodadManagerTests
         var templates = new Dictionary<uint, DoodadTemplate>();
         SetPrivateField(manager, "_templates", templates);
 
-        var mockWorld = Mock.OfPartial<WorldInstance>(new WorldTemplate { Id = 1, Name = "TestWorld" }, 1u, false, 1u);
+        var mockWorld = Mock.Of<WorldInstance>(new WorldTemplate { Id = 1, Name = "TestWorld" }, 1u, false, 1u);
 
         // Act
         var result = manager.Create(mockWorld.Object, 0, 999, null, true);

--- a/AAEmu.UnitTests/Game/Utils/Scripts/SubCommands/DoodadChainSubCommandTests.cs
+++ b/AAEmu.UnitTests/Game/Utils/Scripts/SubCommands/DoodadChainSubCommandTests.cs
@@ -10,7 +10,7 @@ public class DoodadChainSubCommandTests
     public void PreExecute_WhenChain_ShouldCallChainSubCommand()
     {
         var mockSubCommand = Mock.Of<ICommandV2>();
-        var mockUnitCustomModelParams = Mock.OfPartial<UnitCustomModelParams>(UnitCustomModelType.None);
+        var mockUnitCustomModelParams = Mock.Of<UnitCustomModelParams>(UnitCustomModelType.None);
         var fakeCharacter = new Character(mockUnitCustomModelParams.Object);
 
         var command = new TestCommand(new Dictionary<ICommandV2, string[]>
@@ -29,7 +29,7 @@ public class DoodadChainSubCommandTests
     public void PreExecute_WhenChain_ShouldCallChainSubSubCommand()
     {
         var mockSubSubCommand = Mock.Of<ICommandV2>();
-        var mockUnitCustomModelParams = Mock.OfPartial<UnitCustomModelParams>(UnitCustomModelType.None);
+        var mockUnitCustomModelParams = Mock.Of<UnitCustomModelParams>(UnitCustomModelType.None);
         var fakeCharacter = new Character(mockUnitCustomModelParams.Object);
 
         var subCommand = new SubTestCommand(new Dictionary<ICommandV2, string[]>
@@ -54,7 +54,7 @@ public class DoodadChainSubCommandTests
     [Test]
     public void Execute_WhenOnlyCommand_ShouldNotThrowException()
     {
-        var mockUnitCustomModelParams = Mock.OfPartial<UnitCustomModelParams>(UnitCustomModelType.None);
+        var mockUnitCustomModelParams = Mock.Of<UnitCustomModelParams>(UnitCustomModelType.None);
         var fakeCharacter = new Character(mockUnitCustomModelParams.Object);
 
         var mockMessageOutput = Mock.Of<IMessageOutput>();

--- a/AAEmu.UnitTests/Login/Core/Network/Login/LoginConnectionFactoryTests.cs
+++ b/AAEmu.UnitTests/Login/Core/Network/Login/LoginConnectionFactoryTests.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 using System.IO.Pipelines;
 using System.Net;
@@ -171,11 +171,11 @@ public class LoginConnectionFactoryTests
             _loggerFactory);
 
         // Create context where local and remote are the same IP
-        var mockContext = Mock.OfPartial<ConnectionContext>();
+        var mockContext = Mock.Of<ConnectionContext>();
         var endpoint = new IPEndPoint(IPAddress.Loopback, 12345);
-        mockContext.LocalEndPoint.Returns(endpoint);
-        mockContext.RemoteEndPoint.Returns(endpoint);
-        mockContext.Transport.Returns(CreateMockDuplexPipe().Object);
+        mockContext.Object.LocalEndPoint = endpoint;
+        mockContext.Object.RemoteEndPoint = endpoint;
+        mockContext.Object.Transport = CreateMockDuplexPipe().Object;
 
         // Act
         var connection = factory.Create(mockContext.Object);
@@ -201,10 +201,10 @@ public class LoginConnectionFactoryTests
             _loggerFactory);
 
         // Create context where local and remote are different IPs
-        var mockContext = Mock.OfPartial<ConnectionContext>();
-        mockContext.LocalEndPoint.Returns(new IPEndPoint(IPAddress.Loopback, 12345));
-        mockContext.RemoteEndPoint.Returns(new IPEndPoint(IPAddress.Parse("192.168.1.1"), 54321));
-        mockContext.Transport.Returns(CreateMockDuplexPipe().Object);
+        var mockContext = Mock.Of<ConnectionContext>();
+        mockContext.Object.LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 12345);
+        mockContext.Object.RemoteEndPoint = new IPEndPoint(IPAddress.Parse("192.168.1.1"), 54321);
+        mockContext.Object.Transport = CreateMockDuplexPipe().Object;
 
         // Act
         var connection = factory.Create(mockContext.Object);
@@ -215,10 +215,10 @@ public class LoginConnectionFactoryTests
 
     private static Mock<ConnectionContext> CreateMockConnectionContext()
     {
-        var mockContext = Mock.OfPartial<ConnectionContext>();
-        mockContext.RemoteEndPoint.Returns(new IPEndPoint(IPAddress.Loopback, 12345));
-        mockContext.LocalEndPoint.Returns(new IPEndPoint(IPAddress.Loopback, 1234));
-        mockContext.Transport.Returns(CreateMockDuplexPipe().Object);
+        var mockContext = Mock.Of<ConnectionContext>();
+        mockContext.Object.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, 12345);
+        mockContext.Object.LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 1234);
+        mockContext.Object.Transport = CreateMockDuplexPipe().Object;
         return mockContext;
     }
 

--- a/AAEmu.UnitTests/Login/Core/Network/Login/LoginConnectionHandlerTests.cs
+++ b/AAEmu.UnitTests/Login/Core/Network/Login/LoginConnectionHandlerTests.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 using System.Net;
 using AAEmu.Login.Core.Network.Connections;
@@ -97,7 +97,7 @@ public class LoginConnectionHandlerTests
 
     private static Mock<ConnectionContext> CreateMockConnectionContext()
     {
-        var mockContext = Mock.OfPartial<ConnectionContext>();
+        var mockContext = Mock.Of<ConnectionContext>();
         mockContext.RemoteEndPoint.Returns(new IPEndPoint(IPAddress.Loopback, 12345));
         mockContext.ConnectionId.Returns("test-connection-id");
         // DisposeAsync() returns ValueTask by default — no .Returns() needed

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,8 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
     <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="2.2.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,49 +4,50 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Aspire.Hosting.MySql" Version="13.1.0" />
-    <PackageVersion Include="Discord.Net" Version="3.16.0" />
+    <PackageVersion Include="Discord.Net" Version="3.20.1" />
     <PackageVersion Include="Jace" Version="1.0.0" />
+    <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.11.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.3.0" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
-    <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="2.1.0" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.Telemetry" Version="2.1.0" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport.Abstractions" Version="2.1.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
+    <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="2.2.3" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.Telemetry" Version="2.2.3" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport.Abstractions" Version="2.2.3" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="MySql.Data" Version="9.1.0" />
-    <PackageVersion Include="NCrontab" Version="3.3.3" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="NLog" Version="6.0.7" />
-    <PackageVersion Include="NLog.Extensions.Logging" Version="6.1.0" />
-    <PackageVersion Include="NLua" Version="1.7.3" />
+    <PackageVersion Include="MySql.Data" Version="9.7.0" />
+    <PackageVersion Include="NCrontab" Version="3.4.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="NLog" Version="6.1.3" />
+    <PackageVersion Include="NLog.Extensions.Logging" Version="6.1.3" />
+    <PackageVersion Include="NLua" Version="1.7.9" />
     <PackageVersion Include="NetCoreServer" Version="8.0.7" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageVersion Include="OSVersionExt.NetStd" Version="3.0.1" />
-    <PackageVersion Include="Otp.NET" Version="1.4.0" />
+    <PackageVersion Include="Otp.NET" Version="1.4.1" />
     <PackageVersion Include="System.Drawing.Primitives" Version="4.3.0" />
     <PackageVersion Include="System.Numerics.Vectors" Version="4.6.0" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageVersion Include="System.Text.Json" Version="9.0.0" />
-    <PackageVersion Include="Testcontainers" Version="4.4.0" />
-    <PackageVersion Include="Testcontainers.MySql" Version="4.4.0" />
-    <PackageVersion Include="TUnit" Version="1.19.16" />
-    <PackageVersion Include="TUnit.Mocks" Version="1.19.22" />
+    <PackageVersion Include="Testcontainers" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.MySql" Version="4.12.0" />
+    <PackageVersion Include="TUnit" Version="1.54.0" />
+    <PackageVersion Include="TUnit.Mocks" Version="1.54.0" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
-    <PackageVersion Include="Jitter2" Version="2.7.0" />
+    <PackageVersion Include="Jitter2" Version="2.8.8" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updates various NuGet packages and adapts the codebase to recent API changes in the Jitter2 physics engine. Mainly to update packages with vulnerabilities.
The package `Aspire.Hosting.MySql` was kept on 13.1.0 as to not break the build.

- Updated all NuGet packages to their latest versions, as reflected in the regenerated `Directory.Packages.props` file.
- Migrated physics body static/dynamic state checks from the deprecated `IsStatic` boolean property to the `MotionType` enum across multiple physics-related components (Buoyancy, OneShotVelocityKick, HeightmapDetection, ShipController).
- Added the `MessagePack` package reference for future serialization requirements.
- Corrected a minor typo in the MySQL connection string (`Prefered` to `Preferred`) as per update of the related package.
