### PR TITLE
feat(game): broadcast dice roll results via dedicated SCDiceValuePacket packet

### DIFF
--- a/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
@@ -11,7 +11,6 @@ using AAEmu.Game.Models;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Char.Templates;
-using AAEmu.Game.Models.Game.Chat;
 using AAEmu.Game.Models.Game.Housing;
 using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Items.Actions;
@@ -441,7 +440,7 @@ public class CharacterManager(
         }
 
         var roll = Random.Shared.Next(0, max) + 1;
-        player.BroadcastPacket(new SCChatMessagePacket(ChatType.System, $"{player.Name} rolled {roll}."), true);
+        player.BroadcastPacket(new SCDiceValuePacket(player.Name, max, roll), true);
     }
 
     public int GetEffectiveAccessLevel(Character character)

--- a/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
@@ -427,9 +427,20 @@ public class CharacterManager(
         Logger.Info("Loaded {0} character templates", _templates.Count);
     }
 
+    /// <summary>
+    /// Rolls a die for the player and broadcasts the result.
+    /// </summary>
+    /// <param name="player">The player making the roll.</param>
+    /// <param name="max">The highest possible value, inclusive.</param>
     public void PlayerRoll(Character player, int max)
     {
-        var roll = Random.Shared.Next(1, max);
+        if (max < 1)
+        {
+            Logger.Warn("{0} attempted to roll a die with an invalid max of {1}", player.Name, max);
+            return;
+        }
+
+        var roll = Random.Shared.Next(0, max) + 1;
         player.BroadcastPacket(new SCChatMessagePacket(ChatType.System, $"{player.Name} rolled {roll}."), true);
     }
 

--- a/AAEmu.Game/Core/Packets/C2G/CSRollDicePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSRollDicePacket.cs
@@ -8,8 +8,7 @@ public class CSRollDicePacket() : GamePacket(CSOffsets.CSRollDicePacket, 1)
 {
     public override void Read(PacketStream stream)
     {
-
-        var max = stream.ReadUInt32();
-        CharacterManager.Instance.PlayerRoll(Connection.ActiveChar, int.Parse(max.ToString()));
+        var max = stream.ReadInt32();
+        CharacterManager.Instance.PlayerRoll(Connection.ActiveChar, max);
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCDiceValuePacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCDiceValuePacket.cs
@@ -1,0 +1,16 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Network.Game;
+
+namespace AAEmu.Game.Core.Packets.G2C;
+
+public class SCDiceValuePacket(string name, int max, int value) : GamePacket(SCOffsets.SCDiceValuePacket, 1)
+{
+    public override PacketStream Write(PacketStream stream)
+    {
+        stream.Write(name); // TODO max length 48
+        stream.Write(max);
+        stream.Write(value);
+
+        return stream;
+    }
+}


### PR DESCRIPTION
### Changes:

Replaces the chat-message broadcast for /roll with a new `SCDiceValuePacket` carrying the player name, max, and rolled value, allowing localised text to be displayed by the client

### Fixes:

- Roll range was exclusive of max instead of inclusive
- Client's max was read as uint and round-tripped through a string into an int, throwing `OverflowException` for values above `int.MaxValue`

Untested 🤞 