### PR TITLE
fix(game): Fixes the issue with some item skills

### DIFF
--- a/AAEmu.Game/Core/Managers/HousingManager.cs
+++ b/AAEmu.Game/Core/Managers/HousingManager.cs
@@ -1636,4 +1636,39 @@ public class HousingManager(
         }
         return null;
     }
+
+    public uint GetActAbilityBonusFromHouse(int actabilityGroupId, House house)
+    {
+        var res = 0u;
+        if (actabilityGroupId <= 0)
+            return res;
+
+        var furniture = house.ParentWorld.GetDoodadByHouseDbId(house.Id);
+        var bonusByDoodadTemplate = new Dictionary<uint, uint>(); // Make sure every furniture type only counts once
+        // TODO: Implement special decor effect limit
+        // This should not break gameplay as the server-side value would always be greater than or equal to what the client thinks
+
+        foreach (var f in furniture)
+        {
+            // Ignore attached objects (those are doors/windows etc)
+            if (f.AttachPoint != AttachPointKind.None)
+                continue;
+
+            // Ignore for sale signs
+            if (f.TemplateId == ForSaleMarkerDoodadId)
+                continue;
+            var decoDesign = HousingGameData.Instance.GetDecorationDesignFromDoodadId(f.TemplateId);
+            if (decoDesign.ActabilityGroupId == actabilityGroupId)
+            {
+                if (!bonusByDoodadTemplate.ContainsKey(f.TemplateId))
+                    bonusByDoodadTemplate.Add(f.TemplateId, decoDesign.ActabilityUp);
+            }
+        }
+
+        foreach (var bonus in bonusByDoodadTemplate.Values)
+        {
+            res += bonus;
+        }
+        return res;
+    }
 }

--- a/AAEmu.Game/Core/Managers/HousingManager.cs
+++ b/AAEmu.Game/Core/Managers/HousingManager.cs
@@ -1658,7 +1658,7 @@ public class HousingManager(
             if (f.TemplateId == ForSaleMarkerDoodadId)
                 continue;
             var decoDesign = HousingGameData.Instance.GetDecorationDesignFromDoodadId(f.TemplateId);
-            if (decoDesign.ActabilityGroupId == actabilityGroupId)
+            if (decoDesign != null && decoDesign.ActabilityGroupId == actabilityGroupId)
             {
                 if (!bonusByDoodadTemplate.ContainsKey(f.TemplateId))
                     bonusByDoodadTemplate.Add(f.TemplateId, decoDesign.ActabilityUp);

--- a/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
@@ -181,10 +181,6 @@ public class CharacterCraft(Character owner)
             CraftOrCancel();
             return;
         }
-        
-        // Check craft skill level
-        
-        
 
         /*
         // "Proper" Grade inheritance referencing the compact flags, doesn't work for 1.2

--- a/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
@@ -1,5 +1,4 @@
 ﻿using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Managers.UnitManagers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game.Crafts;
 using AAEmu.Game.Models.Game.DoodadObj;
@@ -112,6 +111,32 @@ public class CharacterCraft(Character owner)
         var skill = new Skill(SkillManager.Instance.GetSkillTemplate(craft.SkillId));
         ConsumeLaborPower = skill.Template.ConsumeLaborPower;
         var speedMultiplier = 1f;
+        if (skill.Template.ActabilityGroupId > 0)
+        {
+            var currentActAbilityPoints = 0u;
+            var actAbility = owner.Actability.Actabilities.GetValueOrDefault((uint)skill.Template.ActabilityGroupId);
+            if (actAbility != null)
+            {
+                speedMultiplier *= actAbility.GetProductionTimeMultiplier();
+                currentActAbilityPoints = (uint)actAbility.Point;
+            }
+
+            // Check bonus from housing
+            var house = HousingManager.Instance.GetHouseAtLocation(owner.Transform.World.Position.X, owner.Transform.World.Position.Y);
+            // We don't bother to check house permission here as you can't use the workbench if you don't have permission anyway
+            if (house != null)
+                currentActAbilityPoints += HousingManager.Instance.GetActAbilityBonusFromHouse(skill.Template.ActabilityGroupId, house);
+
+            // Validate skill level
+            if (craft.ActabilityLimit > currentActAbilityPoints)
+            {
+                Owner.SendErrorMessage(ErrorMessageType.ActabilityNotEnoughPoint, (uint)skill.Template.ActabilityGroupId);
+                CancelCraft();
+                // This breaks the craft panel, but shouldn't happen if the client is in sync with the server
+                return;
+            }
+        }
+        /*
         if (craft.AcId > 0)
         {
             var actAbilityId = CharacterManager.Instance.GetActabilityIdByCategoryId(craft.AcId);
@@ -124,6 +149,7 @@ public class CharacterCraft(Character owner)
                 }
             }
         }
+        */
         skill.CastTimeMultiplier = speedMultiplier;
         skill.Use(Owner, caster, target, null, false, out _);
     }
@@ -155,6 +181,10 @@ public class CharacterCraft(Character owner)
             CraftOrCancel();
             return;
         }
+        
+        // Check craft skill level
+        
+        
 
         /*
         // "Proper" Grade inheritance referencing the compact flags, doesn't work for 1.2
@@ -258,12 +288,12 @@ public class CharacterCraft(Character owner)
         {
             // Determine if this product should inherit grade  
             var productTemplate = ItemManager.Instance.GetTemplate(product.ItemId);
-            int gradeToUse = -1;
+            var gradeToUse = -1;
 
             // If we found an equipment material, inherit grade and roll for free regrade
             if (gradeMaterial != null)
             {
-                gradeToUse = FreeRegrade((int)inheritedGrade);
+                gradeToUse = FreeRegrade(inheritedGrade);
             }
             else if (product.ItemGradeId > 0)
             {
@@ -366,10 +396,10 @@ public class CharacterCraft(Character owner)
     ///</summary>
     private static int FreeRegrade(int baseGrade)
     {
-        int grade = baseGrade;
+        var grade = baseGrade;
         var maxGrade = ItemManager.MaxGradeValue;
         //Check grade is not already max
-        if (grade != (int)maxGrade)
+        if (grade != maxGrade)
         {
             //5% chance
             var luckyRoll = Random.Shared.Next(0, 20);

--- a/AAEmu.Game/Models/Game/Skills/Effects/GainLootPackItemEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/GainLootPackItemEffect.cs
@@ -35,43 +35,37 @@ public class GainLootPackItemEffect : EffectTemplate
         if (pack == null || pack.Loots.Count <= 0)
             return;
 
+        Logger.Debug($"GainLootPackItemEffect {LootPackId}");
+        
         // TODO: Find the related ActAbility
         var actAbility = ActabilityType.None;
+        byte? inheritedGrade = null;
 
-        if (!ConsumeSourceItem && ConsumeCount == 0)
+        if (!ConsumeSourceItem && ConsumeItemId > 0 && ConsumeCount > 0)
         {
             // the tractor collects water
             character.Inventory.Bag.ConsumeItem(ItemTaskType.ConsumeSkillSource, ConsumeItemId, ConsumeCount, null);
-            pack.GiveLootPack(character, actAbility, ItemTaskType.SkillEffectGainItem);
-            Logger.Debug($"GainLootPackItemEffect {LootPackId}");
-            return;
-        }
-
-        if (casterObj is not SkillItem skillItem)
-            return;
-
-        var sourceItem = character.Inventory.Bag.GetItemByItemId(skillItem.ItemId);
-        if (sourceItem == null)
-        {
-            Logger.Warn($"Invalid loot result items {skillItem.ItemId} in lootpack {LootPackId}");
-            return;
         }
 
         if (ConsumeSourceItem)
         {
+            if (casterObj is not SkillItem skillItem)
+                return;
+            var sourceItem = character.Inventory.Bag.GetItemByItemId(skillItem.ItemId);
+            if (sourceItem == null)
+            {
+                Logger.Warn($"Invalid loot result items {skillItem.ItemId} in lootpack {LootPackId}");
+                return;
+            }
+            if (InheritGrade)
+                inheritedGrade = sourceItem.Grade;
             character.Inventory.Bag.RemoveItem(ItemTaskType.ConsumeSkillSource, sourceItem, true);
         }
-        else
-        {
-            character.Inventory.Bag.ConsumeItem(ItemTaskType.ConsumeSkillSource, ConsumeItemId, ConsumeCount, null);
-        }
-
-        //Get the source item's grade if we need to inherit it  
-        byte? inheritedGrade = InheritGrade ? sourceItem.Grade : null;
 
         // Give the results
-        pack.GiveLootPack(character, actAbility, ItemTaskType.SkillEffectGainItem, inheritedGrade: inheritedGrade);
-
-        Logger.Debug($"GainLootPackItemEffect {LootPackId}");
+        if (!pack.GiveLootPack(character, actAbility, ItemTaskType.SkillEffectGainItem, inheritedGrade: inheritedGrade))
+        {
+            character.SendErrorMessage(ErrorMessageType.LootItemCreate);
+        }
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -1319,9 +1319,10 @@ public class Skill
             // Related skill Discard Portable Harpoon Cannon (skill 17735) has no reagents attached
             // The item however is marked with use_skill_as_reagent, so if it requires reagent according to the item
             // but has none attached, consume 1 of the source item instead
+            // 2026-07-15 - Added an additional check if the skill has no effects of it's own. This fixed the bug with Wrapped Sugerplum Fairy Music Box (27627) unwrapping
             // TODO: Check if this is intended behaviour, or if this is a bug in the compact.sqlite3 file
             var item = ItemManager.Instance.GetItemByItemId(skillItem.ItemId);
-            if (item?.Template.UseSkillAsReagent == true && reagents.Count <= 0 && skillProducts.Count <= 0 && consumedItems.Count <= 0)
+            if (item?.Template.UseSkillAsReagent == true && reagents.Count <= 0 && skillProducts.Count <= 0 && consumedItems.Count <= 0 && Template.Effects.Count == 0)
             {
                 consumedItems.Add((item, 1));
                 Logger.Debug($"Consumed item template 1 x {item.TemplateId} ({item.Id}) because of missing reagent information with skill {Template.Id}");


### PR DESCRIPTION
- Fixes the issue of `UseReagent` skills that don't have any reagents defined. For example this resulted in the unwrapped version of the sugerplum music box (27627) to be immediately be consumed on unwrapping. Made further changes so dropping the harpoon canon still works.
- Implement craft skill bonus points from furniture.

[BUG] The item "Candy Fairy Music Box" does not work.
 #870
