### PR TITLE
docs: agent setup skill and AGENTS.md

### DIFF
--- a/.agents/skills/aaemu-setup/REFERENCE.md
+++ b/.agents/skills/aaemu-setup/REFERENCE.md
@@ -1,0 +1,218 @@
+# AAEmu setup — reference
+
+## Downloads and HitL
+
+Wiki sources of truth:
+
+- `Docs/wiki/Dependencies-and-Downloads.md`
+- `Docs/wiki/Client.md`
+
+| Asset | Approx size | Source | Automation |
+| --- | --- | --- | --- |
+| Client 1.2 `r208022` | multi‑GB (archive ~8GB+) | MEGA / Google Drive (wiki) | **HitL only** — inventory + user download |
+| Compact / `compact.sqlite3` | tens of MB archive | MEGA (wiki) | **HitL only** — then copy into `AAEmu.Game/Data/` |
+| AAEmu Launcher | ~few MB | GitHub releases | Optional script fetch if missing |
+
+### Inventory scripts (PowerShell + Bash)
+
+Same behavior on both shells: inventory only by default; never pull MEGA multi‑GB
+packages. Exit `0` when all OK; exit `1` when anything MISSING/PARTIAL.
+
+| Action | PowerShell | Bash |
+| --- | --- | --- |
+| Report only | `powershell -File .agents/skills/aaemu-setup/scripts/Test-AaemuAssets.ps1` | `bash .agents/skills/aaemu-setup/scripts/test-aaemu-assets.sh` |
+| Fetch launcher if missing | add `-FetchLauncherIfMissing` | add `--fetch-launcher` |
+| Open missing download pages | add `-OpenMissingDownloadPages` | add `--open-missing` |
+| Custom repo root | `-RepoRoot 'D:\path\AAEmu'` | `--repo-root /path/AAEmu` |
+
+```powershell
+# Windows PowerShell — from repo root
+powershell -File .agents/skills/aaemu-setup/scripts/Test-AaemuAssets.ps1
+powershell -File .agents/skills/aaemu-setup/scripts/Test-AaemuAssets.ps1 -FetchLauncherIfMissing
+powershell -File .agents/skills/aaemu-setup/scripts/Test-AaemuAssets.ps1 -OpenMissingDownloadPages
+```
+
+```bash
+# Linux / macOS / WSL / Git Bash — from repo root
+bash .agents/skills/aaemu-setup/scripts/test-aaemu-assets.sh
+bash .agents/skills/aaemu-setup/scripts/test-aaemu-assets.sh --fetch-launcher
+bash .agents/skills/aaemu-setup/scripts/test-aaemu-assets.sh --open-missing
+```
+
+Optional: `chmod +x .agents/skills/aaemu-setup/scripts/test-aaemu-assets.sh` then run as `./.agents/skills/aaemu-setup/scripts/test-aaemu-assets.sh`.
+
+**Skip rules (do not re-download):**
+
+- Extracted client: `game_pak` exists and size is large (script default ≥ 1 GB) **and** `bin32/archeage.exe` exists  
+- Compact: `AAEmu.Game/Data/compact.sqlite3` exists and size ≥ 1 MB  
+- Launcher: `AAEmu.Launcher.exe` under `.client_files/launcher/`  
+- Archives under `.client_files/*.7z` count as “archive present” but still need extract if runtime files are missing  
+
+**Platform note:** Playing the official client requires Windows (or Wine, unsupported here). Linux hosts commonly run **Path A/B servers only**; bash still validates `game_pak` + `compact.sqlite3` for the game process.
+
+### Expected paths after extract
+
+```text
+.client_files/ArcheAge 1.2 (r208022) for AAEmu/game_pak
+.client_files/ArcheAge 1.2 (r208022) for AAEmu/bin32/archeage.exe
+.client_files/launcher/AAEmu.Launcher/AAEmu.Launcher.exe
+AAEmu.Game/Data/compact.sqlite3
+```
+
+Nested extract folders: move contents up so the paths above resolve.
+
+### Launcher settings (`settings.aelcf`)
+
+- `pathToGame` → absolute `archeage.exe`
+- `serverIPAddress` → `127.0.0.1`
+- `loginType` → `trino_1_2`
+
+## Ports
+
+| Port | Role |
+| --- | --- |
+| 1237 | Login **public** (client) |
+| 1234 | Login **internal** (game registration) default |
+| 1235 | Suggested alternate internal if 1234 busy |
+| 1239 | Game public |
+| 1250 | Game stream |
+| 1280 | Game Web API (optional) |
+| 3306 | Host MySQL (Path B) |
+| 15133 | Aspire dashboard (Path A, http profile) |
+
+Server list for the client comes from login **`GameServers` config**, not MySQL `game_servers` rows.
+
+## Config.Local templates
+
+### Login (`AAEmu.Login/Config.Local.json`) — Path B (+ optional port remap)
+
+```json
+{
+  "SecretKey": "test",
+  "AutoAccount": true,
+  "InternalNetwork": {
+    "Host": "*",
+    "Port": 1235
+  },
+  "Connections": {
+    "MySQLProvider": {
+      "Host": "127.0.0.1",
+      "Port": "3306",
+      "User": "root",
+      "Password": "YOUR_HOST_MYSQL_PASSWORD",
+      "Database": "aaemu_login"
+    }
+  },
+  "GameServers": [
+    {
+      "Id": 1,
+      "Name": "AAEmu.Game",
+      "Host": "127.0.0.1",
+      "Port": 1239,
+      "Hidden": false
+    }
+  ]
+}
+```
+
+### Game (`AAEmu.Game/Config.Local.json`)
+
+Path A often only needs `ClientData`. Path B needs DB + LoginNetwork + ClientData.
+
+```json
+{
+  "SecretKey": "test",
+  "LoginNetwork": {
+    "Host": "127.0.0.1",
+    "Port": "1235"
+  },
+  "Connections": {
+    "MySQLProvider": {
+      "Host": "127.0.0.1",
+      "Port": "3306",
+      "User": "root",
+      "Password": "YOUR_HOST_MYSQL_PASSWORD",
+      "Database": "aaemu_game"
+    }
+  },
+  "ClientData": {
+    "Sources": [
+      "REPO_ROOT\\.client_files\\ArcheAge 1.2 (r208022) for AAEmu\\game_pak",
+      "REPO_ROOT\\.client_files\\ArcheAge 1.2 (r208022) for AAEmu"
+    ]
+  }
+}
+```
+
+Replace `REPO_ROOT` with the absolute repo path. Keep `SecretKey` identical on both sides.
+
+Game load order: `Config.json` → `Configurations/*.json` → **`Config.Local.json`**.
+
+`Config.Local.json` is copied to `bin` on build when present in the project folder.
+
+## Path A — Aspire
+
+- `dotnet run --project AAEmu.Aspire.AppHost --launch-profile http`
+- MySQL container + volume managed by Aspire (password in user secrets)
+- Login/Game are **not** Docker app containers
+- Dashboard token is printed at startup
+
+## Path B — Host MySQL
+
+```text
+[ ] MySQL 8 host service up
+[ ] aaemu_login / aaemu_game created and SQL imported
+[ ] Config.Local on Login + Game
+[ ] SecretKey match; internal ports match and free
+[ ] compact.sqlite3 + game_pak OK (inventory script)
+[ ] Login, then Game
+[ ] Log: Registered GameServer
+```
+
+```bash
+mysql -u root -p -e "CREATE DATABASE IF NOT EXISTS aaemu_login; CREATE DATABASE IF NOT EXISTS aaemu_game;"
+mysql -u root -p aaemu_login < SQL/aaemu_login.sql
+mysql -u root -p aaemu_game  < SQL/aaemu_game.sql
+```
+
+## Process / log hygiene
+
+**Windows (PowerShell agents):**
+
+- Detach launcher/server windows (`Win32_Process.Create`) so agent Job Objects do not kill them.
+- Tee logs: `dotnet app.dll 2>&1 | Tee-Object -FilePath .server_files/logs/login.log`
+
+**Linux / macOS (bash agents):**
+
+- Run Login/Game in separate terminals or `tmux`/`screen`, or:
+
+```bash
+mkdir -p .server_files/logs
+dotnet run --project AAEmu.Login 2>&1 | tee .server_files/logs/login.log
+dotnet run --project AAEmu.Game  2>&1 | tee .server_files/logs/game.log
+```
+
+- Launcher/client play remains a Windows-side step if the human has no Windows client host.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| **Maintenance** on server list | Game not registered (port 1234 conflict, bad LoginNetwork, SecretKey) |
+| Aspire dies at start | Docker/Podman not running |
+| Missing data / sqlite errors | No `compact.sqlite3` |
+| Bad client data | Wrong `ClientData.Sources` |
+| Lost characters after path switch | Path A and Path B databases are separate |
+| Multi‑GB download again | Agent skipped inventory — always run `Test-AaemuAssets.ps1` or `test-aaemu-assets.sh` first |
+
+Success line:
+
+```text
+Registered GameServer ... (AAEmu.Game) from ...
+```
+
+## Not supported as “the” path
+
+- Docker MySQL + host apps labeled as non-Docker setup  
+- Aspire without an OCI runtime  
+- Committing client/launcher/sqlite into git  

--- a/.agents/skills/aaemu-setup/REFERENCE.md
+++ b/.agents/skills/aaemu-setup/REFERENCE.md
@@ -124,7 +124,7 @@ Path A often only needs `ClientData`. Path B needs DB + LoginNetwork + ClientDat
   "SecretKey": "test",
   "LoginNetwork": {
     "Host": "127.0.0.1",
-    "Port": "1235"
+    "Port": 1235
   },
   "Connections": {
     "MySQLProvider": {

--- a/.agents/skills/aaemu-setup/SKILL.md
+++ b/.agents/skills/aaemu-setup/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: aaemu-setup
+description: >
+  Guide anyone (player or contributor) through getting AAEmu running and
+  playable: asset inventory, Human-in-the-Loop downloads, config, then either
+  Docker/Podman + Aspire or non-Docker host MySQL + standalone Login/Game.
+  Use when the user wants to set up AAEmu, install/run the server, play on a
+  local server, get the client/launcher working, choose Docker vs non-Docker,
+  or mentions game_pak, compact.sqlite3, Aspire, Config.Local, or Maintenance.
+---
+
+# AAEmu setup (players and contributors)
+
+Guide the human end-to-end. Do not assume they are a developer. Prefer plain
+language; use technical detail only when needed for the chosen path.
+
+## Non-negotiables
+
+1. **Two pure run paths only** — no hybrids:
+
+| Environment | Path | Database | Login / Game |
+| --- | --- | --- | --- |
+| Docker Desktop **or** Podman available | **A – Aspire** | MySQL **container** (AppHost) | Started by Aspire as host projects |
+| **No** container runtime | **B – Standalone** | **Host MySQL 8 only** | Host processes; Login then Game |
+
+Non-Docker means **zero** containers, including MySQL. Never invent “Docker only for the database” for Path B.
+
+2. **Human-in-the-Loop (HitL) for large game assets** — client and compact DB
+   archives live on MEGA/Drive (~multi‑GB). The agent must **not** silently
+   re-download them. Always inventory first; only ask the human to download
+   what is missing.
+
+3. Official human docs: `Docs/wiki/Installation-&-Setup.md`,
+   `Dependencies-and-Downloads.md`, `Client.md`, `Aspire-Development-Guide.md`.
+
+## Workflow (always in this order)
+
+### Step 0 — Detect audience and path
+
+Ask if unclear:
+
+- Goal: **play** on a local server, **contribute/code**, or both?
+- Is **Docker Desktop or Podman** installed and usable?
+
+Default: Path A if OCI works; Path B if user has or wants no Docker.
+
+### Step 1 — Inventory assets (never blind-download)
+
+Use the matching shell for the host (same checks, same exit codes):
+
+| Shell | Inventory | Fetch launcher if missing | Open missing download pages (HitL) |
+| --- | --- | --- | --- |
+| **PowerShell** (Windows) | `powershell -File .agents/skills/aaemu-setup/scripts/Test-AaemuAssets.ps1` | add `-FetchLauncherIfMissing` | add `-OpenMissingDownloadPages` |
+| **Bash** (Linux / macOS / WSL / Git Bash) | `bash .agents/skills/aaemu-setup/scripts/test-aaemu-assets.sh` | add `--fetch-launcher` | add `--open-missing` |
+
+Examples:
+
+```powershell
+# Windows PowerShell
+powershell -File .agents/skills/aaemu-setup/scripts/Test-AaemuAssets.ps1
+powershell -File .agents/skills/aaemu-setup/scripts/Test-AaemuAssets.ps1 -FetchLauncherIfMissing
+```
+
+```bash
+# Linux / macOS / WSL
+bash .agents/skills/aaemu-setup/scripts/test-aaemu-assets.sh
+bash .agents/skills/aaemu-setup/scripts/test-aaemu-assets.sh --fetch-launcher
+chmod +x .agents/skills/aaemu-setup/scripts/test-aaemu-assets.sh   # optional once
+```
+
+Interpret the report:
+
+| Status | Action |
+| --- | --- |
+| **OK** | Do not download or re-extract that asset |
+| **MISSING** | HitL: give the human the link, wait, re-scan |
+| **PARTIAL** | Archive present but not extracted (or wrong layout) — extract only |
+
+Canonical local layout (gitignored `.client_files/`):
+
+```text
+.client_files/
+  ArcheAge 1.2 (r208022) for AAEmu/     # game_pak + bin32/archeage.exe
+  launcher/AAEmu.Launcher/              # AAEmu.Launcher.exe
+  *.7z / *.zip                          # optional kept archives
+AAEmu.Game/Data/compact.sqlite3
+```
+
+**MEGA / Drive (client, compact.sqlite3):** open the wiki links for the human
+(or browser). Wait until they confirm the file is saved (prefer
+`.client_files/`). Re-run the inventory script. Extract if needed.  
+**Do not** loop re-downloads when `game_pak` / `archeage.exe` / `compact.sqlite3`
+already satisfy the script checks.
+
+**Launcher (GitHub):** safe to auto-fetch with `-FetchLauncherIfMissing` /
+`--fetch-launcher` when absent; still skip when present.
+
+**Note:** The official game client/launcher are **Windows** binaries. Bash
+inventory still validates server-side assets (`game_pak`, `compact.sqlite3`) on
+Linux hosts that only run Login/Game.
+
+Details and URLs: [REFERENCE.md](REFERENCE.md#downloads-and-hitl).
+
+### Step 2 — Machine prerequisites
+
+- **Both paths:** .NET **10** SDK (`dotnet --version`).
+- **Path A:** Docker Desktop or Podman **running**.
+- **Path B:** MySQL **8** installed and running **on the host** (service),
+  schemas imported once (`SQL/aaemu_login.sql`, `SQL/aaemu_game.sql`).
+
+Help non-developers install these with OS-appropriate steps; do not skip
+waiting for services to actually start.
+
+### Step 3 — Local config (gitignored)
+
+Write/update (templates in [REFERENCE.md](REFERENCE.md#configlocal-templates)):
+
+- `AAEmu.Game/Config.Local.json` — at least `ClientData.Sources` (+ DB/LoginNetwork on Path B)
+- `AAEmu.Login/Config.Local.json` — Path B: DB + `GameServers` (+ `InternalNetwork` if port remap)
+
+Use absolute paths under this repo for `game_pak`. Match `SecretKey` on both
+servers. Rebuild after creating `Config.Local.json` so it copies to output.
+
+### Step 4 — Start servers
+
+**Path A** (same `dotnet` commands on PowerShell or bash):
+
+```bash
+dotnet run --project AAEmu.Aspire.AppHost --launch-profile http
+```
+
+Share the dashboard login URL/token from the console. Only MySQL is a container;
+Login/Game are normal processes.
+
+**Path B:**
+
+```bash
+dotnet build
+dotnet run --project AAEmu.Login
+# then
+dotnet run --project AAEmu.Game
+```
+
+Prefer visible consoles + tee to `.server_files/logs/` when helping a human
+watch progress. Detach Windows GUIs so agent shells do not kill them.
+
+### Step 5 — Launcher and first login
+
+1. Start `.client_files/launcher/AAEmu.Launcher/AAEmu.Launcher.exe` (detached).
+2. Path to Game → `.../bin32/archeage.exe`; server IP → `127.0.0.1`.
+3. Account: AutoAccount usually creates on first login.
+
+### Step 6 — Verify “ready to play”
+
+- [ ] Login port **1237** listening  
+- [ ] Game ports **1239** and **1250** listening  
+- [ ] Path B: login log contains `Registered GameServer`  
+- [ ] Client server list is **not** stuck on Maintenance  
+
+If Maintenance: almost always game failed to register (often **port 1234**
+taken). Remap internal Login+Game ports together — see REFERENCE.
+
+## Agent behavior
+
+- Explain what you are doing in short human-facing steps; pause for HitL
+  downloads and software installs.
+- Prefer inventory script over guessing file presence.
+- Never commit `.client_files/`, `Config.Local.json`, `*.sqlite3`, `.server_files/`.
+- Do not re-download multi‑GB assets when checks already pass.
+- Path A and Path B use **different** databases by default — characters do not
+  carry over unless the human migrates data.
+
+More detail: [REFERENCE.md](REFERENCE.md).

--- a/.agents/skills/aaemu-setup/scripts/Test-AaemuAssets.ps1
+++ b/.agents/skills/aaemu-setup/scripts/Test-AaemuAssets.ps1
@@ -103,9 +103,6 @@ function Get-ClientArchives {
         ForEach-Object { $_.FullName }
 }
 
-New-Item -ItemType Directory -Force -Path $clientFiles | Out-Null
-New-Item -ItemType Directory -Force -Path (Join-Path $clientFiles "launcher") | Out-Null
-
 $results = New-Object System.Collections.Generic.List[object]
 function Add-Result([string]$Name, [string]$Status, [string]$Detail, [string]$Path = "") {
     $results.Add([pscustomobject]@{ Name = $Name; Status = $Status; Detail = $Detail; Path = $Path }) | Out-Null
@@ -166,8 +163,10 @@ if ($launcher) {
 }
 elseif ($FetchLauncherIfMissing) {
     Write-Host "Launcher missing - fetching latest GitHub release..." -ForegroundColor Cyan
-    $destArchive = Join-Path $clientFiles "AAEmu.Launcher-latest.7z"
+    New-Item -ItemType Directory -Force -Path $clientFiles | Out-Null
     $extractDir = Join-Path $clientFiles "launcher"
+    New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
+    $destArchive = Join-Path $clientFiles "AAEmu.Launcher-latest.7z"
     try {
         if (Get-Command gh -ErrorAction SilentlyContinue) {
             gh release download --repo ZeromusXYZ/AAEmu-Launcher --pattern "*.7z" --dir $clientFiles --clobber
@@ -182,8 +181,7 @@ elseif ($FetchLauncherIfMissing) {
         }
         $sevenZ = @(
             "${env:ProgramFiles}\7-Zip\7z.exe",
-            "${env:ProgramFiles(x86)}\7-Zip\7z.exe",
-            "C:\Program Files\Unity 6000.3.5f2\Editor\Data\Tools\7z.exe"
+            "${env:ProgramFiles(x86)}\7-Zip\7z.exe"
         ) | Where-Object { Test-Path $_ } | Select-Object -First 1
         if (-not $sevenZ -and (Get-Command 7z -ErrorAction SilentlyContinue)) { $sevenZ = "7z" }
         if ($sevenZ) {

--- a/.agents/skills/aaemu-setup/scripts/Test-AaemuAssets.ps1
+++ b/.agents/skills/aaemu-setup/scripts/Test-AaemuAssets.ps1
@@ -1,0 +1,261 @@
+<#
+.SYNOPSIS
+  Inventory AAEmu local assets; skip re-download when present.
+
+.DESCRIPTION
+  Checks .client_files client/launcher layout and AAEmu.Game/Data/compact.sqlite3.
+  Never downloads MEGA/Drive multi-GB content. Optionally fetches the small
+  GitHub launcher release when missing, or opens wiki download pages for HitL.
+
+.PARAMETER RepoRoot
+  Repository root. Default: three levels above this script.
+
+.PARAMETER FetchLauncherIfMissing
+  If launcher exe is missing, download latest AAEmu-Launcher release asset via gh or HTTPS.
+
+.PARAMETER OpenMissingDownloadPages
+  Open browser tabs for missing client/compact downloads (human completes MEGA/Drive).
+
+.PARAMETER MinGamePakBytes
+  Minimum size to treat game_pak as complete (default 1 GiB).
+
+.PARAMETER MinCompactBytes
+  Minimum size for compact.sqlite3 (default 1 MiB).
+#>
+[CmdletBinding()]
+param(
+    [string] $RepoRoot = "",
+    [switch] $FetchLauncherIfMissing,
+    [switch] $OpenMissingDownloadPages,
+    [long] $MinGamePakBytes = 1GB,
+    [long] $MinCompactBytes = 1MB
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $RepoRoot) {
+    $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..\..\..")).Path
+}
+$RepoRoot = (Resolve-Path $RepoRoot).Path
+Set-Location $RepoRoot
+
+$clientFiles = Join-Path $RepoRoot ".client_files"
+$clientRootCandidates = @(
+    (Join-Path $clientFiles "ArcheAge 1.2 (r208022) for AAEmu"),
+    (Join-Path $clientFiles "ArcheAge 1.2.4.13 (r208022) for AAEmu")
+)
+
+$UrlClientMega = "https://mega.nz/folder/GnwjQCrZ#WNWzX_lDvkzCqoTtt7I42Q"
+$UrlClientMegaAlt = "https://mega.nz/folder/C3Q0WQjT#vRUethZLPiYSo2B4nE_etg"
+$UrlCompactMega = "https://mega.nz/file/6vxlAZiJ#Xb8VWnG4rFRRklxw6LZaYBPdZvC6j73xLPKIPAK80S8"
+$UrlLauncherReleases = "https://github.com/ZeromusXYZ/AAEmu-Launcher/releases"
+
+function Format-Size([long] $n) {
+    if ($n -ge 1GB) { return ("{0:N2} GB" -f ($n / 1GB)) }
+    if ($n -ge 1MB) { return ("{0:N2} MB" -f ($n / 1MB)) }
+    if ($n -ge 1KB) { return ("{0:N2} KB" -f ($n / 1KB)) }
+    return "$n B"
+}
+
+function Find-GamePak {
+    foreach ($root in $clientRootCandidates) {
+        $pak = Join-Path $root "game_pak"
+        if (Test-Path -LiteralPath $pak) {
+            return [pscustomobject]@{ Path = $pak; Root = $root }
+        }
+    }
+    if (-not (Test-Path -LiteralPath $clientFiles)) { return $null }
+    $any = Get-ChildItem -LiteralPath $clientFiles -Recurse -Filter "game_pak" -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($any) {
+        return [pscustomobject]@{ Path = $any.FullName; Root = $any.DirectoryName }
+    }
+    return $null
+}
+
+function Find-ArcheageExe {
+    param([string] $PreferRoot)
+    if ($PreferRoot) {
+        $p = Join-Path $PreferRoot "bin32\archeage.exe"
+        if (Test-Path -LiteralPath $p) { return $p }
+    }
+    if (-not (Test-Path -LiteralPath $clientFiles)) { return $null }
+    $any = Get-ChildItem -LiteralPath $clientFiles -Recurse -Filter "archeage.exe" -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($any) { return $any.FullName }
+    return $null
+}
+
+function Find-LauncherExe {
+    $prefer = Join-Path $clientFiles "launcher\AAEmu.Launcher\AAEmu.Launcher.exe"
+    if (Test-Path -LiteralPath $prefer) { return $prefer }
+    if (-not (Test-Path -LiteralPath $clientFiles)) { return $null }
+    $any = Get-ChildItem -LiteralPath $clientFiles -Recurse -Filter "AAEmu.Launcher.exe" -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($any) { return $any.FullName }
+    return $null
+}
+
+function Get-ClientArchives {
+    if (-not (Test-Path -LiteralPath $clientFiles)) { return @() }
+    Get-ChildItem -LiteralPath $clientFiles -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.Extension -match '\.(7z|zip|rar)$' -or $_.Name -match 'ArcheAge|compact|Launcher' } |
+        ForEach-Object { $_.FullName }
+}
+
+New-Item -ItemType Directory -Force -Path $clientFiles | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $clientFiles "launcher") | Out-Null
+
+$results = New-Object System.Collections.Generic.List[object]
+function Add-Result([string]$Name, [string]$Status, [string]$Detail, [string]$Path = "") {
+    $results.Add([pscustomobject]@{ Name = $Name; Status = $Status; Detail = $Detail; Path = $Path }) | Out-Null
+}
+
+# Client
+$pakInfo = Find-GamePak
+if ($pakInfo) {
+    $pakItem = Get-Item -LiteralPath $pakInfo.Path
+    $exe = Find-ArcheageExe -PreferRoot $pakInfo.Root
+    $sizeText = Format-Size $pakItem.Length
+    if ($pakItem.Length -ge $MinGamePakBytes -and $exe) {
+        Add-Result "client" "OK" "game_pak $sizeText; archeage.exe present - skip re-download" $pakInfo.Path
+    }
+    elseif ($pakItem.Length -lt $MinGamePakBytes) {
+        Add-Result "client" "PARTIAL" "game_pak too small ($sizeText); re-download or extract may be needed" $pakInfo.Path
+    }
+    else {
+        Add-Result "client" "PARTIAL" "game_pak present but archeage.exe missing - finish extract" $pakInfo.Path
+    }
+}
+else {
+    $archives = @(Get-ClientArchives | Where-Object { $_ -match 'ArcheAge|r208022|1\.2' })
+    if ($archives.Count -gt 0) {
+        Add-Result "client" "PARTIAL" ("archive present, not extracted: " + ($archives -join "; ")) $archives[0]
+    }
+    else {
+        Add-Result "client" "MISSING" "Need ArcheAge 1.2 (r208022) client - HitL MEGA/Drive download" ""
+    }
+}
+
+# compact.sqlite3
+$compact = Join-Path $RepoRoot "AAEmu.Game\Data\compact.sqlite3"
+if (Test-Path -LiteralPath $compact) {
+    $c = Get-Item -LiteralPath $compact
+    $sizeText = Format-Size $c.Length
+    if ($c.Length -ge $MinCompactBytes) {
+        Add-Result "compact.sqlite3" "OK" "$sizeText - skip re-download" $compact
+    }
+    else {
+        Add-Result "compact.sqlite3" "PARTIAL" "file too small ($sizeText)" $compact
+    }
+}
+else {
+    $compactArchive = @(Get-ClientArchives | Where-Object { $_ -match 'compact|Compact|Server_Compact' })
+    if ($compactArchive.Count -gt 0) {
+        Add-Result "compact.sqlite3" "PARTIAL" ("archive present; extract and copy to AAEmu.Game\Data\compact.sqlite3: " + $compactArchive[0]) $compactArchive[0]
+    }
+    else {
+        Add-Result "compact.sqlite3" "MISSING" "Need compact.sqlite3 - HitL MEGA download, then place under AAEmu.Game\Data\" ""
+    }
+}
+
+# Launcher
+$launcher = Find-LauncherExe
+if ($launcher) {
+    Add-Result "launcher" "OK" "present - skip re-download" $launcher
+}
+elseif ($FetchLauncherIfMissing) {
+    Write-Host "Launcher missing - fetching latest GitHub release..." -ForegroundColor Cyan
+    $destArchive = Join-Path $clientFiles "AAEmu.Launcher-latest.7z"
+    $extractDir = Join-Path $clientFiles "launcher"
+    try {
+        if (Get-Command gh -ErrorAction SilentlyContinue) {
+            gh release download --repo ZeromusXYZ/AAEmu-Launcher --pattern "*.7z" --dir $clientFiles --clobber
+            $got = Get-ChildItem -LiteralPath $clientFiles -Filter "AAEmu.Launcher*.7z" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+            if ($got) { $destArchive = $got.FullName }
+        }
+        else {
+            $api = Invoke-RestMethod -Uri "https://api.github.com/repos/ZeromusXYZ/AAEmu-Launcher/releases/latest" -Headers @{ "User-Agent" = "aaemu-setup" }
+            $asset = $api.assets | Where-Object { $_.name -like "*.7z" } | Select-Object -First 1
+            if (-not $asset) { throw "No .7z asset on latest release" }
+            Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $destArchive -UseBasicParsing
+        }
+        $sevenZ = @(
+            "${env:ProgramFiles}\7-Zip\7z.exe",
+            "${env:ProgramFiles(x86)}\7-Zip\7z.exe",
+            "C:\Program Files\Unity 6000.3.5f2\Editor\Data\Tools\7z.exe"
+        ) | Where-Object { Test-Path $_ } | Select-Object -First 1
+        if (-not $sevenZ -and (Get-Command 7z -ErrorAction SilentlyContinue)) { $sevenZ = "7z" }
+        if ($sevenZ) {
+            & $sevenZ x $destArchive "-o$extractDir" -y | Out-Null
+        }
+        else {
+            Write-Host "Downloaded $destArchive but no 7z found - extract manually to .client_files\launcher\" -ForegroundColor Yellow
+        }
+        $launcher = Find-LauncherExe
+        if ($launcher) {
+            Add-Result "launcher" "OK" "fetched and extracted" $launcher
+        }
+        else {
+            Add-Result "launcher" "PARTIAL" "archive downloaded; extract to .client_files\launcher\" $destArchive
+        }
+    }
+    catch {
+        Add-Result "launcher" "MISSING" ("fetch failed: {0} - {1}" -f $_.Exception.Message, $UrlLauncherReleases) ""
+    }
+}
+else {
+    Add-Result "launcher" "MISSING" "AAEmu.Launcher.exe not found (use -FetchLauncherIfMissing or HitL GitHub)" ""
+}
+
+Write-Host ""
+Write-Host "AAEmu asset inventory - $RepoRoot" -ForegroundColor Cyan
+Write-Host ("-" * 72)
+foreach ($r in $results) {
+    $color = switch ($r.Status) {
+        "OK" { "Green" }
+        "PARTIAL" { "Yellow" }
+        default { "Red" }
+    }
+    Write-Host ("[{0}] {1}" -f $r.Status, $r.Name) -ForegroundColor $color
+    Write-Host ("      {0}" -f $r.Detail)
+    if ($r.Path) { Write-Host ("      {0}" -f $r.Path) -ForegroundColor DarkGray }
+}
+Write-Host ("-" * 72)
+
+$missing = @($results | Where-Object { $_.Status -eq "MISSING" })
+$partial = @($results | Where-Object { $_.Status -eq "PARTIAL" })
+
+if ($OpenMissingDownloadPages) {
+    if ($missing.Name -contains "client" -or $partial.Name -contains "client") {
+        Start-Process $UrlClientMega
+        Start-Process $UrlClientMegaAlt
+    }
+    if ($missing.Name -contains "compact.sqlite3" -or $partial.Name -contains "compact.sqlite3") {
+        Start-Process $UrlCompactMega
+    }
+    if ($missing.Name -contains "launcher") {
+        Start-Process $UrlLauncherReleases
+    }
+}
+
+if ($missing.Count -eq 0 -and $partial.Count -eq 0) {
+    Write-Host "All required assets present. Do not re-download multi-GB packages." -ForegroundColor Green
+    exit 0
+}
+
+Write-Host ""
+Write-Host "HitL next steps:" -ForegroundColor Yellow
+if ($missing.Name -contains "client" -or $partial.Name -contains "client") {
+    Write-Host "  - Client: $UrlClientMega"
+    Write-Host "    Save under .client_files\ then extract so game_pak and bin32\archeage.exe exist."
+}
+if ($missing.Name -contains "compact.sqlite3" -or $partial.Name -contains "compact.sqlite3") {
+    Write-Host "  - compact.sqlite3: $UrlCompactMega"
+    Write-Host "    Copy final file to AAEmu.Game\Data\compact.sqlite3"
+}
+if ($missing.Name -contains "launcher") {
+    Write-Host "  - Launcher: $UrlLauncherReleases  (or re-run with -FetchLauncherIfMissing)"
+}
+Write-Host "  Re-run this script after downloads/extracts. Existing OK assets will be skipped."
+exit 1

--- a/.agents/skills/aaemu-setup/scripts/test-aaemu-assets.sh
+++ b/.agents/skills/aaemu-setup/scripts/test-aaemu-assets.sh
@@ -49,7 +49,6 @@ while [[ $# -gt 0 ]]; do
 done
 
 CLIENT_FILES="${REPO_ROOT}/.client_files"
-mkdir -p "${CLIENT_FILES}/launcher"
 
 # Result accumulators (parallel arrays)
 declare -a R_NAME=()
@@ -220,6 +219,7 @@ if LAUNCHER="$(find_launcher_exe)"; then
   add_result "launcher" "OK" "present - skip re-download" "$LAUNCHER"
 elif [[ "$FETCH_LAUNCHER" -eq 1 ]]; then
   echo "Launcher missing - fetching latest GitHub release..."
+  mkdir -p "${CLIENT_FILES}/launcher"
   DEST_ARCHIVE="${CLIENT_FILES}/AAEmu.Launcher-latest.7z"
   EXTRACT_DIR="${CLIENT_FILES}/launcher"
   set +e

--- a/.agents/skills/aaemu-setup/scripts/test-aaemu-assets.sh
+++ b/.agents/skills/aaemu-setup/scripts/test-aaemu-assets.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# Inventory AAEmu local assets; skip re-download when present.
+# Never downloads MEGA/Drive multi-GB content.
+# Optional: fetch GitHub launcher when missing; open browser for HitL links.
+#
+# Usage (from repo root or any cwd):
+#   ./scripts/test-aaemu-assets.sh
+#   ./scripts/test-aaemu-assets.sh --fetch-launcher
+#   ./scripts/test-aaemu-assets.sh --open-missing
+#   ./scripts/test-aaemu-assets.sh --repo-root /path/to/AAEmu
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+FETCH_LAUNCHER=0
+OPEN_MISSING=0
+MIN_GAME_PAK=$((1024 * 1024 * 1024))   # 1 GiB
+MIN_COMPACT=$((1024 * 1024))           # 1 MiB
+
+URL_CLIENT_MEGA="https://mega.nz/folder/GnwjQCrZ#WNWzX_lDvkzCqoTtt7I42Q"
+URL_CLIENT_MEGA_ALT="https://mega.nz/folder/C3Q0WQjT#vRUethZLPiYSo2B4nE_etg"
+URL_COMPACT_MEGA="https://mega.nz/file/6vxlAZiJ#Xb8VWnG4rFRRklxw6LZaYBPdZvC6j73xLPKIPAK80S8"
+URL_LAUNCHER="https://github.com/ZeromusXYZ/AAEmu-Launcher/releases"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-root)
+      REPO_ROOT="$(cd "$2" && pwd)"
+      shift 2
+      ;;
+    --fetch-launcher|--fetch-launcher-if-missing)
+      FETCH_LAUNCHER=1
+      shift
+      ;;
+    --open-missing|--open-missing-download-pages)
+      OPEN_MISSING=1
+      shift
+      ;;
+    -h|--help)
+      sed -n '2,12p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+CLIENT_FILES="${REPO_ROOT}/.client_files"
+mkdir -p "${CLIENT_FILES}/launcher"
+
+# Result accumulators (parallel arrays)
+declare -a R_NAME=()
+declare -a R_STATUS=()
+declare -a R_DETAIL=()
+declare -a R_PATH=()
+
+add_result() {
+  R_NAME+=("$1")
+  R_STATUS+=("$2")
+  R_DETAIL+=("$3")
+  R_PATH+=("${4:-}")
+}
+
+format_size() {
+  local n=$1
+  if (( n >= 1073741824 )); then
+    awk -v n="$n" 'BEGIN { printf "%.2f GB", n/1073741824 }'
+  elif (( n >= 1048576 )); then
+    awk -v n="$n" 'BEGIN { printf "%.2f MB", n/1048576 }'
+  elif (( n >= 1024 )); then
+    awk -v n="$n" 'BEGIN { printf "%.2f KB", n/1024 }'
+  else
+    echo "${n} B"
+  fi
+}
+
+file_size() {
+  # portable: GNU stat and BSD stat
+  local f=$1
+  if stat -c%s "$f" >/dev/null 2>&1; then
+    stat -c%s "$f"
+  else
+    stat -f%z "$f"
+  fi
+}
+
+find_game_pak() {
+  local candidates=(
+    "${CLIENT_FILES}/ArcheAge 1.2 (r208022) for AAEmu/game_pak"
+    "${CLIENT_FILES}/ArcheAge 1.2.4.13 (r208022) for AAEmu/game_pak"
+  )
+  local c
+  for c in "${candidates[@]}"; do
+    if [[ -f "$c" ]]; then
+      echo "$c"
+      return 0
+    fi
+  done
+  if [[ -d "$CLIENT_FILES" ]]; then
+    # first match
+    local found
+    found="$(find "$CLIENT_FILES" -type f -name 'game_pak' 2>/dev/null | head -n1 || true)"
+    if [[ -n "${found}" ]]; then
+      echo "$found"
+      return 0
+    fi
+  fi
+  return 1
+}
+
+find_archeage_exe() {
+  local prefer_root=${1:-}
+  if [[ -n "$prefer_root" && -f "${prefer_root}/bin32/archeage.exe" ]]; then
+    echo "${prefer_root}/bin32/archeage.exe"
+    return 0
+  fi
+  if [[ -d "$CLIENT_FILES" ]]; then
+    local found
+    found="$(find "$CLIENT_FILES" -type f -name 'archeage.exe' 2>/dev/null | head -n1 || true)"
+    if [[ -n "${found}" ]]; then
+      echo "$found"
+      return 0
+    fi
+  fi
+  return 1
+}
+
+find_launcher_exe() {
+  local prefer="${CLIENT_FILES}/launcher/AAEmu.Launcher/AAEmu.Launcher.exe"
+  if [[ -f "$prefer" ]]; then
+    echo "$prefer"
+    return 0
+  fi
+  # Wine/native: also accept AAEmu.Launcher without .exe if ever published
+  if [[ -d "$CLIENT_FILES" ]]; then
+    local found
+    found="$(find "$CLIENT_FILES" -type f \( -name 'AAEmu.Launcher.exe' -o -name 'AAEmu.Launcher' \) 2>/dev/null | head -n1 || true)"
+    if [[ -n "${found}" ]]; then
+      echo "$found"
+      return 0
+    fi
+  fi
+  return 1
+}
+
+list_archives() {
+  if [[ ! -d "$CLIENT_FILES" ]]; then
+    return 0
+  fi
+  find "$CLIENT_FILES" -maxdepth 1 -type f \( \
+    -iname '*.7z' -o -iname '*.zip' -o -iname '*.rar' -o \
+    -iname '*ArcheAge*' -o -iname '*compact*' -o -iname '*Launcher*' \
+  \) 2>/dev/null || true
+}
+
+open_url() {
+  local url=$1
+  if command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$url" >/dev/null 2>&1 || true
+  elif command -v open >/dev/null 2>&1; then
+    open "$url" >/dev/null 2>&1 || true
+  elif command -v wslview >/dev/null 2>&1; then
+    wslview "$url" >/dev/null 2>&1 || true
+  else
+    echo "  (open manually) $url"
+  fi
+}
+
+# --- Client ---
+PAK=""
+if PAK="$(find_game_pak)"; then
+  PAK_SIZE="$(file_size "$PAK")"
+  PAK_ROOT="$(dirname "$PAK")"
+  EXE=""
+  EXE="$(find_archeage_exe "$PAK_ROOT" || true)"
+  SIZE_TXT="$(format_size "$PAK_SIZE")"
+  if (( PAK_SIZE >= MIN_GAME_PAK )) && [[ -n "$EXE" ]]; then
+    add_result "client" "OK" "game_pak ${SIZE_TXT}; archeage.exe present - skip re-download" "$PAK"
+  elif (( PAK_SIZE < MIN_GAME_PAK )); then
+    add_result "client" "PARTIAL" "game_pak too small (${SIZE_TXT}); re-download or extract may be needed" "$PAK"
+  else
+    add_result "client" "PARTIAL" "game_pak present but archeage.exe missing - finish extract (Windows client)" "$PAK"
+  fi
+else
+  ARCHIVES="$(list_archives | grep -E 'ArcheAge|r208022|1\.2' || true)"
+  if [[ -n "$ARCHIVES" ]]; then
+    FIRST="$(echo "$ARCHIVES" | head -n1)"
+    add_result "client" "PARTIAL" "archive present, not extracted: ${FIRST}" "$FIRST"
+  else
+    add_result "client" "MISSING" "Need ArcheAge 1.2 (r208022) client - HitL MEGA/Drive download" ""
+  fi
+fi
+
+# --- compact.sqlite3 ---
+COMPACT="${REPO_ROOT}/AAEmu.Game/Data/compact.sqlite3"
+if [[ -f "$COMPACT" ]]; then
+  C_SIZE="$(file_size "$COMPACT")"
+  SIZE_TXT="$(format_size "$C_SIZE")"
+  if (( C_SIZE >= MIN_COMPACT )); then
+    add_result "compact.sqlite3" "OK" "${SIZE_TXT} - skip re-download" "$COMPACT"
+  else
+    add_result "compact.sqlite3" "PARTIAL" "file too small (${SIZE_TXT})" "$COMPACT"
+  fi
+else
+  C_ARCH="$(list_archives | grep -Ei 'compact|Server_Compact' || true)"
+  if [[ -n "$C_ARCH" ]]; then
+    FIRST="$(echo "$C_ARCH" | head -n1)"
+    add_result "compact.sqlite3" "PARTIAL" "archive present; extract and copy to AAEmu.Game/Data/compact.sqlite3: ${FIRST}" "$FIRST"
+  else
+    add_result "compact.sqlite3" "MISSING" "Need compact.sqlite3 - HitL MEGA download, then place under AAEmu.Game/Data/" ""
+  fi
+fi
+
+# --- Launcher ---
+LAUNCHER=""
+if LAUNCHER="$(find_launcher_exe)"; then
+  add_result "launcher" "OK" "present - skip re-download" "$LAUNCHER"
+elif [[ "$FETCH_LAUNCHER" -eq 1 ]]; then
+  echo "Launcher missing - fetching latest GitHub release..."
+  DEST_ARCHIVE="${CLIENT_FILES}/AAEmu.Launcher-latest.7z"
+  EXTRACT_DIR="${CLIENT_FILES}/launcher"
+  set +e
+  FETCH_OK=0
+  if command -v gh >/dev/null 2>&1; then
+    gh release download --repo ZeromusXYZ/AAEmu-Launcher --pattern "*.7z" --dir "$CLIENT_FILES" --clobber
+    GOT="$(ls -t "${CLIENT_FILES}"/AAEmu.Launcher*.7z 2>/dev/null | head -n1 || true)"
+    if [[ -n "$GOT" ]]; then
+      DEST_ARCHIVE="$GOT"
+      FETCH_OK=1
+    fi
+  else
+    API_JSON="$(curl -fsSL -H "User-Agent: aaemu-setup" \
+      https://api.github.com/repos/ZeromusXYZ/AAEmu-Launcher/releases/latest 2>/dev/null || true)"
+    DL_URL="$(echo "$API_JSON" | grep -oE 'https://[^"]+\.7z' | head -n1 || true)"
+    if [[ -n "$DL_URL" ]]; then
+      if curl -fsSL -o "$DEST_ARCHIVE" "$DL_URL"; then
+        FETCH_OK=1
+      fi
+    fi
+  fi
+  if [[ "$FETCH_OK" -eq 1 ]]; then
+    if command -v 7z >/dev/null 2>&1; then
+      7z x "$DEST_ARCHIVE" "-o${EXTRACT_DIR}" -y >/dev/null
+    elif command -v 7za >/dev/null 2>&1; then
+      7za x "$DEST_ARCHIVE" "-o${EXTRACT_DIR}" -y >/dev/null
+    else
+      echo "Downloaded ${DEST_ARCHIVE} but no 7z found - extract manually to .client_files/launcher/"
+    fi
+    if LAUNCHER="$(find_launcher_exe)"; then
+      add_result "launcher" "OK" "fetched and extracted" "$LAUNCHER"
+    else
+      add_result "launcher" "PARTIAL" "archive downloaded; extract to .client_files/launcher/" "$DEST_ARCHIVE"
+    fi
+  else
+    add_result "launcher" "MISSING" "fetch failed - ${URL_LAUNCHER}" ""
+  fi
+  set -u
+else
+  add_result "launcher" "MISSING" "AAEmu.Launcher.exe not found (use --fetch-launcher or HitL GitHub)" ""
+fi
+
+# --- Report ---
+echo ""
+echo "AAEmu asset inventory - ${REPO_ROOT}"
+echo "------------------------------------------------------------------------"
+MISSING=0
+PARTIAL=0
+HAS_CLIENT_ISSUE=0
+HAS_COMPACT_ISSUE=0
+HAS_LAUNCHER_ISSUE=0
+
+i=0
+while [[ $i -lt ${#R_NAME[@]} ]]; do
+  name="${R_NAME[$i]}"
+  status="${R_STATUS[$i]}"
+  detail="${R_DETAIL[$i]}"
+  path="${R_PATH[$i]}"
+  case "$status" in
+    OK) color='\033[0;32m' ;;
+    PARTIAL) color='\033[0;33m'; PARTIAL=1 ;;
+    *) color='\033[0;31m'; MISSING=1 ;;
+  esac
+  nocolor='\033[0m'
+  if [[ ! -t 1 ]]; then
+    color=''; nocolor=''
+  fi
+  printf "%b[%s] %s%b\n" "$color" "$status" "$name" "$nocolor"
+  printf "      %s\n" "$detail"
+  if [[ -n "$path" ]]; then
+    printf "      %s\n" "$path"
+  fi
+  if [[ "$status" != "OK" ]]; then
+    case "$name" in
+      client) HAS_CLIENT_ISSUE=1 ;;
+      compact.sqlite3) HAS_COMPACT_ISSUE=1 ;;
+      launcher) HAS_LAUNCHER_ISSUE=1 ;;
+    esac
+  fi
+  i=$((i + 1))
+done
+echo "------------------------------------------------------------------------"
+
+if [[ "$OPEN_MISSING" -eq 1 ]]; then
+  if [[ "$HAS_CLIENT_ISSUE" -eq 1 ]]; then
+    open_url "$URL_CLIENT_MEGA"
+    open_url "$URL_CLIENT_MEGA_ALT"
+  fi
+  if [[ "$HAS_COMPACT_ISSUE" -eq 1 ]]; then
+    open_url "$URL_COMPACT_MEGA"
+  fi
+  if [[ "$HAS_LAUNCHER_ISSUE" -eq 1 ]]; then
+    open_url "$URL_LAUNCHER"
+  fi
+fi
+
+if [[ "$MISSING" -eq 0 && "$PARTIAL" -eq 0 ]]; then
+  echo "All required assets present. Do not re-download multi-GB packages."
+  exit 0
+fi
+
+echo ""
+echo "HitL next steps:"
+if [[ "$HAS_CLIENT_ISSUE" -eq 1 ]]; then
+  echo "  - Client: ${URL_CLIENT_MEGA}"
+  echo "    Save under .client_files/ then extract so game_pak and bin32/archeage.exe exist."
+fi
+if [[ "$HAS_COMPACT_ISSUE" -eq 1 ]]; then
+  echo "  - compact.sqlite3: ${URL_COMPACT_MEGA}"
+  echo "    Copy final file to AAEmu.Game/Data/compact.sqlite3"
+fi
+if [[ "$HAS_LAUNCHER_ISSUE" -eq 1 ]]; then
+  echo "  - Launcher: ${URL_LAUNCHER}  (or re-run with --fetch-launcher)"
+fi
+echo "  Re-run this script after downloads/extracts. Existing OK assets will be skipped."
+exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ publish/
 /AAEmu.IntegrationTests/Config.json
 *.sqlite3
 .server_files
+.client_files
 .env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ Guidance for coding agents working in this repository.
 
 Open-source **ArcheAge** server emulator in **.NET** (`AAEmu.Login`, `AAEmu.Game`, shared `AAEmu.Commons`). Preferred local orchestration is **.NET Aspire** (`AAEmu.Aspire.AppHost`). Branch of record for active work: **`develop`**.
 
+Target client: **ArcheAge 1.2** (`r208022`).
+
 Human docs live under `Docs/wiki/` (synced to GitHub wiki). Prefer those over inventing setup steps.
 
 ## Getting the stack running (players and contributors)
@@ -29,29 +31,275 @@ Use the in-repo skill — **not developer-only**:
 
 Wiki mirrors: `Docs/wiki/Installation-&-Setup.md`, `Aspire-Development-Guide.md`, `Dependencies-and-Downloads.md`, `Client.md`.
 
-## Layout (high signal)
+---
+
+## Runtime architecture
+
+```text
+                    ┌─────────────────┐
+  Client 1.2 ──────►│  AAEmu.Login    │◄── MySQL aaemu_login (accounts)
+  (launcher)        │  :1237 public   │
+                    │  :1234 internal │
+                    └────────┬────────┘
+                             │ GameServer register + enter-world
+                    ┌────────▼────────┐
+                    │  AAEmu.Game     │◄── MySQL aaemu_game (mutable state)
+                    │  :1239 game     │◄── compact.sqlite3 (read-only reference)
+                    │  :1250 stream   │◄── game_pak / client files
+                    └─────────────────┘
+                             ▲
+              optional: Aspire AppHost (MySQL container + env injection)
+```
+
+| Component | Role |
+| --- | --- |
+| **Login** | Auth, world list, enter-world handoff. Public client TCP via **ASP.NET Core Kestrel**. Internal TCP for Game registration. |
+| **Game** | World simulation: packets, managers, entities, combat, quests, housing, etc. Generic host + `GameService`. |
+| **Stream** | Side channel on Game (`:1250`) for UCC/emblems and related transfers. |
+| **Aspire AppHost** | Local orchestration only; does **not** replace Login/Game. |
+| **SQLite `compact.sqlite3`** | **Read-only** static game data (items, NPCs, skills, quests templates, …). |
+| **MySQL** | **Read/write** state: `aaemu_login` (accounts) + `aaemu_game` (characters, items, world). |
+
+Sequence (play): start Login → start Game (registers with Login) → launcher/client auth on Login → select server → connect to Game.
+
+Authoritative component diagram: [`Docs/wiki/Components.md`](Docs/wiki/Components.md).
+
+---
+
+## Solution and project map
 
 | Path | Role |
 | --- | --- |
-| `AAEmu.Login/` | Login server (public client port **1237**, internal GS port **1234** default) |
-| `AAEmu.Game/` | Game server (public **1239**, stream **1250**) |
-| `AAEmu.Aspire.AppHost/` | Aspire orchestrator (preferred when Docker/Podman available) |
-| `SQL/` | Schema / updates (`aaemu_login.sql`, `aaemu_game.sql`) |
-| `Docs/wiki/` | Setup and contributor documentation |
+| `AAEmu.slnx` | Solution entry (SDK from `global.json`: **.NET 10**) |
+| `Directory.Packages.props` | Central package versions (CPM) — bump deps here |
+| `Directory.Build.props` | Shared MSBuild props |
+| `AAEmu.Commons/` | Shared network primitives (`PacketStream`, `PacketBase`), MySQL helpers, `Singleton<T>`, AAPak, utilities |
+| `AAEmu.Login/` | Login server |
+| `AAEmu.Game/` | Game server (largest codebase) |
+| `AAEmu.Aspire.AppHost/` | .NET Aspire orchestrator |
+| `AAEmu.UnitTests/` | xUnit unit tests (mirror source layout) |
+| `AAEmu.IntegrationTests/` | Game-focused integration tests |
+| `AAEmu.Login.IntegrationTests/` | Login + Testcontainers MySQL |
+| `SQL/` | Base schema + incremental updates |
+| `Docs/wiki/` | Human-facing setup and architecture docs |
+| `Scripts/` | Build/start helpers (bat/ps1/sh) |
+| `Tools/` | Offline utilities (e.g. WorldConverter) |
 | `.client_files/` | **Local only** (gitignored): extracted 1.2 client + launcher |
 | `.server_files/` | **Local only** (gitignored): Compose/runtime data, optional logs |
 | `**/Config.Local.json` | **Local only** (gitignored): machine overrides |
 
 Do not commit client packs, launcher binaries, `compact.sqlite3`, or secrets.
 
+### Game project layout (high signal)
+
+| Path under `AAEmu.Game/` | Role |
+| --- | --- |
+| `Program.cs` | Host builder, **DI registration** for managers/services |
+| `GameService.cs` | Startup/shutdown lifecycle (`IHostedService`) |
+| `Core/Managers/` | Runtime managers (`*Manager` / `I*Manager`); subfolders `Id/`, `UnitManagers/`, `World/`, `Stream/` |
+| `Core/Network/` | `Game/`, `Login/`, `Stream/` networks + protocol handlers + connections |
+| `Core/Packets/` | Wire packets by direction (see [Packet map](#packet-map-and-conventions)) |
+| `GameData/` | Static loaders from SQLite (`IGameDataLoader`); `Framework/GameDataManager` |
+| `Models/Game/` | Domain models (entities, skills, quests, world, items, …) |
+| `Models/Tasks/` | Scheduled/async game tasks |
+| `Physics/` | Ship/vehicle physics (Jitter2) |
+| `Scripts/Commands/` | In-game GM/admin commands (`ICommand`) |
+| `Scripts/SubCommands/` | Nested command implementations |
+| `Services/` | WebApi, Discord bot |
+| `IO/` | Client file / `game_pak` access |
+| `Data/` | Runtime data files (`compact.sqlite3`, worlds JSON, paths) |
+| `Configurations/` | Split JSON config fragments |
+
+### Login project layout
+
+| Path under `AAEmu.Login/` | Role |
+| --- | --- |
+| `Program.cs` | Kestrel + DI; options validation |
+| `LoginService.cs` | Hosted service lifecycle |
+| `Core/Network/Login/` | Public client TCP (Kestrel connection handler) |
+| `Core/Network/Internal/` | Game ↔ Login internal protocol |
+| `Core/Packets/{C2L,L2C,G2L,L2G}/` | Packet DTOs + offset constants |
+| `Core/PacketHandlers/` | Handlers separate from packet types (DI-registered) |
+| `Core/Controllers/` | Login / Game / Request controllers |
+| `Core/Authentication/` | Auth flows (password, Korea challenge, OTP/2FA, reconnect) |
+| `Core/Services/` | Password, 2FA, etc. |
+| `Docs/networking.md` | Login networking deep-dive |
+
+---
+
 ## Configuration rules
 
 - Game config load order: `Config.json` → `Configurations/*.json` → **`Config.Local.json` (wins)**.
+- Login: `Config.json` → `Config.Local.json` → env vars / command line (Aspire injects env).
 - Login listings: **`GameServers` in config**, not MySQL `game_servers` inserts.
 - `SecretKey` must match between Login and Game.
 - `ClientData.Sources` should include the 1.2 `game_pak` (absolute path under `.client_files/` is fine).
 - `compact.sqlite3` → `AAEmu.Game/Data/` (required for game data).
 - `Config.Local.json` is copied to output on build when present in the project directory.
+
+Details: [`Docs/wiki/Working-with-the-Config.json-files-and-server-listings.md`](Docs/wiki/Working-with-the-Config.json-files-and-server-listings.md).
+
+---
+
+## Data stores
+
+| Store | Location / schema | Mutability | Used for |
+| --- | --- | --- | --- |
+| **compact.sqlite3** | `AAEmu.Game/Data/compact.sqlite3` | Read-only at runtime | Templates: items, NPCs, skills, quests, doodads, … via `GameData/*` |
+| **MySQL aaemu_login** | `SQL/aaemu_login.sql` + `SQL/updates/*login*` | Read/write | Accounts, 2FA, bans |
+| **MySQL aaemu_game** | `SQL/aaemu_game.sql` + `SQL/updates/*game*` | Read/write | Characters, inventories, housing, mails, auction, … |
+| **Client files** | `game_pak` / extracted client | Read-only | Models, geodata, assets via `ClientFileManager` |
+| **JSON configs** | `Config*.json`, `Configurations/`, `Data/**/*.json` | Config-time | Server params, worlds, spawns-related data |
+
+### SQL change workflow
+
+When code needs a schema change:
+
+1. Add `SQL/updates/YYYY-MM-DD_aaemu_{login|game}_*.sql` (date orders application).
+2. **Also** patch the base file `SQL/aaemu_login.sql` or `SQL/aaemu_game.sql`.
+3. Servers apply relevant updates once at startup (`MySqlDatabaseUpdater`); applied scripts are recorded in an updates table.
+
+See `SQL/updates/readme.txt`. Prefer `SQL/patches/compact/` only for intentional compact.sqlite3 fixups (not normal gameplay state).
+
+---
+
+## Game startup lifecycle
+
+Entry: `AAEmu.Game/Program.cs` → host → `GameService.StartAsync`.
+
+Approximate stages in `GameService.cs`:
+
+1. **DB migrate** — MySQL updates for `aaemu_game`.
+2. **Client files** — `ClientFileManager.Initialize()` (fatal if no sources).
+3. **Early managers** — some loads still run before orchestration (e.g. Formula/Item user data paths may be hybrid during migration).
+4. **`ManagerOrchestrator.RunLoadAsync()`** — all `ILoadable` managers in **dependency-ordered parallel batches** (topo sort from constructor deps).
+5. **GameData post-load** — `GameDataManager.PostLoadGameData()`.
+6. **Scripts** — compile or reflect `Scripts/Commands` (prefer reflection when debugging).
+7. **`RunInitializeAsync()`** — all `IInitializable` managers, same batching rules.
+8. **World + networks** — static instances, then `GameNetwork` / `StreamNetwork` / `LoginNetwork` start.
+
+Shutdown stops networks, AI, world, ticks, and clears client sources.
+
+`ManagerOrchestrator` (`Core/Managers/ManagerOrchestrator.cs`):
+
+- Builds batches from DI singleton types implementing `ILoadable` / `IInitializable`.
+- Edges come from constructor parameters; **`Lazy<T>` is ignored** (cycle break pattern).
+- Cycles throw; fix by reordering deps or introducing `Lazy<T>`.
+
+---
+
+## Packet map and conventions
+
+### Direction folders (Game)
+
+| Folder | Prefix | Direction | Notes |
+| --- | --- | --- | --- |
+| `Core/Packets/C2G/` | `CS*` | Client → Game | Handled on game TCP; offsets in `CSOffsets.cs` |
+| `Core/Packets/G2C/` | `SC*` | Game → Client | Server responses/events |
+| `Core/Packets/C2S/` | `CT*` | Client → Stream | Stream server |
+| `Core/Packets/S2C/` | `TC*` / stream | Stream → Client | Stream responses |
+| `Core/Packets/G2L/` | `GL*` | Game → Login | Internal |
+| `Core/Packets/L2G/` | `LG*` | Login → Game | Internal |
+| `Core/Packets/Proxy/` | Proxy | Login/proxy-related | Legacy/proxy protocol helpers |
+
+### Direction folders (Login)
+
+| Folder | Prefix | Direction |
+| --- | --- | --- |
+| `Core/Packets/C2L/` | `CA*` | Client → Login |
+| `Core/Packets/L2C/` | `AC*` | Login → Client |
+| `Core/Packets/G2L/` / `L2G/` | `GL*` / `LG*` | Game ↔ Login |
+
+### Patterns
+
+**Game packets** (typical):
+
+- One class per opcode; constructor passes offset + level: `GamePacket(CSOffsets.CSBuyItemsPacket, 1)`.
+- Override `Read(PacketStream)` for inbound; outbound packets implement `Write`.
+- Inbound: `Read` often contains behavior (legacy style). Prefer following neighbors; `Execute()` exists to separate decode vs behavior when used.
+- Register new C2G/G2C types in `GameNetwork` (`RegisterPacket`). Stream/Login side networks have their own `RegisterPacket` lists.
+- Access player via `Connection.ActiveChar`; world lookups via `ParentWorld`.
+
+**Login packets**:
+
+- Packet type (DTO) + **separate** `*PacketHandler` under `Core/PacketHandlers/` (cleaner DI style).
+- Handlers registered via `ServiceCollectionExtensions` in PacketHandlers/Network.
+
+Do not invent opcodes; match client 1.2 tables already in `*Offsets.cs`.
+
+---
+
+## Domain model and terminology
+
+Use **code/wiki terms**, not modern player slang, in identifiers and discussions.
+
+| Term | Meaning |
+| --- | --- |
+| **Doodad** | Spawnable object without a health bar (crops, doors, furniture) |
+| **Unit** | Entity with health / combat participation |
+| **NPC** | Non-player unit |
+| **Mate** | Pet / mount companion |
+| **Slave** | Vehicle (cart, ship, car) |
+| **Transfer** | Fixed-route transport (carriage, airship) |
+| **Expedition** | Guild |
+| **Appellation** | Title |
+| **Ability** | Class combat skill tree |
+| **ActAbility** | Vocational skill |
+| **Dominion** | Castle siege content (not GvG shorthand) |
+| **Indun** | Instance dungeon |
+| **Gimmick** | Moving unit-like object (e.g. elevator) |
+| **Skills** under `Models/Game/Skills` | **Game combat mechanics**, not agent skills |
+
+### Object hierarchy (simplified)
+
+```text
+GameObject          Models/Game/World/GameObject.cs
+  └─ BaseUnit       factions, buffs
+       ├─ Unit      stats, combat, skill controllers
+       │    ├─ Character, Npc (+ Portal), Mate, Slave
+       │    ├─ House, Shipyard, Gimmick, Transfer
+       └─ Doodad (+ DoodadCoffer)
+```
+
+Full glossary: [`Docs/wiki/Code-Terminology.md`](Docs/wiki/Code-Terminology.md).
+
+### Managers vs GameData vs Models
+
+| Layer | Responsibility | Example |
+| --- | --- | --- |
+| **Models** | Entity state and domain behavior | `Character`, `Skill`, `Quest`, `Doodad` |
+| **GameData** | Load/cache **static** templates from SQLite | `ItemGameData`, `NpcGameData`, `BuffGameData` |
+| **Managers** | Runtime orchestration, spawns, persistence, systems | `ItemManager`, `WorldManager`, `QuestManager` |
+| **Packets** | Wire protocol edge | `CSStartSkillPacket` → manager/model |
+
+Static reference data → `GameData` + `compact.sqlite3`.  
+Per-character / world mutable state → managers + MySQL.
+
+---
+
+## Where to change X (task routing)
+
+| Task | Start here |
+| --- | --- |
+| Client packet handling (gameplay action) | `Core/Packets/C2G/CS*.cs` → related `*Manager` / model |
+| Server→client notify | `Core/Packets/G2C/SC*.cs` |
+| Login auth / world list | `AAEmu.Login/Core/PacketHandlers/`, `Authentication/`, `Controllers/` |
+| New manager | Class + `I*` in `Core/Managers/`; implement `ILoadable`/`IInitializable` if needed; **register both concrete and interface in `Program.cs`** |
+| Static template data | `GameData/*` + SQLite schema; optional `SQL/patches/compact/` |
+| Character behavior | `Models/Game/Char/Character*.cs` + `UnitManagers/CharacterManager` |
+| NPC / AI | `Models/Game/NPChar/`, `Models/Game/AI/v2/`, `AIManager` |
+| Skills / buffs / effects | `Models/Game/Skills/` (large `Effects/` tree), `SkillManager`, `BuffGameData` |
+| Quests | `Models/Game/Quests/`, `QuestManager` |
+| Housing / doodads | `Models/Game/Housing/`, `DoodadObj/`, `HousingManager`, `DoodadManager` |
+| World / zones / spawns | `Core/Managers/World/`, `Models/Game/World/`, `Data/Worlds/` |
+| Ships / vehicle physics | `Physics/`, `Models/Game/Units/Slave.cs`, `SlaveManager` |
+| GM commands | `Scripts/Commands/`, `Scripts/SubCommands/`, `CommandManager` |
+| Schema migration | `SQL/updates/` + base `SQL/aaemu_*.sql` |
+| Web API / Discord | `Services/WebApi/`, `Services/DiscordBotService.cs` |
+| Shared serialization / MySQL util | `AAEmu.Commons/` |
+| Package version bump | `Directory.Packages.props` |
+
+---
 
 ## Build and test
 
@@ -61,15 +309,73 @@ dotnet test
 ```
 
 - SDK: .NET **10** (`global.json`).
-- Solution: `AAEmu.slnx` (and related projects).
-- Prefer existing test projects: `AAEmu.UnitTests`, integration test projects as applicable.
+- Solution: `AAEmu.slnx`.
+- Filter example: `dotnet test --filter "FullyQualifiedName~GameNetworkTests"`.
+- Test projects: `AAEmu.UnitTests` (primary), `AAEmu.IntegrationTests`, `AAEmu.Login.IntegrationTests`.
+- Unit test bases: `TestBase`, `SqliteTestBase`, `IntegrationTestBase`; mocks under `Utils/Mocks/`.
+- Naming: `MethodName_Scenario_ExpectedResult` (see `AAEmu.UnitTests/README.md`).
+- Subsystem test priorities: [`Docs/TestingPlan_en.md`](Docs/TestingPlan_en.md).
 
-## Coding norms
+---
 
-- Match existing style in the area you touch (C# naming, managers/packets layout).
-- Prefer small, focused changes; no drive-by refactors.
-- Do not add unsolicited markdown docs; update wiki-facing docs only when setup/behavior changes require it.
-- Game “Skills” under `AAEmu.Game/Models/Game/Skills` are **game mechanics**, not agent skills.
+## Code changes — read first, then match the repo
+
+When asked to modify, fix, or improve code, **do not invent conventions**. Inspect the target area and the sources below, then mirror what is already there.
+
+### Authoritative sources (in order)
+
+1. **Neighboring code** in the same folder, namespace, and subsystem — this is the primary style guide.
+2. **[`.editorconfig`](.editorconfig)** — formatting, naming, analyzer severities (IDE/CA rules). Run `dotnet build` to surface violations.
+3. **[`CONTRIBUTING.md`](CONTRIBUTING.md)** — branch from `develop`, present-tense commits, tests with changes, follow project code style.
+4. **`Docs/wiki/`** — domain language and architecture context:
+   - [`Code-Terminology.md`](Docs/wiki/Code-Terminology.md) — game-object hierarchy, in-game terms.
+   - [`Components.md`](Docs/wiki/Components.md) — Login/Game/Aspire roles and data stores.
+   - [`Developer-Notes.md`](Docs/wiki/Developer-Notes.md) — manager DI and parallel loading.
+   - [`Documentation-Maintenance.md`](Docs/wiki/Documentation-Maintenance.md) — when and how to update wiki pages.
+   - [`Home.md`](Docs/wiki/Home.md) — documentation map.
+5. **[`Docs/TestingPlan_en.md`](Docs/TestingPlan_en.md)** — subsystem map and testing priorities.
+6. **Login networking** — [`AAEmu.Login/Docs/networking.md`](AAEmu.Login/Docs/networking.md).
+
+### C# style highlights (from `.editorconfig`)
+
+- 4-space indent, CRLF, UTF-8 BOM, file-scoped namespaces matching folder paths.
+- `#nullable enable` at file top where the area already uses it.
+- `var` preferred; block bodies for methods; expression bodies for properties/accessors.
+- Naming: `_camelCase` instance fields, `s_camelCase` static fields, `PascalCase` types/members/locals-functions.
+- Avoid `this.` qualification; sort `using` with `System.*` first; NLog `Logger` via `LogManager.GetCurrentClassLogger()`.
+
+### Project patterns to follow
+
+| Area | Location | Pattern |
+| --- | --- | --- |
+| **Managers** | `AAEmu.Game/Core/Managers/` | `*Manager` + `I*Manager`; many still extend `Singleton<T>` **and** are registered in DI. Newer code: constructor injection, `ILoadable` / `IInitializable`. Orchestrator runs Load/Initialize — **register new managers in `Program.cs`** (concrete + interface). |
+| **Packets (Game)** | `Core/Packets/{C2G,G2C,...}/` | One class per packet; prefix = direction; offsets in `*Offsets.cs`; inherit `GamePacket` / stream variants; register in `*Network`. |
+| **Packets (Login)** | `Packets/` + `PacketHandlers/` | Split DTO vs handler; handlers in DI. |
+| **Game data** | `GameData/` | `IGameDataLoader` (`Load(SqliteConnection)`, `PostLoad`); discovered/orchestrated by `GameDataManager`. |
+| **Models** | `Models/Game/` | Domain types separate from managers/packets; use wiki terminology. |
+| **Network** | `Core/Network/` | Protocol handlers route to packet classes; connections in `Connections/`. |
+| **ID allocation** | `Core/Managers/Id/` | Typed `*IdManager` per object kind. |
+| **Commands** | `Scripts/Commands/` | `ICommand` implementations loaded by script reflector/compiler. |
+| **Shared** | `AAEmu.Commons/` | Network primitives and utilities for Login + Game. |
+| **Tests** | `AAEmu.UnitTests/` | xUnit; mirror source layout; reuse fixtures/mocks. |
+
+Legacy `Singleton<T>.Instance` and static access still exist — **do not mass-migrate** unless the task explicitly calls for it. For new dependencies, follow the constructor-injection style used in recently touched managers. `SingletonContainer.ServiceProvider` bridges some legacy paths.
+
+Circular manager deps: inject `Lazy<T>` so the orchestrator does not treat them as hard edges.
+
+### Workflow for modifications and improvements
+
+1. **Scope** — identify the subsystem (packet, manager, GameData, model, config) and read 2–3 representative files plus any `I*` interface and tests for that type.
+2. **Implement** — smallest change that solves the task; match naming, file placement, logging, and error-handling patterns of the surrounding code.
+3. **Wire-up** — new manager/service: register in `Program.cs` like peers; new game packet: offsets + `RegisterPacket` in the correct `*Network`; new login handler: packet + handler + DI extension.
+4. **SQL** — if schema changes, add `SQL/updates/…` **and** update base `SQL/aaemu_*.sql`.
+5. **Test** — add or extend tests in `AAEmu.UnitTests` when changing behavior; reuse existing patterns.
+6. **Verify** — `dotnet build` and `dotnet test` must pass before claiming done.
+7. **Document** — update `Docs/wiki/` only when user-facing setup, config, or behavior changes; follow `Documentation-Maintenance.md`. Do not add unsolicited markdown elsewhere.
+
+**Avoid:** drive-by refactors, new frameworks, reformatting unrelated files, renaming domain terms away from wiki vocabulary, and broad style “cleanup” outside the requested change.
+
+---
 
 ## Windows agent pitfalls
 
@@ -77,12 +383,17 @@ dotnet test
 - Port **1234** often conflicted (e.g. ManyCam): remap Login `InternalNetwork` + Game `LoginNetwork` together or the client shows **Maintenance**.
 - Aspire dashboard token is printed by AppHost at startup (`/login?t=...`).
 
+---
+
 ## Out of scope unless asked
 
 - Shipping client assets into git
 - Silent multi‑GB MEGA re-downloads without inventory + HitL
 - Changing default production Docker Compose passwords casually
 - Full protocol reverse-engineering writeups without a concrete task
+- Mass migration off `Singleton<T>` without an explicit request
+
+---
 
 ## Quick verify (before saying “ready to play”)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,93 @@
+# AGENTS.md — AAEmu
+
+Guidance for coding agents working in this repository.
+
+## What this repo is
+
+Open-source **ArcheAge** server emulator in **.NET** (`AAEmu.Login`, `AAEmu.Game`, shared `AAEmu.Commons`). Preferred local orchestration is **.NET Aspire** (`AAEmu.Aspire.AppHost`). Branch of record for active work: **`develop`**.
+
+Human docs live under `Docs/wiki/` (synced to GitHub wiki). Prefer those over inventing setup steps.
+
+## Getting the stack running (players and contributors)
+
+Use the in-repo skill — **not developer-only**:
+
+- **[`.agents/skills/aaemu-setup/SKILL.md`](.agents/skills/aaemu-setup/SKILL.md)** — guided setup with HitL downloads  
+- **[`.agents/skills/aaemu-setup/REFERENCE.md`](.agents/skills/aaemu-setup/REFERENCE.md)** — ports, configs, troubleshooting  
+- **Inventory (skip re-downloads)** — use the host shell:  
+  - PowerShell: `powershell -File .agents/skills/aaemu-setup/scripts/Test-AaemuAssets.ps1`  
+  - Bash: `bash .agents/skills/aaemu-setup/scripts/test-aaemu-assets.sh`
+
+| Path | When | MySQL | Apps |
+| --- | --- | --- | --- |
+| **A – Aspire** | Docker Desktop or Podman available | Container via AppHost | Login/Game as host projects |
+| **B – Standalone** | No container runtime | **Host MySQL 8 only** | Host `dotnet` Login then Game |
+
+**No hybrids** for non-Docker: if there is no Docker/Podman, do not introduce containers for MySQL either.
+
+**Assets:** always run the inventory script before downloading. Multi‑GB MEGA/Drive packages are **Human-in-the-Loop**; do not re-fetch when the script reports **OK**.
+
+Wiki mirrors: `Docs/wiki/Installation-&-Setup.md`, `Aspire-Development-Guide.md`, `Dependencies-and-Downloads.md`, `Client.md`.
+
+## Layout (high signal)
+
+| Path | Role |
+| --- | --- |
+| `AAEmu.Login/` | Login server (public client port **1237**, internal GS port **1234** default) |
+| `AAEmu.Game/` | Game server (public **1239**, stream **1250**) |
+| `AAEmu.Aspire.AppHost/` | Aspire orchestrator (preferred when Docker/Podman available) |
+| `SQL/` | Schema / updates (`aaemu_login.sql`, `aaemu_game.sql`) |
+| `Docs/wiki/` | Setup and contributor documentation |
+| `.client_files/` | **Local only** (gitignored): extracted 1.2 client + launcher |
+| `.server_files/` | **Local only** (gitignored): Compose/runtime data, optional logs |
+| `**/Config.Local.json` | **Local only** (gitignored): machine overrides |
+
+Do not commit client packs, launcher binaries, `compact.sqlite3`, or secrets.
+
+## Configuration rules
+
+- Game config load order: `Config.json` → `Configurations/*.json` → **`Config.Local.json` (wins)**.
+- Login listings: **`GameServers` in config**, not MySQL `game_servers` inserts.
+- `SecretKey` must match between Login and Game.
+- `ClientData.Sources` should include the 1.2 `game_pak` (absolute path under `.client_files/` is fine).
+- `compact.sqlite3` → `AAEmu.Game/Data/` (required for game data).
+- `Config.Local.json` is copied to output on build when present in the project directory.
+
+## Build and test
+
+```powershell
+dotnet build
+dotnet test
+```
+
+- SDK: .NET **10** (`global.json`).
+- Solution: `AAEmu.slnx` (and related projects).
+- Prefer existing test projects: `AAEmu.UnitTests`, integration test projects as applicable.
+
+## Coding norms
+
+- Match existing style in the area you touch (C# naming, managers/packets layout).
+- Prefer small, focused changes; no drive-by refactors.
+- Do not add unsolicited markdown docs; update wiki-facing docs only when setup/behavior changes require it.
+- Game “Skills” under `AAEmu.Game/Models/Game/Skills` are **game mechanics**, not agent skills.
+
+## Windows agent pitfalls
+
+- Detach long-lived GUIs (launcher, server consoles) from the agent shell Job Object or they die when the command ends.
+- Port **1234** often conflicted (e.g. ManyCam): remap Login `InternalNetwork` + Game `LoginNetwork` together or the client shows **Maintenance**.
+- Aspire dashboard token is printed by AppHost at startup (`/login?t=...`).
+
+## Out of scope unless asked
+
+- Shipping client assets into git
+- Silent multi‑GB MEGA re-downloads without inventory + HitL
+- Changing default production Docker Compose passwords casually
+- Full protocol reverse-engineering writeups without a concrete task
+
+## Quick verify (before saying “ready to play”)
+
+1. Inventory script: client + compact + launcher **OK**
+2. Login listens on **1237**
+3. Game listens on **1239** / **1250**
+4. Standalone: login log shows **Registered GameServer**
+5. Launcher points at `.client_files/.../bin32/archeage.exe`, server `127.0.0.1`


### PR DESCRIPTION
## Summary
- Add an in-repo setup skill (Aspire vs host MySQL) with asset inventory scripts
- Add AGENTS.md covering layout, config, architecture, and where to change code

## Test plan
- [ ] Skim AGENTS.md against current project layout
- [ ] Optionally run the asset inventory script on a known setup