### PR TITLE
style(editorconfig): use LF line endings for C# files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -41,7 +41,7 @@ spelling_error_severity = error
 spelling_exclusion_path = exclusion.dic
 spelling_use_default_exclusion_dictionary = false
 
-end_of_line = crlf
+end_of_line = lf
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true
 # Avoid "this." and "Me." if not necessary


### PR DESCRIPTION
Align .editorconfig with .gitattributes, which already pins "*.cs text eol=lf": every .cs file in the Git index is stored with LF line endings, and Git checks them out as LF.

Previously the two configs contradicted each other: .editorconfig required CRLF, so on every save editors rewrote files as CRLF, and Git then silently normalized them back to LF on staging. This caused a pointless back-and-forth conversion on each edit/commit cycle.

LF is chosen as the single convention because:
- the repository is already 100% LF in the index, so no history renormalization is needed;
- the project is built and run in Linux-based Docker containers, where LF is native;
- modern .NET tooling (VS 2022, Rider, dotnet format) handles LF files on Windows without issues.

No code changes are involved. Working-tree files that still have CRLF are considered clean by Git and will converge to LF as they are edited and saved.