### PR TITLE
fix(game): Make sure all doodads get the new owner set on house sale

### DIFF
--- a/AAEmu.Game/Core/Managers/HousingManager.cs
+++ b/AAEmu.Game/Core/Managers/HousingManager.cs
@@ -1062,7 +1062,9 @@ public class HousingManager(
 
             // Set new doodad owner if needed
             if (newOwner != null)
+            {
                 f.OwnerId = newOwner.Id;
+            }
 
             if (newOwner == null || returnedThisItem)
             {
@@ -1326,17 +1328,16 @@ public class HousingManager(
     /// </summary>
     /// <param name="house"></param>
     /// <param name="characterId"></param>
+    /// <param name="newFaction"></param>
     /// <returns>The number of items that have their owner information updated</returns>
-    private static uint UpdateFurnitureOwner(House house, uint characterId)
+    private static uint UpdateFurnitureOwner(House house, uint characterId, FactionsEnum newFaction)
     {
         uint res = 0;
         var furnitureList = house.ParentWorld.GetDoodadByHouseDbId(house.Id);
         foreach (var furniture in furnitureList)
         {
-            if (furniture.AttachPoint != AttachPointKind.None)
-                continue;
             furniture.OwnerId = characterId;
-            furniture.BroadcastPacket(new SCDoodadOriginatorPacket(furniture.ObjId, characterId, 0), true);
+            furniture.BroadcastPacket(new SCDoodadOriginatorPacket(furniture.ObjId, characterId, newFaction), true);
             res++;
         }
         return res;
@@ -1465,7 +1466,7 @@ public class HousingManager(
         if (oldOwner is { IsOnline: true })
             oldOwner.SendPacket(new SCMyHouseRemovedPacket(house.TlId));
 
-        UpdateFurnitureOwner(house, character.Id);
+        UpdateFurnitureOwner(house, character.Id, character.Faction.Id);
 
         house.IsDirty = true;
 

--- a/AAEmu.Game/Core/Managers/HousingManager.cs
+++ b/AAEmu.Game/Core/Managers/HousingManager.cs
@@ -1338,6 +1338,8 @@ public class HousingManager(
         {
             furniture.OwnerId = characterId;
             furniture.BroadcastPacket(new SCDoodadOriginatorPacket(furniture.ObjId, characterId, newFaction), true);
+            if (furniture.IsPersistent)
+                furniture.Save();
             res++;
         }
         return res;

--- a/AAEmu.Game/Core/Packets/G2C/SCDoodadOriginatorPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCDoodadOriginatorPacket.cs
@@ -1,16 +1,17 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.StaticValues;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCDoodadOriginatorPacket(uint objId, uint newOwnerId, uint faction)
+public class SCDoodadOriginatorPacket(uint objId, uint newOwnerId, FactionsEnum newFaction)
     : GamePacket(SCOffsets.SCDoodadOriginatorPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
         stream.WriteBc(objId);
         stream.Write(newOwnerId);
-        stream.Write(faction);
+        stream.Write((uint)newFaction);
 
         return stream;
     }


### PR DESCRIPTION
This fixes #871 [BUG] building plaque.

When a house was sold, furniture owner information was not being fully updated. It only updated furniture place by the player and omitted the default house parts like doors and the building plaque.

This included:
- `UpdateFurnitureOwner` previously only updated furniture without a specific `AttachPointKind`, potentially missing other furniture types.
- The `SCDoodadOriginatorPacket` sent a hardcoded `0` instead of the new owner's actual faction ID.

This change ensures all furniture in a sold house has its owner ID updated, and clients receive the correct new owner's faction ID via the `SCDoodadOriginatorPacket`.
