### PR TITLE
fix(game): Time before planted objects become public property

### DIFF
--- a/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
@@ -507,7 +507,8 @@ public class Doodad : BaseUnit
             // CrimePoint > 0 as an *additional* explicit-crime signal when an actual skill is involved.
             var isExplicitCrimeSkill = startedSkillTemplate?.CrimePoint > 0;
             var isSkillLessPickup = startedSkillId == 0;
-            var shouldGenerateTheftEvidence = isDifferentCharacterOwner && (isSkillLessPickup || isExplicitCrimeSkill);
+            var isPublicPropertyByAge = (PlantTime.AddHours(24) < DateTime.UtcNow);
+            var shouldGenerateTheftEvidence = isDifferentCharacterOwner && (isSkillLessPickup || isExplicitCrimeSkill) && (!isPublicPropertyByAge);
 
             if (shouldGenerateTheftEvidence)
             {


### PR DESCRIPTION
Added the 24 hours rule so after that time, stolen things no longer leave footprints.
