### PR TITLE
fix(utils): make interval cache thread-safe

### DIFF
--- a/AAEmu.Commons/Utils/Helper.cs
+++ b/AAEmu.Commons/Utils/Helper.cs
@@ -48,7 +48,7 @@ namespace AAEmu.Commons.Utils;
 
 public static class Helper
 {
-    private static Dictionary<Tuple<object, int>, DateTime> intervals = [];
+    private static ConcurrentDictionary<Tuple<object, int>, DateTime> intervals = new();
 
     /// <summary>
     /// Возвращает true если прошло не менее указанного интервала времени (после предыдущего срабатывания)


### PR DESCRIPTION
`Helper.CheckInterval` stores its per-caller state in a static plain
`Dictionary`, which is read and written concurrently from many threads
(every skill cast plus AI behaviors) without any synchronization. The
sibling `conditions` field right next to it is already a
`ConcurrentDictionary`, but `intervals` was left as a plain one.

Under concurrent access this can corrupt the dictionary's internal
buckets, leading to an infinite loop (100% CPU) or an
`IndexOutOfRangeException`.

This changes `intervals` to a `ConcurrentDictionary` so the reads and
writes are safe, matching the neighbouring `conditions` field.