### PR TITLE
fix(network): drop invalid game packets before encoding

### DIFF
--- a/AAEmu.Game/Core/Network/Connections/GameConnection.cs
+++ b/AAEmu.Game/Core/Network/Connections/GameConnection.cs
@@ -10,10 +10,14 @@ using AAEmu.Game.Models;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Housing;
 
+using NLog;
+
 namespace AAEmu.Game.Core.Network.Connections;
 
 public class GameConnection
 {
+    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
+
     private readonly ISession _session;
 
     public uint Id => _session.SessionId;
@@ -48,6 +52,12 @@ public class GameConnection
     /// <param name="packet"></param>
     public void SendPacket(GamePacket packet)
     {
+        if (packet.TypeId == 0xFFF)
+        {
+            Logger.Warn("Dropping invalid game packet with opcode 0xFFF.");
+            return;
+        }
+
         packet.Connection = this;
         SendPacket(packet.Encode());
     }

--- a/AAEmu.Game/Core/Network/Connections/GameConnection.cs
+++ b/AAEmu.Game/Core/Network/Connections/GameConnection.cs
@@ -54,7 +54,7 @@ public class GameConnection
     {
         if (packet.TypeId == 0xFFF)
         {
-            Logger.Warn("Dropping invalid game packet with opcode 0xFFF.");
+            Logger.Error("Dropping invalid game packet with opcode 0xFFF.");
             return;
         }
 


### PR DESCRIPTION
When a packet with an unmapped opcode (`0xFFF`) reaches `GameConnection.SendPacket`, `GamePacket.Encode` throws a `SystemException`, which propagates out of the send path and drops the client connection.

Any feature that sends such a packet ends up disconnecting the player instead of failing quietly.

This adds a guard in `SendPacket` that drops packets with the `0xFFF` opcode and logs a warning, so an unmapped packet no longer takes down the connection.