### PR TITLE
fix(chat): snapshot channel members before sending

### DIFF
--- a/AAEmu.Game/Core/Managers/ChatManager.cs
+++ b/AAEmu.Game/Core/Managers/ChatManager.cs
@@ -104,42 +104,32 @@ public class ChatManager : Singleton<ChatManager>, IChatManager
     /// </summary>
     public int CleanUpChannels()
     {
+        return CleanUpChannels(ZoneChannels)
+               + CleanUpChannels(PartyChannels)
+               + CleanUpChannels(RaidChannels)
+               + CleanUpChannels(GuildChannels)
+               + CleanUpChannels(FamilyChannels);
+    }
+
+    private static int CleanUpChannels<TKey>(ConcurrentDictionary<TKey, ChatChannel> channels)
+        where TKey : notnull
+    {
         var res = 0;
-        foreach (var c in ZoneChannels)
-            if (c.Value.Members.Count <= 0)
-            {
-                ChatIdManager.Instance.ReleaseId(c.Value.InternalId);
-                ZoneChannels.TryRemove(c.Key, out _);
-                res++;
-            }
-        foreach (var c in PartyChannels)
-            if (c.Value.Members.Count <= 0)
-            {
-                ChatIdManager.Instance.ReleaseId(c.Value.InternalId);
-                PartyChannels.TryRemove(c.Key, out _);
-                res++;
-            }
-        foreach (var c in RaidChannels)
-            if (c.Value.Members.Count <= 0)
-            {
-                ChatIdManager.Instance.ReleaseId(c.Value.InternalId);
-                RaidChannels.TryRemove(c.Key, out _);
-                res++;
-            }
-        foreach (var c in GuildChannels)
-            if (c.Value.Members.Count <= 0)
-            {
-                ChatIdManager.Instance.ReleaseId(c.Value.InternalId);
-                GuildChannels.TryRemove(c.Key, out _);
-                res++;
-            }
-        foreach (var c in FamilyChannels)
-            if (c.Value.Members.Count <= 0)
-            {
-                ChatIdManager.Instance.ReleaseId(c.Value.InternalId);
-                FamilyChannels.TryRemove(c.Key, out _);
-                res++;
-            }
+        foreach (var c in channels)
+        {
+            if (!c.Value.TryRemoveIfEmpty(() =>
+                {
+                    if (!((ICollection<KeyValuePair<TKey, ChatChannel>>)channels).Remove(c))
+                        return false;
+
+                    ChatIdManager.Instance.ReleaseId(c.Value.InternalId);
+                    return true;
+                }))
+                continue;
+
+            res++;
+        }
+
         return res;
     }
 

--- a/AAEmu.Game/Models/Game/Chat/ChatChannel.cs
+++ b/AAEmu.Game/Models/Game/Chat/ChatChannel.cs
@@ -37,6 +37,17 @@ public class ChatChannel
         }
     }
 
+    public bool TryRemoveIfEmpty(Func<bool> removeChannel)
+    {
+        lock (_membersLock)
+        {
+            if (Members.Count > 0)
+                return false;
+
+            return removeChannel();
+        }
+    }
+
     /// <summary>
     /// Internal Id
     /// </summary>

--- a/AAEmu.Game/Models/Game/Chat/ChatChannel.cs
+++ b/AAEmu.Game/Models/Game/Chat/ChatChannel.cs
@@ -29,6 +29,14 @@ public class ChatChannel
     /// </summary>
     public List<Character> Members { get; set; } = [];
 
+    public Character[] GetMembersSnapshot()
+    {
+        lock (_membersLock)
+        {
+            return Members.ToArray();
+        }
+    }
+
     /// <summary>
     /// Internal Id
     /// </summary>
@@ -99,11 +107,7 @@ public class ChatChannel
     public int SendMessage(Character origin, string msg, int ability = 0, byte languageType = 0)
     {
         var res = 0;
-        Character[] members;
-        lock (_membersLock)
-        {
-            members = Members.ToArray();
-        }
+        var members = GetMembersSnapshot();
 
         foreach (var m in members)
         {
@@ -121,11 +125,7 @@ public class ChatChannel
     public int SendPacket(GamePacket packet)
     {
         var res = 0;
-        Character[] members;
-        lock (_membersLock)
-        {
-            members = Members.ToArray();
-        }
+        var members = GetMembersSnapshot();
 
         foreach (var m in members)
         {

--- a/AAEmu.Game/Models/Game/Chat/ChatChannel.cs
+++ b/AAEmu.Game/Models/Game/Chat/ChatChannel.cs
@@ -7,6 +7,8 @@ namespace AAEmu.Game.Models.Game.Chat;
 
 public class ChatChannel
 {
+    private readonly object _membersLock = new();
+
     /// <summary>
     /// Chat channel type
     /// </summary>
@@ -47,11 +49,15 @@ public class ChatChannel
         if (character == null)
             return false;
 
-        if (Members.Contains(character))
-            return false;
+        lock (_membersLock)
+        {
+            if (Members.Contains(character))
+                return false;
+
+            Members.Add(character);
+        }
 
         // character.SendMessage(ChatType.System, "ChatManager.JoinChannel {0} - {1} - {2}", chatType, internalId, internalName);
-        Members.Add(character);
         character.SendPacket(new SCJoinedChatChannelPacket(ChatType, SubType, Faction));
 
         return true;
@@ -68,7 +74,13 @@ public class ChatChannel
             return false;
 
         // character.SendMessage(ChatType.System, "ChatManager.LeaveChannel {0} - {1} - {2}", chatType, internalId, internalName);
-        if (Members.Remove(character))
+        var removed = false;
+        lock (_membersLock)
+        {
+            removed = Members.Remove(character);
+        }
+
+        if (removed)
         {
             character.SendPacket(new SCLeavedChatChannelPacket(ChatType, SubType, Faction));
             return true;
@@ -87,7 +99,13 @@ public class ChatChannel
     public int SendMessage(Character origin, string msg, int ability = 0, byte languageType = 0)
     {
         var res = 0;
-        foreach (var m in Members)
+        Character[] members;
+        lock (_membersLock)
+        {
+            members = Members.ToArray();
+        }
+
+        foreach (var m in members)
         {
             m.SendPacket(new SCChatMessagePacket(ChatType, origin ?? m, msg, ability, languageType));
             res++;
@@ -103,7 +121,13 @@ public class ChatChannel
     public int SendPacket(GamePacket packet)
     {
         var res = 0;
-        foreach (var m in Members)
+        Character[] members;
+        lock (_membersLock)
+        {
+            members = Members.ToArray();
+        }
+
+        foreach (var m in members)
         {
             m.SendPacket(packet);
             res++;

--- a/AAEmu.Game/Scripts/Commands/TestChatChannel.cs
+++ b/AAEmu.Game/Scripts/Commands/TestChatChannel.cs
@@ -36,8 +36,9 @@ public class TestChatChannel : ICommand
             var channels = ChatManager.Instance.ListAllChannels();
             foreach (var c in channels)
             {
+                var memberCount = c.GetMembersSnapshot().Length;
                 CommandManager.SendNormalText(this, messageOutput,
-                    $"{c.InternalId} - T:{c.ChatType} ST:{c.SubType} F:{c.Faction} => {c.InternalName} ({c.Members.Count})");
+                    $"{c.InternalId} - T:{c.ChatType} ST:{c.SubType} F:{c.Faction} => {c.InternalName} ({memberCount})");
             }
 
             CommandManager.SendNormalText(this, messageOutput, $"End of list");
@@ -57,11 +58,12 @@ public class TestChatChannel : ICommand
                 CommandManager.SendErrorText(this, messageOutput, $"ChannelId {channelId} not found");
                 return;
             }
-            CommandManager.SendNormalText(this, messageOutput, $"List {thisChannel.Members.Count} members of {thisChannel.InternalName} ({thisChannel.InternalId})");
+            var members = thisChannel.GetMembersSnapshot();
+            CommandManager.SendNormalText(this, messageOutput, $"List {members.Length} members of {thisChannel.InternalName} ({thisChannel.InternalId})");
             var t = string.Empty;
             var c = 0;
             var first = true;
-            foreach (var m in thisChannel.Members)
+            foreach (var m in members)
             {
                 if (first)
                 {


### PR DESCRIPTION
`ChatChannel` keeps its members in a plain `List` that is iterated in the send path while other threads add or remove members on join and leave. Iterating the list while it is being modified throws `InvalidOperationException: Collection was modified`, which is easy to hit on busy zone or faction channels.

This snapshots the member list before iterating (and guards join/leave), so sending while the membership changes no longer crashes.