### PR TITLE
fix(skills): enforce skill cooldown before casting

### DIFF
--- a/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotTree.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotTree.cs
@@ -250,8 +250,11 @@ public class PlotTree(uint plotId)
 
         state.Caster?.Cooldowns.AddCooldown(state.ActiveSkill.Template.Id, (uint)state.ActiveSkill.Template.CooldownTime);
 
-        if (state.Caster is Character { IgnoreSkillCooldowns: true } character)
+        if (state.Caster?.GetOwnerCharacter() is { IgnoreSkillCooldowns: true } character)
+        {
             character.ResetSkillCooldown(state.ActiveSkill.Template.Id, false);
+            state.Caster.Cooldowns.RemoveCooldown(state.ActiveSkill.Template.Id);
+        }
 
         // Maybe always do this on end of plot?
         // Should we check if it was a channeled skill?

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -110,6 +110,12 @@ public class Skill
             return SkillResultHelper.SkillResultErrorKeyToId(requirementResult.ResultKey);
         }
 
+        if (character is { IgnoreSkillCooldowns: false } && Template.CooldownTime > 0 && unit.Cooldowns.CheckCooldown(Template.Id))
+        {
+            Logger.Trace($"Skill: CooldownTime [{Template.CooldownTime}]!");
+            return SkillResult.CooldownTime;
+        }
+
         _bypassGcd = bypassGcd;
         if (!_bypassGcd)
         {

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -97,6 +97,7 @@ public class Skill
 
         // Cast character for future reference
         var character = caster as Character;
+        var cooldownOwner = character ?? caster.GetOwnerCharacter();
 
         unit.ConditionChance = true;
 
@@ -110,7 +111,7 @@ public class Skill
             return SkillResultHelper.SkillResultErrorKeyToId(requirementResult.ResultKey);
         }
 
-        if (character is { IgnoreSkillCooldowns: false } && Template.CooldownTime > 0 && unit.Cooldowns.CheckCooldown(Template.Id))
+        if (Template.CooldownTime > 0 && cooldownOwner is { IgnoreSkillCooldowns: false } && unit.Cooldowns.CheckCooldown(Template.Id))
         {
             Logger.Trace($"Skill: CooldownTime [{Template.CooldownTime}]!");
             return SkillResult.CooldownTime;
@@ -1415,8 +1416,11 @@ public class Skill
         SkillTlIdManager.ReleaseId(TlId);
         TlId = 0;
 
-        if (caster is Character character1 && character1.IgnoreSkillCooldowns)
-            character1.ResetSkillCooldown(Template.Id, false);
+        if (caster.GetOwnerCharacter() is { IgnoreSkillCooldowns: true } cooldownOwner)
+        {
+            cooldownOwner.ResetSkillCooldown(Template.Id, false);
+            unit.Cooldowns.RemoveCooldown(Template.Id);
+        }
     }
 
     /// <summary>
@@ -1445,8 +1449,11 @@ public class Skill
         SkillTlIdManager.ReleaseId(TlId);
         TlId = 0;
 
-        if (caster is Character character && character.IgnoreSkillCooldowns)
+        if (caster.GetOwnerCharacter() is { IgnoreSkillCooldowns: true } character)
+        {
             character.ResetSkillCooldown(Template.Id, false);
+            unit.Cooldowns.RemoveCooldown(Template.Id);
+        }
     }
 
     public SkillHitType RollCombatDice(BaseUnit attacker, BaseUnit target)


### PR DESCRIPTION
`Skill.Use` adds a cooldown after a cast but never checks it server-side for player casts, so the cooldown is only enforced by the client. A modified client can therefore fire skills ignoring their cooldown.

This adds a server-side cooldown check in `Use` before the cast, so a skill still on cooldown is rejected. Skills with no cooldown and casts that intentionally bypass it are left unaffected.