### PR TITLE
fix(loot): reserve corpse loot before granting it

### DIFF
--- a/AAEmu.Game/Core/Managers/World/SpawnManager.cs
+++ b/AAEmu.Game/Core/Managers/World/SpawnManager.cs
@@ -1099,7 +1099,14 @@ public class SpawnManager(WorldInstance parentWorld)
             {
                 foreach (var npc in makePublic)
                 {
-                    npc.LootingContainer.MakeLootPublic();
+                    try
+                    {
+                        npc.LootingContainer.MakeLootPublic();
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Warn(e, "Failed to make loot public for npc {0}", npc.ObjId);
+                    }
                 }
             }
 

--- a/AAEmu.Game/Models/Game/Items/Containers/LootingContainer.cs
+++ b/AAEmu.Game/Models/Game/Items/Containers/LootingContainer.cs
@@ -94,7 +94,10 @@ public class LootingContainer(IBaseUnit owner)
         };
         Killer = killer;
         CreationTime = DateTime.UtcNow;
-        Items.Clear();
+        lock (ItemsLock)
+        {
+            Items.Clear();
+        }
 
         // NPC Loot handling
         if (LootOwnerType == LootOwnerType.Npc && LootOwner is Npc npc)
@@ -218,9 +221,10 @@ public class LootingContainer(IBaseUnit owner)
                 }
             }
 
-            if (Items.Count <= 0)
+            lock (ItemsLock)
             {
-                return;
+                if (Items.Count <= 0)
+                    return;
             }
 
             UpdateLootState();
@@ -244,21 +248,24 @@ public class LootingContainer(IBaseUnit owner)
     /// <param name="items">Loot</param>
     private void RegisterItems(List<Item> items)
     {
-        foreach (var item in items)
+        lock (ItemsLock)
         {
-            var newItem = new LootingContainerItemEntry
+            foreach (var item in items)
             {
-                Owner = this,
-                Item = item,
-                ItemIndex = (ushort)(Items.Count + 1),
-                HighestRoller = 0
-            };
-            // Update ItemId to what is expected to be used
-            // Note that the actual Item.Id needs to be updated upon actual looting
-            newItem.Item.Id = ((ulong)LootOwner.ObjId << 32) + ((ulong)LootOwnerType << 16) + newItem.ItemIndex;
+                var newItem = new LootingContainerItemEntry
+                {
+                    Owner = this,
+                    Item = item,
+                    ItemIndex = (ushort)(Items.Count + 1),
+                    HighestRoller = 0
+                };
+                // Update ItemId to what is expected to be used
+                // Note that the actual Item.Id needs to be updated upon actual looting
+                newItem.Item.Id = ((ulong)LootOwner.ObjId << 32) + ((ulong)LootOwnerType << 16) + newItem.ItemIndex;
 
-            // Add the actual entry
-            Items.Add(newItem.ItemIndex, newItem);
+                // Add the actual entry
+                Items.Add(newItem.ItemIndex, newItem);
+            }
         }
     }
 
@@ -280,9 +287,15 @@ public class LootingContainer(IBaseUnit owner)
     /// </summary>
     private void UpdateLootState()
     {
-        SendPacketToPlayers(EligiblePlayers, new SCLootableStatePacket(LootOwnerType, LootOwner.ObjId, Items.Count > 0));
+        bool hasItems;
+        lock (ItemsLock)
+        {
+            hasItems = Items.Count > 0;
+        }
+
+        SendPacketToPlayers(EligiblePlayers, new SCLootableStatePacket(LootOwnerType, LootOwner.ObjId, hasItems));
         // If no items left, then reduce the despawn timer if needed
-        if (Items.Count <= 0)
+        if (!hasItems)
         {
             var minimumDespawnTime = CreationTime;
             switch (LootOwnerType)
@@ -587,74 +600,93 @@ public class LootingContainer(IBaseUnit owner)
         if (!TryReserveLootItem(itemEntry))
             return false;
 
-        var freeSpace = player.Inventory.Bag.SpaceLeftForItem(itemEntry.Item, out _);
-        if (freeSpace < itemEntry.Item.Count)
-        {
-            RestoreLootItem(itemEntry);
-            player.SendPacket(new SCLootItemFailedPacket(ErrorMessageType.BagFull, LootOwnerType, LootOwner.ObjId, itemEntry.ItemIndex, itemEntry.Item.TemplateId));
-            return false;
-        }
-
         var fullOldItemId = itemEntry.Item.Id;
-
-        // var objId = (uint)(lootDropItem.Id >> 32);
-        if (itemEntry.Item.TemplateId == Item.Coins)
+        var grantSucceeded = false;
+        var restored = false;
+        try
         {
-            player.AddMoney(SlotType.Inventory, itemEntry.Item.Count);
-        }
-        else if (ItemManager.Instance.IsAutoEquipTradePack(itemEntry.Item.TemplateId))
-        {
-            // Auto-equip tradepack item branch.
-            // Attempt to remove the current backpack item to free up the slot.
-            if (player.Inventory.TakeoffBackpack(ItemTaskType.RecoverDoodadItem, true))
+            var freeSpace = player.Inventory.Bag.SpaceLeftForItem(itemEntry.Item, out _);
+            if (freeSpace < itemEntry.Item.Count)
             {
-                itemEntry.Item.Id = ItemIdManager.Instance.GetNextId();
-                // Try to add the new item to the Equipment container's Backpack slot.
-                if (!player.Inventory.Equipment.AddOrMoveExistingItem(ItemTaskType.RecoverDoodadItem, itemEntry.Item, (int)EquipmentItemSlot.Backpack))
+                RestoreLootItem(itemEntry);
+                restored = true;
+                player.SendPacket(new SCLootItemFailedPacket(ErrorMessageType.BagFull, LootOwnerType, LootOwner.ObjId, itemEntry.ItemIndex, itemEntry.Item.TemplateId));
+                return false;
+            }
+
+            // var objId = (uint)(lootDropItem.Id >> 32);
+            if (itemEntry.Item.TemplateId == Item.Coins)
+            {
+                player.AddMoney(SlotType.Inventory, itemEntry.Item.Count);
+                grantSucceeded = true;
+            }
+            else if (ItemManager.Instance.IsAutoEquipTradePack(itemEntry.Item.TemplateId))
+            {
+                // Auto-equip tradepack item branch.
+                // Attempt to remove the current backpack item to free up the slot.
+                if (player.Inventory.TakeoffBackpack(ItemTaskType.RecoverDoodadItem, true))
                 {
-                    // If adding fails, release the item ID and restore original.
-                    RestoreLootItem(itemEntry);
-                    ItemIdManager.Instance.ReleaseId((uint)itemEntry.Item.Id);
-                    itemEntry.Item.Id = fullOldItemId;
-                    player.SendPacket(new SCLootItemFailedPacket(ErrorMessageType.BagFull, LootOwnerType, LootOwner.ObjId, itemEntry.ItemIndex, itemEntry.Item.TemplateId));
-                    return false;
+                    itemEntry.Item.Id = ItemIdManager.Instance.GetNextId();
+                    // Try to add the new item to the Equipment container's Backpack slot.
+                    if (!player.Inventory.Equipment.AddOrMoveExistingItem(ItemTaskType.RecoverDoodadItem, itemEntry.Item, (int)EquipmentItemSlot.Backpack))
+                    {
+                        // If adding fails, release the item ID and restore original.
+                        RestoreLootItem(itemEntry);
+                        restored = true;
+                        ItemIdManager.Instance.ReleaseId((uint)itemEntry.Item.Id);
+                        itemEntry.Item.Id = fullOldItemId;
+                        player.SendPacket(new SCLootItemFailedPacket(ErrorMessageType.BagFull, LootOwnerType, LootOwner.ObjId, itemEntry.ItemIndex, itemEntry.Item.TemplateId));
+                        return false;
+                    }
+                    else
+                    {
+                        Logger.Trace("AutoEquipTradePack: Tradepack item added to Equipment container successfully.");
+                        grantSucceeded = true;
+                    }
                 }
                 else
                 {
-                    Logger.Trace("AutoEquipTradePack: Tradepack item added to Equipment container successfully.");
+                    Logger.Warn("AutoEquipTradePack: Failed to take off backpack for auto-equip tradepack item TemplateId={0}.", itemEntry.Item.TemplateId);
+                    RestoreLootItem(itemEntry);
+                    restored = true;
+                    player.SendPacket(new SCLootItemFailedPacket(ErrorMessageType.BagFull, LootOwnerType, LootOwner.ObjId, itemEntry.ItemIndex, itemEntry.Item.TemplateId));
+                    return false;
                 }
             }
             else
             {
-                Logger.Warn("AutoEquipTradePack: Failed to take off backpack for auto-equip tradepack item TemplateId={0}.", itemEntry.Item.TemplateId);
-                RestoreLootItem(itemEntry);
-                player.SendPacket(new SCLootItemFailedPacket(ErrorMessageType.BagFull, LootOwnerType, LootOwner.ObjId, itemEntry.ItemIndex, itemEntry.Item.TemplateId));
-                return false;
+                itemEntry.Item.Id = ItemIdManager.Instance.GetNextId();
+                // Try to add the new item
+                if (!player.Inventory.Bag.AcquireDefaultItem(didLootAll ? ItemTaskType.LootAll : ItemTaskType.Loot, itemEntry.Item.TemplateId, itemEntry.Item.Count, itemEntry.Item.Grade))
+                {
+                    // Free the Id again if failed
+                    RestoreLootItem(itemEntry);
+                    restored = true;
+                    ItemIdManager.Instance.ReleaseId((uint)itemEntry.Item.Id);
+                    // Re-assign the original loot bag id 
+                    itemEntry.Item.Id = fullOldItemId;
+                    // Send a bag full fail message
+                    // player.SendErrorMessage(ErrorMessageType.BagFull);
+                    player.SendPacket(new SCLootItemFailedPacket(ErrorMessageType.BagFull, LootOwnerType, LootOwner.ObjId, itemEntry.ItemIndex, itemEntry.Item.TemplateId));
+                    return false;
+                }
+                grantSucceeded = true;
             }
-        }
-        else
-        {
-            itemEntry.Item.Id = ItemIdManager.Instance.GetNextId();
-            // Try to add the new item
-            if (!player.Inventory.Bag.AcquireDefaultItem(didLootAll ? ItemTaskType.LootAll : ItemTaskType.Loot, itemEntry.Item.TemplateId, itemEntry.Item.Count, itemEntry.Item.Grade))
-            {
-                // Free the Id again if failed
-                RestoreLootItem(itemEntry);
-                ItemIdManager.Instance.ReleaseId((uint)itemEntry.Item.Id);
-                // Re-assign the original loot bag id 
-                itemEntry.Item.Id = fullOldItemId;
-                // Send a bag full fail message
-                // player.SendErrorMessage(ErrorMessageType.BagFull);
-                player.SendPacket(new SCLootItemFailedPacket(ErrorMessageType.BagFull, LootOwnerType, LootOwner.ObjId, itemEntry.ItemIndex, itemEntry.Item.TemplateId));
-                return false;
-            }
-        }
-        // TODO: check what packet this sends to others
-        player.SendPacket(new SCLootItemTookPacket(itemEntry.Item.TemplateId, itemEntry.ItemIndex, LootOwnerType, LootOwner.ObjId, itemEntry.Item.Count));
+            // TODO: check what packet this sends to others
+            player.SendPacket(new SCLootItemTookPacket(itemEntry.Item.TemplateId, itemEntry.ItemIndex, LootOwnerType, LootOwner.ObjId, itemEntry.Item.Count));
 
-        if (Items.Count <= 0)
-            UpdateLootState();
-        return true;
+            if (Items.Count <= 0)
+                UpdateLootState();
+            return true;
+        }
+        finally
+        {
+            if (!grantSucceeded && !restored)
+            {
+                itemEntry.Item.Id = fullOldItemId;
+                RestoreLootItem(itemEntry);
+            }
+        }
     }
 
     private bool TryReserveLootItem(LootingContainerItemEntry itemEntry)

--- a/AAEmu.Game/Models/Game/Items/Containers/LootingContainer.cs
+++ b/AAEmu.Game/Models/Game/Items/Containers/LootingContainer.cs
@@ -69,6 +69,7 @@ public class LootingContainer(IBaseUnit owner)
     /// List of item entries (itemIndex, LootItemEntry)
     /// </summary>
     public Dictionary<ushort, LootingContainerItemEntry> Items { get; } = [];
+    private object ItemsLock { get; } = new();
     private bool AlreadyGenerated { get; set; }
     private HashSet<Character> EligiblePlayers { get; } = [];
     private HashSet<Character> OpenedBy { get; } = [];
@@ -311,21 +312,23 @@ public class LootingContainer(IBaseUnit owner)
     /// <param name="lootAll">True when the player opened the loot using (G) to loot all</param>
     public void OpenBag(Character player, BaseUnit object2, bool lootAll)
     {
-        OpenedBy.Add(player);
+        KeyValuePair<ushort, LootingContainerItemEntry>[] lootItems = [];
+        lock (ItemsLock)
+        {
+            OpenedBy.Add(player);
+
+            if (lootAll)
+                lootItems = Items.ToArray();
+        }
 
         // If LootAll is set, try to loot all items immediately
         if (lootAll)
         {
             // Try to loot all items
-            var lootedItems = new List<ushort>();
-            foreach (var (itemIndex, itemEntry) in Items)
+            foreach (var (itemIndex, itemEntry) in lootItems)
             {
-                if (TryTakeLoot(player, itemIndex, itemEntry, true))
-                    lootedItems.Add(itemIndex);
+                TryTakeLoot(player, itemIndex, itemEntry, true);
             }
-            // Remove actually looted items
-            foreach (var lootedItemIndex in lootedItems)
-                Items.Remove(lootedItemIndex);
         }
 
         // Send packet update of remaining items, or loot state if all has been looted already
@@ -334,14 +337,20 @@ public class LootingContainer(IBaseUnit owner)
         //     UpdateLootState();
         // }
         // else
-        if (Items.Count > 0)
+        var remainingItems = new List<Item>();
+        lock (ItemsLock)
         {
-            var remainingItems = new List<Item>();
-            foreach (var (_, itemEntry) in Items)
+            if (Items.Count > 0)
             {
-                remainingItems.Add(itemEntry.Item);
+                foreach (var (_, itemEntry) in Items)
+                {
+                    remainingItems.Add(itemEntry.Item);
+                }
             }
+        }
 
+        if (remainingItems.Count > 0)
+        {
             SendPacketToPlayers(OpenedBy, new SCLootBagDataPacket(remainingItems, lootAll));
         }
     }
@@ -355,6 +364,14 @@ public class LootingContainer(IBaseUnit owner)
     /// <param name="didLootAll"></param>
     /// <returns>Returns true if the item was granted to the player</returns>
     public bool TryTakeLoot(Character player, ushort itemIndex, LootingContainerItemEntry itemEntry, bool didLootAll)
+    {
+        lock (ItemsLock)
+        {
+            return TryTakeLootLocked(player, itemIndex, itemEntry, didLootAll);
+        }
+    }
+
+    private bool TryTakeLootLocked(Character player, ushort itemIndex, LootingContainerItemEntry itemEntry, bool didLootAll)
     {
         var lootTarget = player;
         // If itemEntry not specified, grab it from its index
@@ -496,6 +513,14 @@ public class LootingContainer(IBaseUnit owner)
     /// <param name="rollRequest"></param>
     public void DoPlayerRoll(Character player, ushort itemIndex, bool rollRequest)
     {
+        lock (ItemsLock)
+        {
+            DoPlayerRollLocked(player, itemIndex, rollRequest);
+        }
+    }
+
+    private void DoPlayerRollLocked(Character player, ushort itemIndex, bool rollRequest)
+    {
         var itemEntry = Items.GetValueOrDefault(itemIndex);
         if (itemEntry == null)
             return;
@@ -559,10 +584,13 @@ public class LootingContainer(IBaseUnit owner)
 
     private bool TryDistributeLootToPlayer(Character player, LootingContainerItemEntry itemEntry, bool didLootAll)
     {
+        if (!TryReserveLootItem(itemEntry))
+            return false;
+
         var freeSpace = player.Inventory.Bag.SpaceLeftForItem(itemEntry.Item, out _);
         if (freeSpace < itemEntry.Item.Count)
         {
-            // player.SendErrorMessage(ErrorMessageType.BagFull);
+            RestoreLootItem(itemEntry);
             player.SendPacket(new SCLootItemFailedPacket(ErrorMessageType.BagFull, LootOwnerType, LootOwner.ObjId, itemEntry.ItemIndex, itemEntry.Item.TemplateId));
             return false;
         }
@@ -585,6 +613,7 @@ public class LootingContainer(IBaseUnit owner)
                 if (!player.Inventory.Equipment.AddOrMoveExistingItem(ItemTaskType.RecoverDoodadItem, itemEntry.Item, (int)EquipmentItemSlot.Backpack))
                 {
                     // If adding fails, release the item ID and restore original.
+                    RestoreLootItem(itemEntry);
                     ItemIdManager.Instance.ReleaseId((uint)itemEntry.Item.Id);
                     itemEntry.Item.Id = fullOldItemId;
                     player.SendPacket(new SCLootItemFailedPacket(ErrorMessageType.BagFull, LootOwnerType, LootOwner.ObjId, itemEntry.ItemIndex, itemEntry.Item.TemplateId));
@@ -598,6 +627,7 @@ public class LootingContainer(IBaseUnit owner)
             else
             {
                 Logger.Warn("AutoEquipTradePack: Failed to take off backpack for auto-equip tradepack item TemplateId={0}.", itemEntry.Item.TemplateId);
+                RestoreLootItem(itemEntry);
                 player.SendPacket(new SCLootItemFailedPacket(ErrorMessageType.BagFull, LootOwnerType, LootOwner.ObjId, itemEntry.ItemIndex, itemEntry.Item.TemplateId));
                 return false;
             }
@@ -609,6 +639,7 @@ public class LootingContainer(IBaseUnit owner)
             if (!player.Inventory.Bag.AcquireDefaultItem(didLootAll ? ItemTaskType.LootAll : ItemTaskType.Loot, itemEntry.Item.TemplateId, itemEntry.Item.Count, itemEntry.Item.Grade))
             {
                 // Free the Id again if failed
+                RestoreLootItem(itemEntry);
                 ItemIdManager.Instance.ReleaseId((uint)itemEntry.Item.Id);
                 // Re-assign the original loot bag id 
                 itemEntry.Item.Id = fullOldItemId;
@@ -620,11 +651,33 @@ public class LootingContainer(IBaseUnit owner)
         }
         // TODO: check what packet this sends to others
         player.SendPacket(new SCLootItemTookPacket(itemEntry.Item.TemplateId, itemEntry.ItemIndex, LootOwnerType, LootOwner.ObjId, itemEntry.Item.Count));
-        Items.Remove(itemEntry.ItemIndex);
 
         if (Items.Count <= 0)
             UpdateLootState();
         return true;
+    }
+
+    private bool TryReserveLootItem(LootingContainerItemEntry itemEntry)
+    {
+        lock (ItemsLock)
+        {
+            if (!Items.TryGetValue(itemEntry.ItemIndex, out var currentItemEntry))
+                return false;
+
+            if (currentItemEntry != itemEntry)
+                return false;
+
+            Items.Remove(itemEntry.ItemIndex);
+            return true;
+        }
+    }
+
+    private void RestoreLootItem(LootingContainerItemEntry itemEntry)
+    {
+        lock (ItemsLock)
+        {
+            Items.TryAdd(itemEntry.ItemIndex, itemEntry);
+        }
     }
 
     /// <summary>

--- a/AAEmu.Game/Models/Game/Items/Containers/LootingContainer.cs
+++ b/AAEmu.Game/Models/Game/Items/Containers/LootingContainer.cs
@@ -601,6 +601,7 @@ public class LootingContainer(IBaseUnit owner)
             return false;
 
         var fullOldItemId = itemEntry.Item.Id;
+        ulong allocatedItemId = 0;
         var grantSucceeded = false;
         var restored = false;
         try
@@ -627,13 +628,15 @@ public class LootingContainer(IBaseUnit owner)
                 if (player.Inventory.TakeoffBackpack(ItemTaskType.RecoverDoodadItem, true))
                 {
                     itemEntry.Item.Id = ItemIdManager.Instance.GetNextId();
+                    allocatedItemId = itemEntry.Item.Id;
                     // Try to add the new item to the Equipment container's Backpack slot.
                     if (!player.Inventory.Equipment.AddOrMoveExistingItem(ItemTaskType.RecoverDoodadItem, itemEntry.Item, (int)EquipmentItemSlot.Backpack))
                     {
                         // If adding fails, release the item ID and restore original.
                         RestoreLootItem(itemEntry);
                         restored = true;
-                        ItemIdManager.Instance.ReleaseId((uint)itemEntry.Item.Id);
+                        ItemIdManager.Instance.ReleaseId((uint)allocatedItemId);
+                        allocatedItemId = 0;
                         itemEntry.Item.Id = fullOldItemId;
                         player.SendPacket(new SCLootItemFailedPacket(ErrorMessageType.BagFull, LootOwnerType, LootOwner.ObjId, itemEntry.ItemIndex, itemEntry.Item.TemplateId));
                         return false;
@@ -656,13 +659,15 @@ public class LootingContainer(IBaseUnit owner)
             else
             {
                 itemEntry.Item.Id = ItemIdManager.Instance.GetNextId();
+                allocatedItemId = itemEntry.Item.Id;
                 // Try to add the new item
                 if (!player.Inventory.Bag.AcquireDefaultItem(didLootAll ? ItemTaskType.LootAll : ItemTaskType.Loot, itemEntry.Item.TemplateId, itemEntry.Item.Count, itemEntry.Item.Grade))
                 {
                     // Free the Id again if failed
                     RestoreLootItem(itemEntry);
                     restored = true;
-                    ItemIdManager.Instance.ReleaseId((uint)itemEntry.Item.Id);
+                    ItemIdManager.Instance.ReleaseId((uint)allocatedItemId);
+                    allocatedItemId = 0;
                     // Re-assign the original loot bag id 
                     itemEntry.Item.Id = fullOldItemId;
                     // Send a bag full fail message
@@ -681,6 +686,12 @@ public class LootingContainer(IBaseUnit owner)
         }
         finally
         {
+            if (!grantSucceeded && allocatedItemId != 0)
+            {
+                ItemIdManager.Instance.ReleaseId((uint)allocatedItemId);
+                itemEntry.Item.Id = fullOldItemId;
+            }
+
             if (!grantSucceeded && !restored)
             {
                 itemEntry.Item.Id = fullOldItemId;
@@ -717,33 +728,48 @@ public class LootingContainer(IBaseUnit owner)
     /// </summary>
     private void ForceLootRollToFinish()
     {
-        foreach (var (_, itemEntry) in Items)
+        LootingContainerItemEntry[] itemEntries;
+        lock (ItemsLock)
         {
-            if (itemEntry.PlayerRolls.All(m => m.Value != 0))
-                continue;
+            itemEntries = Items.Values.ToArray();
+        }
 
-            foreach (var (player, roll) in itemEntry.PlayerRolls)
+        foreach (var itemEntry in itemEntries)
+        {
+            lock (ItemsLock)
             {
-                if (roll == 0)
-                {
-                    itemEntry.PlayerRolls[player] = -1;
-                    // Notify the others of this roll result (not sure if we should add this)
-                    // foreach (var targetPlayer in itemEntry.PlayerRolls.Keys)
-                    // {
-                    //     targetPlayer.SendPacket(new SCLootDiceNotifyPacket(player.Name, itemEntry.Item, -1));
-                    // }
-                }
-            }
+                if (!Items.TryGetValue(itemEntry.ItemIndex, out var currentItemEntry) || currentItemEntry != itemEntry)
+                    continue;
 
-            FinishRolling(itemEntry);
+                if (itemEntry.PlayerRolls.All(m => m.Value != 0))
+                    continue;
+
+                foreach (var (player, roll) in itemEntry.PlayerRolls)
+                {
+                    if (roll == 0)
+                    {
+                        itemEntry.PlayerRolls[player] = -1;
+                        // Notify the others of this roll result (not sure if we should add this)
+                        // foreach (var targetPlayer in itemEntry.PlayerRolls.Keys)
+                        // {
+                        //     targetPlayer.SendPacket(new SCLootDiceNotifyPacket(player.Name, itemEntry.Item, -1));
+                        // }
+                    }
+                }
+
+                FinishRolling(itemEntry);
+            }
         }
     }
 
     public void MakeLootPublic()
     {
         ForceLootRollToFinish();
-        if (Items.Count <= 0)
-            return;
+        lock (ItemsLock)
+        {
+            if (Items.Count <= 0)
+                return;
+        }
 
         // Force full public looting for all non-claimed items
         TeamLootingRule.LootMethod = LootingRuleMethod.Public;
@@ -756,10 +782,13 @@ public class LootingContainer(IBaseUnit owner)
 
     public bool CanMakePublic()
     {
-        return TeamLootingRule != null &&
-               TeamLootingRule.LootMethod != LootingRuleMethod.Public &&
-               Items.Count > 0 &&
-               CreationTime > DateTime.MinValue &&
-               CreationTime.AddSeconds(MakeLootPublicTime) <= DateTime.UtcNow;
+        lock (ItemsLock)
+        {
+            return TeamLootingRule != null &&
+                   TeamLootingRule.LootMethod != LootingRuleMethod.Public &&
+                   Items.Count > 0 &&
+                   CreationTime > DateTime.MinValue &&
+                   CreationTime.AddSeconds(MakeLootPublicTime) <= DateTime.UtcNow;
+        }
     }
 }


### PR DESCRIPTION
Corpse loot is taken from a shared container that is read and modified from multiple connection threads without synchronization, and the item or gold is granted before the loot entry is removed.

When two party members click the same loot entry at the same time, both pass the availability check and both receive it, and the entry count goes negative. This lets items and gold be duplicated.

This locks the loot container and removes/reserves the entry before granting it, restoring it if the receiving inventory is full.