### PR TITLE
fix(world): refresh child visibility after transform

### DIFF
--- a/AAEmu.Game/Models/Game/World/Transform/Transform.cs
+++ b/AAEmu.Game/Models/Game/World/Transform/Transform.cs
@@ -536,8 +536,11 @@ public class Transform : IDisposable
             {
                 var child = _children[i];
                 if (child != null)
+                {
                     // ReSharper disable once ConditionIsAlwaysTrueOrFalse
                     child.FinalizeTransform(includeChildren);
+                    WorldManager.Instance.AddVisibleObject(child._owningObject);
+                }
             }
         }
 


### PR DESCRIPTION
When a parent transform moves, its child transforms have their coordinates updated but not their region and visibility. The sticky-child path already refreshes visibility, but the normal child path does not, so mounts and pets can desync or briefly disappear while being ridden.

This refreshes child visibility after the child transform is finalized, using the same call the sticky-child path already uses.