### PR TITLE
fix(housing): release coffer when its owner logs out

### DIFF
--- a/AAEmu.Game/Core/Managers/UnitManagers/DoodadManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/DoodadManager.cs
@@ -3113,6 +3113,22 @@ public class DoodadManager(IObjectIdManager objectIdManager, IDoodadIdManager do
         return true;
     }
 
+    public void CloseCoffersOpenedBy(Character character)
+    {
+        if (character?.ParentWorld == null)
+        {
+            return;
+        }
+
+        foreach (var doodad in character.ParentWorld.GetAllDoodads())
+        {
+            if (doodad is DoodadCoffer { OpenedBy: not null } coffer && coffer.OpenedBy.Id == character.Id)
+            {
+                coffer.OpenedBy = null;
+            }
+        }
+    }
+
     public static bool ChangeDoodadData(Character player, Doodad doodad, int data)
     {
         // TODO: Can non-coffer doodads that use this packet only be changed by their owner ?

--- a/AAEmu.Game/Core/Managers/UnitManagers/IDoodadManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/IDoodadManager.cs
@@ -28,4 +28,5 @@ public interface IDoodadManager : ILoadable
     List<uint> GetTreasureChestTemplateIds();
 
     Doodad CreatePlayerDoodad(Character character, uint id, float x, float y, float z, float zRot, float scale, ulong itemId, FarmType farmType = FarmType.Invalid, uint itemTemplateId = 0, int customData = 0, bool ignoreHouses = false);
+    void CloseCoffersOpenedBy(Character character);
 }

--- a/AAEmu.Game/Core/Managers/World/EnterWorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/EnterWorldManager.cs
@@ -1,5 +1,6 @@
 ﻿using AAEmu.Commons.Utils;
 using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.UnitManagers;
 using AAEmu.Game.Core.Network.Connections;
 using AAEmu.Game.Core.Network.Login;
 using AAEmu.Game.Core.Packets.G2C;
@@ -174,6 +175,7 @@ public class EnterWorldManager(
             // Despawn and unmount everybody from owned Mates
             activeChar.ParentWorld.MateManager.RemoveAndDespawnAllActiveOwnedMates(activeChar);
             activeChar.ParentWorld.SlaveManager.RemoveAndDespawnAllActiveOwnedSlaves(activeChar);
+            DoodadManager.Instance.CloseCoffersOpenedBy(activeChar);
 
             // Check if still mounted on somebody else's mount and dismount that if needed
             activeChar.ForceDismount(/*AttachUnitReason.PrefabChanged*/); // Dismounting a mount because of unsummoning sends "10" for this

--- a/AAEmu.Game/Core/Network/Connections/GameConnection.cs
+++ b/AAEmu.Game/Core/Network/Connections/GameConnection.cs
@@ -90,6 +90,7 @@ public class GameConnection
 
             ActiveChar.Events?.OnDisconnect(this, new OnDisconnectArgs { Player = ActiveChar });
             ActiveChar.RemoveAndDespawnActiveOwnedMatesSlaves();
+            DoodadManager.Instance.CloseCoffersOpenedBy(ActiveChar);
         }
 
         foreach (var subscriber in Subscribers)


### PR DESCRIPTION
A coffer/trunk keeps an `OpenedBy` reference that is only cleared by the client close packet, never when that character logs out or disconnects. After a disconnect the coffer stays flagged as in use, so it can no longer be opened.

This clears any coffers a character had open when they log out or disconnect.

Fixes #875