### PR TITLE
fix(portal): despawn owned mates and slaves on instance teleport

### DIFF
--- a/AAEmu.Game/Core/Managers/PortalManager.cs
+++ b/AAEmu.Game/Core/Managers/PortalManager.cs
@@ -408,8 +408,16 @@ public class PortalManager(ILocalizationManager localizationManager, IWorldManag
         // TODO - Maybe need unitState?
         if (portalInfo.TeleportPosition.InstanceId != character.Transform.InstanceId)
         {
+            var slaveManager = character.ParentWorld?.SlaveManager;
+            var activeSlave = slaveManager?.GetActiveSlaveByOwnerObjId(character.ObjId);
+            if (activeSlave?.AttachedDoodads.Any(doodad => doodad.ItemId != 0 || doodad.ItemTemplateId != 0) == true)
+            {
+                character.SendErrorMessage(ErrorMessageType.SlaveEquipmentLoadedItem);
+                return;
+            }
+
             character.ParentWorld?.MateManager?.RemoveAndDespawnAllActiveOwnedMates(character);
-            character.ParentWorld?.SlaveManager?.RemoveAndDespawnAllActiveOwnedSlaves(character, true);
+            slaveManager?.RemoveAndDespawnAllActiveOwnedSlaves(character);
 
             character.SendPacket(
                 new SCLoadInstancePacket(

--- a/AAEmu.Game/Core/Managers/PortalManager.cs
+++ b/AAEmu.Game/Core/Managers/PortalManager.cs
@@ -408,6 +408,9 @@ public class PortalManager(ILocalizationManager localizationManager, IWorldManag
         // TODO - Maybe need unitState?
         if (portalInfo.TeleportPosition.InstanceId != character.Transform.InstanceId)
         {
+            character.ParentWorld?.MateManager?.RemoveAndDespawnAllActiveOwnedMates(character);
+            character.ParentWorld?.SlaveManager?.RemoveAndDespawnAllActiveOwnedSlaves(character);
+
             character.SendPacket(
                 new SCLoadInstancePacket(
                     portalInfo.TeleportPosition.WorldId,

--- a/AAEmu.Game/Core/Managers/PortalManager.cs
+++ b/AAEmu.Game/Core/Managers/PortalManager.cs
@@ -409,7 +409,7 @@ public class PortalManager(ILocalizationManager localizationManager, IWorldManag
         if (portalInfo.TeleportPosition.InstanceId != character.Transform.InstanceId)
         {
             character.ParentWorld?.MateManager?.RemoveAndDespawnAllActiveOwnedMates(character);
-            character.ParentWorld?.SlaveManager?.RemoveAndDespawnAllActiveOwnedSlaves(character);
+            character.ParentWorld?.SlaveManager?.RemoveAndDespawnAllActiveOwnedSlaves(character, true);
 
             character.SendPacket(
                 new SCLoadInstancePacket(

--- a/AAEmu.Game/Core/Managers/SlaveManager.cs
+++ b/AAEmu.Game/Core/Managers/SlaveManager.cs
@@ -1035,11 +1035,21 @@ public class SlaveManager(WorldInstance parentWorldInstance)
     /// <param name="owner"></param>
     public void RemoveAndDespawnAllActiveOwnedSlaves(Character owner)
     {
+        RemoveAndDespawnAllActiveOwnedSlaves(owner, false);
+    }
+
+    /// <summary>
+    /// De-spawns all vehicles owned by the specified player
+    /// </summary>
+    /// <param name="owner"></param>
+    /// <param name="forceDelete">If true, will force delete attached items</param>
+    public void RemoveAndDespawnAllActiveOwnedSlaves(Character owner, bool forceDelete)
+    {
         var activeSlaveInfo = GetActiveSlaveByOwnerObjId(owner.ObjId);
         if (activeSlaveInfo != null)
         {
             activeSlaveInfo.Save();
-            Delete(owner, activeSlaveInfo.ObjId, false);
+            Delete(owner, activeSlaveInfo.ObjId, forceDelete);
         }
     }
 


### PR DESCRIPTION
Entering an instance through a portal or Mirage teleport only changes the character's `InstanceId`, without despawning their active mounts and slaves from the previous world. The dungeon path already despawns them, the portal path does not.

This despawns the character's owned mates and slaves before the instance switch, matching the dungeon path.

Fixes #958