### PR TITLE
fix(spawn): base npc respawn on time of death

### DIFF
--- a/AAEmu.Game/Models/Game/NPChar/Npc.cs
+++ b/AAEmu.Game/Models/Game/NPChar/Npc.cs
@@ -32,6 +32,7 @@ public partial class Npc : Unit
     public NpcTemplate Template { get; set; }
     //public Item[] Equip { get; set; }
     public NpcSpawner Spawner { get; set; }
+    public DateTime DeadTime { get; set; } = DateTime.MinValue;
 
     /// <summary>
     /// This is the "Idle Animation Id" that is used in UnitModelChangePosture, it can change depending on the time of the day
@@ -836,6 +837,8 @@ public partial class Npc : Unit
 
     public override void DoDie(BaseUnit killer, KillReason killReason)
     {
+        DeadTime = DateTime.UtcNow;
+
         var eligiblePlayers = new HashSet<Character>();
         if (CharacterTagging.TagTeam != 0)
         {

--- a/AAEmu.Game/Models/Game/NPChar/NpcSpawner.cs
+++ b/AAEmu.Game/Models/Game/NPChar/NpcSpawner.cs
@@ -742,7 +742,8 @@ public class NpcSpawner : Spawner<Npc>
                     // Планируем респаун и обновляем _scheduledCount
                     IncrementCount(true);
                     //Logger.Info($"Scheduled respawn for NPC {UnitId}:{SpawnerId}:{npc.ObjId} in {RespawnTime} seconds.");
-                    npc.Respawn = DateTime.UtcNow.AddSeconds(RespawnTime);
+                    var deathTime = npc.DeadTime == DateTime.MinValue ? DateTime.UtcNow : npc.DeadTime;
+                    npc.Respawn = deathTime.AddSeconds(RespawnTime);
                     npc.ParentWorld.SpawnManager.AddRespawn(npc);
                 }
                 else


### PR DESCRIPTION
NPC respawn is scheduled from the corpse despawn time rather than the time of death. Looting a corpse shortens its despawn, which then triggers the respawn almost immediately.

This records the time of death and schedules the respawn from it, so looting no longer causes an instant respawn.

Fixes #1192