### PR TITLE
fix(skills): guard skill casts and buff-effect application against mi…

### DIFF
--- a/AAEmu.Game/Core/Packets/C2G/CSStartSkillPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSStartSkillPacket.cs
@@ -63,6 +63,10 @@ public class CSStartSkillPacket() : GamePacket(CSOffsets.CSStartSkillPacket, 1)
         
         Logger.Info($"StartSkill: Id {skillId}, flag {flag}, caster={skillCaster.ObjId}, target={skillCastTarget.ObjId}");
 
+        var requestedSkillTemplate = SkillManager.Instance.GetSkillTemplate(skillId);
+        if (requestedSkillTemplate == null)
+            return;
+
         var skillResult = SkillResult.Success;
         var skillResultErrorValue = 0u;
         Skill skill = null;
@@ -78,7 +82,7 @@ public class CSStartSkillPacket() : GamePacket(CSOffsets.CSStartSkillPacket, 1)
         {
             // Mount or Slave skill
             Logger.Trace($"SkillCasterMount - MountSkillTemplateId {scm.MountSkillTemplateId}");
-            skill = new Skill(SkillManager.Instance.GetSkillTemplate(skillId));
+            skill = new Skill(requestedSkillTemplate);
 
             var caster = world.GetBaseUnit(skillCaster.ObjId);
             var mate = caster as Mate;
@@ -124,7 +128,7 @@ public class CSStartSkillPacket() : GamePacket(CSOffsets.CSStartSkillPacket, 1)
         else if (SkillManager.Instance.IsDefaultSkill(skillId) || SkillManager.Instance.IsCommonSkill(skillId) && skillCaster is not SkillItem)
         {
             // Is it a common skill?
-            skill = new Skill(SkillManager.Instance.GetSkillTemplate(skillId)); // TODO: переделать / rewrite ...
+            skill = new Skill(requestedSkillTemplate); // TODO: переделать / rewrite ...
             skillResult = skill.Use(Connection.ActiveChar, skillCaster, skillCastTarget, skillObject, false, out skillResultErrorValue);
             if (skillResult == SkillResult.Success && skillId < 5000 && skillCaster.ObjId == Connection.ActiveChar.ObjId)
             {
@@ -142,20 +146,19 @@ public class CSStartSkillPacket() : GamePacket(CSOffsets.CSStartSkillPacket, 1)
             if (si.SkillSourceItem == null || skillId != si.SkillSourceItem.Template.UseSkillId && si.SkillSourceItem.Template.BindType != ItemBindType.BindOnPickup)
                 return;
             // si.ItemTemplateId = item.TemplateId;
-            skill = new Skill(SkillManager.Instance.GetSkillTemplate(skillId));
+            skill = new Skill(requestedSkillTemplate);
             skillResult = skill.Use(player, skillCaster, skillCastTarget, skillObject, false, out skillResultErrorValue);
         }
         else if (Connection.ActiveChar.Skills.Skills.ContainsKey(skillId))
         {
             // Is it one of our learned character skills?
-            var template = SkillManager.Instance.GetSkillTemplate(skillId);
-            skill = new Skill(template, Connection.ActiveChar);
+            skill = new Skill(requestedSkillTemplate, Connection.ActiveChar);
             skillResult = skill.Use(Connection.ActiveChar, skillCaster, skillCastTarget, skillObject, false, out skillResultErrorValue);
         }
         else if (skillId > 0 && Connection.ActiveChar.Skills.IsVariantOfSkill(skillId))
         {
             // Variant of learned skill?
-            skill = new Skill(SkillManager.Instance.GetSkillTemplate(skillId));
+            skill = new Skill(requestedSkillTemplate);
             skillResult = skill.Use(Connection.ActiveChar, skillCaster, skillCastTarget, skillObject, false, out skillResultErrorValue);
         }
         else
@@ -163,7 +166,7 @@ public class CSStartSkillPacket() : GamePacket(CSOffsets.CSStartSkillPacket, 1)
             // No idea what this is
             Logger.Warn($"StartSkill: Id {skillId}, undefined use type");
             // If it's a valid skill cast it. This fixes interactions with quest items/doodads.
-            skill = new Skill(SkillManager.Instance.GetSkillTemplate(skillId));
+            skill = new Skill(requestedSkillTemplate);
             skillResult = skill.Use(Connection.ActiveChar, skillCaster, skillCastTarget, skillObject, false, out skillResultErrorValue);
         }
 

--- a/AAEmu.Game/Models/Game/AI/v2/Behaviors/Common/SpawningBehavior.cs
+++ b/AAEmu.Game/Models/Game/AI/v2/Behaviors/Common/SpawningBehavior.cs
@@ -43,6 +43,8 @@ public class SpawningBehavior : BaseCombatBehavior
             foreach (var npcSkill in skills)
             {
                 var skillTemplate = SkillManager.Instance.GetSkillTemplate(npcSkill.SkillId);
+                if (skillTemplate == null)
+                    continue;
                 var skill = new Skill(skillTemplate);
 
                 var skillCaster = SkillCaster.GetByType(SkillCasterType.Unit);

--- a/AAEmu.Game/Models/Game/AI/v2/Behaviors/WildBoar/WildBoarAttackBehavior.cs
+++ b/AAEmu.Game/Models/Game/AI/v2/Behaviors/WildBoar/WildBoarAttackBehavior.cs
@@ -73,7 +73,11 @@ public class WildBoarAttackBehavior : BaseCombatBehavior
             {
                 var skillTemplate = SkillManager.Instance.GetSkillTemplate(startCombatSkillId);
                 if (skillTemplate == null)
+                {
+                    Logger.Warn($"WildBoarAttackBehavior: OnCombatStart skill {startCombatSkillId} has no template (npc {Ai.Owner?.TemplateId}); skipping. Set flag so it only triggers once.");
+                    _combatStartSkill = true;
                     return;
+                }
                 Ai.Owner.StopMovement();
                 var skill = new Skill(skillTemplate);
                 UseSkill(skill, Ai.Owner.CurrentTarget);

--- a/AAEmu.Game/Models/Game/AI/v2/Behaviors/WildBoar/WildBoarAttackBehavior.cs
+++ b/AAEmu.Game/Models/Game/AI/v2/Behaviors/WildBoar/WildBoarAttackBehavior.cs
@@ -71,8 +71,10 @@ public class WildBoarAttackBehavior : BaseCombatBehavior
             var startCombatSkillId = _aiParams.OnCombatStartSkills.FirstOrDefault();
             if (startCombatSkillId != 0)
             {
-                Ai.Owner.StopMovement();
                 var skillTemplate = SkillManager.Instance.GetSkillTemplate(startCombatSkillId);
+                if (skillTemplate == null)
+                    return;
+                Ai.Owner.StopMovement();
                 var skill = new Skill(skillTemplate);
                 UseSkill(skill, Ai.Owner.CurrentTarget);
                 _combatStartSkill = true;
@@ -99,6 +101,8 @@ public class WildBoarAttackBehavior : BaseCombatBehavior
             if (_currHealth < skillData.HealthCondition/* && skillData.HealthCondition <= _prevHealth*/)
             {
                 var skillTemplate = SkillManager.Instance.GetSkillTemplate(skillData.SkillType);
+                if (skillTemplate == null)
+                    continue;
                 var skill = new Skill(skillTemplate);
                 if (targetDist >= skill.Template.MinRange && targetDist <= skill.Template.MaxRange)
                 {

--- a/AAEmu.Game/Models/Game/AI/v2/Framework/Behavior.cs
+++ b/AAEmu.Game/Models/Game/AI/v2/Framework/Behavior.cs
@@ -69,6 +69,8 @@ public abstract class Behavior
             }
             var skillSelfId = skills[Random.Shared.Next(skills.Count)].SkillId;
             var skillTemplateSelf = SkillManager.Instance.GetSkillTemplate(skillSelfId);
+            if (skillTemplateSelf == null)
+                return res;
             var skillSelf = new Skill(skillTemplateSelf);
 
             var delay1 = (int)(Ai.Owner.Template.BaseSkillDelay * 1000);
@@ -100,6 +102,8 @@ public abstract class Behavior
             return SkillResult.TooFarRange;
         }
         var skillTemplate = SkillManager.Instance.GetSkillTemplate(pickedSkillId);
+        if (skillTemplate == null)
+            return res;
         var skill = new Skill(skillTemplate);
 
         SetWeaponRange(skill, target); // set the maximum distance for the skill attack

--- a/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
@@ -100,6 +100,13 @@ public class CharacterCraft(Character owner)
             return;
         }
 
+        var skillTemplate = SkillManager.Instance.GetSkillTemplate(craft.SkillId);
+        if (skillTemplate == null)
+        {
+            CancelCraft();
+            return;
+        }
+
         IsCrafting = true;
 
         var caster = SkillCaster.GetByType(SkillCasterType.Unit);
@@ -108,7 +115,7 @@ public class CharacterCraft(Character owner)
         var target = SkillCastTarget.GetByType(SkillCastTargetType.Doodad);
         target.ObjId = doodadId;
 
-        var skill = new Skill(SkillManager.Instance.GetSkillTemplate(craft.SkillId));
+        var skill = new Skill(skillTemplate);
         ConsumeLaborPower = skill.Template.ConsumeLaborPower;
         var speedMultiplier = 1f;
         if (skill.Template.ActabilityGroupId > 0)
@@ -361,6 +368,11 @@ public class CharacterCraft(Character owner)
     {
         var newCraft = new CraftTask(Owner, CurrentCraft.Id, DoodadId, Count);
         var skillTemplate = SkillManager.Instance.GetSkillTemplate(CurrentCraft.SkillId);
+        if (skillTemplate == null)
+        {
+            CancelCraft();
+            return;
+        }
         var timeToGlobalCooldown = Owner.GlobalCooldown - DateTime.UtcNow;
         var nextCraftDelay = timeToGlobalCooldown.TotalMilliseconds > skillTemplate.CooldownTime
             ? timeToGlobalCooldown

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncFakeUse.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncFakeUse.cs
@@ -43,7 +43,10 @@ public class DoodadFuncFakeUse : DoodadFuncTemplate
                 target.ObjId = owner.ParentObjId;
             }
 
-            var skill = new Skill(SkillManager.Instance.GetSkillTemplate(SkillId));
+            var fakeUseTemplate = SkillManager.Instance.GetSkillTemplate(SkillId);
+            if (fakeUseTemplate == null)
+                return;
+            var skill = new Skill(fakeUseTemplate);
             skill.Use(caster, skillCaster, target, null, false, out _);
             owner.ToNextPhase = true;
         }

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncFakeUse.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncFakeUse.cs
@@ -45,7 +45,10 @@ public class DoodadFuncFakeUse : DoodadFuncTemplate
 
             var fakeUseTemplate = SkillManager.Instance.GetSkillTemplate(SkillId);
             if (fakeUseTemplate == null)
+            {
+                Logger.Warn($"DoodadFuncFakeUse: SkillId {SkillId} has no skill template (doodad {owner?.TemplateId}); doodad data is misconfigured.");
                 return;
+            }
             var skill = new Skill(fakeUseTemplate);
             skill.Use(caster, skillCaster, target, null, false, out _);
             owner.ToNextPhase = true;

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncSkillHit.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncSkillHit.cs
@@ -26,7 +26,10 @@ public class DoodadFuncSkillHit : DoodadFuncTemplate
                 var target = SkillCastTarget.GetByType(SkillCastTargetType.Doodad);
                 target.ObjId = owner.ObjId;
 
-                var skill = new Skill(SkillManager.Instance.GetSkillTemplate(SkillId));
+                var skillHitTemplate = SkillManager.Instance.GetSkillTemplate(SkillId);
+                if (skillHitTemplate == null)
+                    return;
+                var skill = new Skill(skillHitTemplate);
 
                 if (skillCaster is SkillItem sc)
                 {

--- a/AAEmu.Game/Models/Game/Gimmicks/Gimmick.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/Gimmick.cs
@@ -157,6 +157,10 @@ public class Gimmick : Unit
         if (skillId <= 0)
             return;
 
+        var skillTemplate = SkillManager.Instance.GetSkillTemplate(skillId);
+        if (skillTemplate == null)
+            return;
+
         lock (_skillStartedLock)
         {
             if (SkillStarted)
@@ -164,7 +168,6 @@ public class Gimmick : Unit
             SkillStarted = true;
         }
 
-        var skillTemplate = SkillManager.Instance.GetSkillTemplate(skillId);
         var caster = ParentWorld.GetUnit(SpawnerUnitId);
         var skillCaster = new SkillDoodad(ObjId);
         var skillCastTarget = new SkillCastPositionTarget

--- a/AAEmu.Game/Models/Game/Skills/Effects/BuffEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/BuffEffect.cs
@@ -20,6 +20,9 @@ public class BuffEffect : EffectTemplate
         CastAction castObj, EffectSource source, SkillObject skillObject, DateTime time,
         CompressedGamePackets packetBuilder = null)
     {
+        if (Buff == null)
+            return;
+
         if (target is Unit trg)
         {
             var hitType = SkillHitType.Invalid;

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/SkillUse.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/SkillUse.cs
@@ -36,7 +36,10 @@ public class SkillUse : SpecialEffectAction
         }
 
         //target = ((Unit)caster).CurrentTarget;
-        var useSkill = new Skill(SkillManager.Instance.GetSkillTemplate((uint)skillId));
+        var useSkillTemplate = SkillManager.Instance.GetSkillTemplate((uint)skillId);
+        if (useSkillTemplate == null)
+            return;
+        var useSkill = new Skill(useSkillTemplate);
         targetObj = new SkillCastUnitTarget(target?.ObjId ?? 0);
         caster.Buffs.TriggerRemoveOn(Buffs.BuffRemoveOn.UseSkill);//Not sure if it belongs here.
         TaskManager.Instance.Schedule(new UseSkillTask(useSkill, caster, casterObj, target, targetObj, skillObject), TimeSpan.FromMilliseconds(delay));

--- a/AAEmu.Game/Models/Game/Units/Route/Simulation.cs
+++ b/AAEmu.Game/Models/Game/Units/Route/Simulation.cs
@@ -523,15 +523,19 @@ public class Simulation : Patrol
                     var time = 100.0;
                     if (SkillId > 0)
                     {
-                        npc.UseSkill(SkillId, npc);
-                        var useSkill = new Skill(SkillManager.Instance.GetSkillTemplate(SkillId));
-                        if (Timeout > 0)
+                        var skillTemplate = SkillManager.Instance.GetSkillTemplate(SkillId);
+                        if (skillTemplate != null)
                         {
-                            time = Timeout * 1000;
-                        }
-                        else if (useSkill.Template.CastingTime != 0 && useSkill.Template.CooldownTime != 0)
-                        {
-                            time = useSkill.Template.CastingTime + useSkill.Template.CooldownTime;
+                            npc.UseSkill(SkillId, npc);
+                            var useSkill = new Skill(skillTemplate);
+                            if (Timeout > 0)
+                            {
+                                time = Timeout * 1000;
+                            }
+                            else if (useSkill.Template.CastingTime != 0 && useSkill.Template.CooldownTime != 0)
+                            {
+                                time = useSkill.Template.CastingTime + useSkill.Template.CooldownTime;
+                            }
                         }
 
                         SkillId = 0;
@@ -584,15 +588,19 @@ public class Simulation : Patrol
                     var time = 100.0;
                     if (SkillId > 0)
                     {
-                        npc.UseSkill(SkillId, npc);
-                        var useSkill = new Skill(SkillManager.Instance.GetSkillTemplate(SkillId));
-                        if (Timeout > 0)
+                        var skillTemplate = SkillManager.Instance.GetSkillTemplate(SkillId);
+                        if (skillTemplate != null)
                         {
-                            time = Timeout * 1000;
-                        }
-                        else if (useSkill.Template.CastingTime != 0 && useSkill.Template.CooldownTime != 0)
-                        {
-                            time = useSkill.Template.CastingTime + useSkill.Template.CooldownTime;
+                            npc.UseSkill(SkillId, npc);
+                            var useSkill = new Skill(skillTemplate);
+                            if (Timeout > 0)
+                            {
+                                time = Timeout * 1000;
+                            }
+                            else if (useSkill.Template.CastingTime != 0 && useSkill.Template.CooldownTime != 0)
+                            {
+                                time = useSkill.Template.CastingTime + useSkill.Template.CooldownTime;
+                            }
                         }
 
                         SkillId = 0;

--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -995,7 +995,10 @@ public class Unit : BaseUnit, IUnit
 
     public virtual SkillResult UseSkill(uint skillId, IUnit target)
     {
-        var skill = new Skill(SkillManager.Instance.GetSkillTemplate(skillId));
+        var skillTemplate = SkillManager.Instance.GetSkillTemplate(skillId);
+        if (skillTemplate == null)
+            return SkillResult.InvalidSkill;
+        var skill = new Skill(skillTemplate);
 
         var caster = SkillCaster.GetByType(SkillCasterType.Unit);
         caster.ObjId = ObjId;
@@ -1008,7 +1011,10 @@ public class Unit : BaseUnit, IUnit
 
     public virtual SkillResult UseSkill(uint skillId, Doodad target)
     {
-        var skill = new Skill(SkillManager.Instance.GetSkillTemplate(skillId));
+        var skillTemplate = SkillManager.Instance.GetSkillTemplate(skillId);
+        if (skillTemplate == null)
+            return SkillResult.InvalidSkill;
+        var skill = new Skill(skillTemplate);
 
         var caster = SkillCaster.GetByType(SkillCasterType.Unit);
         caster.ObjId = ObjId;

--- a/PR-NOTE.md
+++ b/PR-NOTE.md
@@ -1,0 +1,41 @@
+## Summary
+
+Adds minimal null guards for missing skill and buff templates before runtime casts/effects dereference them. Invalid template references now return, continue, or cancel only the affected cast path instead of crashing AI/server execution.
+
+## Per File
+
+- `AAEmu.Game/Models/Game/AI/v2/Framework/Behavior.cs`: Returns the existing `InvalidSkill` result when idle self-skill or combat skill templates are missing.
+- `AAEmu.Game/Models/Game/AI/v2/Behaviors/Common/SpawningBehavior.cs`: Skips missing spawn-skill templates and continues the spawn-skill loop.
+- `AAEmu.Game/Models/Game/AI/v2/Behaviors/WildBoar/WildBoarAttackBehavior.cs`: Aborts the start-combat skill when its template is missing and skips missing spurt-skill templates.
+- `AAEmu.Game/Models/Game/Units/Unit.cs`: Returns `SkillResult.InvalidSkill` for unit and doodad casts with missing templates.
+- `AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/SkillUse.cs`: Returns before scheduling a triggered skill when the referenced template is missing.
+- `AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncSkillHit.cs`: Returns before fake item/doodad skill-hit processing when the referenced template is missing.
+- `AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncFakeUse.cs`: Returns before fake doodad skill use when the referenced template is missing, leaving phase advancement only for legitimate paths.
+- `AAEmu.Game/Models/Game/Units/Route/Simulation.cs`: Skips missing patrol skill casts, clears `SkillId`, and continues patrol movement with the default delay.
+- `AAEmu.Game/Models/Game/Gimmicks/Gimmick.cs`: Checks the skill template before marking `SkillStarted` or scheduling the gimmick skill.
+- `AAEmu.Game/Core/Packets/C2G/CSStartSkillPacket.cs`: Fetches one `requestedSkillTemplate` once, returns when missing, and reuses it in the active mount/slave, item, learned, variant, undefined, and common/default branches.
+- `AAEmu.Game/Models/Game/Skills/Effects/BuffEffect.cs`: Returns at the start of `Apply` when the loader left `Buff` null.
+- `AAEmu.Game/Models/Game/Char/CharacterCraft.cs`: Cancels crafting when a craft references a missing skill template, including repeat scheduling.
+
+## Safety Grep
+
+`rg -n "new Skill\\([^;\\n]*GetSkillTemplate\\(" AAEmu.Game -g '*.cs'` leaves only commented legacy examples in `Combat.cs` and `Gimmick.cs`.
+
+## Changed Files
+
+- `AAEmu.Game/Core/Packets/C2G/CSStartSkillPacket.cs`
+- `AAEmu.Game/Models/Game/AI/v2/Behaviors/Common/SpawningBehavior.cs`
+- `AAEmu.Game/Models/Game/AI/v2/Behaviors/WildBoar/WildBoarAttackBehavior.cs`
+- `AAEmu.Game/Models/Game/AI/v2/Framework/Behavior.cs`
+- `AAEmu.Game/Models/Game/Char/CharacterCraft.cs`
+- `AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncFakeUse.cs`
+- `AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncSkillHit.cs`
+- `AAEmu.Game/Models/Game/Gimmicks/Gimmick.cs`
+- `AAEmu.Game/Models/Game/Skills/Effects/BuffEffect.cs`
+- `AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/SkillUse.cs`
+- `AAEmu.Game/Models/Game/Units/Route/Simulation.cs`
+- `AAEmu.Game/Models/Game/Units/Unit.cs`
+
+## Tests
+
+Not run by request.


### PR DESCRIPTION
…ssing templates

Dangling data references (np_skills, mount_skills, tagged_skills, buff_skills, buff_effects pointing at non-existent skills/buffs) cause NRE crashes: new Skill(GetSkillTemplate(id)) dereferences a null template, and BuffEffect.Apply dereferences a null Buff. Adds null-guards at the affected casters:

- Unit.UseSkill(uint, IUnit/Doodad) -> return SkillResult.InvalidSkill
- AI: Framework/Behavior.cs (self+combat), SpawningBehavior, WildBoarAttackBehavior
- SpecialEffects/SkillUse (skill-triggers-skill)
- DoodadFuncSkillHit / DoodadFuncFakeUse
- BuffEffect.Apply -> early return when the referenced buff is missing

Valid casts/effects are unchanged.