### PR TITLE
Fix boss/combat quests auto-completing without an NPC acceptor

### DIFF
--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -1637,7 +1637,7 @@ public class Unit : BaseUnit, IUnit
                 {
                     if (!player.Quests.IsQuestComplete(npc.Template.EngageCombatGiveQuestId) &&
                         !player.Quests.HasQuest(npc.Template.EngageCombatGiveQuestId))
-                        player.Quests.AddQuest(npc.Template.EngageCombatGiveQuestId);
+                        player.Quests.AddQuestFromNpc(npc.Template.EngageCombatGiveQuestId, npc.ObjId);
                 }
             }
 


### PR DESCRIPTION
Quests using `engage_combat_give_quest_id` were being started/completed without going through the NPC quest-acceptor path.

Fixes #1283
Fixes #1284
Fixes #1285
Fixes #1286
Fixes #1287