### PR TITLE
Harden StoreBuy: trade-pack crash, free-buy affordability, no partial charge

### DIFF
--- a/AAEmu.Game/Core/Packets/C2G/CSBuyItemsPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSBuyItemsPacket.cs
@@ -122,11 +122,35 @@ public class CSBuyItemsPacket() : GamePacket(CSOffsets.CSBuyItemsPacket, 1)
             return;
 
         var tasks = new List<ItemTask>();
+
+        // Make sure every purchased item can actually be stored before charging
+        // the player. Trade-pack items (backpacks) must be equipped rather than
+        // stuffed into a bag slot; going through Bag.AcquireDefaultItem directly
+        // crashed on them (#1276). Reserve one bag slot per non-pack line so a
+        // full inventory aborts the purchase instead of partially applying it.
+        var neededBagSlots = 0;
         foreach (var (itemId, grade, count) in itemsBuy)
         {
-            // Omit grade when creating to prevent "cheating" when creating the grade
-            Connection.ActiveChar.Inventory.Bag.AcquireDefaultItem(ItemTaskType.StoreBuy, itemId, count, -1);
-            // Connection.ActiveChar.Inventory.Bag.AcquireDefaultItem(ItemTaskType.StoreBuy, itemId, count, grade);
+            if (!ItemManager.Instance.IsAutoEquipTradePack(itemId))
+                neededBagSlots++;
+        }
+
+        if (Connection.ActiveChar.Inventory.Bag.FreeSlotCount < neededBagSlots)
+        {
+            Connection.ActiveChar.SendErrorMessage(ErrorMessageType.BagFull);
+            return;
+        }
+
+        foreach (var (itemId, grade, count) in itemsBuy)
+        {
+            // Omit grade when creating to prevent "cheating" when creating the grade.
+            // TryAddNewItem routes trade-packs to the back slot instead of a bag slot.
+            if (!Connection.ActiveChar.Inventory.TryAddNewItem(ItemTaskType.StoreBuy, itemId, count, -1))
+            {
+                Logger.Warn($"StoreBuy: failed to add item {itemId} x{count} for {Connection.ActiveChar.Name}; aborting purchase.");
+                Connection.ActiveChar.SendErrorMessage(ErrorMessageType.BagFull);
+                return;
+            }
         }
 
         foreach (var (item, index) in itemsBuyBack)

--- a/AAEmu.Game/Core/Packets/C2G/CSBuyItemsPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSBuyItemsPacket.cs
@@ -116,8 +116,11 @@ public class CSBuyItemsPacket() : GamePacket(CSOffsets.CSBuyItemsPacket, 1)
 
         var useAAPoint = stream.ReadBoolean();
 
-        if (money > Connection.ActiveChar.Money &&
-            honorPoints > Connection.ActiveChar.HonorPoint &&
+        // Abort if the player cannot afford ANY of the three currencies. This was
+        // previously an && chain, so a purchase only aborted when money AND honor
+        // AND vocation were all insufficient at once, letting players buy for free.
+        if (money > Connection.ActiveChar.Money ||
+            honorPoints > Connection.ActiveChar.HonorPoint ||
             vocationBadges > Connection.ActiveChar.VocationPoint)
             return;
 


### PR DESCRIPTION
Two fixes to the StoreBuy handler:

1. **Crash / #1276** — route purchases through `Inventory.TryAddNewItem` (your suggestion) so auto-equip trade-packs equip to the back slot instead of crashing on a bag slot, plus a free-slot pre-check so a full inventory aborts before any currency is deducted.
2. **Free-buy exploit** — the affordability guard used `&&` across money/honor/vocation, so a purchase only aborted when all three were insufficient at once. Buying with money while honor/vocation cost is 0 bypassed it and granted items for free. Changed to `||`.

Fixes #1276