### PR TITLE
fix(loot): skip null items when building a loot container

### DIFF
--- a/AAEmu.Game/Models/Game/Items/Containers/LootingContainer.cs
+++ b/AAEmu.Game/Models/Game/Items/Containers/LootingContainer.cs
@@ -215,6 +215,10 @@ public class LootingContainer(IBaseUnit owner)
                     foreach (var singleItemInGroup in selectByGroup)
                     {
                         var item = ItemManager.Instance.Create(singleItemInGroup.itemId, singleItemInGroup.count, singleItemInGroup.grade, false);
+                        // A loot pack can reference an item id that has no template; Create returns null.
+                        // Skip it instead of adding null, otherwise RegisterItems dereferences Item.Id and throws.
+                        if (item == null)
+                            continue;
                         resultsToAdd.Add(item);
                     }
                     RegisterItems(resultsToAdd);


### PR DESCRIPTION
A loot pack can reference an item id that no longer has a template (ItemManager.Create returns null). The loot builder added that null directly into the results list, and RegisterItems then dereferences newItem.Item.Id, throwing a NullReferenceException the moment a player loots the affected corpse. Skip null Create results.

Builds cleanly (dotnet build AAEmu.Game, 0 errors).