### PR TITLE
Fix sold items duplicating on relogin

### DIFF
--- a/AAEmu.Game/Core/Managers/ItemManager.cs
+++ b/AAEmu.Game/Core/Managers/ItemManager.cs
@@ -1914,6 +1914,24 @@ public class ItemManager(ISkillManager skillManager, IItemIdManager itemIdManage
     }
 
     /// <summary>
+    /// Queues an item's DB row for deletion on the next save WITHOUT freeing its
+    /// runtime id or removing it from the live item list. Used when an item moves
+    /// into a non-persisted (SlotType.None) container such as the BuyBack container,
+    /// so its old persisted row is not reloaded and duplicated on relogin. Because
+    /// Save() deletes queued rows before re-inserting current items, buying the item
+    /// back (which moves it into a persisted container again) still persists correctly.
+    /// </summary>
+    /// <param name="itemId">itemId whose database row should be removed</param>
+    public void MarkItemForDbDeletion(ulong itemId)
+    {
+        lock (_removedItems)
+        {
+            if (itemId != 0 && !_removedItems.Contains(itemId))
+                _removedItems.Add(itemId);
+        }
+    }
+
+    /// <summary>
     /// Releases a itemId for re-use, will also add it to the removed items list, use instead of itemIdManager.ReleaseId();
     /// </summary>
     /// <param name="itemId">itemId of the item to be freed up</param>

--- a/AAEmu.Game/Core/Packets/C2G/CSSellItemsPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSSellItemsPacket.cs
@@ -50,6 +50,14 @@ public class CSSellItemsPacket() : GamePacket(CSOffsets.CSSellItemsPacket, 1)
             {
                 Logger.Warn($"Failed to move sold itemId {item.Id} ({item.TemplateId}) to BuyBack ItemContainer for {Connection.ActiveChar.Name}");
             }
+            else
+            {
+                // BuyBack is a non-persisted (SlotType.None) container. Without this the
+                // item's existing persisted row would be reloaded and duplicated on
+                // relogin (#1189). Queue that row for deletion; buying the item back
+                // re-enters a persisted container and re-saves it.
+                ItemManager.Instance.MarkItemForDbDeletion(item.Id);
+            }
             money += (int)(item.Template.Refund * ItemManager.Instance.GetGradeTemplate(item.Grade).RefundMultiplier / 100f) *
                      item.Count;
         }


### PR DESCRIPTION
Selling an item moves it into the BuyBack container (a non-persisted `SlotType.None` container). The item left the Bag in memory but its persisted `items` row was never updated or deleted, so on relogin the stale row reloaded and the item reappeared while the player kept the sale money.

Queue the sold row for deletion via a new `ItemManager.MarkItemForDbDeletion` helper (adds to the removed-items list without freeing the runtime id). `Save()` deletes queued rows before re-inserting current items, so buying the item back still persists correctly.

Fixes #1189