### PR TITLE
Do not fire an offhand auto-attack when a shield is equipped

### DIFF
--- a/AAEmu.Game/Models/Tasks/Skills/UseAutoAttackSkillTask.cs
+++ b/AAEmu.Game/Models/Tasks/Skills/UseAutoAttackSkillTask.cs
@@ -93,7 +93,13 @@ public class UseAutoAttackSkillTask : SkillTask
             return null;
 
         var offhandItem = _caster.Equipment?.GetItemBySlot((int)EquipmentItemSlot.Offhand);
-        if (offhandItem?.Template is not WeaponTemplate)
+        if (offhandItem?.Template is not WeaponTemplate offhandWeapon)
+            return null;
+
+        // A shield is also a WeaponTemplate, but it must NOT produce an offhand
+        // auto-attack swing. Without this guard a sword+shield loadout swung the
+        // shield as if it were a dual-wield weapon (#1454).
+        if (offhandWeapon.HoldableTemplate?.SlotTypeId == (uint)EquipmentItemSlotType.Shield)
             return null;
 
         if (_offhandSkill != null)


### PR DESCRIPTION
`ResolveOffhandSkill` only rejected empty / non-weapon offhands, but a shield is also a `WeaponTemplate`, so a sword+shield loadout swung the shield as a dual-wield offhand auto-attack. Guard the shield slot type explicitly (same idiom already used in `UnitReqs`/`CharacterCombat`).

Fixes #1454