### PR TITLE
fix(sql): Remove USE statement

### DIFF
--- a/SQL/updates/2026-05-20_aaemu_game_died_in_pvp_flags.sql
+++ b/SQL/updates/2026-05-20_aaemu_game_died_in_pvp_flags.sql
@@ -1,5 +1,3 @@
-USE aaemu_game;
-
 -- Persist the PvP-death flags across server restarts so post-revive debuffs
 -- routing in CSResurrectCharacterPacket can recover the correct death context
 -- when a player happens to be dead at restart time.


### PR DESCRIPTION
Removed the stray USE statement.
Keeping it there, breaks the updates for anybody who didn't have their database schema named as `aaemu_game`