### PR TITLE
fix(docker): use glibc runtime image for the game server

### DIFF
--- a/AAEmu.Game/Dockerfile
+++ b/AAEmu.Game/Dockerfile
@@ -11,7 +11,7 @@ COPY ./AAEmu.Commons ./AAEmu.Commons
 COPY ./AAEmu.Game ./AAEmu.Game
 RUN dotnet publish ./AAEmu.Game/AAEmu.Game.csproj -c $CONFIGURATION -o /app/publish
 
-FROM mcr.microsoft.com/dotnet/runtime:10.0-alpine
+FROM mcr.microsoft.com/dotnet/runtime:10.0
 
 ARG CONFIGURATION
 ARG LOGIN_HOST
@@ -21,7 +21,7 @@ ARG DB_PORT
 ARG DB_USER
 ARG DB_PASSWORD
 
-RUN apk add --no-cache openssl mysql-client
+RUN apt-get update && apt-get install -y --no-install-recommends openssl default-mysql-client && rm -rf /var/lib/apt/lists/*
 
 WORKDIR app
 COPY --from=builder /app/publish ./


### PR DESCRIPTION
## Problem

The game server container crash-loops with SIGSEGV (exit 139) ~35s into boot on Linux, always during `AiGameData` load. The app log ends silently with no error; Docker daemon logs show `exitCode=139`.

## Root cause

The NLua native library (`liblua54.so`, Lua 5.4.8) bundled with AAEmu.Game is a **glibc build**, but `AAEmu.Game/Dockerfile` uses `mcr.microsoft.com/dotnet/runtime:10.0-alpine` (musl). Verified with `ldd`:

```
Error relocating /app/runtimes/linux-x64/native/liblua54.so: __snprintf_chk: symbol not found
Error relocating /app/runtimes/linux-x64/native/liblua54.so: __memcpy_chk: symbol not found
Error relocating /app/runtimes/linux-x64/native/liblua54.so: __longjmp_chk: symbol not found
Error relocating /app/runtimes/linux-x64/native/liblua54.so: __fprintf_chk: symbol not found
```

The binary loads lazily and runs fine until the Lua parser formats an error message (number formatting path `luaO_pushfstring` → `addnum2buff`), calls a missing glibc fortify symbol and jumps to a garbage address. Backtrace from gdb: `luaL_loadbufferx → luaY_parser → constructor → luaO_pushfstring → addnum2buff` at `0x7276`. First poisoned script is a npc_ai_params entry parsed during AiGameData load — the Docker install guide flow (`docker-install-local.sh` + `docker compose up -d`) hits this on every fresh Linux install.

## Fix

Switch the game runtime stage to the glibc-based `mcr.microsoft.com/dotnet/runtime:10.0` image and install `default-mysql-client` via apt instead of apk. The builder stage stays alpine (publish output is identical; only the runtime base changes).

## Verification

- Before: container restart-loops, dies at `GameDataManager - Loading AiGameData`
- After: server boots fully, all containers healthy, world spawns, clients connect
- Full Docker guide flow verified end-to-end on Ubuntu 24.04 / Docker 29

## Notes

- Present-tense commit, single squashed commit, branched from `develop` per CONTRIBUTING.md
- No tests apply (Dockerfile-only change); the Docker compose workflow is the test