### PR TITLE
feat(doodads): implement Devote, ReactDevote and ChangeOtherDoodadPhase funcs

### DIFF
--- a/AAEmu.Game/Core/Managers/UnitManagers/DoodadManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/DoodadManager.cs
@@ -919,6 +919,79 @@ public class DoodadManager(INonUnitObjectIdManager objectIdManager, IDoodadIdMan
             }
 
 
+            // doodad_func_devotes
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT * FROM doodad_func_devotes";
+                command.Prepare();
+                using (var reader = new SQLiteWrapperReader(command.ExecuteReader()))
+                {
+                    while (reader.Read())
+                    {
+                        var func = new DoodadFuncDevote
+                        {
+                            Id = reader.GetUInt32("id"),
+                            Count = reader.GetInt32("count"),
+                            ItemId = reader.GetUInt32("item_id"),
+                            ItemCount = reader.GetInt32("item_count"),
+                            TooltipText = reader.GetString("tooltip_text")
+                        };
+                        _funcTemplates["DoodadFuncDevote"].Add(func.Id, func);
+                    }
+                }
+            }
+
+
+            // doodad_func_change_other_doodad_phases
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT * FROM doodad_func_change_other_doodad_phases";
+                command.Prepare();
+                using (var reader = new SQLiteWrapperReader(command.ExecuteReader()))
+                {
+                    while (reader.Read())
+                    {
+                        // target_doodad_id is a varchar in the client data and is null on a couple of rows
+                        var targetDoodadId = 0u;
+                        if (!reader.IsDBNull("target_doodad_id"))
+                            _ = uint.TryParse(reader.GetString("target_doodad_id"), out targetDoodadId);
+
+                        var func = new DoodadFuncChangeOtherDoodadPhase
+                        {
+                            Id = reader.GetUInt32("id"),
+                            TargetDoodadId = targetDoodadId,
+                            TargetPhase = reader.GetInt32("target_phase"),
+                            NextPhase = reader.GetInt32("next_phase")
+                        };
+                        _phaseFuncTemplates["DoodadFuncChangeOtherDoodadPhase"].Add(func.Id, func);
+                    }
+                }
+            }
+
+
+            // doodad_func_react_devotes
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT * FROM doodad_func_react_devotes";
+                command.Prepare();
+                using (var reader = new SQLiteWrapperReader(command.ExecuteReader()))
+                {
+                    while (reader.Read())
+                    {
+                        var func = new DoodadFuncReactDevote
+                        {
+                            Id = reader.GetUInt32("id"),
+                            SkillId = reader.GetUInt32("skill_id"),
+                            Count = reader.GetInt32("count"),
+                            TooltipText = reader.GetString("tooltip_text"),
+                            NextPhase = reader.GetInt32("next_phase")
+                        };
+                        _phaseFuncTemplates["DoodadFuncReactDevote"].Add(func.Id, func);
+                    }
+                }
+            }
+
+
             // doodad_func_dig_terrains
             using (var command = connection.CreateCommand())
             {

--- a/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
@@ -855,6 +855,24 @@ public class Doodad : BaseUnit
     /// <param name="skillId"></param>
     public void OnSkillHit(BaseUnit caster, uint skillId)
     {
+        // Contribution counters on later construction phases react to a counting skill rather than
+        // to a player interaction, and live as phase funcs. Handled here because the phase func
+        // interface has no skill id to match against.
+        foreach (var phaseFunc in DoodadManager.Instance.GetPhaseFunc(FuncGroupId))
+        {
+            if (phaseFunc?.FuncType != nameof(DoodadFuncReactDevote))
+                continue;
+
+            if (DoodadManager.Instance.GetPhaseFuncTemplate(phaseFunc.FuncId, phaseFunc.FuncType)
+                is not DoodadFuncReactDevote reactDevote || reactDevote.SkillId != skillId)
+                continue;
+
+            if (reactDevote.RegisterHit(this))
+                DoChangePhase(caster, reactDevote.NextPhase);
+
+            return;
+        }
+
         var funcs = DoodadManager.Instance.GetFuncsForGroup(FuncGroupId);
         if (funcs == null) { return; }
 

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncChangeOtherDoodadPhase.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncChangeOtherDoodadPhase.cs
@@ -1,0 +1,61 @@
+using AAEmu.Game.Models.Game.DoodadObj.Templates;
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.Game.Models.Game.DoodadObj.Funcs;
+
+/// <summary>
+/// Drives doodads other than the one entering the phase. Used by the Auroria faction bases to switch
+/// their rank rewards on and off: reaching Prosperous (rank 4) flips the faction's Trade Outlet and
+/// its two Gilda Star merchants into their active phase, and the destroyed phase reverts them.
+/// </summary>
+/// <remarks>
+/// <see cref="TargetDoodadId"/> is a doodad *template* id, not an object id, so every doodad of that
+/// template in the same world is switched. In practice each template is faction-specific
+/// (12329 Nuian Trade Outlet vs 12330 Haranyan), so this does not leak across factions.
+/// The column is a varchar in the client data, but all 1010 rows hold a single plain integer or null.
+/// </remarks>
+public class DoodadFuncChangeOtherDoodadPhase : DoodadPhaseFuncTemplate
+{
+    // doodad_func_change_other_doodad_phases
+    public uint TargetDoodadId { get; set; }
+    public int TargetPhase { get; set; }
+    public int NextPhase { get; set; }
+
+    public override bool Use(BaseUnit caster, Doodad owner)
+    {
+        Logger.Trace("DoodadFuncChangeOtherDoodadPhase: TargetDoodadId {0}, TargetPhase {1}, ObjId {2}",
+            TargetDoodadId, TargetPhase, owner.ObjId);
+
+        if (TargetDoodadId > 0 && TargetPhase > 0 && owner.ParentWorld != null)
+        {
+            var changed = 0;
+            // Snapshot the matches: changing a phase can spawn or despawn doodads
+            foreach (var target in owner.ParentWorld.GetDoodadsByTemplateId(TargetDoodadId))
+            {
+                if (target == null || target.ObjId == owner.ObjId)
+                    continue;
+
+                target.DoChangePhase(caster, TargetPhase);
+                changed++;
+            }
+
+            if (changed > 0)
+            {
+                Logger.Info($"DoodadFuncChangeOtherDoodadPhase: doodad {owner.TemplateId} (objId {owner.ObjId}) moved {changed} doodad(s) of template {TargetDoodadId} to phase {TargetPhase}");
+            }
+            else
+            {
+                Logger.Warn($"DoodadFuncChangeOtherDoodadPhase: doodad {owner.TemplateId} (objId {owner.ObjId}) found no doodad of template {TargetDoodadId} to move to phase {TargetPhase}");
+            }
+        }
+
+        // A few rows carry no target and exist purely to move the owner on
+        if (NextPhase > 0)
+        {
+            owner.OverridePhase = NextPhase;
+            return true; // stop the remaining phase funcs so the override is taken
+        }
+
+        return false;
+    }
+}

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncDevote.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncDevote.cs
@@ -32,20 +32,31 @@ public class DoodadFuncDevote : DoodadFuncTemplate
         if (caster is not Character character)
             return;
 
-        // ConsumeItem happily consumes a partial amount, so verify the full cost is available first
+        // ConsumeItem happily consumes a partial amount, so verify the full cost is available first.
+        // The check has to run against the same container the consume does: Inventory.GetItemsCount
+        // would total up Inventory, Equipment and Bank, and materials split across those would pass
+        // the check while only the bag portion actually got taken.
         if (ItemId > 0 && ItemCount > 0)
         {
-            if (character.Inventory.GetItemsCount(ItemId) < ItemCount)
+            character.Inventory.Bag.GetAllItemsByTemplate(ItemId, -1, out _, out var availableInBag);
+            if (availableInBag < ItemCount)
             {
-                Logger.Debug($"DoodadFuncDevote: {character.Name} lacks {ItemCount}x item {ItemId} for doodad {owner.TemplateId} (objId {owner.ObjId})");
+                Logger.Debug($"DoodadFuncDevote: {character.Name} has {availableInBag}/{ItemCount} of item {ItemId} in their bag for doodad {owner.TemplateId} (objId {owner.ObjId})");
                 return;
             }
 
             var consumed = character.Inventory.Bag.ConsumeItem(ItemTaskType.DoodadItemChanger, ItemId, ItemCount, null);
+            if (consumed <= 0)
+            {
+                Logger.Warn($"DoodadFuncDevote: consumed nothing of item {ItemId} for doodad {owner.TemplateId} (objId {owner.ObjId})");
+                return;
+            }
+
             if (consumed < ItemCount)
             {
-                Logger.Warn($"DoodadFuncDevote: consumed only {consumed}/{ItemCount} of item {ItemId} for doodad {owner.TemplateId} (objId {owner.ObjId})");
-                return;
+                // Should be unreachable now the check matches the container, but the items are already
+                // gone at this point, so credit the contribution rather than take them for nothing
+                Logger.Error($"DoodadFuncDevote: consumed only {consumed}/{ItemCount} of item {ItemId} for doodad {owner.TemplateId} (objId {owner.ObjId}), crediting anyway");
             }
         }
 

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncDevote.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncDevote.cs
@@ -1,0 +1,84 @@
+using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.DoodadObj.Templates;
+using AAEmu.Game.Models.Game.Items.Actions;
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.Game.Models.Game.DoodadObj.Funcs;
+
+/// <summary>
+/// Contribution ("devote") interaction used by the Auroria faction bases, walls, bridges and
+/// purification monoliths. Each use consumes <see cref="ItemCount"/> of <see cref="ItemId"/> and
+/// raises the doodad's contribution counter by one. Once the counter reaches <see cref="Count"/>
+/// the doodad advances to the func's next phase.
+/// </summary>
+public class DoodadFuncDevote : DoodadFuncTemplate
+{
+    // doodad_func_devotes
+    /// <summary>Number of contributions required to advance to the next phase</summary>
+    public int Count { get; set; }
+    /// <summary>Item consumed per contribution</summary>
+    public uint ItemId { get; set; }
+    /// <summary>Amount of <see cref="ItemId"/> consumed per contribution</summary>
+    public int ItemCount { get; set; }
+    public string TooltipText { get; set; }
+
+    public override void Use(BaseUnit caster, Doodad owner, uint skillId, int nextPhase = 0)
+    {
+        Logger.Trace("DoodadFuncDevote: ItemId {0}, ItemCount {1}, Count {2}, ObjId {3}", ItemId, ItemCount, Count, owner.ObjId);
+
+        owner.ToNextPhase = false;
+
+        if (caster is not Character character)
+            return;
+
+        // ConsumeItem happily consumes a partial amount, so verify the full cost is available first
+        if (ItemId > 0 && ItemCount > 0)
+        {
+            if (character.Inventory.GetItemsCount(ItemId) < ItemCount)
+            {
+                Logger.Debug($"DoodadFuncDevote: {character.Name} lacks {ItemCount}x item {ItemId} for doodad {owner.TemplateId} (objId {owner.ObjId})");
+                return;
+            }
+
+            var consumed = character.Inventory.Bag.ConsumeItem(ItemTaskType.DoodadItemChanger, ItemId, ItemCount, null);
+            if (consumed < ItemCount)
+            {
+                Logger.Warn($"DoodadFuncDevote: consumed only {consumed}/{ItemCount} of item {ItemId} for doodad {owner.TemplateId} (objId {owner.ObjId})");
+                return;
+            }
+        }
+
+        var contributions = owner.Data + 1;
+
+        // Count <= 0 would mean a single contribution completes it
+        if (contributions < Count)
+        {
+            Logger.Debug($"DoodadFuncDevote: doodad {owner.TemplateId} (objId {owner.ObjId}) at {contributions}/{Count}, {Count - contributions} left");
+            PublishProgress(owner, contributions);
+            return;
+        }
+
+        // Target reached - reset so the counter is clean for whatever the next phase requires
+        Logger.Info($"DoodadFuncDevote: doodad {owner.TemplateId} (objId {owner.ObjId}) reached {Count} contributions, advancing to phase {nextPhase}");
+        PublishProgress(owner, 0);
+        owner.ToNextPhase = true;
+    }
+
+    /// <summary>
+    /// Stores the contribution counter and pushes it to nearby clients. The client already knows
+    /// the required total from its own copy of doodad_func_devotes and renders the remaining
+    /// amount, so Data carries the number of contributions made so far.
+    /// </summary>
+    /// <remarks>
+    /// Data is the doodad's generic per-instance int: it is serialized in Doodad.Write, persisted to
+    /// the doodads.data column, and its setter saves automatically when the doodad IsPersistent.
+    /// Using it as the counter means construction progress survives a restart with no extra storage.
+    /// Other doodad kinds (coffers) use Data for their own purpose, but a doodad is never both.
+    /// </remarks>
+    public static void PublishProgress(Doodad owner, int contributions)
+    {
+        owner.Data = contributions;
+        owner.BroadcastPacket(new SCDoodadChangedPacket(owner.ObjId, owner.Data), true);
+    }
+}

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncReactDevote.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncReactDevote.cs
@@ -1,0 +1,62 @@
+using AAEmu.Game.Models.Game.DoodadObj.Templates;
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.Game.Models.Game.DoodadObj.Funcs;
+
+/// <summary>
+/// Contribution counter driven by skill hits rather than direct interaction, used for the later
+/// Auroria base ranks. Every hit of <see cref="SkillId"/> raises the counter by one; reaching
+/// <see cref="Count"/> moves the doodad to <see cref="NextPhase"/>.
+/// </summary>
+/// <remarks>
+/// The counting skills (31315 Nuian / 30929 Haranyan) are effect-less 20m radius AoEs fired by
+/// quest components on completion, so finishing a colonization quest near the base lands one count.
+/// This is stored as a phase func, but the actual counting is driven from Doodad.OnSkillHit since
+/// the phase func interface carries no skill id.
+/// </remarks>
+public class DoodadFuncReactDevote : DoodadPhaseFuncTemplate
+{
+    // doodad_func_react_devotes
+    public uint SkillId { get; set; }
+    /// <summary>Number of skill hits required to advance to <see cref="NextPhase"/></summary>
+    public int Count { get; set; }
+    public string TooltipText { get; set; }
+    public int NextPhase { get; set; }
+
+    /// <summary>
+    /// Runs when the doodad enters this phase.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately does NOT reset the counter. Restoring a persistent doodad assigns FuncGroupId and
+    /// Data first, then calls InitDoodad, which runs DoChangePhase against the phase it is already in
+    /// and therefore reaches this method - zeroing here would wipe the restored progress on every
+    /// server start. The counter is instead cleared by whichever func advances the phase, which is
+    /// the only point where it genuinely needs to start over.
+    /// </remarks>
+    public override bool Use(BaseUnit caster, Doodad owner)
+    {
+        Logger.Trace("DoodadFuncReactDevote: SkillId {0}, Count {1}, ObjId {2}, at {3}", SkillId, Count, owner.ObjId, owner.Data);
+
+        return false; // don't stop the remaining phase funcs
+    }
+
+    /// <summary>
+    /// Registers one skill hit. Returns true when the target count is reached and the caller
+    /// should move the doodad to <see cref="NextPhase"/>.
+    /// </summary>
+    public bool RegisterHit(Doodad owner)
+    {
+        var contributions = owner.Data + 1;
+
+        if (contributions < Count)
+        {
+            Logger.Debug($"DoodadFuncReactDevote: doodad {owner.TemplateId} (objId {owner.ObjId}) at {contributions}/{Count}, {Count - contributions} left");
+            DoodadFuncDevote.PublishProgress(owner, contributions);
+            return false;
+        }
+
+        Logger.Info($"DoodadFuncReactDevote: doodad {owner.TemplateId} (objId {owner.ObjId}) reached {Count} hits of skill {SkillId}, advancing to phase {NextPhase}");
+        DoodadFuncDevote.PublishProgress(owner, 0);
+        return true;
+    }
+}

--- a/AAEmu.Game/Models/Game/World/WorldInstance.cs
+++ b/AAEmu.Game/Models/Game/World/WorldInstance.cs
@@ -426,6 +426,22 @@ public partial class WorldInstance(WorldTemplate template, uint channelId, bool 
     }
 
     /// <summary>
+    /// Get all Doodads in this instance that use a given template
+    /// </summary>
+    /// <param name="templateId">Doodad template id to match</param>
+    /// <returns></returns>
+    /// <remarks>
+    /// Filters in place rather than going through GetAllDoodads, which materialises a list of every
+    /// doodad in the world. DoodadFuncChangeOtherDoodadPhase can run this up to 15 times for a single
+    /// phase change, so the copy is what costs, not the comparison.
+    /// </remarks>
+    public List<Doodad> GetDoodadsByTemplateId(uint templateId)
+    {
+        var ret = _doodads.Where(x => x.Value.TemplateId == templateId).Select(y => y.Value).ToList();
+        return ret;
+    }
+
+    /// <summary>
     /// Get Active Unit by ObjId
     /// </summary>
     /// <param name="objId"></param>

--- a/AAEmu.Game/Scripts/Commands/DoodadCmd.cs
+++ b/AAEmu.Game/Scripts/Commands/DoodadCmd.cs
@@ -18,6 +18,7 @@ public class DoodadCmd : SubCommandBase, ICommand
         CallPrefix = $"{CommandManager.CommandPrefix}{CommandNames[0]}";
 
         Register(new DoodadChainSubCommand(), "chain");
+        Register(new DoodadDevoteSubCommand(), "devote");
         Register(new DoodadPhaseSubCommand(), "phase", "setphase");
         Register(new DoodadSaveSubCommand(), "save");
         Register(new DoodadPositionSubCommand(), "position", "pos");

--- a/AAEmu.Game/Scripts/SubCommands/Doodads/DoodadDevoteSubCommand.cs
+++ b/AAEmu.Game/Scripts/SubCommands/Doodads/DoodadDevoteSubCommand.cs
@@ -1,0 +1,125 @@
+using System.Drawing;
+
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.UnitManagers;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.DoodadObj.Funcs;
+using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Utils.Scripts;
+using AAEmu.Game.Utils.Scripts.SubCommands;
+
+namespace AAEmu.Game.Scripts.SubCommands.Doodads;
+
+/// <summary>
+/// Inspects or overrides the contribution counter used by DoodadFuncDevote, so construction
+/// content (Auroria bases, walls, bridges, purification monoliths) can be tested without
+/// grinding out every contribution.
+/// </summary>
+public class DoodadDevoteSubCommand : SubCommandBase
+{
+    public DoodadDevoteSubCommand()
+    {
+        Title = "[Doodad Devote]";
+        Description = "Show or set a doodad's contribution counter. Omit Count to just inspect. " +
+                      "Setting it to one below the target lets the next real contribution trigger the phase change.";
+        CallPrefix = $"{CommandManager.CommandPrefix}doodad devote";
+        AddParameter(new NumericSubCommandParameter<uint>("ObjId", "Object Id", true));
+        AddParameter(new NumericSubCommandParameter<int>("Count", "contributions made", false));
+    }
+
+    public override void Execute(ICharacter character, string triggerArgument, IDictionary<string, ParameterValue> parameters, IMessageOutput messageOutput)
+    {
+        uint doodadObjId = parameters["ObjId"];
+        var doodad = ((Character)character).ParentWorld.GetDoodad(doodadObjId);
+        if (doodad is null)
+        {
+            SendColorMessage(messageOutput, Color.Red, $"Doodad with objId {doodadObjId} does not exist");
+            return;
+        }
+
+        // The current phase counts contributions through either an interactive DoodadFuncDevote or a
+        // skill-driven DoodadFuncReactDevote. Work out which, so we can report the target and cost.
+        var target = 0;
+        var nextPhase = 0;
+        var describeCost = "";
+
+        foreach (var func in DoodadManager.Instance.GetFuncsForGroup(doodad.FuncGroupId))
+        {
+            if (func.FuncType != nameof(DoodadFuncDevote))
+                continue;
+
+            if (DoodadManager.Instance.GetFuncTemplate(func.FuncId, func.FuncType) is not DoodadFuncDevote devote)
+                continue;
+
+            target = devote.Count;
+            // For an interactive devote the destination lives on the doodad_funcs row, not the template
+            nextPhase = func.NextPhase;
+            describeCost = $"costing {devote.ItemCount}x item {devote.ItemId} each, then phase {nextPhase}";
+            break;
+        }
+
+        if (target == 0)
+        {
+            foreach (var phaseFunc in DoodadManager.Instance.GetPhaseFunc(doodad.FuncGroupId))
+            {
+                if (phaseFunc?.FuncType != nameof(DoodadFuncReactDevote))
+                    continue;
+
+                if (DoodadManager.Instance.GetPhaseFuncTemplate(phaseFunc.FuncId, phaseFunc.FuncType)
+                    is not DoodadFuncReactDevote reactDevote)
+                    continue;
+
+                target = reactDevote.Count;
+                nextPhase = reactDevote.NextPhase;
+                describeCost = $"driven by hits of skill {reactDevote.SkillId}, then phase {nextPhase}";
+                break;
+            }
+        }
+
+        if (target == 0)
+        {
+            SendColorMessage(messageOutput, Color.Orange,
+                $"Doodad {doodad.TemplateId} (objId {doodad.ObjId}) has no contribution counter on its current phase {doodad.FuncGroupId} - nothing to count");
+            return;
+        }
+
+        if (parameters.TryGetValue("Count", out var newCountValue))
+        {
+            int newCount = newCountValue;
+            if (newCount < 0)
+            {
+                SendColorMessage(messageOutput, Color.Red, "Count cannot be negative");
+                return;
+            }
+
+            DoodadFuncDevote.PublishProgress(doodad, newCount);
+            Logger.Warn($"{Title}: TemplateId {doodad.TemplateId}, objId {doodad.ObjId}, contributions set to {newCount}/{target}");
+
+            // Reaching the target normally advances the doodad, but that happens inside DoFunc /
+            // OnSkillHit which this command bypasses - so do it here too.
+            if (newCount >= target)
+            {
+                DoodadFuncDevote.PublishProgress(doodad, 0);
+
+                if (nextPhase > 0)
+                {
+                    SendMessage(messageOutput, $"Target reached, advancing to phase {nextPhase}");
+                    Logger.Warn($"{Title}: TemplateId {doodad.TemplateId}, objId {doodad.ObjId}, advancing to phase {nextPhase}");
+                    doodad.DoChangePhase((Unit)character, nextPhase);
+                }
+                else
+                {
+                    SendColorMessage(messageOutput, Color.Orange,
+                        $"Target reached but this phase has no next phase ({nextPhase}) - counter reset, doodad unchanged");
+                }
+
+                return;
+            }
+        }
+
+        SendMessage(messageOutput,
+            $"TemplateId {doodad.TemplateId}, ObjId {doodad.ObjId}, phase {doodad.FuncGroupId}: " +
+            $"{doodad.Data}/{target} contributions ({target - doodad.Data} left), " +
+            describeCost + (doodad.IsPersistent ? " [persistent]" : " [not persistent - progress lost on restart]"));
+    }
+}


### PR DESCRIPTION
Three doodad func types exist in the client data but were never implemented, so DoodadFunc.Use() resolved them to null and did nothing. That's ~1600 rows of data being ignored.

- DoodadFuncDevote (596 rows, 139 doodads) — contribution interactions. Used by the Auroria faction bases, walls and bridges, Territory Warehouse and Market Merchant, and the Red Dragon Daru events.
- DoodadFuncChangeOtherDoodadPhase (1010 rows, 118 doodads) — switches other doodads into another phase. Used by the base rank rewards and the god Authority doodads.
- DoodadFuncReactDevote (22 rows, 9 doodads) — same counter as Devote, but driven by skill hits instead of interaction.

Contribution progress is kept in Doodad.Data. The client already reads the remaining count from there, and it persists through doodads.data, so progress and rank survive a restart with no schema change.

Also adds WorldInstance.GetDoodadsByTemplateId — a single phase can carry up to 15 ChangeOtherDoodadPhase funcs and GetAllDoodads() copies the entire world list on every call — and a //doodad devote command to set a doodad's counter for testing.

Tested on 10.0.2.13: base site → rank 1 → rank 2, item consumption, the UI counter, persistence across restart, and rank 4 switching on the Trade Outlet and both merchants.

Video: https://discord.com/channels/479677351618281472/480106920401829909/1534635844160192614

Content data placing the Auroria structures will follow separately.