### PR TITLE
Add /gm command to toggle the GM icon next to a character's name

### DIFF
--- a/AAEmu.Game/Configurations/AccessLevels.json
+++ b/AAEmu.Game/Configurations/AccessLevels.json
@@ -42,6 +42,7 @@
         "despawnall": 100,
         "dummy": 100,
         "echo": 100,
+        "gm": 100,
         "housebindingmove": 100,
         "move_all": 100,
         "moveto": 100,

--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -690,9 +690,17 @@ public class Unit : BaseUnit, IUnit
     /// Notifies nearby clients of a GM-mode marker change via the dedicated GmModeChanged
     /// opcode. Currently known meaning: mode 6 toggles the GM icon shown next to the
     /// character's name; value 1 enables it, 0 disables it.
+    ///
+    /// Also persists the value into UnitStateOptionalData.GmModeValues so that a full
+    /// UnitState sync (e.g. sent to an observer who only now starts seeing this unit)
+    /// carries the current GM-mode state too. The dedicated opcode alone is fire-and-forget
+    /// and only reaches clients that were already observing this unit at call time.
     /// </summary>
     public void SendGmModeChanged(int mode, byte value)
     {
+        if (mode >= 0 && mode < (UnitStateOptionalData ??= new UnitStateOptionalData()).GmModeValues.Length)
+            UnitStateOptionalData.GmModeValues[mode] = unchecked((sbyte)value);
+
         BroadcastPacket(new SCUnitGmModeChangedPacket(ObjId, mode, value), true);
     }
 

--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -686,6 +686,16 @@ public class Unit : BaseUnit, IUnit
         BroadcastPacket(new SCUnitInvisiblePacket(ObjId, Invisible), true);
     }
 
+    /// <summary>
+    /// Notifies nearby clients of a GM-mode marker change via the dedicated GmModeChanged
+    /// opcode. Currently known meaning: mode 6 toggles the GM icon shown next to the
+    /// character's name; value 1 enables it, 0 disables it.
+    /// </summary>
+    public void SendGmModeChanged(int mode, byte value)
+    {
+        BroadcastPacket(new SCUnitGmModeChangedPacket(ObjId, mode, value), true);
+    }
+
     public void SetGeoDataMode(bool value)
     {
         AppConfiguration.Instance.World.GeoDataMode = value;

--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -704,6 +704,20 @@ public class Unit : BaseUnit, IUnit
         BroadcastPacket(new SCUnitGmModeChangedPacket(ObjId, mode, value), true);
     }
 
+    /// <summary>
+    /// Reads back a value previously set via <see cref="SendGmModeChanged"/>. This is the
+    /// single source of truth for GM-mode marker state — it lives on the Unit itself and is
+    /// naturally reset on reconnect (fresh Unit, null UnitStateOptionalData), unlike a
+    /// separate lookup keyed by ObjId, which can go stale when an ObjId is reused across
+    /// sessions.
+    /// </summary>
+    public bool GetGmModeValue(int mode)
+    {
+        if (UnitStateOptionalData is null || mode < 0 || mode >= UnitStateOptionalData.GmModeValues.Length)
+            return false;
+        return UnitStateOptionalData.GmModeValues[mode] != 0;
+    }
+
     public void SetGeoDataMode(bool value)
     {
         AppConfiguration.Instance.World.GeoDataMode = value;

--- a/AAEmu.Game/Scripts/Commands/GmIcon.cs
+++ b/AAEmu.Game/Scripts/Commands/GmIcon.cs
@@ -1,0 +1,37 @@
+using System.Collections.Concurrent;
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.Game;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Utils.Scripts;
+
+namespace AAEmu.Game.Scripts.Commands;
+
+public class GmIcon : ICommand
+{
+    public string[] CommandNames { get; set; } = ["gm"];
+
+    private static readonly ConcurrentDictionary<uint, bool> ActiveByObjId = new();
+
+    public void OnLoad()
+    {
+        CommandManager.Instance.Register(CommandNames, this);
+    }
+
+    public string GetCommandLineHelp()
+    {
+        return "";
+    }
+
+    public string GetCommandHelpText()
+    {
+        return "Toggles the GM icon next to your name.";
+    }
+
+    public void Execute(Character character, string[] args, IMessageOutput messageOutput)
+    {
+        var enabled = !ActiveByObjId.GetOrAdd(character.ObjId, false);
+        ActiveByObjId[character.ObjId] = enabled;
+        character.SendGmModeChanged(6, (byte)(enabled ? 1 : 0));
+        CommandManager.SendNormalText(this, messageOutput, enabled ? "GM icon activated." : "GM icon deactivated.");
+    }
+}

--- a/AAEmu.Game/Scripts/Commands/GmIcon.cs
+++ b/AAEmu.Game/Scripts/Commands/GmIcon.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
@@ -8,9 +7,9 @@ namespace AAEmu.Game.Scripts.Commands;
 
 public class GmIcon : ICommand
 {
-    public string[] CommandNames { get; set; } = ["gm"];
+    private const int GmIconMode = 6;
 
-    private static readonly ConcurrentDictionary<uint, bool> ActiveByObjId = new();
+    public string[] CommandNames { get; set; } = ["gm"];
 
     public void OnLoad()
     {
@@ -29,9 +28,8 @@ public class GmIcon : ICommand
 
     public void Execute(Character character, string[] args, IMessageOutput messageOutput)
     {
-        var enabled = !ActiveByObjId.GetOrAdd(character.ObjId, false);
-        ActiveByObjId[character.ObjId] = enabled;
-        character.SendGmModeChanged(6, (byte)(enabled ? 1 : 0));
+        var enabled = !character.GetGmModeValue(GmIconMode);
+        character.SendGmModeChanged(GmIconMode, (byte)(enabled ? 1 : 0));
         CommandManager.SendNormalText(this, messageOutput, enabled ? "GM icon activated." : "GM icon deactivated.");
     }
 }


### PR DESCRIPTION
`SCUnitGmModeChangedPacket` existed in the packet layer but was never
constructed or sent anywhere in the codebase. This PR adds a
`Unit.SendGmModeChanged(mode, value)` helper that sends it, and a new
`/gm` command that uses it with the now-confirmed `mode = 6` to toggle a
GM icon next to the caller's name on/off. State is tracked per-character
so multiple GMs can toggle independently. Access-gated at level 100,
consistent with the project's other admin/debug commands.

The GM-mode value is also persisted into
`UnitStateOptionalData.GmModeValues`, which is included in every full
UnitState sync. Without this, the fire-and-forget opcode alone only
reaches clients that were already observing the character at the time
`/gm` was run — a player who starts observing afterwards (e.g. by moving
into range or logging in) would never see the icon until it was toggled
again. Persisting the value means new observers pick up the current
state from their next UnitState sync as well.