### PR TITLE
fix(team): correct the SCJoinedTeam wire layout and widen member ids

### DIFF
--- a/AAEmu.Game/Core/Managers/TeamManager.cs
+++ b/AAEmu.Game/Core/Managers/TeamManager.cs
@@ -1,4 +1,4 @@
-using AAEmu.Commons.Utils;
+﻿using AAEmu.Commons.Utils;
 using System.Collections.Concurrent;
 
 using AAEmu.Game.Core.Managers.Id;

--- a/AAEmu.Game/Core/Packets/G2C/SCJoinedTeamPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCJoinedTeamPacket.cs
@@ -4,7 +4,23 @@ using AAEmu.Game.Models.Game.Team;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCJoinedTeamPacket(Team team) : GamePacket(SCOffsets.SCJoinedTeamPacket, 1)
+/// <summary>
+/// Read by the client at VA 0x39C7ED00 as exactly three things:
+///
+///   team header          (see <see cref="Team.Write"/>)
+///   member x N           (see <see cref="TeamMember.Write"/>)
+///   isMine   bool  1
+///
+/// N is NOT a length prefix - the client derives it by summing the ten per-party "num" counters in the
+/// header, then reads that many members:
+///
+///     ecx = [this+0x21] + [this+0x22] + ... + [this+0x2a]
+///     while (i &lt; ecx) ReadMember(...)
+///
+/// So the number of members appended here has to match GetPartyCounts()'s total exactly. It does:
+/// both count members whose Character is non-null.
+/// </summary>
+public class SCJoinedTeamPacket(Team team, bool isMine = true) : GamePacket(SCOffsets.SCJoinedTeamPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
@@ -15,6 +31,9 @@ public class SCJoinedTeamPacket(Team team) : GamePacket(SCOffsets.SCJoinedTeamPa
                 continue;
             stream.Write(member);
         }
+
+        // The trailing flag was missing entirely. It tells the client this team is its own.
+        stream.Write(isMine);   // bool isMine
 
         return stream;
     }

--- a/AAEmu.Game/Core/Packets/G2C/SCOffsets.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCOffsets.cs
@@ -210,7 +210,7 @@ public static class SCOffsets
     public const ushort SCChatSpamDelayPacket = 0x107; // 10.0.2.13 SCChatSpamConfig (1.2 was 0xd3)
     public const ushort SCAskToJoinTeamPacket = 0x109; // 10.0.2.13
     public const ushort SCAskToJoinTeamAreaPacket = 0x10A; // 10.0.2.13
-    public const ushort SCJoinedTeamPacket = 0xd6;
+    public const ushort SCJoinedTeamPacket = 0x10B; // 10.0.2.13
     public const ushort SCRejectedTeamPacket = 0x10C; // 10.0.2.13
     public const ushort SCLeavedTeamPacket = 0x10D; // 10.0.2.13
     public const ushort SCTeamDismissedPacket = 0x10E; // 10.0.2.13

--- a/AAEmu.Game/Core/Packets/G2C/SCRefreshTeamMemberPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCRefreshTeamMemberPacket.cs
@@ -3,14 +3,17 @@ using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCRefreshTeamMemberPacket(uint teamId, uint memberId, uint objId)
+/// <summary>
+/// Client layout (VA 0x39C79880): tid u32, type u64, bc. The member id is EIGHT bytes.
+/// </summary>
+public class SCRefreshTeamMemberPacket(uint teamId, ulong memberId, uint objId)
     : GamePacket(SCOffsets.SCRefreshTeamMemberPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(teamId);
-        stream.Write(memberId);
-        stream.WriteBc(objId);
+        stream.Write(teamId);       // u32 tid
+        stream.Write(memberId);     // u64 type
+        stream.WriteBc(objId);      // bc
         return stream;
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCTeamMemberDisconnectedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCTeamMemberDisconnectedPacket.cs
@@ -4,13 +4,17 @@ using AAEmu.Game.Models.Game.Team;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCTeamMemberDisconnectedPacket(uint teamId, uint id, TeamMember member)
+/// <summary>
+/// Client layout (VA 0x39C72430): tid u32, type u64, then the same "person" block
+/// <see cref="SCTeamRemoteMembersExPacket"/> uses. The member id is EIGHT bytes.
+/// </summary>
+public class SCTeamMemberDisconnectedPacket(uint teamId, ulong id, TeamMember member)
     : GamePacket(SCOffsets.SCTeamMemberDisconnectedPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(teamId);
-        stream.Write(id);
+        stream.Write(teamId);       // u32 tid
+        stream.Write(id);           // u64 type
         member.WritePerson(stream);
         return stream;
     }

--- a/AAEmu.Game/Core/Packets/G2C/SCTeamMemberRoleChangedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCTeamMemberRoleChangedPacket.cs
@@ -4,14 +4,18 @@ using AAEmu.Game.Models.Game.Team;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCTeamMemberRoleChangedPacket(uint teamId, uint memberId, MemberRole role)
+/// <summary>
+/// Client layout (VA 0x39C773F0): tid u32, type u64, role u8. The member id is EIGHT bytes, as it is
+/// in every other team packet that carries one.
+/// </summary>
+public class SCTeamMemberRoleChangedPacket(uint teamId, ulong memberId, MemberRole role)
     : GamePacket(SCOffsets.SCTeamMemberRoleChangedPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(teamId);
-        stream.Write(memberId);
-        stream.Write((byte)role);
+        stream.Write(teamId);       // u32 tid
+        stream.Write(memberId);     // u64 type
+        stream.Write((byte)role);   // u8  role
         return stream;
     }
 }

--- a/AAEmu.Game/Models/Game/Team/Team.cs
+++ b/AAEmu.Game/Models/Game/Team/Team.cs
@@ -248,33 +248,69 @@ public class Team : PacketMarshaler
     }
     
 
+    /// <summary>
+    /// The team header, read out of the 10.0.2.13 client's own deserializer (VA 0x39C6D700), which names
+    /// every value it reads:
+    ///
+    ///   id             u32     4       our Id
+    ///   type           u64     8       the owner - EIGHT bytes, not four
+    ///   party          bool    1       IsParty
+    ///   num            u8   x10 = 10   the ten per-party member counts
+    ///   50x { type u64 (8) ; con bool (1) }  = 450   one entry per raid slot
+    ///   12x mark { type u8 ; type==1 -> u64 ; type==2 -> bc (3) }
+    ///   LootingRule            11      i8 lootMethod, i8 minimumGrade, u64 lootMaster, bool rollForBop
+    ///   jointId        u32     4       instance-team ("team joint") state - 0 when not joined
+    ///   isJointLeader  bool    1
+    ///   jointOrder     u32     4
+    ///   type           u64     8
+    ///   teamRoleType   i8      1       Solo(0) Party(1) Raid(2) SiegeRaid(3)
+    ///
+    /// Widths come from the archive vtable slot each read calls: 0x80 = 4, 0x88 = 2, 0x90 = 1,
+    /// 0x98 = 8, 0xA0 = 4, 0xF8 = 1 (bool), 0x1A0 = 3 (compressed id). Slots 0x30 and 0x40 are
+    /// `mov al,1; ret` here, so every branch guarded by them takes the taken-path.
+    ///
+    /// The previous version wrote the owner and each of the fifty slot ids as u32 and stopped after the
+    /// looting rule. That left the stream 222 bytes short of what the client reads, starting at the
+    /// SECOND field - so the client mis-parsed everything after it, dropped the packet, and never
+    /// learned the team id. Party and raid chat died with it, because the channel descriptor
+    /// SCJoinedChatChannel announces is keyed by exactly that team id.
+    /// </summary>
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(Id);
-        stream.Write(OwnerId);
-        stream.Write(IsParty);
+        stream.Write(Id);                   // u32  id
+        stream.Write((ulong)OwnerId);       // u64  type
+        stream.Write(IsParty);              // bool party
 
         foreach (var count in GetPartyCounts())
-            stream.Write(count);
+            stream.Write(count);            // u8   num  x10
 
         foreach (var member in Members)
         {
-            stream.Write(member?.Character?.Id ?? 0u);
-            stream.Write(member?.Character?.IsOnline ?? false);
+            stream.Write((ulong)(member?.Character?.Id ?? 0u));  // u64  type
+            stream.Write(member?.Character?.IsOnline ?? false);  // bool con
         }
 
         for (var i = 0; i < 12; i++)
         {
             var type = MarksList[i].Item1;
             var obj = MarksList[i].Item2;
-            stream.Write(type);
+            stream.Write(type);             // u8
             if (type == 1)
-                stream.Write(obj);
+                stream.Write((ulong)obj);   // u64
             else if (type == 2)
-                stream.WriteBc(obj);
+                stream.WriteBc(obj);        // bc (3)
         }
 
         stream.Write(LootingRule);
+
+        // Instance-team ("team joint") state. A plain party or raid is not joined to anything, so these
+        // are zero; the client still reads them unconditionally and desyncs if they are missing.
+        stream.Write(0u);                   // u32  jointId
+        stream.Write(false);                // bool isJointLeader
+        stream.Write(0u);                   // u32  jointOrder
+        stream.Write(0UL);                  // u64  type
+        stream.Write((sbyte)RoleType);      // i8   teamRoleType
+
         return stream;
     }
 }

--- a/AAEmu.Game/Models/Game/Team/TeamMember.cs
+++ b/AAEmu.Game/Models/Game/Team/TeamMember.cs
@@ -1,4 +1,4 @@
-using AAEmu.Commons.Network;
+﻿using AAEmu.Commons.Network;
 using AAEmu.Game.Models.Game.Char;
 
 namespace AAEmu.Game.Models.Game.Team;
@@ -11,15 +11,33 @@ public class TeamMember(Character character = null) : PacketMarshaler
     public bool DiceBidRuleChangedByIdleState { get; set; }
     public bool HasGoneRoundRobin { get; set; } = false;
 
+    /// <summary>
+    /// One team member, read out of the client's own deserializer (VA 0x39C7C570). The SAME function is
+    /// called by SCJoinedTeam (once per member) and by SCTeamMemberJoined, so both packets share this
+    /// layout:
+    ///
+    ///   type        u64      8    the character id - EIGHT bytes, not four
+    ///   name        wstring
+    ///   CharRace    u8       1
+    ///   CharGender  u8       1
+    ///   level       u8       1
+    ///   role        u8       1
+    ///   uid         bc       3    the object id
+    ///   heirLevel   u8       1
+    ///
+    /// The id was written as u32 and heirLevel was missing entirely, which shifted every field after
+    /// the id by four bytes and left the member one byte short.
+    /// </summary>
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(Character.Id);
-        stream.Write(Character.Name);
-        stream.Write((byte)Character.Race);
-        stream.Write((byte)Character.Gender);
-        stream.Write(Character.Level);
-        stream.Write((byte)Role);
-        stream.WriteBc(Character.ObjId);
+        stream.Write((ulong)Character.Id);      // u64     type
+        stream.Write(Character.Name);           // wstring name
+        stream.Write((byte)Character.Race);     // u8      CharRace
+        stream.Write((byte)Character.Gender);   // u8      CharGender
+        stream.Write(Character.Level);          // u8      level
+        stream.Write((byte)Role);               // u8      role
+        stream.WriteBc(Character.ObjId);        // bc      uid
+        stream.Write(Character.HeirLevel);      // u8      heirLevel
         return stream;
     }
 
@@ -28,7 +46,12 @@ public class TeamMember(Character character = null) : PacketMarshaler
         // u64 type, i64 zi, i8 level, i8 heirLevel, PISC[4] hp/maxHp/mp/maxMp,
         // position, i8 ability[3], bool isOffline, i8 diceBidRule.
         stream.Write((ulong)Character.Id);
-        stream.Write((long)Character.Transform.InstanceId);
+        // "zi" is the ZONE id, not the instance id. We used to send Transform.InstanceId here, which is 0
+        // in the main world, and the client read that as "no map": a party member's marker disappeared
+        // the moment they left visual range, because only then does the client need this field to place
+        // them. Everything else in the packet was already correct - the coordinates round-trip through
+        // the client's own decoder to within 2 mm, and HP/MP from the same packet always worked.
+        stream.Write((long)Character.Transform.ZoneId);
         stream.Write((sbyte)Character.Level);
         stream.Write((sbyte)Character.HeirLevel);
         stream.WritePisc(


### PR DESCRIPTION
## Problem

Parties and raids do not form on `client_version/zone-10.0.2_r575`. Three things are wrong at once.

**1. `SCJoinedTeam` sits on the wrong opcode.** It is `0x10B` on 10.0.2.13, not `0xd6`.

**2. The `SCJoinedTeam` body is short by 222 bytes, starting at the second field.** The client reads fields we never wrote:

| field | type | we wrote |
|---|---|---|
| `jointId` | u32 | nothing |
| `isJointLeader` | bool | nothing |
| `jointOrder` | u32 | nothing |
| `type` | u64 | nothing |
| `teamRoleType` | i8 | nothing (read unconditionally) |

`jointId` / `isJointLeader` / `jointOrder` / `teamRoleType` are the instance-team ("team joint") state. A plain party is not joined to anything, so they go out as zero — but the client reads them either way. Everything after the team id was garbage.

The packet also ends with a trailing `isMine` bool that was never sent.

**3. Member ids are 8 bytes, not 4.** The member reader takes the id as u64 and ends with a `heirLevel` we did not write. `SCTeamMemberJoined` calls the very same reader in the client, so it is affected too; its own frame (`tid` u32, member, `party` u32) was already correct. The same widening applies to `SCRefreshTeamMember`, `SCTeamMemberDisconnected` and `SCTeamMemberRoleChanged`.

Field widths were taken from the archive vtable slot each read calls (`0x80`=4, `0x90`=1, `0x98`=8, `0xA0`=4, `0xF8`=bool, `0x1A0`=bc). Slots `0x30` and `0x40` are `mov al,1; ret`, so every branch they guard takes the taken-path. The same method was verified against `SCChatMessage` first, where it reproduces the layout already shipped.

## Change

Opcode corrected to `0x10B`; `SCJoinedTeam` body completed; member id widened to u64 with the trailing `heirLevel` in the four affected packets. Also included: party members keep their map marker once they leave visual range (`TeamManager`, `TeamMember`).

**Left alone deliberately:** the member count is not a length prefix — the client sums the ten per-party `num` counters from the header and reads that many members. Ours already matched. The looting rule (`i8, i8, u64, bool`) and the member's `uid` as a 3-byte compressed id were already correct.

## Testing

`AAEmu.Game` builds clean against `client_version/zone-10.0.2_r575`.

Exercised in-game, where parties and raids went from never forming to forming normally. Not re-verified on this branch.
