### PR TITLE
fix(world): players can see each other move

### DIFF
--- a/AAEmu.Game/Core/Packets/C2G/CSMoveUnitPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSMoveUnitPacket.cs
@@ -136,6 +136,17 @@ public class CSMoveUnitPacket() : GamePacket(CSOffsets.CSMoveUnitPacket, 1)
                     (float)MathUtil.ConvertDirectionToRadian(umt.RotationZ));
                 character.Transform.FinalizeTransform();
                 character.SetPlayerMoved();
+
+                // Fan this player's movement out to everyone around them.
+                //
+                // The zone-authority design assumed the zone would stream player movement back to us as
+                // part of ZWUnitMovements, which is why this path deliberately sent no SC packet. It does
+                // not: measured with two clients walking towards each other, every ZWUnitMovements batch
+                // contained only NPC ids and never a player's - so nobody ever saw anybody else move.
+                //
+                // Sent to everyone BUT the mover: the client integrates its own character locally and
+                // reports the finished state through CSMoveUnit, so echoing it back fights that prediction.
+                character.BroadcastPacket(new SCOneUnitMovementPacket(_objId, umt), false);
             }
             else if (_moveType is UnitMoveType controlledUnitMove)
             {
@@ -146,6 +157,11 @@ public class CSMoveUnitPacket() : GamePacket(CSOffsets.CSMoveUnitPacket, 1)
                     (float)MathUtil.ConvertDirectionToRadian(controlledUnitMove.RotationY),
                     (float)MathUtil.ConvertDirectionToRadian(controlledUnitMove.RotationZ));
                 mirrorTarget.Transform.FinalizeTransform();
+
+                // Same gap as for the character above: the zone never streams this back, so without a
+                // broadcast a ridden mount would stand still for everybody else. Mirrors what the
+                // pre-zone path does for mates.
+                mirrorTarget.BroadcastPacket(new SCOneUnitMovementPacket(_objId, controlledUnitMove), false);
             }
             else if (_moveType is VehicleMoveType vehicleMove && mirrorTarget is Slave vehicle)
             {
@@ -155,6 +171,10 @@ public class CSMoveUnitPacket() : GamePacket(CSOffsets.CSMoveUnitPacket, 1)
                 vehicle.Transform.Local.SetPosition(
                     vehicleMove.X, vehicleMove.Y, vehicleMove.Z, rotX, rotY, rotZ);
                 vehicle.Transform.FinalizeTransform();
+
+                // As above. The driver's own client authored this position, so the relay filters the
+                // zone's copy of wheeled vehicles back out for them anyway; observers need it from here.
+                vehicle.BroadcastPacket(new SCOneUnitMovementPacket(_objId, vehicleMove), false);
             }
             else if (_moveType is ShipRequestMoveType shipRequest && mirrorTarget is Slave ship)
             {


### PR DESCRIPTION
## Problem

Under zone authority, players cannot see each other move. Everyone stands frozen at the position they were first observed at.

`CSMoveUnitPacket` forwards the move to the dedicate and returns without broadcasting anything, on the assumption that the zone streams player movement back as part of `ZWUnitMovements`:

```
// Commercial: zone owns locomotion - forward CS move as WZ; do not
// broadcast Game SC as authority.
```

It does not. Instrumented with two clients walking towards each other, every batch carried only NPC ids and never a player's:

```
[MoveDiag] entries=12 online=2 [1104,1103] playerEntries=0 []
```

So the per-client AOI filter in `MovementRelay` was never the problem — it had nothing to drop.

## Change

`SCOneUnitMovement` is broadcast again from `CSMoveUnitPacket`, the way the pre-zone path already did, but **to everyone except the mover**: the client integrates its own character locally and reports the finished state through `CSMoveUnit`, so echoing it back fights that prediction.

The mount and vehicle branches returned without a broadcast for the same reason and get the same treatment. For the vehicle case the driver's own client authored the position, and the relay already filters the zone's copy of wheeled vehicles back out for them, so only observers need it from here.

One file, twenty added lines.

## Testing

`AAEmu.Game` builds clean against `client_version/zone-10.0.2_r575`.

Behaviour was confirmed with two clients — that is where the `[MoveDiag]` numbers above come from. Not re-verified in-game on this branch.
