### PR TITLE
fix(combat): a shield no longer triggers an offhand auto-attack

### DIFF
--- a/AAEmu.Game/Models/Tasks/Skills/UseAutoAttackSkillTask.cs
+++ b/AAEmu.Game/Models/Tasks/Skills/UseAutoAttackSkillTask.cs
@@ -94,7 +94,13 @@ public class UseAutoAttackSkillTask : SkillTask
             return null;
 
         var offhandItem = _caster.Equipment?.GetItemBySlot((int)EquipmentItemSlot.Offhand);
-        if (offhandItem?.Template is not WeaponTemplate)
+        if (offhandItem?.Template is not WeaponTemplate offhandWeapon)
+            return null;
+
+        // A shield is also a WeaponTemplate, but it must NOT produce an offhand
+        // auto-attack swing. Without this guard a sword+shield loadout swung the
+        // shield as if it were a dual-wield weapon (#1454).
+        if (offhandWeapon.HoldableTemplate?.SlotTypeId == (uint)EquipmentItemSlotType.Shield)
             return null;
 
         if (_offhandSkill != null)


### PR DESCRIPTION
## Problem

Equipping a shield triggers an offhand auto-attack. A shield is not a weapon, so the offhand swing should never fire for it.

This is the same defect as AAEmu#1454; `UseAutoAttackSkillTask` is unchanged on this branch, so the fix has not reached `client_version/zone-10.0.2_r575`.

## Change

`UseAutoAttackSkillTask` checks the offhand slot type before scheduling the offhand swing, so only an actual weapon in the offhand produces one.

One file, seven added lines.

## Testing

`AAEmu.Game` builds clean against `client_version/zone-10.0.2_r575`. Not re-verified in-game on this branch.
