### PR TITLE
fix(duel): make duelling work end to end on 10.0.2

### DIFF
--- a/AAEmu.Game/Core/Managers/DuelManager.cs
+++ b/AAEmu.Game/Core/Managers/DuelManager.cs
@@ -47,14 +47,47 @@ public class DuelManager : Singleton<DuelManager>, IDuelManager
         _duels.TryRemove(duel.Challenged.Id, out _);
     }
 
-    public void DuelRequest(Character challenger, uint challengedId)
+    public void DuelRequest(Character challenger, uint challengedId, byte duelType = 0)
     {
-        // приходит ID того, кого вызвали на дуэль
+        if (challenger == null)
+            return;
+
+        // The target used to be taken on trust: an unknown id produced a Duel with a null Challenged,
+        // and DuelAdd then threw on its Id, leaving a half-registered duel behind.
         var challenged = WorldManager.Instance.GetCharacterById(challengedId);
+        if (challenged == null)
+        {
+            challenger.SendErrorMessage(ErrorMessageType.BadDuelTarget);
+            Logger.Warn($"DuelRequest: challenged id {challengedId} is not online");
+            return;
+        }
+
+        if (challenged.Id == challenger.Id)
+        {
+            challenger.SendErrorMessage(ErrorMessageType.BadDuelSelf);
+            return;
+        }
+
+        // Neither side may already be involved. Without this the table kept an entry from every earlier
+        // request - including ones nobody ever answered - and both players stayed stuck as "already in
+        // a duel" with no way out short of a server restart. Both error messages already existed in
+        // ErrorMessageType and were never used by anything.
+        if (_duels.ContainsKey(challenger.Id))
+        {
+            challenger.SendErrorMessage(ErrorMessageType.AlreadyInDuel);
+            return;
+        }
+
+        if (_duels.ContainsKey(challenged.Id))
+        {
+            challenger.SendErrorMessage(ErrorMessageType.OtherAlreadyInDuel);
+            return;
+        }
+
         var duel = new Duel(challenger, challenged);
         DuelAdd(duel);
-        challenged.SendPacket(new SCDuelChallengedPacket(challenger.Id)); // we send only to the enemy
-        Logger.Warn($"DuelRequest: challenger={challenger.Id}:{challenger.ObjId}, challenged={challengedId}:{challenged.Id}:{challenged.ObjId}");
+        challenged.SendPacket(new SCDuelChallengedPacket(challenger.Id, duelType)); // we send only to the enemy
+        Logger.Info($"DuelRequest: challenger={challenger.Id}:{challenger.ObjId}, challenged={challenged.Id}:{challenged.ObjId}, type={duelType}");
     }
 
     public void DuelAccepted(Character challenged, uint challengerId)

--- a/AAEmu.Game/Core/Managers/DuelManager.cs
+++ b/AAEmu.Game/Core/Managers/DuelManager.cs
@@ -31,6 +31,13 @@ public class DuelManager : Singleton<DuelManager>, IDuelManager
     /// </summary>
     private static readonly TimeSpan CountdownDuration = TimeSpan.FromMilliseconds(3000);
 
+    /// <summary>
+    /// How long an unanswered invitation keeps both players reserved. The client has no timer of its
+    /// own - its challenge handler only builds the dialog - so if we do not expire the request nobody
+    /// will, and an ignored popup blocks both players from duelling for the rest of the session.
+    /// </summary>
+    private static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(30);
+
     // there can be several duels at the same time
     private readonly ConcurrentDictionary<uint, Duel> _duels = new();
     public Dictionary<uint, FactionsEnum> SaveFactions { get; set; } = [];
@@ -98,8 +105,73 @@ public class DuelManager : Singleton<DuelManager>, IDuelManager
 
         var duel = new Duel(challenger, challenged, duelType);
         DuelAdd(duel);
+
+        // Both players are now reserved. Arm the release before the invitation goes out, so that an
+        // ignored popup cannot leave them reserved for good.
+        duel.DuelRequestTimeoutTask = new DuelRequestTimeoutTask(challenger.Id);
+        TaskManager.Instance.Schedule(duel.DuelRequestTimeoutTask, RequestTimeout);
+
         challenged.SendPacket(new SCDuelChallengedPacket(challenger.Id, duelType)); // we send only to the enemy
         Logger.Info($"DuelRequest: challenger={challenger.Id}:{challenger.ObjId}, challenged={challenged.Id}:{challenged.ObjId}, type={duelType}");
+    }
+
+    /// <summary>
+    /// Called when nobody answered an invitation within <see cref="RequestTimeout"/>. Releases both
+    /// players. A duel that has already been accepted is left alone - it has its own end conditions.
+    /// </summary>
+    public void DuelRequestExpired(uint challengerId)
+    {
+        if (!_duels.TryGetValue(challengerId, out var duel))
+            return;
+
+        if (duel.DuelStarted)
+            return;
+
+        Logger.Info($"DuelRequestExpired: {duel.Challenger.Name} -> {duel.Challenged.Name} went unanswered, releasing both");
+        duel.Challenger.SendErrorMessage(ErrorMessageType.TargetRejectedDuel);
+        ReleaseDuel(duel);
+    }
+
+    /// <summary>
+    /// Cancels whatever duel a character is involved in when they leave the world.
+    /// </summary>
+    /// <remarks>
+    /// Logging out used to release nothing: the entry, and with it the reference to the Character, sat
+    /// in the table until the server restarted, and the player was refused every duel after their next
+    /// login. A duel already in progress is ended as cancelled so the opponent gets a result and their
+    /// faction and flag are cleaned up.
+    /// </remarks>
+    public void OnCharacterLogout(Character character)
+    {
+        if (character == null || !_duels.TryGetValue(character.Id, out var duel))
+            return;
+
+        if (duel.DuelStarted)
+        {
+            Logger.Info($"OnCharacterLogout: {character.Name} left during a duel, cancelling it");
+            DuelStop(character.Id, DuelDetType.Cancel, character.Id);
+            return;
+        }
+
+        // Still only an invitation. Tell whoever is left that it is off.
+        var other = duel.Challenger.Id == character.Id ? duel.Challenged : duel.Challenger;
+        Logger.Info($"OnCharacterLogout: {character.Name} left with a duel invitation pending, releasing both");
+        other.SendErrorMessage(ErrorMessageType.TargetRejectedDuel);
+        ReleaseDuel(duel);
+    }
+
+    /// <summary>
+    /// Frees both players from a duel that never started: cancel the timeout and drop the entry.
+    /// </summary>
+    private void ReleaseDuel(Duel duel)
+    {
+        if (duel.DuelRequestTimeoutTask != null)
+        {
+            _ = duel.DuelRequestTimeoutTask.Cancel();
+            duel.DuelRequestTimeoutTask = null;
+        }
+
+        DuelRemove(duel);
     }
 
     public void DuelAccepted(Character challenged, uint challengerId)
@@ -108,13 +180,27 @@ public class DuelManager : Singleton<DuelManager>, IDuelManager
         // приходит ID того, кто вызвал на дуэль
         try
         {
-            var duel = _duels[challengerId];
+            // The invitation can have expired while the popup sat on screen, so accepting one we no
+            // longer know about is normal rather than exceptional - say so instead of failing mutely.
+            if (!_duels.TryGetValue(challengerId, out var duel))
+            {
+                challenged.SendErrorMessage(ErrorMessageType.BadDuelTarget);
+                Logger.Info($"DuelAccepted: no pending duel for challenger {challengerId} - expired or withdrawn");
+                return;
+            }
 
             if (duel.DuelStarted == false)
             {
                 duel.DuelStarted = true;
                 duel.Challenger.IsInDuel = true;
                 duel.Challenged.IsInDuel = true;
+
+                // Answered in time - the reservation is now the duel's own business.
+                if (duel.DuelRequestTimeoutTask != null)
+                {
+                    _ = duel.DuelRequestTimeoutTask.Cancel();
+                    duel.DuelRequestTimeoutTask = null;
+                }
 
                 // spawn flag
                 _combatFlag = new DoodadSpawner
@@ -180,9 +266,13 @@ public class DuelManager : Singleton<DuelManager>, IDuelManager
 
     private void RestoreFaction(Unit owner)
     {
-        // restore the fraction
-        owner.SetFaction(SaveFactions[owner.Id]);
-        SaveFactions.Remove(owner.Id);
+        // A duel that never got as far as swapping factions has nothing saved here. Indexing blindly
+        // threw, and since this runs in the middle of winding the duel down, that throw used to take
+        // the release of both players with it.
+        if (!SaveFactions.Remove(owner.Id, out var faction))
+            return;
+
+        owner.SetFaction(faction);
     }
 
     public void DuelStart(uint id)
@@ -254,40 +344,56 @@ public class DuelManager : Singleton<DuelManager>, IDuelManager
 
     private void DuelCleanUp(uint id)
     {
+        if (!_duels.TryGetValue(id, out var duel))
+            return;
+
         try
         {
-            var duel = _duels[id];
-
             duel.Challenger.IsInDuel = false;
             duel.Challenged.IsInDuel = false;
 
-            if (duel.DuelStartTask != null)
-            {
-                _ = duel.DuelStartTask.Cancel();
-                duel.DuelStartTask = null;
-            }
-
-            if (duel.DuelEndTimerTask != null)
-            {
-                _ = duel.DuelEndTimerTask.Cancel();
-                duel.DuelEndTimerTask = null;
-            }
-
-            DuelRemove(duel);
+            // Every task has to go, not just the two that used to be listed here. The distance and
+            // result checks reschedule themselves once a second and each one holds the Duel - and with
+            // it both Characters - alive until it next fails to find the duel in the table.
+            duel.DuelRequestTimeoutTask = CancelTask(duel.DuelRequestTimeoutTask);
+            duel.DuelStartTask = CancelTask(duel.DuelStartTask);
+            duel.DuelEndTimerTask = CancelTask(duel.DuelEndTimerTask);
+            duel.DuelDistanceСheckTask = CancelTask(duel.DuelDistanceСheckTask);
+            duel.DuelResultСheckTask = CancelTask(duel.DuelResultСheckTask);
         }
         catch (Exception e)
         {
-            // id is missing in the database
-            Logger.Warn($"CleanUpDuel: Id={id} not found in duels[], error code: {e}");
+            Logger.Error($"CleanUpDuel: Id={id} threw while tidying up, dropping the entry anyway: {e}");
         }
+        finally
+        {
+            DuelRemove(duel);
+        }
+    }
+
+    /// <summary>Cancels a scheduled task if there is one, and hands back the null to store.</summary>
+    private static T CancelTask<T>(T task) where T : Models.Tasks.Task
+    {
+        if (task != null)
+            _ = task.Cancel();
+
+        return null;
     }
 
     public void DuelStop(uint id, DuelDetType det, uint loseId = 0)
     {
+        if (!_duels.TryGetValue(id, out var duel))
+        {
+            Logger.Warn($"DuelStop: Id={id} not found in duels[]");
+            return;
+        }
+
+        // Winding a duel down touches players who may already be halfway out of the world, so any of
+        // the steps below can throw. Releasing them is the one thing that must happen regardless -
+        // DuelCleanUp used to sit last inside the try, where a single throw above it skipped the
+        // release and left both players registered as duelling until the server restarted.
         try
         {
-            Logger.Warn("DuelStop: Duel ended");
-            var duel = _duels[id];
             duel.DuelAllowed = false;
 
             // A decided duel needs somebody to have lost it. Without that we cannot say who won, and
@@ -329,13 +435,14 @@ public class DuelManager : Singleton<DuelManager>, IDuelManager
             // Player cannot be attacked
             duel.Challenger.IsInBattle = false;
             duel.Challenged.IsInBattle = false;
-
-            DuelCleanUp(id);
         }
         catch (Exception e)
         {
-            // id is missing in the database
-            Logger.Warn($"DuelStop: Id={id} not found in duels[], error code: {e}");
+            Logger.Error($"DuelStop: Id={id} did not wind down cleanly, releasing both players anyway: {e}");
+        }
+        finally
+        {
+            DuelCleanUp(id);
         }
     }
 

--- a/AAEmu.Game/Core/Managers/DuelManager.cs
+++ b/AAEmu.Game/Core/Managers/DuelManager.cs
@@ -24,6 +24,13 @@ public class DuelManager : Singleton<DuelManager>, IDuelManager
     private const float DistanceForSurrender = 75; // square 75 meters
     private const double DuelDurationTime = 5;    // 5 min
 
+    /// <summary>
+    /// How long the client counts down before a duel begins. Not our choice: its countdown handler
+    /// (RVA 0x105E20) writes the constant 0xBB8 = 3000 ms, so anything else here would put our start
+    /// packet out of step with what the player is watching.
+    /// </summary>
+    private static readonly TimeSpan CountdownDuration = TimeSpan.FromMilliseconds(3000);
+
     // there can be several duels at the same time
     private readonly ConcurrentDictionary<uint, Duel> _duels = new();
     public Dictionary<uint, FactionsEnum> SaveFactions { get; set; } = [];
@@ -84,7 +91,12 @@ public class DuelManager : Singleton<DuelManager>, IDuelManager
             return;
         }
 
-        var duel = new Duel(challenger, challenged);
+        // The client discards SCDuelStarted when the duel type is 0, so a request that arrives without
+        // one would produce a duel that silently never begins. Fall back to a normal 1v1.
+        if (duelType == 0)
+            duelType = Duel.NormalDuel;
+
+        var duel = new Duel(challenger, challenged, duelType);
         DuelAdd(duel);
         challenged.SendPacket(new SCDuelChallengedPacket(challenger.Id, duelType)); // we send only to the enemy
         Logger.Info($"DuelRequest: challenger={challenger.Id}:{challenger.ObjId}, challenged={challenged.Id}:{challenged.ObjId}, type={duelType}");
@@ -120,9 +132,15 @@ public class DuelManager : Singleton<DuelManager>, IDuelManager
                 SetFaction(duel.Challenger, FactionsEnum.RedTeam);
                 SetFaction(duel.Challenged, FactionsEnum.BlueTeam);
 
+                // Start the client's countdown NOW, not together with the duel itself. The client runs
+                // it for a fixed 3000 ms of its own (see SCDuelStartCountdownPacket), so the start task
+                // below has to wait exactly that long - otherwise the countdown and the "fight" cue
+                // land in the same frame and the player never sees one.
+                duel.SendPacketsBoth(new SCDuelStartCountdownPacket());
+
                 //Schedule duel start task.
                 duel.DuelStartTask = new DuelStartTask(duel.Challenger.Id);
-                TaskManager.Instance.Schedule(duel.DuelStartTask, TimeSpan.FromSeconds(3));
+                TaskManager.Instance.Schedule(duel.DuelStartTask, CountdownDuration);
             }
             else
                 Logger.Warn($"DuelAccepted: Duel with challengerId = {challengerId} is already started");
@@ -172,10 +190,15 @@ public class DuelManager : Singleton<DuelManager>, IDuelManager
         try
         {
             var duel = _duels[id];
-            duel.SendPacketsBoth(new SCDuelStartedPacket(duel.Challenger.ObjId, duel.Challenged.ObjId));
+
+            // Each side is told who it is fighting, so the two packets are not the same - and the duel
+            // type has to travel with them or the client drops both. The countdown was sent three
+            // seconds ago, when the challenge was accepted.
+            duel.SendPacketChallenger(new SCDuelStartedPacket(duel.Challenged.ObjId, duel.DuelType));
+            duel.SendPacketChallenged(new SCDuelStartedPacket(duel.Challenger.ObjId, duel.DuelType));
+
             duel.SendPacketsBoth(new SCAreaChatBubblePacket(true, duel.Challenger.ObjId, 543));
             //duel.SendPacketChallenger(new SCAreaChatBubblePacket(true, duel.Challenged.ObjId, 543));
-            duel.SendPacketsBoth(new SCDuelStartCountdownPacket());
             duel.Challenger.DuelStateObjectId = duel.DuelFlag.ObjId;
             duel.Challenged.DuelStateObjectId = duel.DuelFlag.ObjId;
             duel.SendPacketsBoth(new SCDuelStatePacket(
@@ -266,26 +289,18 @@ public class DuelManager : Singleton<DuelManager>, IDuelManager
             Logger.Warn("DuelStop: Duel ended");
             var duel = _duels[id];
             duel.DuelAllowed = false;
-            // Duel is over, det 00=lose, 01=win, 02=surrender (Fled beyond the flag action border), 03=draw
-            if (det == DuelDetType.Draw)
+
+            // A decided duel needs somebody to have lost it. Without that we cannot say who won, and
+            // announcing a winner to both sides is worse than calling it a draw.
+            if (det == DuelDetType.Decided && loseId == 0)
             {
-                duel.SendPacketChallenged(new SCDuelEndedPacket(duel.Challenger.Id, duel.Challenged.Id, duel.Challenger.ObjId, duel.Challenged.ObjId, det));
-                duel.SendPacketChallenger(new SCDuelEndedPacket(duel.Challenged.Id, duel.Challenger.Id, duel.Challenged.ObjId, duel.Challenger.ObjId, det));
-                Logger.Warn("DuelStop: Draw!");
+                Logger.Warn($"DuelStop: Id={id} decided but no loser given, reporting a draw");
+                det = DuelDetType.Draw;
             }
-            else if (loseId != 0)
-            {
-                if (loseId == duel.Challenger.Id)
-                {
-                    duel.SendPacketsBoth(new SCDuelEndedPacket(duel.Challenged.Id, duel.Challenger.Id, duel.Challenged.ObjId, duel.Challenger.ObjId, det));
-                    Logger.Warn($"DuelStop: Challenger:{duel.Challenger.Name} Lose, Challenged:{duel.Challenged.Name} Win!");
-                }
-                else if (loseId == duel.Challenged.Id)
-                {
-                    duel.SendPacketsBoth(new SCDuelEndedPacket(duel.Challenger.Id, duel.Challenged.Id, duel.Challenger.ObjId, duel.Challenged.ObjId, det));
-                    Logger.Warn($"DuelStop: Challenger:{duel.Challenger.Name} Win, Challenged:{duel.Challenged.Name} Lose!");
-                }
-            }
+
+            SendDuelEnded(duel, det, loseId);
+            Logger.Info($"DuelStop: {duel.Challenger.Name} vs {duel.Challenged.Name}, det={det}, loser={loseId}");
+
             // Duel Status - Duel ended
             duel.Challenged.DuelStateObjectId = 0;
             duel.Challenger.DuelStateObjectId = 0;
@@ -322,6 +337,26 @@ public class DuelManager : Singleton<DuelManager>, IDuelManager
             // id is missing in the database
             Logger.Warn($"DuelStop: Id={id} not found in duels[], error code: {e}");
         }
+    }
+
+    /// <summary>
+    /// Announces the outcome to both duellists. SCDuelEnded carries an isWin flag and a list of
+    /// opponents, both from the receiving player's point of view, so the two sides get different
+    /// packets rather than one broadcast.
+    /// </summary>
+    private static void SendDuelEnded(Duel duel, DuelDetType det, uint loseId)
+    {
+        SendDuelEndedTo(duel.Challenger, duel.Challenged, det, loseId);
+        SendDuelEndedTo(duel.Challenged, duel.Challenger, det, loseId);
+    }
+
+    private static void SendDuelEndedTo(Character receiver, Character opponent, DuelDetType det, uint loseId)
+    {
+        // isWin only selects a text when the duel was decided; for a draw and for a cancelled duel the
+        // client's win and lose tables hold the same string, so the flag makes no difference there.
+        var isWin = det == DuelDetType.Decided && loseId != receiver.Id;
+
+        receiver.SendPacket(new SCDuelEndedPacket(isWin, det, [opponent.ObjId], [opponent.Id]));
     }
 
     public bool DuelResultСheck(uint id)

--- a/AAEmu.Game/Core/Managers/DuelManager.cs
+++ b/AAEmu.Game/Core/Managers/DuelManager.cs
@@ -189,6 +189,19 @@ public class DuelManager : Singleton<DuelManager>, IDuelManager
                 return;
             }
 
+            // challengerId is whatever the client sent. Without this the only thing needed to seize
+            // somebody else's pending duel is their challenger id: the accept would mutate that duel's
+            // participants and spawn its flag in the CALLER's world, with neither of the two players
+            // involved having agreed to anything.
+            if (duel.Challenged.Id != challenged.Id)
+            {
+                challenged.SendErrorMessage(ErrorMessageType.BadDuelTarget);
+                Logger.Warn(
+                    "DuelAccepted: {0} ({1}) tried to accept the duel {2} -> {3}, which is not theirs",
+                    challenged.Name, challenged.Id, challengerId, duel.Challenged.Id);
+                return;
+            }
+
             if (duel.DuelStarted == false)
             {
                 duel.DuelStarted = true;
@@ -323,22 +336,47 @@ public class DuelManager : Singleton<DuelManager>, IDuelManager
         }
     }
 
-    public void DuelCancel(uint challengerId, ErrorMessageType errorMessage)
+    /// <summary>
+    /// Declines or withdraws a pending duel.
+    /// </summary>
+    /// <param name="caller">
+    /// The character the request came from. Only the two participants may end their own duel - the
+    /// challenger withdrawing, the challenged declining. Null skips the check, for the server-side
+    /// callers that are not acting on behalf of a player.
+    /// </param>
+    public void DuelCancel(uint challengerId, ErrorMessageType errorMessage, Character caller = null)
     {
+        if (!_duels.TryGetValue(challengerId, out var duel))
+        {
+            Logger.Info($"DuelCancel: no pending duel for challenger {challengerId} - expired or already ended");
+            return;
+        }
+
+        // Same reasoning as in DuelAccepted: challengerId comes from the client, so without this a
+        // third party could cancel any duel whose challenger id they know.
+        if (caller != null && duel.Challenger.Id != caller.Id && duel.Challenged.Id != caller.Id)
+        {
+            Logger.Warn(
+                "DuelCancel: {0} ({1}) tried to cancel the duel {2} -> {3}, which they are not part of",
+                caller.Name, caller.Id, challengerId, duel.Challenged.Id);
+            return;
+        }
+
         try
         {
-            var duel = _duels[challengerId];
             duel.DuelAllowed = false;
             if (errorMessage != 0)
                 duel.Challenger.SendErrorMessage(errorMessage);
 
-            Logger.Warn($"DuelCancel: Duel with challengerId={challengerId} canceled, error={errorMessage}");
-            DuelCleanUp(challengerId);
+            Logger.Info($"DuelCancel: Duel with challengerId={challengerId} canceled, error={errorMessage}");
         }
         catch (Exception e)
         {
-            // id is missing in the database
-            Logger.Warn($"DuelCancel: Id={challengerId} not found in duels[], error code: {e}");
+            Logger.Error($"DuelCancel: Id={challengerId} did not cancel cleanly, releasing both players anyway: {e}");
+        }
+        finally
+        {
+            DuelCleanUp(challengerId);
         }
     }
 

--- a/AAEmu.Game/Core/Managers/IDuelManager.cs
+++ b/AAEmu.Game/Core/Managers/IDuelManager.cs
@@ -13,7 +13,7 @@ public interface IDuelManager : IInitializable
     void OnCharacterLogout(Character character);
     void DuelAccepted(Character challenged, uint challengerId);
     void DuelStart(uint id);
-    void DuelCancel(uint challengerId, ErrorMessageType errorMessage);
+    void DuelCancel(uint challengerId, ErrorMessageType errorMessage, Character caller = null);
     void DuelStop(uint id, DuelDetType det, uint loseId = 0);
     bool DuelResultСheck(uint id);
     DuelDistance DuelDistanceСheck(uint id);

--- a/AAEmu.Game/Core/Managers/IDuelManager.cs
+++ b/AAEmu.Game/Core/Managers/IDuelManager.cs
@@ -1,4 +1,4 @@
-using AAEmu.Game.Models.Game;
+﻿using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Duels;
 using AAEmu.Game.Models.StaticValues;
@@ -8,7 +8,7 @@ namespace AAEmu.Game.Core.Managers;
 public interface IDuelManager : IInitializable
 {
     Dictionary<uint, FactionsEnum> SaveFactions { get; set; }
-    void DuelRequest(Character challenger, uint challengedId);
+    void DuelRequest(Character challenger, uint challengedId, byte duelType = 0);
     void DuelAccepted(Character challenged, uint challengerId);
     void DuelStart(uint id);
     void DuelCancel(uint challengerId, ErrorMessageType errorMessage);

--- a/AAEmu.Game/Core/Managers/IDuelManager.cs
+++ b/AAEmu.Game/Core/Managers/IDuelManager.cs
@@ -9,6 +9,8 @@ public interface IDuelManager : IInitializable
 {
     Dictionary<uint, FactionsEnum> SaveFactions { get; set; }
     void DuelRequest(Character challenger, uint challengedId, byte duelType = 0);
+    void DuelRequestExpired(uint challengerId);
+    void OnCharacterLogout(Character character);
     void DuelAccepted(Character challenged, uint challengerId);
     void DuelStart(uint id);
     void DuelCancel(uint challengerId, ErrorMessageType errorMessage);

--- a/AAEmu.Game/Core/Managers/World/EnterWorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/EnterWorldManager.cs
@@ -253,6 +253,11 @@ public class EnterWorldManager(
             // Check if still mounted on somebody else's mount and dismount that if needed
             activeChar.ForceDismount(/*AttachUnitReason.PrefabChanged*/); // Dismounting a mount because of unsummoning sends "10" for this
 
+            // Cancel any duel or pending duel invitation. This has to happen before the character is
+            // deleted below: a duel that is still running needs the flag removed and both factions
+            // restored, and a reservation nobody releases blocks the player from ever duelling again.
+            DuelManager.Instance.OnCharacterLogout(activeChar);
+
             // Remove from Team (raid/party)
             teamManager.MemberRemoveFromTeam(activeChar, activeChar, RiskyAction.Leave);
 

--- a/AAEmu.Game/Core/Network/Connections/GameConnection.cs
+++ b/AAEmu.Game/Core/Network/Connections/GameConnection.cs
@@ -91,6 +91,11 @@ public class GameConnection
 
         if (ActiveChar != null)
         {
+            // Cancel any duel or pending invitation. This path is the one a crash or an Alt+F4 takes -
+            // it never reaches EnterWorldManager.LeaveWorldTask - so without it a player who dropped
+            // mid-duel stayed registered as duelling and was refused every duel after relogging.
+            DuelManager.Instance.OnCharacterLogout(ActiveChar);
+
             ActiveChar.ParentWorld?.GimmickManager?.ReleaseGrasps(ActiveChar.ObjId);
             AAEmu.Game.WorldIntegration.ReleaseZoneGimmickGrasps?.Invoke(ActiveChar);
             AAEmu.Game.WorldIntegration.OnPlayerLeave?.Invoke(ActiveChar.ObjId);

--- a/AAEmu.Game/Core/Packets/C2G/CSChallengeDuelPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSChallengeDuelPacket.cs
@@ -8,8 +8,11 @@ public class CSChallengeDuelPacket() : GamePacket(CSOffsets.CSChallengeDuelPacke
 {
     public override void Read(PacketStream stream)
     {
-        var challengedId = stream.ReadUInt32(); // Id the one we challenged to a duel
+        // Client layout (VA 0x39C673E0): duelType u8, then the challenged id as u64. We read a bare
+        // u32 and no duelType, so the id came out of the wrong bytes entirely.
+        var duelType = stream.ReadByte();       // u8  duelType
+        var challengedId = stream.ReadUInt64(); // u64 type - who we challenged
 
-        DuelManager.Instance.DuelRequest(Connection.ActiveChar, challengedId); // only to the enemy
+        DuelManager.Instance.DuelRequest(Connection.ActiveChar, (uint)challengedId, duelType);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSStartDuelPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSStartDuelPacket.cs
@@ -9,8 +9,12 @@ public class CSStartDuelPacket() : GamePacket(CSOffsets.CSStartDuelPacket, 1)
 {
     public override void Read(PacketStream stream)
     {
-        var challengerId = stream.ReadUInt32();  // ID of the one who challenged us to a duel
-        var errorMessage = stream.ReadInt16();  // 0 - accepted the duel, 507 - refused
+        // Client layout (VA 0x39C772B0): challenger id u64, error i16, duelType u8. Reading the id as
+        // u32 meant a decline looked up the wrong key, threw, and left the duel entry behind - which is
+        // how both players stayed "already in a duel" until a restart.
+        var challengerId = (uint)stream.ReadUInt64(); // u64 type - who challenged us
+        var errorMessage = stream.ReadInt16();        // i16 - 0 accepted, 507 refused
+        _ = stream.ReadByte();                        // u8  duelType
 
         Logger.Warn("StartDuel, Id: {0}, ErrorMessage: {1}", challengerId, errorMessage);
 

--- a/AAEmu.Game/Core/Packets/C2G/CSStartDuelPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSStartDuelPacket.cs
@@ -16,14 +16,20 @@ public class CSStartDuelPacket() : GamePacket(CSOffsets.CSStartDuelPacket, 1)
         var errorMessage = stream.ReadInt16();        // i16 - 0 accepted, 507 refused
         _ = stream.ReadByte();                        // u8  duelType
 
-        Logger.Warn("StartDuel, Id: {0}, ErrorMessage: {1}", challengerId, errorMessage);
+        Logger.Info("StartDuel, Id: {0}, ErrorMessage: {1}", challengerId, errorMessage);
 
+        var caller = Connection.ActiveChar;
+        if (caller == null)
+            return;
+
+        // Both paths are handed the caller, because challengerId is the client's word for whose duel
+        // this is. DuelManager checks it against the duel's own participants.
         if (errorMessage != 0)
         {
-            DuelManager.Instance.DuelCancel(challengerId, (ErrorMessageType)errorMessage);
+            DuelManager.Instance.DuelCancel(challengerId, (ErrorMessageType)errorMessage, caller);
             return;
         }
 
-        DuelManager.Instance.DuelAccepted(Connection.ActiveChar, challengerId);
+        DuelManager.Instance.DuelAccepted(caller, challengerId);
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCDuelChallengedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCDuelChallengedPacket.cs
@@ -3,11 +3,17 @@ using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCDuelChallengedPacket(uint challengedId) : GamePacket(SCOffsets.SCDuelChallengedPacket, 1)
+/// <summary>
+/// Client layout (VA 0x39C5B530): the challenger's id as u64, then duelType u8. We wrote a bare u32 -
+/// five bytes short, so the challenge popup had no valid challenger to answer to.
+/// </summary>
+public class SCDuelChallengedPacket(uint challengerId, byte duelType = 0)
+    : GamePacket(SCOffsets.SCDuelChallengedPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(challengedId);  // challengerId
+        stream.Write((ulong)challengerId);  // u64 type - who is challenging
+        stream.Write(duelType);             // u8  duelType
 
         return stream;
     }

--- a/AAEmu.Game/Core/Packets/G2C/SCDuelEndedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCDuelEndedPacket.cs
@@ -1,24 +1,44 @@
-﻿using AAEmu.Commons.Network;
+using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Models.Game.Duels;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
+/// <summary>
+/// Client layout (read at RVA 0xC88060), which names every field it reads:
+///
+///   isWin           bool                    did THIS recipient win
+///   det             u8                      see <see cref="DuelDetType"/>
+///   opponentUnitIds u32 count, count x bc   helper at RVA 0xC87350
+///   opponentCharIds u32 count, count x u64  helper at RVA 0xACD460
+///
+/// Both lists use the engine's standard vector encoding: a u32 "Size" followed by that many elements.
+/// We used to send "u32 challengerId, u32 challengedId, bc, bc, u8 det" - fifteen bytes of a layout
+/// this client never had. It read our first four bytes as isWin+det+the start of a count, then ran off
+/// the end of the packet, so no result message could ever appear.
+///
+/// The packet is written from the recipient's point of view, so each side gets its own copy. The lists
+/// are plural because a party duel has more than one opponent; a 1v1 sends one entry each.
+/// </summary>
 public class SCDuelEndedPacket(
-    uint challengerId,
-    uint challengedId,
-    uint challengerObjId,
-    uint challengedObjId,
-    DuelDetType det)
+    bool isWin,
+    DuelDetType det,
+    uint[] opponentObjIds,
+    ulong[] opponentCharIds)
     : GamePacket(SCOffsets.SCDuelEndedPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(challengerId);         // challengerId
-        stream.Write(challengedId);        // challengedId
-        stream.WriteBc(challengerObjId);  // challengerObjId
-        stream.WriteBc(challengedObjId); // challengedObjId
-        stream.Write((byte)det);        // det 00=lose, 01=win, 02=surrender, 3=draw
+        stream.Write(isWin);        // bool isWin
+        stream.Write((byte)det);    // u8   det
+
+        stream.Write((uint)opponentObjIds.Length);      // u32 Size
+        foreach (var objId in opponentObjIds)
+            stream.WriteBc(objId);                      // bc  v
+
+        stream.Write((uint)opponentCharIds.Length);     // u32 Size
+        foreach (var charId in opponentCharIds)
+            stream.Write(charId);                       // u64 type
 
         return stream;
     }

--- a/AAEmu.Game/Core/Packets/G2C/SCDuelStartCountdownPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCDuelStartCountdownPacket.cs
@@ -1,13 +1,24 @@
-﻿using AAEmu.Commons.Network;
+using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
+/// <summary>
+/// Tells the client to run its duel countdown. The packet genuinely has no body - its read function
+/// (RVA 0x5E5690) is a bare `ret`.
+/// </summary>
+/// <remarks>
+/// The duration is the client's, not ours: the handler at RVA 0x105E20 stamps the current time and
+/// writes the constant 0xBB8 - 3000 ms - so the countdown always runs for exactly three seconds. That
+/// is why this has to be sent when the duel is accepted and SCDuelStarted three seconds later. We used
+/// to send both from DuelStart in the same breath, and a countdown that ends the instant it begins is
+/// a countdown nobody sees.
+/// </remarks>
 public class SCDuelStartCountdownPacket() : GamePacket(SCOffsets.SCDuelStartCountdownPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        //<!-- no body -->
+        // no body
 
         return stream;
     }

--- a/AAEmu.Game/Core/Packets/G2C/SCDuelStartedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCDuelStartedPacket.cs
@@ -1,15 +1,34 @@
-﻿using AAEmu.Commons.Network;
+using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCDuelStartedPacket(uint challengerObjId, uint challengedObjId)
+/// <summary>
+/// Client layout (read at RVA 0xC5B5B0): a single bc, then duelType u8 - four bytes, not six.
+/// </summary>
+/// <remarks>
+/// Two things were wrong here. We wrote a second bc where the client reads duelType, so the byte it
+/// took as the duel type was the low byte of an object id; and nothing ever set a duel type in the
+/// first place. The handler at RVA 0x106710 opens with
+///
+///     call 0x7709D0        ; unit = GetUnitByObjId(bc)
+///     test rax, rax / je   ; unknown object -> do nothing
+///     test ebx, ebx / je   ; duelType == 0   -> do nothing
+///     cmp  ebx, 1          ; "start"
+///     cmp  ebx, 2          ; "start_party_duel"
+///
+/// so a zero duel type makes the client discard the packet in silence - no countdown, no start cue.
+/// The bc is the unit the start cue attaches to, and this packet therefore goes to each side
+/// separately carrying the OTHER player's object id, the same way SCDuelEnded is written from the
+/// recipient's point of view ("opponentUnitIds").
+/// </remarks>
+public class SCDuelStartedPacket(uint opponentObjId, byte duelType)
     : GamePacket(SCOffsets.SCDuelStartedPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.WriteBc(challengerObjId);  // challengerObjId
-        stream.WriteBc(challengedObjId); // challengedObjId
+        stream.WriteBc(opponentObjId);  // bc - whom this recipient is duelling
+        stream.Write(duelType);         // u8 duelType - 1 normal, 2 party duel; 0 is ignored
 
         return stream;
     }

--- a/AAEmu.Game/Core/Packets/G2C/UnitState/UnitStateCharacterSerializer.cs
+++ b/AAEmu.Game/Core/Packets/G2C/UnitState/UnitStateCharacterSerializer.cs
@@ -1,4 +1,4 @@
-using AAEmu.Commons.Network;
+﻿using AAEmu.Commons.Network;
 
 namespace AAEmu.Game.Core.Packets.G2C.UnitState;
 
@@ -31,8 +31,11 @@ internal static class UnitStateCharacterSerializer
         foreach (var ability in activeAbilities)
             stream.Write((byte)ability);
 
-        var factionId = (uint)(character.Faction?.Id ?? 0);
-        stream.WriteBc(factionId);
+        // This bc is the DUEL STATE object, not the faction. The client reads the block as
+        // "bc, duelTeamType, camp" (VA 0x39C3A61C4), and we wrote the faction id into it - so every
+        // player, having a non-zero faction, looked to the client as if they were already duelling,
+        // and "That person is already dueling." blocked every invite before the client sent one.
+        stream.WriteBc(character.DuelStateObjectId);
         stream.Write(unchecked((sbyte)character.DuelTeamType));
         stream.Write(unchecked((sbyte)character.Camp));
         character.VisualOptions.WriteOptions(stream);

--- a/AAEmu.Game/Models/Game/Duels/Duel.cs
+++ b/AAEmu.Game/Models/Game/Duels/Duel.cs
@@ -5,10 +5,22 @@ using AAEmu.Game.Models.Tasks.Duels;
 
 namespace AAEmu.Game.Models.Game.Duels;
 
-public class Duel(Character challenger, Character challenged)
+public class Duel(Character challenger, Character challenged, byte duelType = 1)
 {
+    /// <summary>A plain 1v1. The client's start handler maps this to its "start" cue.</summary>
+    public const byte NormalDuel = 1;
+
+    /// <summary>A party duel - the client's "start_party_duel" cue.</summary>
+    public const byte PartyDuel = 2;
+
     public Character Challenger { get; set; } = challenger; // это персонаж который вызвал нас на дуэль
     public Character Challenged { get; set; } = challenged; // это наш персонаж (т.е. connection.ActiveChar)
+
+    /// <summary>
+    /// Echoed back in SCDuelStarted. The client ignores that packet outright when this is 0, so it has
+    /// to be carried from the challenge all the way to the start.
+    /// </summary>
+    public byte DuelType { get; set; } = duelType;
     public Doodad DuelFlag { get; set; }
     public DuelStartTask DuelStartTask { get; set; }
     public DuelEndTimerTask DuelEndTimerTask { get; set; }

--- a/AAEmu.Game/Models/Game/Duels/Duel.cs
+++ b/AAEmu.Game/Models/Game/Duels/Duel.cs
@@ -23,6 +23,9 @@ public class Duel(Character challenger, Character challenged, byte duelType = 1)
     public byte DuelType { get; set; } = duelType;
     public Doodad DuelFlag { get; set; }
     public DuelStartTask DuelStartTask { get; set; }
+
+    /// <summary>Releases both players again if the invitation is never answered.</summary>
+    public DuelRequestTimeoutTask DuelRequestTimeoutTask { get; set; }
     public DuelEndTimerTask DuelEndTimerTask { get; set; }
     public DuelDistanceСheckTask DuelDistanceСheckTask { get; set; }
     public DuelResultСheckTask DuelResultСheckTask { get; set; }

--- a/AAEmu.Game/Models/Game/Duels/DuelDetType.cs
+++ b/AAEmu.Game/Models/Game/Duels/DuelDetType.cs
@@ -1,10 +1,26 @@
-﻿namespace AAEmu.Game.Models.Game.Duels;
+namespace AAEmu.Game.Models.Game.Duels;
 
+/// <summary>
+/// The outcome code carried by SCDuelEnded. These are the client's own values, taken from the two
+/// message tables its handler indexes with this field (RVA 0x1551118 for a loss, 0x1551130 for a win):
+///
+///   det 0 -> "result_draw"    both tables
+///   det 1 -> "result_loser" / "result_winner"   - the isWin flag picks between them
+///   det 2 -> "result_cancel"  both tables
+///
+/// There is no entry 3: the win table ends after three pointers, so a det of 3 reads past it and the
+/// client shows garbage. The previous values (Lose=0, Win=1, Surrender=2, Draw=3) were from an older
+/// protocol - a draw addressed the missing fourth slot and every decided duel announced "draw" to the
+/// loser, which is why no result message ever appeared correctly.
+/// </summary>
 public enum DuelDetType : byte
 {
-    // det 00=lose, 01=win, 02=surrender (Fled beyond the flag action border), 03=draw
-    Lose = 0,
-    Win = 1,
-    Surrender = 2,
-    Draw = 3
+    /// <summary>Nobody won - both sides see "result_draw".</summary>
+    Draw = 0,
+
+    /// <summary>Someone won; the per-recipient isWin flag decides which text each side gets.</summary>
+    Decided = 1,
+
+    /// <summary>The duel was broken off (fled past the flag, timed out) - both sides see "result_cancel".</summary>
+    Cancel = 2
 }

--- a/AAEmu.Game/Models/Tasks/Duels/DuelDistanceСheckTask.cs
+++ b/AAEmu.Game/Models/Tasks/Duels/DuelDistanceСheckTask.cs
@@ -18,10 +18,10 @@ public class DuelDistanceСheckTask(Duel duel) : Task
         switch (res)
         {
             case DuelDistance.ChallengerFar:
-                DuelManager.Instance.DuelStop(_challengedId, DuelDetType.Surrender, _challengerId);
+                DuelManager.Instance.DuelStop(_challengedId, DuelDetType.Cancel, _challengerId);
                 break;
             case DuelDistance.ChallengedFar:
-                DuelManager.Instance.DuelStop(_challengerId, DuelDetType.Surrender, _challengedId);
+                DuelManager.Instance.DuelStop(_challengerId, DuelDetType.Cancel, _challengedId);
                 break;
             case DuelDistance.Error:
                 break;

--- a/AAEmu.Game/Models/Tasks/Duels/DuelEndTimerTask.cs
+++ b/AAEmu.Game/Models/Tasks/Duels/DuelEndTimerTask.cs
@@ -32,11 +32,11 @@ public class DuelEndTimerTask(Duel duel, uint challengerId) : Task
 
         if (_duel.Challenger.Hp < _duel.Challenged.Hp)
         {
-            DuelManager.Instance.DuelStop(_duel.Challenged.Id, DuelDetType.Win, _challengerId);
+            DuelManager.Instance.DuelStop(_duel.Challenged.Id, DuelDetType.Decided, _challengerId);
         }
         else if (_duel.Challenger.Hp > _duel.Challenged.Hp)
         {
-            DuelManager.Instance.DuelStop(_challengerId, DuelDetType.Win, _duel.Challenged.Id);
+            DuelManager.Instance.DuelStop(_challengerId, DuelDetType.Decided, _duel.Challenged.Id);
         }
         else if (_duel.Challenger.Hp == _duel.Challenged.Hp)
         {

--- a/AAEmu.Game/Models/Tasks/Duels/DuelRequestTimeoutTask.cs
+++ b/AAEmu.Game/Models/Tasks/Duels/DuelRequestTimeoutTask.cs
@@ -1,0 +1,21 @@
+using AAEmu.Game.Core.Managers;
+
+namespace AAEmu.Game.Models.Tasks.Duels;
+
+/// <summary>
+/// Drops a duel invitation that was never answered.
+/// </summary>
+/// <remarks>
+/// A request reserves both players the moment it is sent, but nothing released that reservation
+/// unless the target explicitly accepted or declined. The client offers no way out either - its
+/// challenge handler (RVA 0x106690) only builds the dialog and stores the challenger id; there is no
+/// timer behind it, so an ignored popup simply stays on screen. Without this task both players stayed
+/// registered forever and every later duel was refused with "already in a duel".
+/// </remarks>
+public class DuelRequestTimeoutTask(uint challengerId) : Task
+{
+    public override void Execute()
+    {
+        DuelManager.Instance.DuelRequestExpired(challengerId);
+    }
+}

--- a/AAEmu.Game/Models/Tasks/Duels/DuelResultСheckTask.cs
+++ b/AAEmu.Game/Models/Tasks/Duels/DuelResultСheckTask.cs
@@ -19,11 +19,11 @@ public class DuelResultСheckTask(Duel duel) : Task
         {
             if (_duel.Challenger.Hp <= 1)
             {
-                DuelManager.Instance.DuelStop(_challengedId, DuelDetType.Win, _challengerId);
+                DuelManager.Instance.DuelStop(_challengedId, DuelDetType.Decided, _challengerId);
             }
             else if (_duel.Challenged.Hp <= 1)
             {
-                DuelManager.Instance.DuelStop(_challengerId, DuelDetType.Win, _challengedId);
+                DuelManager.Instance.DuelStop(_challengerId, DuelDetType.Decided, _challengedId);
             }
             else if (_duel.Challenger.Hp <= 1 && _duel.Challenged.Hp <= 1)
             {


### PR DESCRIPTION
## Problem

Duelling does not work on `client_version/zone-10.0.2_r575`. Every stage of it is broken, and each failure is silent — the client simply does nothing, so none of these are visible from the log. On top of that, a duel that ended badly never released the players again.

**Nobody can be challenged.** `UnitStateCharacterSerializer` writes the faction id into a `bc` that the client reads as the *duel state* object — the block is `bc, duelTeamType, camp` (RVA 0x39C3A61C4). Every player carries a non-zero faction, so to every client everyone already looked like they were duelling, and *"That person is already dueling."* rejected the invite before it was ever sent.

**The challenge packet is misread.** `CSChallengeDuel` is `duelType u8` followed by the challenged id as **u64** (RVA 0x39C673E0). We read a bare u32 and no duel type, so the id came out of the wrong bytes entirely.

**The start cue is discarded.** `SCDuelStarted` is a single `bc` plus `duelType u8` — four bytes, not two `bc`s. We wrote a second `bc` where the client reads the type, and nothing ever set a duel type in the first place. Its handler (RVA 0x106710) opens with:

```
call 0x7709D0        ; unit = GetUnitByObjId(bc)
test rax, rax / je   ; unknown object -> do nothing
test ebx, ebx / je   ; duelType == 0   -> do nothing
cmp  ebx, 1          ; "start"
cmp  ebx, 2          ; "start_party_duel"
```

A zero duel type makes the client drop the packet without a trace.

**The countdown is never seen.** `SCDuelStartCountdown` has no body — its read function (RVA 0x5E5690) is a bare `ret` — and its duration is the client's own: the handler (RVA 0x105E20) stamps the time and writes the constant `0xBB8` = 3000 ms. It has to be sent when the challenge is **accepted**, with the start following three seconds later. Both were sent from `DuelStart` in the same breath, and a countdown that ends the instant it begins is one nobody sees.

**No result is ever shown.** `SCDuelEnded` is written from the recipient's point of view (RVA 0xC88060):

| field | type |
|---|---|
| `isWin` | bool |
| `det` | u8 |
| `opponentUnitIds` | u32 count, then count × bc |
| `opponentCharIds` | u32 count, then count × u64 |

Both lists use the engine's standard vector encoding. We sent `u32 challengerId, u32 challengedId, bc, bc, u8 det` — fifteen bytes of a layout this client never had, so it read our first four bytes as `isWin` + `det` + the start of a count and then ran off the end of the packet.

**The outcome codes are from an older protocol.** The client indexes two message tables with `det` (0x1551118 for a loss, 0x1551130 for a win):

| det | lose table | win table |
|---|---|---|
| 0 | `result_draw` | `result_draw` |
| 1 | `result_loser` | `result_winner` |
| 2 | `result_cancel` | `result_cancel` |

There is no entry 3 — the win table ends after three pointers. The old `Lose=0, Win=1, Surrender=2, Draw=3` meant a draw read past the end of the table, and every decided duel announced *"draw"* to the loser.

**And once you were in a duel, you could stay in it forever.** A duel reserves both players the moment the invitation is sent, but almost nothing released that reservation again:

- An **unanswered invitation** was never dropped. The client offers no way out of it either — its challenge handler (RVA 0x106690) only builds the dialog and stores the challenger id, with no timer behind it — so an ignored popup blocked both players for the rest of the session.
- **Logging out released nothing.** The entry, and with it the reference to the `Character`, stayed in the table; the player was refused every duel after their next login.
- **`DuelStop` did its cleanup last inside the `try`**, so a single throw while winding down — easy enough when a player is already halfway out of the world — skipped the release entirely.
- **`DuelCleanUp` cancelled only two of the five tasks.** The distance and result checks reschedule themselves once a second and each one holds the `Duel`, and with it both `Character`s, alive until it next fails to find the duel in the table.
- **`RestoreFaction` indexed `SaveFactions` blindly.** A duel that never got as far as swapping factions has nothing stored there, and the throw took the release of both players with it.

## Change

Wire format:

- `UnitStateCharacterSerializer` carries `DuelStateObjectId` instead of the faction id.
- `CSChallengeDuel` reads `duelType u8` + `u64` id; the type is carried through `DuelRequest` → `SCDuelChallenged` → `Duel` → `SCDuelStarted`. A request arriving without a type falls back to a normal 1v1, since 0 would be dropped.
- `SCDuelStarted` sends one packet per side naming the **other** player, with the duel type.
- `SCDuelStartCountdown` goes out on accept; the start task waits the client's own 3000 ms.
- `SCDuelEnded` rewritten to the real layout and sent per recipient with its own `isWin`.
- `DuelDetType` becomes `Draw = 0`, `Decided = 1`, `Cancel = 2`; the distance and result tasks follow.

Lifecycle:

- `DuelRequestTimeoutTask` expires an unanswered invitation after 30 seconds and releases both players.
- `OnCharacterLogout` is called from both the clean leave path (`EnterWorldManager`) and the disconnect path (`GameConnection`, which is what a crash or Alt+F4 takes). A duel in progress ends as cancelled, so the opponent gets a result and the flag and factions are cleaned up.
- `DuelStop` moves its cleanup into a `finally`; `DuelCleanUp` cancels every task and drops the entry regardless of what threw.
- `RestoreFaction` no longer throws when there is nothing saved.
- `DuelRequest` stops trusting the target: an unknown id used to build a `Duel` with a null `Challenged`, and `DuelAdd` then threw on its `Id`, leaving a half-registered duel behind. Self-duels and repeat requests are rejected.
- Accepting an invitation that has already expired is an ordinary outcome with a message, instead of an unhandled lookup.

## Review fix

**Only the two participants may answer their own duel.** `challengerId` arrives from the client and nothing bound it to the character sending it, so knowing or guessing one was enough to seize a pending duel between two other players: the accept mutated that duel's participants and spawned its flag in the **caller's** world, with neither of the two actual players having agreed to anything. Declining had the same hole.

`DuelAccepted` now requires the responder to be the duel's `Challenged`, and `DuelCancel` takes the caller and requires them to be one of the two. `CSStartDuel` passes the connection's own character down both paths; the parameter is optional so the server-side callers that act on nobody's behalf keep working.

`DuelCancel` also stops indexing `_duels` blindly — a decline for a duel that had already expired threw — and moves its cleanup into a `finally`, the way `DuelStop` does, so a throw cannot leave both players registered as duelling.

The other finding, that pending duels never expire, is covered by the lifecycle commit already in this PR: `DuelRequestTimeoutTask` drops an unanswered invitation after 30 seconds and `OnCharacterLogout` releases both players on a clean leave and on a disconnect.

## Testing

`AAEmu.Game` builds clean against `client_version/zone-10.0.2_r575`.

Verified in-game on a 10.0.2.13 client: a duel now runs end to end — challenge, the three-second countdown, the fight, and the result message on both sides.

The layouts themselves were derived from the client's own read functions and message tables, at the RVAs quoted above.
