### PR TITLE
feat(plot): implement the v10 condition kinds, fix AoE targeting and the plot-skill crash

### DIFF
--- a/AAEmu.Game/Core/Managers/PlotManager.cs
+++ b/AAEmu.Game/Core/Managers/PlotManager.cs
@@ -108,7 +108,11 @@ public class PlotManager : Singleton<PlotManager>, IPlotManager
                             Kind = (PlotConditionType)reader.GetInt32("kind_id"),
                             Param1 = reader.GetInt32("param1"),
                             Param2 = reader.GetInt32("param2"),
-                            Param3 = reader.GetInt32("param3")
+                            Param3 = reader.GetInt32("param3"),
+                            // Kind 20 (unit_reqs) carries its checks in unit_reqs rows owned by this condition
+                            // rather than in param1..3 — 1519 of the 1605 rows leave all three at 0. This flag
+                            // decides whether those rows are ANDed or ORed, exactly as skills.or_unit_reqs does.
+                            OrUnitReqs = reader.GetBoolean("or_unit_reqs", true)
                         };
                         _conditions.Add(template.Id, template);
                     }

--- a/AAEmu.Game/Core/Managers/World/WorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/WorldManager.cs
@@ -149,6 +149,16 @@ public class WorldManager(
     public const float DefaultCombatTimeout = 15f;
 
     /// <summary>
+    /// Radius used for a sphere aoe_shape whose value1 is 0. Not derived from anything — those rows carry
+    /// no geometry at all — so it is a placeholder that keeps such an AoE finding something instead of
+    /// nothing. See the warning in <see cref="GetAroundByShape{T}(GameObject, AreaShape)"/>.
+    /// </summary>
+    private const float DefaultSphereRadiusForBlankShape = 40f;
+
+    /// <summary>Shape ids already reported as radius-less; used as a set so the warning fires once each.</summary>
+    private static readonly ConcurrentDictionary<uint, byte> WarnedBlankSphereShapes = new();
+
+    /// <summary>
     /// Called every second and forwards the tick to all live player related objects
     /// </summary>
     /// <param name="delta"></param>
@@ -317,7 +327,9 @@ public class WorldManager(
                             Type = (AreaShapeType)reader.GetUInt32("kind_id"),
                             Value1 = reader.GetFloat("value1"),
                             Value2 = reader.GetFloat("value2"),
-                            Value3 = reader.GetFloat("value3")
+                            Value3 = reader.GetFloat("value3"),
+                            // Only line shapes use it, but every kind_id 3 row carries one.
+                            AreaTargetKind = (AreaTargetKindType)reader.GetUInt32("area_target_kind_id", 0)
                         };
                         _areaShapes.TryAdd(shape.Id, shape);
                     }
@@ -1149,19 +1161,40 @@ public class WorldManager(
     /// <param name="shape"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    public static List<T> GetAroundByShape<T>(GameObject obj, AreaShape shape) where T : GameObject
+    /// <param name="trace">
+    /// Optional per-step counter. The shape's own geometry filters run inside here, so without it a
+    /// caller only ever sees the final count and cannot tell a radius miss from a cone miss.
+    /// </param>
+    public static List<T> GetAroundByShape<T>(GameObject obj, AreaShape shape, List<(string step, int left)> trace = null) where T : GameObject
     {
         switch (shape.Type)
         {
             case AreaShapeType.Sphere:
                 {
-                    var radius = shape.Value1 > 0 ? shape.Value1 : 40f;
+                    var radius = shape.Value1;
+                    if (radius <= 0)
+                    {
+                        // ~497 shape rows are entirely blank (value1..3 all 0) yet 502 plot events search
+                        // them for up to 50 targets. There is no radius in the data to recover, so the
+                        // historical 40m guess stands — but it is loud now instead of invisible, because a
+                        // 40m sweep is wide enough to explain an AoE that "hits things it shouldn't".
+                        radius = DefaultSphereRadiusForBlankShape;
+                        if (WarnedBlankSphereShapes.TryAdd(shape.Id, 0))
+                            Logger.Warn(
+                                "aoe_shape {0} is a sphere with no radius; falling back to {1}m. Any AoE using it over-reaches.",
+                                shape.Id, radius);
+                    }
+
                     var around = GetAround<T>(obj, radius, true);
+                    trace?.Add(($"radius{radius:F1}", around.Count));
                     // value3 > 0: frontal cone half-angle (shotgun plots 5796/5604/5231). Without
                     // this filter the sphere is a full 360° disc and MaxTargets=3 hits every mob
                     // around the caster — combat floaters spam and total damage stacks per pellet.
                     if (shape.SphereConeHalfAngleDegrees > 0f)
+                    {
                         around = shape.FilterSphereCone(obj, around);
+                        trace?.Add(($"cone±{shape.SphereConeHalfAngleDegrees:F0}", around.Count));
+                    }
                     return around;
                 }
             case AreaShapeType.Cuboid:
@@ -1171,15 +1204,60 @@ public class WorldManager(
                     res = shape.ComputeCuboid(obj, res);
                     return res;
                 }
+            case AreaShapeType.Line:
+                {
+                    // Fallback only. A line is a corridor and needs a start and an aim point, which
+                    // this 2-argument overload does not have - use the 4-argument one below. Centring
+                    // a box on the anchor is wrong twice over: it reaches behind the origin, and it
+                    // puts the aimed-at unit exactly on the rectangle's diagonal where the strict
+                    // point-in-triangle test drops it.
+                    var diagonal = Math.Sqrt(shape.Value1 * shape.Value1 + shape.Value2 * shape.Value2);
+                    var res = GetAround<T>(obj, (float)diagonal, true);
+                    res = shape.ComputeCuboid(obj, res);
+                    return res;
+                }
             default:
                 {
-                    Logger.Error("AreaShape had impossible type");
-                    //throw new ArgumentNullException(nameof(shape), "AreaShape type does not exist!");
+                    Logger.Error("AreaShape {0} has unsupported type {1}", shape.Id, shape.Type);
                     break;
                 }
         }
 
-        return null;
+        // Never null: callers feed this straight into LINQ filters, so a null here surfaced as an
+        // exception several frames away and took the calling plot down with it.
+        return [];
+    }
+
+    /// <summary>
+    /// Line-aware variant. kind_id 3 shapes are a corridor running from <paramref name="corridorStart"/>
+    /// towards <paramref name="corridorAnchor"/> — the unit named by aoe_shapes.area_target_kind_id.
+    /// Every other shape type falls through to the two-argument overload.
+    /// </summary>
+    public static List<T> GetAroundByShape<T>(GameObject obj, AreaShape shape, GameObject corridorStart, GameObject corridorAnchor) where T : GameObject
+    {
+        if (shape.Type != AreaShapeType.Line || corridorStart?.Region == null)
+            return GetAroundByShape<T>(obj, shape);
+
+        var start = corridorStart.Transform.World.Position;
+        var forward = Vector3.Zero;
+        var aimDistance = 0f;
+        if (corridorAnchor != null && !ReferenceEquals(corridorAnchor, corridorStart))
+        {
+            var a = corridorAnchor.Transform.World.Position;
+            forward = new Vector3(a.X - start.X, a.Y - start.Y, 0f);
+            aimDistance = forward.Length();
+        }
+
+        if (forward.LengthSquared() < 0.0001f)
+        {
+            // Anchor sits on the origin: fall back to where the origin is facing.
+            var rot = corridorStart.Transform.World.Rotation.Z;
+            forward = new Vector3(-MathF.Sin(rot), MathF.Cos(rot), 0f);
+        }
+
+        var radius = shape.Value1 + (shape.Value2 > 0f ? shape.Value2 : aimDistance);
+        var res = GetAround<T>(corridorStart, radius, true);
+        return shape.ComputeCorridor(start, forward, res, aimDistance);
     }
 
     /// <summary>

--- a/AAEmu.Game/Core/Packets/C2G/CSNotifyInGamePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSNotifyInGamePacket.cs
@@ -88,6 +88,13 @@ public class CSNotifyInGamePacket() : GamePacket(CSOffsets.CSNotifyInGamePacket,
 
         Connection.ActiveChar.UpdateGearBonuses(null, null);
 
+        // Combat resources (combat_resources) after Spawn(): seeding applies each pool's bar buff, and
+        // both that buff and the point packet address the local player unit, which only exists once the
+        // character is spawned. default_point had never been read, so every pool started each session at
+        // 0 and the abilities gated on them could not reach their first tier.
+        Connection.ActiveChar.InitializeCombatResources();
+        Connection.ActiveChar.SendAllCombatResources();
+
         // The player-frame event window shows during the post-NotifyInGame load and reads its event counts; the
         // client crashes on show without them. The reference server sends this (all-zero, no active events) at
         // world entry — emit it here so the window has data before it renders.

--- a/AAEmu.Game/GameData/CombatResourceGameData.cs
+++ b/AAEmu.Game/GameData/CombatResourceGameData.cs
@@ -4,7 +4,18 @@ using AAEmu.Game.Utils.DB;
 
 using Microsoft.Data.Sqlite;
 
+using NLog;
+
 namespace AAEmu.Game.GameData;
+
+/// <summary>enum_buff_conditions — when <see cref="CombatResource.BuffId"/> is meant to be on the unit.</summary>
+public enum CombatResourceBuffCondition
+{
+    Invalid = 1,
+    Max = 2,
+    Min = 3,
+    Active = 4
+}
 
 /// <summary>
 /// One combat resource — the combo-point style pools an ability accumulates (광란, 착취, 근성 and the rest).
@@ -17,11 +28,50 @@ public class CombatResource
     /// <summary>Cap on the accumulated amount; 5 for most, 5000 for 근성.</summary>
     public int Max { get; init; }
 
-    /// <summary>Amount a unit starts with, non-zero only for 죽음의 낙인.</summary>
+    /// <summary>Amount a unit starts with, non-zero only for 죽음의 낙인, 기쁨 and 슬픔.</summary>
     public int DefaultPoint { get; init; }
 
     /// <summary>enum_combat_resource_send_types: 1 Self, 2 Broadcast.</summary>
     public int SendTypeId { get; init; }
+
+    /// <summary>
+    /// Milliseconds between two decay steps. 0 means the pool never drains on its own
+    /// (기쁨 / 슬픔), which is why the tick has to treat it as "no timer" rather than "every tick".
+    /// </summary>
+    public int RecoveryCycle { get; init; }
+
+    /// <summary>Applied every <see cref="RecoveryCycle"/> while the unit is out of combat. Negative throughout the shipped data.</summary>
+    public int PeaceRecoveryAmount { get; init; }
+
+    /// <summary>Applied every <see cref="RecoveryCycle"/> while the unit is in combat.</summary>
+    public int CombatRecoveryAmount { get; init; }
+
+    /// <summary>enum_recovery_states: 1 invalid, 2 always, 5 nomoving. Every shipped row is 1, so nothing acts on it yet.</summary>
+    public int EtcRecoveryStateId { get; init; }
+
+    /// <summary>Companion amount to <see cref="EtcRecoveryStateId"/>; 0 throughout the shipped data.</summary>
+    public int EtcRecoveryAmount { get; init; }
+
+    /// <summary>
+    /// Buff carrying the client-side resource bar. Held while <see cref="BuffCondition"/> is satisfied;
+    /// without it the pip UI never appears even though the point packets arrive.
+    /// </summary>
+    public uint BuffId { get; init; }
+
+    /// <summary>When <see cref="BuffId"/> should be on the unit.</summary>
+    public CombatResourceBuffCondition BuffCondition { get; init; }
+
+    /// <summary>Amount applied per decay step for a unit in the given combat state.</summary>
+    public int RecoveryAmountFor(bool inCombat) => inCombat ? CombatRecoveryAmount : PeaceRecoveryAmount;
+
+    /// <summary>True when <paramref name="amount"/> satisfies this resource's bar-buff condition.</summary>
+    public bool ShouldHoldBuff(int amount) => BuffId != 0 && BuffCondition switch
+    {
+        CombatResourceBuffCondition.Active => amount > 0,
+        CombatResourceBuffCondition.Max => Max > 0 && amount >= Max,
+        CombatResourceBuffCondition.Min => amount <= 0,
+        _ => false
+    };
 }
 
 /// <summary>
@@ -31,6 +81,8 @@ public class CombatResource
 [GameData]
 public class CombatResourceGameData : Singleton<CombatResourceGameData>, IGameDataLoader
 {
+    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
+
     private Dictionary<int, CombatResource> _resources;
 
     public void Load(SqliteConnection connection)
@@ -51,11 +103,20 @@ public class CombatResourceGameData : Singleton<CombatResourceGameData>, IGameDa
                 Max = reader.GetInt32("max"),
                 DefaultPoint = reader.GetInt32("default_point"),
                 // Column is spelled "resouece_send_type_id" in the shipped schema.
-                SendTypeId = reader.GetInt32("resouece_send_type_id")
+                SendTypeId = reader.GetInt32("resouece_send_type_id"),
+                RecoveryCycle = reader.GetInt32("recovery_cycle", 0),
+                PeaceRecoveryAmount = reader.GetInt32("peace_recovery_amount", 0),
+                CombatRecoveryAmount = reader.GetInt32("combat_recovery_amount", 0),
+                EtcRecoveryStateId = reader.GetInt32("etc_recovery_state_id", 1),
+                EtcRecoveryAmount = reader.GetInt32("etc_recovery_amount", 0),
+                BuffId = reader.GetUInt32("buff_id", 0),
+                BuffCondition = (CombatResourceBuffCondition)reader.GetInt32("resource_buff_condition_id", 1)
             };
 
             _resources[resource.Id] = resource;
         }
+
+        Logger.Info("Loaded {0} combat resources", _resources.Count);
     }
 
     public void PostLoad()
@@ -66,4 +127,10 @@ public class CombatResourceGameData : Singleton<CombatResourceGameData>, IGameDa
 
     /// <summary>Ceiling for a resource, 0 when the id is unknown.</summary>
     public int GetMax(int id) => Get(id)?.Max ?? 0;
+
+    /// <summary>Every defined resource — used to seed a unit's pools and to drive the decay tick.</summary>
+    public IEnumerable<CombatResource> All => _resources?.Values ?? Enumerable.Empty<CombatResource>();
+
+    /// <summary>Resources that start non-empty, so a unit only has to be seeded with those.</summary>
+    public IEnumerable<CombatResource> WithDefaultPoint => All.Where(r => r.DefaultPoint > 0);
 }

--- a/AAEmu.Game/GameData/UnitRequirementsGameData.cs
+++ b/AAEmu.Game/GameData/UnitRequirementsGameData.cs
@@ -6,6 +6,7 @@ using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Items.Templates;
 using AAEmu.Game.Models.Game.Quests;
 using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models.Game.Skills.Plots;
 using AAEmu.Game.Models.Game.Skills.Static;
 using AAEmu.Game.Models.Game.Skills.Templates;
 using AAEmu.Game.Models.Game.Units;
@@ -134,6 +135,50 @@ public class UnitRequirementsGameData : Singleton<UnitRequirementsGameData>, IGa
     public List<UnitReqs> GetSphereRequirements(uint sphereId)
     {
         return GetRequirement("Sphere", sphereId).ToList();
+    }
+
+    public List<UnitReqs> GetPlotConditionRequirements(uint plotConditionId)
+    {
+        return GetRequirement("PlotCondition", plotConditionId).ToList();
+    }
+
+    /// <summary>
+    /// Evaluates a plot condition of kind 20 (unit_reqs).
+    /// </summary>
+    /// <remarks>
+    /// The condition carries no parameters of its own — 1519 of the 1605 shipped rows leave param1..3 at 0.
+    /// Its checks live in the 1869 unit_reqs rows whose owner_type is "PlotCondition" and whose owner_id is
+    /// the condition's id, covering 1504 of those conditions. Until this existed, kind 20 fell through
+    /// PlotCondition.Check's permissive default and every plot gated on it took its first branch regardless
+    /// of stance, weapon, buff or resource state.
+    /// </remarks>
+    /// <param name="condition">The plot condition being evaluated.</param>
+    /// <param name="ownerUnit">Unit resolved from plot_event_conditions.source_id.</param>
+    /// <param name="target">Unit resolved from plot_event_conditions.target_id.</param>
+    public bool CanPassPlotCondition(PlotCondition condition, BaseUnit ownerUnit, BaseUnit target)
+    {
+        if (condition == null || ownerUnit == null)
+            return false;
+
+        var reqs = GetPlotConditionRequirements(condition.Id);
+        // 101 kind-20 conditions own no rows at all. "No requirements" passes, matching CanUseSkill and
+        // CanComponentRun — the caller still applies not_condition on top of this result.
+        if (reqs.Count == 0)
+            return true;
+
+        var res = !condition.OrUnitReqs;
+        foreach (var unitReq in reqs)
+        {
+            var reqRes = unitReq.Validate(ownerUnit, target ?? ownerUnit).ResultKey == SkillResultKeys.ok;
+
+            if (condition.OrUnitReqs && reqRes)
+                return true;
+
+            if (!condition.OrUnitReqs && !reqRes)
+                return false;
+        }
+
+        return res;
     }
 
     public TreasureMap GetTreasureMapWithCoordinatesNearbyItem(Character character, double maxRange)

--- a/AAEmu.Game/IO/ClientSource.cs
+++ b/AAEmu.Game/IO/ClientSource.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Linq;
+using System.Text.RegularExpressions;
 using AAEmu.Commons.Utils.AAPak;
 
 namespace AAEmu.Game.IO;
@@ -89,9 +90,16 @@ public class ClientSource
                     var wildCard = WildcardToRegex("*" + searchPattern.ToLower() + "*");// Hopefully this behaves the same as the Directory.GetFiles pattern
                     if (includeSubDirectories)
                     {
-                        foreach (var pfiName in GamePak.pakFiles.Keys)
+                        // Ordinal, not CurrentCulture: these are pak paths, so a culture-sensitive
+                        // comparison is both semantically wrong and routed through native ICU. The
+                        // ICU path crashed the whole process with 0xC0000005 when a plot asked for
+                        // terrain height (Plot.RunAsync -> GetHeight -> VerifyCellLoaded ->
+                        // LoadBaiFiles -> here) while the startup BAI loader was still enumerating,
+                        // and it also ran over all ~523k pak entries per call. Snapshot the keys so
+                        // the enumeration cannot observe the dictionary mid-write either.
+                        foreach (var pfiName in GamePak.pakFiles.Keys.ToArray())
                         {
-                            if (pfiName.StartsWith(rootDir, System.StringComparison.CurrentCultureIgnoreCase))
+                            if (pfiName.StartsWith(rootDir, System.StringComparison.OrdinalIgnoreCase))
                             {
                                 if (string.IsNullOrWhiteSpace(searchPattern) ||
                                     Regex.Match(pfiName.ToLower(), wildCard).Success)

--- a/AAEmu.Game/Models/Game/Items/Procs/ItemProc.cs
+++ b/AAEmu.Game/Models/Game/Items/Procs/ItemProc.cs
@@ -1,6 +1,10 @@
+using System.Collections.Concurrent;
+
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Units;
+
+using NLog;
 
 namespace AAEmu.Game.Models.Game.Items.Procs;
 
@@ -9,16 +13,36 @@ namespace AAEmu.Game.Models.Game.Items.Procs;
 /// </summary>
 public class ItemProc(uint templateId)
 {
+    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
+
+    /// <summary>Proc template ids already reported as unusable; keeps the warning to one per id.</summary>
+    private static readonly ConcurrentDictionary<uint, byte> WarnedMissing = new();
+
     public uint TemplateId { get; set; } = templateId;
     public ItemProcTemplate Template { get; set; } = ItemManager.Instance.GetItemProcTemplate(templateId);
     public DateTime LastProc { get; set; } = DateTime.MinValue;
 
     public bool Apply(Unit owner, bool ignoreRoll = false)
     {
+        // A proc row whose template or skill is missing used to reach Skill.Use with a null Template and
+        // NRE on Template.Id. That threw inside DamageEffect's TakeDamageAny roll, which runs inside
+        // PlotEventEffect's per-target loop — so one bad proc aborted every remaining target of that plot
+        // effect, and an AoE that should hit five stopped after two.
+        if (Template?.SkillTemplate == null)
+        {
+            if (WarnedMissing.TryAdd(TemplateId, 0))
+                Logger.Warn("ItemProc {0} has no {1}; proc skipped",
+                    TemplateId, Template == null ? "template" : "skill template");
+            return false;
+        }
+
         if (DateTime.UtcNow < LastProc.AddSeconds(Template.CooldownSec))
             return false;
 
-        if (ignoreRoll || Random.Shared.Next(0, 100) > Template.ChanceRate)
+        // ignoreRoll is meant to force the proc through, not to block it. And chance_rate is a plain
+        // percentage (0-100 across every row of item_procs), so the roll has to fail on >= rate: with ">"
+        // a 15% proc fired 16 times in 100, and the rows that carry rate 0 still fired on a roll of 0.
+        if (!ignoreRoll && Random.Shared.Next(0, 100) >= Template.ChanceRate)
             return false;
 
         var caster = SkillCaster.GetByType(SkillCasterType.Unit);

--- a/AAEmu.Game/Models/Game/Skills/Effects/CombatResourceEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/CombatResourceEffect.cs
@@ -1,5 +1,4 @@
 using AAEmu.Game.Core.Packets;
-using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.GameData;
 using AAEmu.Game.Models.Game.Skills.Templates;
 using AAEmu.Game.Models.Game.Units;
@@ -24,6 +23,10 @@ public class CombatResourceEffect : EffectTemplate
         if (target is not Unit unit)
             return;
 
+        var resourceId = ResolveCombatResourceId(source);
+        if (resourceId == 0)
+            return;
+
         // chance 0 is "always" throughout the shipped rows, not "never" — every combat_resource_effects row
         // carries 0 and these are the builders an ability relies on, so a literal reading would make the whole
         // system dead. Anything above zero rolls out of 100.
@@ -37,19 +40,39 @@ public class CombatResourceEffect : EffectTemplate
         if (amount == 0)
             return;
 
-        var before = unit.GetCombatResource(CombatResourceId);
-        var after = unit.AddCombatResource(CombatResourceId, amount);
+        var before = unit.GetCombatResource(resourceId);
+        var after = unit.AddCombatResource(resourceId, amount, ResetRemainTime);
 
-        Logger.Debug($"CombatResourceEffect: resource {CombatResourceId} on {unit.ObjId} {before} -> {after} (amount {amount}, resetRemainTime {ResetRemainTime})");
+        Logger.Debug($"CombatResourceEffect: resource {resourceId} on {unit.ObjId} {before} -> {after} (amount {amount}, resetRemainTime {ResetRemainTime})");
 
         // combat_resources.resouece_send_type_id decides the audience: 1 Self, 2 Broadcast.
-        var resource = CombatResourceGameData.Instance.Get(CombatResourceId);
+        var resource = CombatResourceGameData.Instance.Get(resourceId);
         var updateTime = ResetRemainTime ? 0 : (int)(DateTime.UtcNow - time).TotalMilliseconds;
-        var packet = new SCCombatResourcePointPacket(unit.ObjId, CombatResourceId, (ulong)after, updateTime);
+        unit.BroadcastCombatResource(resource, after, updateTime);
+    }
 
-        if (resource is { SendTypeId: 2 })
-            unit.BroadcastPacket(packet, true);
-        else
-            (unit as Char.Character)?.SendPacket(packet);
+    /// <summary>
+    /// Resolves which pool this effect feeds.
+    /// </summary>
+    /// <remarks>
+    /// <c>combat_resource_effects.combat_resource_id</c> is 0 on 51 plot effects and 20 skill effects, and
+    /// combat_resources has no id 0 — those rows mean "the resource the casting skill owns", named by
+    /// <c>skills.combat_resource_id</c>. Their amounts confirm it: the id-0 rows carry ±300…±600, which fits
+    /// no pool with a ceiling of 3–60 but matches 근성 (id 3, max 5000) exactly, and 근성 is what all 12
+    /// skills carrying a non-zero skills.combat_resource_id point at. Writing them to bucket 0 instead put
+    /// the whole grant somewhere nothing ever reads.
+    /// </remarks>
+    private int ResolveCombatResourceId(EffectSource source)
+    {
+        if (CombatResourceId != 0)
+            return CombatResourceId;
+
+        var fromSkill = source?.Skill?.Template?.CombatResourceId ?? 0;
+        if (fromSkill != 0)
+            return fromSkill;
+
+        Logger.Debug("CombatResourceEffect: combat_resource_id 0 and skill {0} names no resource — skipped",
+            source?.Skill?.Template?.Id ?? 0);
+        return 0;
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Plots/PlotCondition.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/PlotCondition.cs
@@ -1,5 +1,6 @@
 ﻿using AAEmu.Commons.Exceptions;
 using AAEmu.Game.Core.Managers;
+using AAEmu.Game.GameData;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Faction;
 using AAEmu.Game.Models.Game.Items;
@@ -21,6 +22,12 @@ public class PlotCondition
     public int Param1 { get; set; }
     public int Param2 { get; set; }
     public int Param3 { get; set; }
+
+    /// <summary>
+    /// plot_conditions.or_unit_reqs — whether the unit_reqs rows owned by this condition pass when ANY of
+    /// them holds (94 rows) or only when ALL do (1511 rows).
+    /// </summary>
+    public bool OrUnitReqs { get; set; }
 
     /// <summary>
     /// Checks if this PlotCondition is true
@@ -46,7 +53,7 @@ public class PlotCondition
             PlotConditionType.Dead => ConditionDead(caster, casterCaster, target, targetCaster, skillObject, Param1, Param2, Param3),
             PlotConditionType.CombatDiceResult => ConditionCombatDiceResult(caster, casterCaster, target, targetCaster, skillObject, Param1, Param2, Param3, skill), // Every CombatDiceResult is a NotCondition -> false makes it true.
             PlotConditionType.InstrumentType => ConditionInstrumentType(caster, casterCaster, target, targetCaster, skillObject, Param1, Param2, Param3),
-            PlotConditionType.Range => ConditionRange(caster, casterCaster, target, targetCaster, skillObject, Param1, Param2, Param3),
+            PlotConditionType.Range => ConditionRange(caster, casterCaster, target, targetCaster, skillObject, Param1, Param2, Param3, skill),
             PlotConditionType.Variable => ConditionVariable(caster, casterCaster, target, targetCaster, skillObject, Param1, Param2, Param3, skill),
             PlotConditionType.UnitAttrib => ConditionUnitAttrib(caster, casterCaster, target, targetCaster, skillObject, Param1, Param2, Param3),
             PlotConditionType.Actability => ConditionActability(caster, casterCaster, target, targetCaster, skillObject, Param1, Param2, Param3),
@@ -54,6 +61,7 @@ public class PlotCondition
             PlotConditionType.Visible => ConditionVisible(caster, casterCaster, target, targetCaster, skillObject, Param1, Param2, Param3),
             PlotConditionType.ABLevel => ConditionAbLevel(caster, casterCaster, target, targetCaster, skillObject, Param1, Param2, Param3),
             PlotConditionType.CombatResource => ConditionCombatResource(caster, Param1, Param2, Param3),
+            PlotConditionType.UnitReqs => ConditionUnitReqs(caster, target),
             _ => UnhandledKind()
         };
 
@@ -62,10 +70,25 @@ public class PlotCondition
         return NotCondition ? !res : res;
     }
 
+    // 20
+    /// <summary>
+    /// unit_reqs: the condition's checks live in unit_reqs rows owned by it, not in its own params.
+    /// </summary>
+    /// <remarks>
+    /// The most used gate in the shipped plots after buff_tag and dead — 1605 conditions, of which 1504 own
+    /// unit_reqs rows. It is the "may this unit do this here" test: stance, equipped weapon type, buff, zone,
+    /// gear score, combat resource. While it was unimplemented all 1605 passed, so every plot branching on it
+    /// took its first edge unconditionally.
+    /// </remarks>
+    private bool ConditionUnitReqs(BaseUnit caster, BaseUnit target)
+    {
+        return UnitRequirementsGameData.Instance.CanPassPlotCondition(this, caster, target);
+    }
+
     /// <summary>
     /// Fallback for condition kinds this server does not implement yet. Stays permissive so an
     /// unknown kind cannot silently block a plot, but says so once per kind instead of passing
-    /// invisibly - kinds 18/20/21 are still unimplemented and used to look like working gates.
+    /// invisibly - kinds 18/21 are still unimplemented and used to look like working gates.
     /// </summary>
     private bool UnhandledKind()
     {
@@ -261,16 +284,40 @@ public class PlotCondition
     }
 
     // 11
+    /// <summary>
+    /// Range gate. Its max is widened to the radius of the area search that selected this target, when
+    /// that search reached further than the gate allows.
+    /// </summary>
+    /// <remarks>
+    /// The shipped data disagrees with itself: Backdraft (44200) selects with aoe_shapes 19754 (r 9.7) and
+    /// then re-checks with Range 0..9, so a unit between 9.0 and 9.7m is found, counted into the target
+    /// list, and only then dropped — while the client, which draws the telegraph from the shape, shows it
+    /// comfortably inside the cone. Left alone, the outer 0.7m of every such cone is decorative.
+    ///
+    /// This is a deliberate deviation from the raw data, and it is scoped to that contradiction: the gate
+    /// only ever grows, only for a target that an area search actually selected, and only up to that
+    /// search's own radius (blank shape rows, which fall back to a 40m guess, are never recorded). A
+    /// target that was never area-selected, or one further out than the selection reached, is judged by
+    /// the unmodified value.
+    /// </remarks>
     private static bool ConditionRange(BaseUnit caster, SkillCaster casterCaster, BaseUnit target,
-        SkillCastTarget targetCaster, SkillObject skillObject, int minRange, int maxRange, int unused3)
+        SkillCastTarget targetCaster, SkillObject skillObject, int minRange, int maxRange, int unused3,
+        Skill skill = null)
     {
         // Param1 = Min range
         // Param2 = Max range
-        // var range = MathUtil.CalculateDistance(caster.Transform.World.Position, target.Transform.World.Position);
-        // range -= 2;//Temp fix because the calculation is off
-        // range = Math.Max(0f, range);
         var range = caster.GetDistanceTo(target);
-        return range >= minRange && range <= maxRange;
+
+        var effectiveMax = (float)maxRange;
+        var plotState = skill?.ActivePlotState ?? (caster as Unit)?.ActivePlotState;
+        if (target != null && plotState != null &&
+            plotState.AreaSelectionRadius.TryGetValue(target.ObjId, out var selectionRadius) &&
+            selectionRadius > effectiveMax)
+        {
+            effectiveMax = selectionRadius;
+        }
+
+        return range >= minRange && range <= effectiveMax;
     }
 
     // 12
@@ -285,6 +332,19 @@ public class PlotCondition
             Logger.Warn("PlotCondition Variable check without ActivePlotState");
             return false;
         }
+
+        // enum_plot_variable_kinds: 1..10 = a..j, 11 = zero, 12 = targets. 11 and 12 are engine
+        // pseudo variables that content never writes — special_effects of type set_variable only
+        // ever target indices 1..5 and 10. Variables is int[12] (0..11), so index 12 fell straight
+        // through the range guard below and returned false, which hard-wired every "did this event's
+        // area search hit anything?" gate to failure. 268 plot_conditions rows use param1=12, among
+        // them 20527 on event 48423 of Crashing Wave's plot 3523.
+        const int variableZero = 11;
+        const int variableTargets = 12;
+        if (variableIndex == variableTargets)
+            return CompareWithOperator(plotState.LastEffectedTargetCount, operation, compareValue);
+        if (variableIndex == variableZero)
+            return CompareWithOperator(0, operation, compareValue);
 
         if (variableIndex < 0 || variableIndex >= plotState.Variables.Length)
             return false;

--- a/AAEmu.Game/Models/Game/Skills/Plots/PlotCondition.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/PlotCondition.cs
@@ -53,12 +53,52 @@ public class PlotCondition
             PlotConditionType.Stealth => ConditionStealth(caster, casterCaster, target, targetCaster, skillObject, Param1, Param2, Param3),
             PlotConditionType.Visible => ConditionVisible(caster, casterCaster, target, targetCaster, skillObject, Param1, Param2, Param3),
             PlotConditionType.ABLevel => ConditionAbLevel(caster, casterCaster, target, targetCaster, skillObject, Param1, Param2, Param3),
-            _ => true
+            PlotConditionType.CombatResource => ConditionCombatResource(caster, Param1, Param2, Param3),
+            _ => UnhandledKind()
         };
 
         Logger.Trace($"PlotCondition : {Kind} | Params : {Param1}, {Param2}, {Param3} | Result : {(NotCondition ? "NOT" : "")} {res}");
 
         return NotCondition ? !res : res;
+    }
+
+    /// <summary>
+    /// Fallback for condition kinds this server does not implement yet. Stays permissive so an
+    /// unknown kind cannot silently block a plot, but says so once per kind instead of passing
+    /// invisibly - kinds 18/20/21 are still unimplemented and used to look like working gates.
+    /// </summary>
+    private bool UnhandledKind()
+    {
+        if (_warnedKinds.Add(Kind))
+            Logger.Warn($"PlotCondition kind {(int)Kind} ({Kind}) is not implemented - treated as true. Plots gated on it take their first branch unconditionally.");
+        return true;
+    }
+
+    private static readonly HashSet<PlotConditionType> _warnedKinds = [];
+
+    // 19
+    /// <summary>
+    /// combat_resource: is the caster's amount of combat resource <paramref name="combatResourceId"/>
+    /// within [<paramref name="min"/>, <paramref name="max"/>]?
+    /// </summary>
+    /// <remarks>
+    /// This is the v10 combo-point gate. Malediction is the clearest case: Ghastly Pack (plot 5477)
+    /// carries three of these on resource 15 - (1,4), (5,9) and (10,10) - which are exactly the
+    /// base / "5 Malice Charges" / "10 Malice Charges" tiers the tooltip advertises. While kind 19
+    /// was unimplemented all three passed, so the plot always took its first branch, never reached
+    /// the higher tiers, and never ran the plot_effects that spend the charges.
+    /// 233 conditions across the shipped data are gated this way.
+    /// </remarks>
+    private static bool ConditionCombatResource(BaseUnit caster, int min, int max, int combatResourceId)
+    {
+        if (caster is not Unit casterUnit)
+        {
+            Logger.Warn($"PlotCondition CombatResource check without caster being a Unit");
+            return false;
+        }
+
+        var amount = casterUnit.GetCombatResource(combatResourceId);
+        return amount >= min && amount <= max;
     }
 
     // 1

--- a/AAEmu.Game/Models/Game/Skills/Plots/PlotConditionType.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/PlotConditionType.cs
@@ -19,6 +19,12 @@ public enum PlotConditionType
     Stealth = 15,
     Visible = 16,
     ABLevel = 17,
+    // 18..21 arrived with the v10 data. Until they were named here every one of them fell into
+    // PlotCondition.Check's "_ => true" arm, i.e. passed unconditionally.
+    CastingUseable = 18,
+    CombatResource = 19,
+    UnitReqs = 20,
+    AccrueDamageMonster = 21,
 }
 
 // No clue what that shit does fam

--- a/AAEmu.Game/Models/Game/Skills/Plots/PlotEventCondition.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/PlotEventCondition.cs
@@ -61,6 +61,25 @@ public class PlotEventCondition
         }
 
         var result = true;
+
+        if (targetInfo.EffectedTargets.Count == 0)
+        {
+            // With no hits the loop below never executes, so the method returns its initial `true` —
+            // a "did we find a target?" gate reports SUCCESS precisely when nothing was found. The
+            // plot then takes the success edge, whose children are per_target and expand to nothing,
+            // the queue drains and SCPlotEnded fires. That is what made Crashing Wave (plot 3523)
+            // dead-end at event 48423. Evaluate the condition once against the non-per-target unit.
+            var fallbackTarget = TargetId switch
+            {
+                PlotEffectTarget.OriginalSource => state.Caster,
+                PlotEffectTarget.OriginalTarget => state.Target,
+                PlotEffectTarget.Source => targetInfo.Source,
+                _ => targetInfo.Target
+            };
+            return condition.Condition.Check(source, state.CasterCaster, fallbackTarget,
+                state.TargetCaster, state.SkillObject, state.ActiveSkill);
+        }
+
         foreach (var newTarget in targetInfo.EffectedTargets)
         {
             BaseUnit target;

--- a/AAEmu.Game/Models/Game/Skills/Plots/PlotEventEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/PlotEventEffect.cs
@@ -6,10 +6,14 @@ using AAEmu.Game.Models.Game.Skills.Plots.Type;
 using AAEmu.Game.Models.Game.Skills.Templates;
 using AAEmu.Game.Models.Game.Units;
 
+using NLog;
+
 namespace AAEmu.Game.Models.Game.Skills.Plots;
 
 public class PlotEventEffect
 {
+    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
+
     public int Position { get; set; }
     public PlotEffectSource SourceId { get; set; }
     public PlotEffectTarget TargetId { get; set; }
@@ -61,8 +65,21 @@ public class PlotEventEffect
                 ? newTarget
                 : ResolveFixedTarget(state, targetInfo);
 
-            ApplyToResolvedTarget(source, target, state, evt, buffEffect, channeled, gamePackets,
-                deferUntilPlotEventProcessed, template);
+            // One target must not cost the others. The nearest try/catch used to be a whole level up in
+            // PlotNode.Execute, so anything thrown while applying target N — an item proc with a missing
+            // skill template was the live case — silently dropped targets N..last of this effect. An AoE
+            // that found five units then damaged two and reported "Plot Effects Error" once.
+            try
+            {
+                ApplyToResolvedTarget(source, target, state, evt, buffEffect, channeled, gamePackets,
+                    deferUntilPlotEventProcessed, template);
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e,
+                    "Plot effect {0} (event {1}, skill {2}) failed on target {3}; continuing with the remaining targets",
+                    template.GetType().Name, evt.Id, state.ActiveSkill?.Template?.Id, target.ObjId);
+            }
         }
     }
 

--- a/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotState.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotState.cs
@@ -34,6 +34,17 @@ public class PlotState(
 
     public Dictionary<uint, List<GameObject>> HitObjects { get; set; } = [];
 
+    /// <summary>
+    /// Radius (metres) of the area search that selected each unit, by unit ObjId.
+    /// </summary>
+    /// <remarks>
+    /// Lets the plot's own Range gate (PlotCondition kind 11) know how far the selection legitimately
+    /// reached. Backdraft picks its targets with aoe_shapes 19754 (r 9.7) and then re-checks them with
+    /// Range 0..9, so a unit between 9.0 and 9.7m is selected, counted, and then silently dropped — while
+    /// the client, which draws the telegraph from the shape, shows it well inside the cone.
+    /// </remarks>
+    public Dictionary<uint, float> AreaSelectionRadius { get; } = [];
+
     public bool CancellationRequested() => _cancellationRequest;
     public bool RequestCancellation() => _cancellationRequest = true;
     public bool ChannelingFinishRequested() => _finishChanneling;

--- a/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotTargetInfo.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotTargetInfo.cs
@@ -426,30 +426,6 @@ public class PlotTargetInfo
             Step("aoeConditions");
         }
 
-        // plot_aoe_conditions (loaded on PlotEventTemplate.AoeConditions) gate Area / Random*
-        // picks. Crime Aura 40917 event 35070 requires BuffTag 894 (현상수배); without this
-        // filter every character in the 25m sphere is "wanted" → taunt, chip damage, and the
-        // criminal bubble on a Friendly Nuia guard.
-        if (plotEvent.AoeConditions is { Count: > 0 })
-        {
-            filtered = filtered.Where(unit =>
-            {
-                foreach (var aoe in plotEvent.AoeConditions)
-                {
-                    if (!aoe.Condition.Check(
-                            state.Caster,
-                            state.CasterCaster,
-                            unit,
-                            state.TargetCaster,
-                            state.SkillObject,
-                            state.ActiveSkill))
-                        return false;
-                }
-
-                return true;
-            });
-        }
-
         return filtered;
 
         // Materialises only while the probe is on; otherwise the whole chain stays lazy.

--- a/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotTargetInfo.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotTargetInfo.cs
@@ -4,13 +4,75 @@ using AAEmu.Game.Models.Game.Skills.Plots.Type;
 using AAEmu.Game.Models.Game.Skills.Plots.UpdateTargetMethods;
 using AAEmu.Game.Models.Game.Skills.Utils;
 using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.Game.World;
 using AAEmu.Game.Utils;
+
+using NLog;
 
 namespace AAEmu.Game.Models.Game.Skills.Plots.Tree;
 
 public class PlotTargetInfo
 {
     public BaseUnit Source { get; set; }
+    /// <summary>enum_plot_area_target_kinds: which unit an area shape is aimed at.</summary>
+    private BaseUnit ResolveAreaAnchor(AreaShape shape, PlotState state, BaseUnit currentPosition) =>
+        shape.AreaTargetKind switch
+        {
+            AreaTargetKindType.OriginalSource => state.Caster,
+            AreaTargetKindType.OriginalTarget => state.Target,
+            AreaTargetKindType.PreviousSource => PreviousSource,
+            AreaTargetKindType.PreviousTarget => PreviousTarget,
+            AreaTargetKindType.CurrentPosition => currentPosition,
+            _ => PreviousTarget
+        };
+
+    /// <summary>
+    /// Origin a cone-shaped sphere (aoe_shapes value3 &gt; 0) is measured from.
+    /// </summary>
+    /// <remarks>
+    /// A cone has a direction, and <see cref="AreaShape.FilterSphereCone"/> takes that direction from the
+    /// origin's own world rotation. Anchoring it on <see cref="PreviousTarget"/> like a plain sphere aimed
+    /// it along the TARGET's facing, from the TARGET's position — so Ceaseless Fire (44196, shape 20447:
+    /// r 22.7, cone 45) swept out of the mob in whatever direction it happened to be looking, while the
+    /// client drew the telegraph out of the player. The search then came back empty, the per_target edge
+    /// to the projectile/damage node expanded to nothing, and the skill played its animation and cooldown
+    /// without ever dealing damage.
+    ///
+    /// Plain spheres are unaffected: "everything within R of the target" stays anchored on the target.
+    /// Where area_target_kind_id IS set the data wins, exactly as for line corridors.
+    /// </remarks>
+    private BaseUnit ResolveConeOrigin(AreaShape shape, PlotState state, BaseUnit fallback)
+    {
+        var origin = shape.AreaTargetKind != AreaTargetKindType.None
+            ? ResolveAreaAnchor(shape, state, fallback)
+            : Source ?? state.Caster;
+
+        // GetAround walks the origin's region; an origin without one would find nothing at all.
+        return origin?.Region != null ? origin : fallback;
+    }
+
+    /// <summary>
+    /// Records how far the search that picked these units legitimately reached, so the plot's own Range
+    /// gate can honour it instead of cutting inside its own selection. See
+    /// <see cref="PlotState.AreaSelectionRadius"/>.
+    /// </summary>
+    /// <remarks>
+    /// Only for spheres with a real radius. Blank shape rows fall back to a 40m guess in WorldManager, and
+    /// letting that guess widen a range gate would turn a placeholder into reach.
+    /// </remarks>
+    private static void RememberSelectionRadius(PlotState state, AreaShape shape, IEnumerable<Unit> units)
+    {
+        if (shape is not { Type: AreaShapeType.Sphere } || shape.Value1 <= 0f)
+            return;
+
+        foreach (var unit in units)
+            state.AreaSelectionRadius[unit.ObjId] = shape.Value1;
+    }
+
+    /// <summary>True when this shape is a sphere carrying a cone rather than a full 360° disc.</summary>
+    private static bool IsCone(AreaShape shape) =>
+        shape is { Type: AreaShapeType.Sphere } && shape.SphereConeHalfAngleDegrees > 0f;
+
     private BaseUnit PreviousSource { get; set; }
     public BaseUnit Target { get; set; }
     private BaseUnit PreviousTarget { get; set; }
@@ -109,14 +171,32 @@ public class PlotTargetInfo
             return posUnit;
         }
 
-        // posUnit.Position.Z = get heightmap value for x:y     
+        // posUnit.Position.Z = get heightmap value for x:y
         //TODO: Get Targets around posUnit?
-        var unitsInRange = FilterTargets(WorldManager.GetAroundByShape<Unit>(posUnit, args.Shape), state, args, plotEvent);
-        unitsInRange = unitsInRange.Take(args.MaxTargets);
+        // A line shape is a corridor, not a box around the anchor: it starts at this event's Source
+        // and is aimed at whatever area_target_kind_id names. Handing it the centred-box path put the
+        // aimed-at unit exactly on the rectangle's diagonal, where the strict point-in-triangle test
+        // drops it — the search came back empty and every per-target edge behind it enqueued nothing.
+        var searchOrigin = IsCone(args.Shape) ? ResolveConeOrigin(args.Shape, state, posUnit) : posUnit;
+        var trace = AreaDebug ? new List<(string step, int left)>() : null;
+        var candidates = args.Shape switch
+        {
+            { Type: AreaShapeType.Line } =>
+                WorldManager.GetAroundByShape<Unit>(posUnit, args.Shape, Source, ResolveAreaAnchor(args.Shape, state, posUnit)),
+            _ when IsCone(args.Shape) =>
+                WorldManager.GetAroundByShape<Unit>(searchOrigin, args.Shape, trace),
+            _ => WorldManager.GetAroundByShape<Unit>(posUnit, args.Shape, trace)
+        };
+        var unitsInRange = FilterTargets(candidates, state, args, plotEvent, trace).Take(args.MaxTargets).ToList();
         // TODO : Filter min distance
         // TODO : Compute Unit Relation
         // TODO : Compute Unit Flag
         // unitsInRange = unitsInRange.Where(u => u.);
+
+        RememberSelectionRadius(state, args.Shape, unitsInRange);
+
+        if (AreaDebug)
+            LogAreaSearch(plotEvent, args, searchOrigin, state, candidates.Count, trace, unitsInRange.Count, args.MaxTargets);
 
         EffectedTargets.AddRange(unitsInRange);
         if (state.HitObjects.TryGetValue(plotEvent.Id, out var o))
@@ -177,10 +257,28 @@ public class PlotTargetInfo
             return posUnit;
         }
 
-        // posUnit.Position.Z = get heightmap value for x:y     
+        // posUnit.Position.Z = get heightmap value for x:y
         //TODO: Get Targets around posUnit?
-        var unitsInRange = FilterTargets(WorldManager.GetAroundByShape<Unit>(posUnit, args.Shape), state, args, plotEvent);
-        unitsInRange = unitsInRange.Take(args.MaxTargets);
+        // A line shape is a corridor, not a box around the anchor: it starts at this event's Source
+        // and is aimed at whatever area_target_kind_id names. Handing it the centred-box path put the
+        // aimed-at unit exactly on the rectangle's diagonal, where the strict point-in-triangle test
+        // drops it — the search came back empty and every per-target edge behind it enqueued nothing.
+        var searchOrigin = IsCone(args.Shape) ? ResolveConeOrigin(args.Shape, state, posUnit) : posUnit;
+        var trace = AreaDebug ? new List<(string step, int left)>() : null;
+        var candidates = args.Shape switch
+        {
+            { Type: AreaShapeType.Line } =>
+                WorldManager.GetAroundByShape<Unit>(posUnit, args.Shape, Source, ResolveAreaAnchor(args.Shape, state, posUnit)),
+            _ when IsCone(args.Shape) =>
+                WorldManager.GetAroundByShape<Unit>(searchOrigin, args.Shape, trace),
+            _ => WorldManager.GetAroundByShape<Unit>(posUnit, args.Shape, trace)
+        };
+        var unitsInRange = FilterTargets(candidates, state, args, plotEvent, trace).Take(args.MaxTargets).ToList();
+
+        RememberSelectionRadius(state, args.Shape, unitsInRange);
+
+        if (AreaDebug)
+            LogAreaSearch(plotEvent, args, searchOrigin, state, candidates.Count, trace, unitsInRange.Count, args.MaxTargets);
 
         // TODO : Filter min distance
         // TODO : Compute Unit Relation
@@ -200,7 +298,74 @@ public class PlotTargetInfo
         return posUnit;
     }
 
-    private static IEnumerable<Unit> FilterTargets(IEnumerable<Unit> units, PlotState state, IPlotTargetParams args, PlotEventTemplate plotEvent)
+    /// <summary>
+    /// Reports, per plot area search, where it looked and how many units each filter step drops.
+    /// Set AAEMU_PLOT_AREA_DEBUG=0 to turn it off.
+    /// </summary>
+    /// <remarks>
+    /// On by default while plot AoE target counts are under investigation. It materialises the
+    /// intermediate lists, but one line per area search is nothing next to the per-packet and per-doodad
+    /// TRACE this log already carries — and it is the one step whose outcome nothing else records:
+    /// events without effects or conditions emit no SCPlotEvent, so an empty search looks exactly like an
+    /// event that never ran.
+    /// </remarks>
+    private static readonly bool AreaDebug = Environment.GetEnvironmentVariable("AAEMU_PLOT_AREA_DEBUG") != "0";
+
+    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
+
+    /// <summary>
+    /// One line describing where a plot area search looked and what each filter step removed. This is the
+    /// question the ordinary log cannot answer: events without effects or conditions emit no SCPlotEvent,
+    /// so an empty search is indistinguishable from an event that never ran.
+    /// </summary>
+    private static void LogAreaSearch(
+        PlotEventTemplate plotEvent, IPlotTargetParams args, GameObject origin, PlotState state,
+        int found, IReadOnlyList<(string step, int left)> steps, int taken, int maxTargets)
+    {
+        var shape = args.Shape;
+        var pos = origin?.Transform?.World?.Position ?? System.Numerics.Vector3.Zero;
+        var yaw = origin?.Transform?.World?.Rotation.Z ?? 0f;
+        Logger.Info(
+            "PlotArea evt={0} skill={1} shape={2}(kind={3} v1={4:F1} v2={5:F1} v3={6:F1}) origin={7} pos=({8:F1},{9:F1},{10:F1}) yawDeg={11:F0} rel={12} typeFlag={13} maxT={14} | found={15} → {16} | taken={17}",
+            plotEvent.Id, state.ActiveSkill?.Template?.Id, shape?.Id, shape?.Type, shape?.Value1, shape?.Value2,
+            shape?.Value3, origin?.ObjId, pos.X, pos.Y, pos.Z, yaw.RadToDeg(), args.UnitRelationType,
+            args.UnitTypeFlag, maxTargets, found,
+            string.Join(" → ", steps.Select(s => $"{s.step}:{s.left}")), taken);
+
+        LogNeighbourhood(origin, shape);
+    }
+
+    /// <summary>
+    /// Lists what the server believes stands near the search origin, with each unit's distance and bearing.
+    /// </summary>
+    /// <remarks>
+    /// The counts above answer "how many survived each filter" but not "did the server ever know this unit
+    /// was there". With six dummies visibly at 3-8m and a 9.7m sphere reporting two, that is the question
+    /// that matters: a unit listed here at 4m but absent from the search points at the region index, while
+    /// a unit listed at 30m means the server's position for it disagrees with what the client draws.
+    /// </remarks>
+    private static void LogNeighbourhood(GameObject origin, AreaShape shape)
+    {
+        if (origin?.Region == null || shape is not { Type: AreaShapeType.Sphere })
+            return;
+
+        // Raw 2D centre-to-centre distance, matching what GetAround measures — deliberately without the
+        // model-radius subtraction GetDistanceTo applies, so the number here is pure geometry.
+        var near = WorldManager.GetAround<Unit>(origin, NeighbourhoodProbeRadius, true)
+            .Select(u => (u, dist: MathUtil.CalculateDistance(
+                origin.Transform.World.Position, u.Transform.World.Position, false)))
+            .OrderBy(x => x.dist)
+            .Take(12)
+            .Select(x => $"{x.u.ObjId}({x.u.TemplateId}) d={x.dist:F1} a={MathUtil.ClampDegAngle(MathUtil.CalculateAngleFrom(origin, x.u)):F0}°");
+
+        Logger.Info("PlotArea   neighbourhood({0}m): {1}", NeighbourhoodProbeRadius, string.Join(", ", near));
+    }
+
+    /// <summary>How far the neighbourhood dump looks — wide enough to catch units the shape radius missed.</summary>
+    private const float NeighbourhoodProbeRadius = 40f;
+
+    private static IEnumerable<Unit> FilterTargets(IEnumerable<Unit> units, PlotState state, IPlotTargetParams args, PlotEventTemplate plotEvent,
+        List<(string step, int left)> trace = null)
     {
         var template = state.ActiveSkill.Template;
         var filtered = units;
@@ -208,6 +373,7 @@ public class PlotTargetInfo
             filtered = filtered.Where(o => o.Hp == 0);
         if (!template.TargetDead)
             filtered = filtered.Where(o => o.Hp > 0);
+        Step("alive/dead");
         if (args.HitOnce)
         {
             filtered = filtered.Where(o =>
@@ -217,6 +383,7 @@ public class PlotTargetInfo
                 else
                     return true;
             });
+            Step("hitOnce");
         }
 
         filtered = filtered
@@ -227,9 +394,37 @@ public class PlotTargetInfo
                     return false;
                 return true;
             });
+        Step("notNeutral");
 
         filtered = SkillTargetingUtil.FilterWithRelation(args.UnitRelationType, state.Caster, filtered);
+        Step("relation");
         filtered = filtered.Where(o => ((byte)o.TypeFlag & args.UnitTypeFlag) != 0);
+        Step("typeFlag");
+
+        // plot_aoe_conditions (loaded on PlotEventTemplate.AoeConditions) gate Area / Random*
+        // picks. Crime Aura 40917 event 35070 requires BuffTag 894 (현상수배); without this
+        // filter every character in the 25m sphere is "wanted" → taunt, chip damage, and the
+        // criminal bubble on a Friendly Nuia guard.
+        if (plotEvent.AoeConditions is { Count: > 0 })
+        {
+            filtered = filtered.Where(unit =>
+            {
+                foreach (var aoe in plotEvent.AoeConditions)
+                {
+                    if (!aoe.Condition.Check(
+                            state.Caster,
+                            state.CasterCaster,
+                            unit,
+                            state.TargetCaster,
+                            state.SkillObject,
+                            state.ActiveSkill))
+                        return false;
+                }
+
+                return true;
+            });
+            Step("aoeConditions");
+        }
 
         // plot_aoe_conditions (loaded on PlotEventTemplate.AoeConditions) gate Area / Random*
         // picks. Crime Aura 40917 event 35070 requires BuffTag 894 (현상수배); without this
@@ -256,5 +451,15 @@ public class PlotTargetInfo
         }
 
         return filtered;
+
+        // Materialises only while the probe is on; otherwise the whole chain stays lazy.
+        void Step(string name)
+        {
+            if (trace == null)
+                return;
+            var list = filtered.ToList();
+            filtered = list;
+            trace.Add((name, list.Count));
+        }
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotTargetInfo.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotTargetInfo.cs
@@ -216,16 +216,19 @@ public class PlotTargetInfo
         //TODO for now we get all units in a 5 meters radius
         var randomUnits = WorldManager.GetAroundByShape<Unit>(Source, args.Shape);
 
-        var filteredUnits = FilterTargets(randomUnits, state, args, plotEvent);
+        // Materialise once, before anything counts or indexes it. FilterTargets is lazy and now runs
+        // plot_aoe_conditions, which include kinds that are not idempotent - Chance rolls a die and
+        // CombatDiceResult writes the result the rest of the plot reads. Enumerating the sequence three
+        // times (Count, Any, ElementAt) rolled them three times, so each pass could see a different
+        // population and the index could point past the end of the last one.
+        var filteredUnits = FilterTargets(randomUnits, state, args, plotEvent).ToList();
         if (args.HitOnce)
-            filteredUnits = filteredUnits.Where(unit => unit.ObjId != PreviousTarget.ObjId);
+            filteredUnits = filteredUnits.Where(unit => unit.ObjId != PreviousTarget.ObjId).ToList();
 
-        var index = Random.Shared.Next(0, filteredUnits.Count());
-
-        if (!filteredUnits.Any())
+        if (filteredUnits.Count == 0)
             return null;
 
-        var randomUnit = filteredUnits.ElementAt(index);
+        var randomUnit = filteredUnits[Random.Shared.Next(0, filteredUnits.Count)];
 
         EffectedTargets.Add(randomUnit);
         if (state.HitObjects.TryGetValue(plotEvent.Id, out var o))
@@ -299,17 +302,17 @@ public class PlotTargetInfo
     }
 
     /// <summary>
-    /// Reports, per plot area search, where it looked and how many units each filter step drops.
-    /// Set AAEMU_PLOT_AREA_DEBUG=0 to turn it off.
+    /// AAEMU_PLOT_AREA_DEBUG=1 reports, per plot area search, where it looked and how many units each
+    /// filter step drops. Off by default.
     /// </summary>
     /// <remarks>
-    /// On by default while plot AoE target counts are under investigation. It materialises the
-    /// intermediate lists, but one line per area search is nothing next to the per-packet and per-doodad
-    /// TRACE this log already carries — and it is the one step whose outcome nothing else records:
-    /// events without effects or conditions emit no SCPlotEvent, so an empty search looks exactly like an
-    /// event that never ran.
+    /// Off because this sits on the combat hot path: it materialises every intermediate list, and a
+    /// sphere search additionally runs a 40m neighbourhood query and sorts it. Worth turning on when a
+    /// plot AoE hits the wrong number of targets — that is the one step whose outcome nothing else
+    /// records, since events without effects or conditions emit no SCPlotEvent, so an empty search looks
+    /// exactly like an event that never ran.
     /// </remarks>
-    private static readonly bool AreaDebug = Environment.GetEnvironmentVariable("AAEMU_PLOT_AREA_DEBUG") != "0";
+    private static readonly bool AreaDebug = Environment.GetEnvironmentVariable("AAEMU_PLOT_AREA_DEBUG") == "1";
 
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
@@ -325,7 +328,7 @@ public class PlotTargetInfo
         var shape = args.Shape;
         var pos = origin?.Transform?.World?.Position ?? System.Numerics.Vector3.Zero;
         var yaw = origin?.Transform?.World?.Rotation.Z ?? 0f;
-        Logger.Info(
+        Logger.Debug(
             "PlotArea evt={0} skill={1} shape={2}(kind={3} v1={4:F1} v2={5:F1} v3={6:F1}) origin={7} pos=({8:F1},{9:F1},{10:F1}) yawDeg={11:F0} rel={12} typeFlag={13} maxT={14} | found={15} → {16} | taken={17}",
             plotEvent.Id, state.ActiveSkill?.Template?.Id, shape?.Id, shape?.Type, shape?.Value1, shape?.Value2,
             shape?.Value3, origin?.ObjId, pos.X, pos.Y, pos.Z, yaw.RadToDeg(), args.UnitRelationType,
@@ -358,7 +361,7 @@ public class PlotTargetInfo
             .Take(12)
             .Select(x => $"{x.u.ObjId}({x.u.TemplateId}) d={x.dist:F1} a={MathUtil.ClampDegAngle(MathUtil.CalculateAngleFrom(origin, x.u)):F0}°");
 
-        Logger.Info("PlotArea   neighbourhood({0}m): {1}", NeighbourhoodProbeRadius, string.Join(", ", near));
+        Logger.Debug("PlotArea   neighbourhood({0}m): {1}", NeighbourhoodProbeRadius, string.Join(", ", near));
     }
 
     /// <summary>How far the neighbourhood dump looks — wide enough to catch units the shape radius missed.</summary>

--- a/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotTree.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotTree.cs
@@ -81,6 +81,13 @@ public class PlotTree(uint plotId)
                     if (item.targetInfo.Target == null)
                         continue;
 
+                    // enum_plot_variable_kinds id 12 ("targets") is engine-provided: the hit count of
+                    // THIS event's target update. Conditions run BEFORE Execute, so the count has to be
+                    // published here as well — PlotNode.Execute recomputes the identical value, but by
+                    // then the gate below has already branched on a stale number.
+                    state.LastEffectedTargetCount = item.targetInfo.EffectedTargets.Count(
+                        t => t != null && t.ObjId != 0 && t.ObjId != uint.MaxValue);
+
                     var condition = node.CheckConditions(state, item.targetInfo);
 
                     if (condition)

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -114,6 +114,15 @@ public class Skill
             return SkillResult.InvalidSource;
         }
 
+        // Every line below dereferences Template. A Skill built from a missing template (item procs did
+        // exactly that) used to NRE on the first Template.Id read, and callers inside a plot effect turned
+        // that into a lost target list rather than a visible failure.
+        if (Template == null)
+        {
+            Logger.Warn("Skill.Use called with no template (caster {0})", caster.ObjId);
+            return SkillResult.InvalidSkill;
+        }
+
         // Cast character for future reference
         var character = caster as Character;
 
@@ -1796,6 +1805,15 @@ AlwaysHit:
         if (Template.Id is 2 or 3 or 4)
             return;
 
+        // A skill flagged ignore_global_cooldown neither waits for the GCD nor arms it. The wait side was
+        // already honoured in Use(); arming it here anyway meant 8659 skills put every OTHER skill on a
+        // cooldown they themselves are declared to sit outside of — Backdraft (44200) among them.
+        if (Template.IgnoreGlobalCooldown)
+            return;
+
+        // NOTE: default_gcd overriding custom_gcd is deliberate and matches the data — 29054 of the 29669
+        // skills with default_gcd set carry custom_gcd 0, i.e. "use the server default". The 619 that carry
+        // both are ambiguous and are left on the default rather than guessed at.
         var gcd = Template.CustomGcd;
         if (Template.DefaultGcd)
             gcd = unit is Npc ? 1500 : 1000;

--- a/AAEmu.Game/Models/Game/Skills/SkillTargetRelation.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillTargetRelation.cs
@@ -1,5 +1,10 @@
 namespace AAEmu.Game.Models.Game.Skills;
 
+/// <summary>
+/// Raw enum_skill_target_relation ids. The enum used to stop at <see cref="Others"/>, so the five v10
+/// members below fell through SkillTargetingUtil's permissive default and were not filtered at all —
+/// 15 plot events and 2 skills in the shipped data.
+/// </summary>
 public enum SkillTargetRelation : byte
 {
     Any = 0,
@@ -7,5 +12,10 @@ public enum SkillTargetRelation : byte
     Party = 2,
     Raid = 3,
     Hostile = 4,
-    Others = 5
+    Others = 5,
+    FriendlyForDebuff = 6,
+    SiegeOffenseHqUser = 7,
+    Family = 8,
+    IgnoreProtected = 9,
+    ExpeditionMember = 10
 }

--- a/AAEmu.Game/Models/Game/Skills/Utils/SkillTargetingUtil.cs
+++ b/AAEmu.Game/Models/Game/Skills/Utils/SkillTargetingUtil.cs
@@ -1,4 +1,5 @@
 ﻿using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Faction;
 using AAEmu.Game.Models.Game.Units;
 
@@ -25,9 +26,38 @@ public static class SkillTargetingUtil
                 return units.Append(caster);
             case SkillTargetRelation.Others:
                 return units.Where(o => caster.GetRelationStateTo(o) == RelationState.Neutral);
+            case SkillTargetRelation.FriendlyForDebuff:
+                // Friendly by faction, but deliberately targetable — this is the relation used by effects
+                // that land a debuff on an ally, so the !CanAttack clause of Friendly must not apply.
+                return units.Where(o => caster.GetRelationStateTo(o) == RelationState.Friendly);
+            case SkillTargetRelation.Family:
+                return units.Where(o => IsSameFamily(caster, o));
+            case SkillTargetRelation.ExpeditionMember:
+                return units.Where(o => IsSameExpedition(caster, o));
+            case SkillTargetRelation.IgnoreProtected:
+                // "Ignore protected" widens the selection rather than narrowing it: it means protection
+                // flags do not exclude a unit. Nothing to filter here.
+                return units;
+            case SkillTargetRelation.SiegeOffenseHqUser:
+            // Siege HQ ownership is not modelled server-side yet. Used by a single plot event; stays
+            // permissive rather than silently emptying that event's target list.
             default:
                 return units;
         }
+    }
+
+    private static bool IsSameFamily(BaseUnit caster, BaseUnit target)
+    {
+        return caster is Character { Family: > 0 } casterChar &&
+               target is Character targetChar &&
+               casterChar.Family == targetChar.Family;
+    }
+
+    private static bool IsSameExpedition(BaseUnit caster, BaseUnit target)
+    {
+        return caster is Unit { Expedition: not null } casterUnit &&
+               target is Unit targetUnit &&
+               targetUnit.Expedition?.Id == casterUnit.Expedition.Id;
     }
 
     public static bool IsRelationValid(SkillTargetRelation relation, BaseUnit caster, BaseUnit target)
@@ -49,6 +79,14 @@ public static class SkillTargetingUtil
             case SkillTargetRelation.Others:
                 // return caster.GetRelationStateTo(target) == RelationState.Neutral;
                 return caster?.ObjId != target.ObjId;
+            case SkillTargetRelation.FriendlyForDebuff:
+                return caster?.GetRelationStateTo(target) == RelationState.Friendly;
+            case SkillTargetRelation.Family:
+                return IsSameFamily(caster, target);
+            case SkillTargetRelation.ExpeditionMember:
+                return IsSameExpedition(caster, target);
+            case SkillTargetRelation.IgnoreProtected:
+            case SkillTargetRelation.SiegeOffenseHqUser:
             default:
                 return true;
         }

--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -302,10 +302,17 @@ public class Unit : BaseUnit, IUnit
 
     /// <summary>
     /// Accumulated combat resources by combat_resources id — the combo-point style pools an ability builds up
-    /// (광란, 착취, 근성 …). Plot flow already gates on these through plot_next_events'
-    /// start_combat_resource / end_combat_resource and skill_effects' target_combat_resource_id.
+    /// (광란, 착취, 근성 …). Plot flow gates on these through PlotCondition kind 19 and skill_effects'
+    /// target_combat_resource_id.
     /// </summary>
     public Dictionary<int, int> CombatResources { get; } = [];
+
+    /// <summary>
+    /// When each resource next loses <c>combat_resources.peace_recovery_amount</c> /
+    /// <c>combat_recovery_amount</c>. A resource with no entry is idle: it is either empty or its
+    /// <c>recovery_cycle</c> is 0 (기쁨 / 슬픔 never drain).
+    /// </summary>
+    private readonly Dictionary<int, DateTime> _combatResourceDecayAt = [];
 
     public int GetCombatResource(int combatResourceId) => CombatResources.GetValueOrDefault(combatResourceId, 0);
 
@@ -313,7 +320,14 @@ public class Unit : BaseUnit, IUnit
     /// Adds to a combat resource, clamped to that resource's own ceiling from combat_resources.max and never
     /// below zero. Returns the amount actually held afterwards.
     /// </summary>
-    public int AddCombatResource(int combatResourceId, int amount)
+    /// <param name="combatResourceId">combat_resources id.</param>
+    /// <param name="amount">Signed delta; negative spends.</param>
+    /// <param name="resetDecayTimer">
+    /// <c>combat_resource_effects.reset_remain_time</c>. The shipped rows set it on every builder, which is
+    /// what makes the short cycles workable: 증오 drains its whole pool every 5s, so without restarting the
+    /// timer on each gain the window to spend it would depend on when the last tick happened to land.
+    /// </param>
+    public int AddCombatResource(int combatResourceId, int amount, bool resetDecayTimer = true)
     {
         var max = CombatResourceGameData.Instance.GetMax(combatResourceId);
         var current = GetCombatResource(combatResourceId);
@@ -324,7 +338,163 @@ public class Unit : BaseUnit, IUnit
             : Math.Max(0, current + amount);
 
         CombatResources[combatResourceId] = updated;
+        ArmCombatResourceDecay(combatResourceId, updated, resetDecayTimer);
+        SyncCombatResourceBuff(combatResourceId, updated);
         return updated;
+    }
+
+    /// <summary>
+    /// Seeds <c>combat_resources.default_point</c>. Called once when a unit enters the world — 죽음의 낙인
+    /// starts at 6 and 기쁨 / 슬픔 at 5, and until this ran every ability that reads them saw 0.
+    /// </summary>
+    public void InitializeCombatResources()
+    {
+        foreach (var resource in CombatResourceGameData.Instance.WithDefaultPoint)
+        {
+            CombatResources[resource.Id] = resource.Max > 0
+                ? Math.Min(resource.DefaultPoint, resource.Max)
+                : resource.DefaultPoint;
+            ArmCombatResourceDecay(resource.Id, CombatResources[resource.Id], restart: true);
+            SyncCombatResourceBuff(resource.Id, CombatResources[resource.Id]);
+        }
+    }
+
+    /// <summary>
+    /// Drains pools whose cycle has elapsed. Driven from <see cref="OnActiveRegionTick"/>, i.e. about once a
+    /// second for units in a region a player is watching.
+    /// </summary>
+    private void CombatResourceTick(TimeSpan delta)
+    {
+        if (_combatResourceDecayAt.Count == 0)
+            return;
+
+        var now = DateTime.UtcNow;
+        List<int> due = null;
+        foreach (var (resourceId, at) in _combatResourceDecayAt)
+        {
+            if (at <= now)
+                (due ??= []).Add(resourceId);
+        }
+
+        if (due == null)
+            return;
+
+        foreach (var resourceId in due)
+        {
+            var resource = CombatResourceGameData.Instance.Get(resourceId);
+            if (resource == null)
+            {
+                _combatResourceDecayAt.Remove(resourceId);
+                continue;
+            }
+
+            var step = resource.RecoveryAmountFor(IsInBattle);
+            if (step == 0)
+            {
+                _combatResourceDecayAt.Remove(resourceId);
+                continue;
+            }
+
+            // Decay must not restart its own timer from the change — that would make a pool that drains in
+            // several steps re-arm on every step and never reach the next one on schedule.
+            var before = GetCombatResource(resourceId);
+            var after = AddCombatResource(resourceId, step, resetDecayTimer: false);
+            if (after == before)
+            {
+                _combatResourceDecayAt.Remove(resourceId);
+                continue;
+            }
+
+            BroadcastCombatResource(resource, after, updateTimeMs: 0);
+
+            if (after > 0)
+                _combatResourceDecayAt[resourceId] = now.AddMilliseconds(resource.RecoveryCycle);
+            else
+                _combatResourceDecayAt.Remove(resourceId);
+        }
+    }
+
+    /// <summary>Starts, restarts or clears a resource's decay timer for its current amount.</summary>
+    private void ArmCombatResourceDecay(int combatResourceId, int amount, bool restart)
+    {
+        var resource = CombatResourceGameData.Instance.Get(combatResourceId);
+        // recovery_cycle 0 means the pool is not on a timer at all, not "drain every tick".
+        if (resource == null || resource.RecoveryCycle <= 0 || amount <= 0)
+        {
+            _combatResourceDecayAt.Remove(combatResourceId);
+            return;
+        }
+
+        if (restart || !_combatResourceDecayAt.ContainsKey(combatResourceId))
+            _combatResourceDecayAt[combatResourceId] = DateTime.UtcNow.AddMilliseconds(resource.RecoveryCycle);
+    }
+
+    /// <summary>
+    /// Holds or drops the resource's bar buff. The client draws the pip UI off this buff, so without it the
+    /// point packets arrive against a bar that was never shown.
+    /// </summary>
+    private void SyncCombatResourceBuff(int combatResourceId, int amount)
+    {
+        var resource = CombatResourceGameData.Instance.Get(combatResourceId);
+        if (resource is not { BuffId: > 0 } || Buffs == null)
+            return;
+
+        var shouldHold = resource.ShouldHoldBuff(amount);
+        var holds = Buffs.CheckBuff(resource.BuffId);
+        if (shouldHold == holds)
+            return;
+
+        if (shouldHold)
+        {
+            // An id with no template would NRE inside Buffs.AddBuff. Every shipped bar buff resolves, but
+            // this runs on data we do not control.
+            if (SkillManager.Instance.GetBuffTemplate(resource.BuffId) == null)
+            {
+                Logger.Warn("Combat resource {0} names buff {1}, which is not loaded", resource.Id, resource.BuffId);
+                return;
+            }
+
+            Buffs.AddBuff(resource.BuffId, this);
+            return;
+        }
+
+        // 기쁨 (26) and 슬픔 (27) share buff 29976. Dropping it for one while the other still qualifies would
+        // take the bar away from both.
+        foreach (var other in CombatResourceGameData.Instance.All)
+        {
+            if (other.Id != combatResourceId && other.BuffId == resource.BuffId &&
+                other.ShouldHoldBuff(GetCombatResource(other.Id)))
+                return;
+        }
+
+        Buffs.RemoveBuff(resource.BuffId);
+    }
+
+    /// <summary>
+    /// Pushes a resource total to whoever combat_resources.resouece_send_type_id says should see it
+    /// (1 Self, 2 Broadcast).
+    /// </summary>
+    public void BroadcastCombatResource(CombatResource resource, int amount, int updateTimeMs)
+    {
+        if (resource == null)
+            return;
+
+        var packet = new SCCombatResourcePointPacket(ObjId, resource.Id, (ulong)Math.Max(0, amount), updateTimeMs);
+        if (resource.SendTypeId == 2)
+            BroadcastPacket(packet, true);
+        else
+            (this as Char.Character)?.SendPacket(packet);
+    }
+
+    /// <summary>Sends every non-empty pool, so a freshly entered client starts with a bar that matches the server.</summary>
+    public void SendAllCombatResources()
+    {
+        foreach (var resource in CombatResourceGameData.Instance.All)
+        {
+            var amount = GetCombatResource(resource.Id);
+            if (amount != 0)
+                BroadcastCombatResource(resource, amount, updateTimeMs: 0);
+        }
     }
 
     private bool _isInBattle;
@@ -1666,6 +1836,7 @@ public class Unit : BaseUnit, IUnit
     {
         CombatTick(delta);
         RegenTick(delta);
+        CombatResourceTick(delta);
     }
 
     /// <summary>

--- a/AAEmu.Game/Models/Game/Units/UnitProcs.cs
+++ b/AAEmu.Game/Models/Game/Units/UnitProcs.cs
@@ -12,17 +12,34 @@ public class UnitProcs(Unit owner)
 
     public void AddProc(uint procId)
     {
+        var template = ItemManager.Instance.GetItemProcTemplate(procId);
+        if (template == null)
+            return;
+
+        if (!_procsByChanceKind.TryGetValue(template.ChanceKind, out var kindProcs))
+        {
+            kindProcs = [];
+            _procsByChanceKind.Add(template.ChanceKind, kindProcs);
+        }
+
+        // Has to stay idempotent: ApplyEquipItemSetBonuses re-runs on every equipment change and re-adds
+        // the procs of every set still worn, so without this a worn set gained one more copy of its proc
+        // per gear update and rolled that many times per trigger.
+        if (kindProcs.Exists(p => p.TemplateId == procId))
+            return;
+
         var proc = new ItemProc(procId);
         _procs.Add(proc);
-        if (!_procsByChanceKind.ContainsKey(proc.Template.ChanceKind))
-            _procsByChanceKind.Add(proc.Template.ChanceKind, []);
-        _procsByChanceKind[proc.Template.ChanceKind].Add(proc);
+        kindProcs.Add(proc);
     }
 
     public void RemoveProc(uint procId)
     {
         var procTemplate = ItemManager.Instance.GetItemProcTemplate(procId);
+        if (procTemplate == null)
+            return;
 
+        _procs.RemoveAll(p => p.TemplateId == procId);
         if (_procsByChanceKind.TryGetValue(procTemplate.ChanceKind, out var value))
             value.RemoveAll(p => p.TemplateId == procId);
     }
@@ -31,13 +48,16 @@ public class UnitProcs(Unit owner)
     {
         if (!_procsByChanceKind.TryGetValue(kind, out var procs))
             return;
-        foreach (var proc in procs)
-        {
-            if (proc.LastProc.AddSeconds(proc.Template.CooldownSec) <= DateTime.UtcNow)
-                continue;
 
-            proc.Apply(Owner);
-            proc.LastProc = DateTime.UtcNow;
+        // Snapshot: a proc casts a skill on the owner, which can come back around into Add/RemoveProc.
+        foreach (var proc in procs.ToArray())
+        {
+            // Apply owns both the cooldown gate and the chance roll, and only a proc that really fired
+            // starts a new cooldown. The guard that used to stand here was inverted - it skipped exactly
+            // those procs whose cooldown had expired - and since LastProc was advanced only inside the
+            // branch that could therefore never run, no item proc in the game ever fired.
+            if (proc.Apply(Owner))
+                proc.LastProc = DateTime.UtcNow;
         }
     }
 }

--- a/AAEmu.Game/Models/Game/World/AreaShape.cs
+++ b/AAEmu.Game/Models/Game/World/AreaShape.cs
@@ -1,4 +1,6 @@
-﻿using AAEmu.Game.Utils;
+﻿using System.Numerics;
+
+using AAEmu.Game.Utils;
 
 namespace AAEmu.Game.Models.Game.World;
 public class AreaShape
@@ -10,11 +12,37 @@ public class AreaShape
     public float Value3 { get; set; }
 
     /// <summary>
-    /// Sphere cone half-angle in degrees. On <see cref="AreaShapeType.Sphere"/>, content stores
-    /// radius in <see cref="Value1"/> and this half-angle in <see cref="Value3"/> (e.g. shotgun
-    /// aoe_shapes 20454 / 20458: 15.7m, ±45°). Cuboid uses Value3 as vertical extent instead.
+    /// aoe_shapes.area_target_kind_id (enum_plot_area_target_kinds). For <see cref="AreaShapeType.Line"/>
+    /// this names the unit the corridor is aimed at; the corridor itself starts at the plot event's Source.
     /// </summary>
-    public float SphereConeHalfAngleDegrees => Type == AreaShapeType.Sphere ? Value3 : 0f;
+    public AreaTargetKindType AreaTargetKind { get; set; } = AreaTargetKindType.None;
+
+    /// <summary>
+    /// Whether <c>aoe_shapes.value3</c> on a sphere is the FULL sweep of the cone (so the accepted
+    /// bearing is ±value3/2) rather than the half-angle (±value3).
+    /// </summary>
+    /// <remarks>
+    /// UNRESOLVED, and deliberately left on the historical reading. The only evidence either way is that
+    /// 108 sphere rows carry value3 exactly 360 — meaningless as a half-angle, exactly "omni" as a full
+    /// sweep — but for those very rows both readings accept every bearing, so the difference is not
+    /// observable there. Flipping this halves 215 cones that are in active use (44 of the 360-rows alone
+    /// back live AoEs), and if the historical reading is right, those skills would quietly stop hitting
+    /// targets they should — indistinguishable from the bug this was meant to fix.
+    ///
+    /// To settle it: stand roughly 40° off a caster's facing inside a known cone skill whose shape has
+    /// value3 60 (e.g. 19232, Crashing Wave's target picker) and see whether the hit lands. Hit ⇒ ±60,
+    /// leave this false. Miss ⇒ ±30, set it true.
+    /// </remarks>
+    private const bool SphereConeValue3IsFullSweep = false;
+
+    /// <summary>
+    /// Sphere cone half-angle in degrees: the bearing from the origin's facing that still counts as a hit.
+    /// On <see cref="AreaShapeType.Sphere"/> content stores the radius in <see cref="Value1"/> and the cone
+    /// in <see cref="Value3"/>. Cuboid uses Value3 as vertical extent instead.
+    /// </summary>
+    public float SphereConeHalfAngleDegrees => Type == AreaShapeType.Sphere
+        ? (SphereConeValue3IsFullSweep ? Value3 / 2f : Value3)
+        : 0f;
 
     public List<T> ComputeCuboid<T>(GameObject origin, List<T> toCheck) where T : GameObject
     {
@@ -35,13 +63,62 @@ public class AreaShape
             var tri1 = MathUtil.PointInTriangle((o.Transform.World.Position.X, o.Transform.World.Position.Y), vertices[0], vertices[1],
                 vertices[2]);
 
-            var tri2 = MathUtil.PointInTriangle((o.Transform.World.Position.X, o.Transform.World.Position.Y), vertices[1], vertices[2],
+            // Fan from vertex 0, not (v1,v2,v3): the quad's two triangles have to share a diagonal
+            // through the SAME corner. Splitting it as (v0,v1,v2)+(v1,v2,v3) leaves a quarter-wedge
+            // of every cuboid uncovered, so an entire quarter of each box AoE never registered a hit.
+            var tri2 = MathUtil.PointInTriangle((o.Transform.World.Position.X, o.Transform.World.Position.Y), vertices[0], vertices[2],
                 vertices[3]);
 
             return tri1 || tri2;
         }).ToList();
 
         return toCheck;
+    }
+
+    /// <summary>
+    /// Line AoE (enum_aoe_shape_kinds 3): a corridor starting at <paramref name="start"/>, running
+    /// <see cref="Value2"/> metres along <paramref name="forward"/>, <see cref="Value1"/> metres to
+    /// each side and ±<see cref="Value3"/> metres vertically.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not built on <see cref="ComputeCuboid"/>. A box centred on the aimed-at unit puts
+    /// that unit exactly on the rectangle's diagonal, and <see cref="MathUtil.PointInTriangle"/> tests
+    /// strictly (Sign(...) &lt; 0), so a point on an edge is rejected — the search then returned nothing
+    /// and every per-target edge behind it expanded to zero hits.
+    /// </remarks>
+    public List<T> ComputeCorridor<T>(Vector3 start, Vector3 forward, List<T> toCheck, float aimDistance = 0f) where T : GameObject
+    {
+        if (toCheck == null || toCheck.Count == 0)
+            return toCheck ?? [];
+
+        var dir = new Vector3(forward.X, forward.Y, 0f);
+        if (dir.LengthSquared() < 0.0001f)
+            return [];
+        dir = Vector3.Normalize(dir);
+
+        // value2 == 0 means "as far as the anchor", otherwise it is a fixed reach.
+        var length = Value2 > 0f ? Value2 : aimDistance;
+        if (length <= 0f)
+            return [];
+
+        var halfWidth = Value1;
+        var zOffset = Value3;
+
+        return toCheck.Where(o =>
+        {
+            var p = o.Transform.World.Position;
+            if (p.Z < start.Z - zOffset || p.Z > start.Z + zOffset)
+                return false;
+
+            var dx = p.X - start.X;
+            var dy = p.Y - start.Y;
+            var along = dx * dir.X + dy * dir.Y;
+            if (along < -o.ModelSize || along > length + o.ModelSize)
+                return false;
+
+            var side = dx * -dir.Y + dy * dir.X;
+            return Math.Abs(side) <= halfWidth + o.ModelSize;
+        }).ToList();
     }
 
     /// <summary>

--- a/AAEmu.Game/Models/Game/World/AreaShapeType.cs
+++ b/AAEmu.Game/Models/Game/World/AreaShapeType.cs
@@ -3,5 +3,11 @@
 public enum AreaShapeType
 {
     Sphere = 1,
-    Cuboid = 2
+    Cuboid = 2,
+    /// <summary>
+    /// enum_aoe_shape_kinds id 3. A forward corridor from the origin towards the anchor named by
+    /// the shape's area_target_kind_id. 58 plot events use it, among them Crashing Wave's "라인"
+    /// nodes (plot 3523, shapes 13617 and 23158) — the only paths to that plot's damage effect.
+    /// </summary>
+    Line = 3
 }

--- a/AAEmu.Game/Models/Game/World/AreaTargetKindType.cs
+++ b/AAEmu.Game/Models/Game/World/AreaTargetKindType.cs
@@ -1,0 +1,15 @@
+namespace AAEmu.Game.Models.Game.World;
+
+/// <summary>
+/// enum_plot_area_target_kinds. Names the unit an area shape is AIMED at. Only line shapes need it:
+/// every aoe_shapes row with kind_id 3 carries a non-zero value, while spheres almost always carry 0.
+/// </summary>
+public enum AreaTargetKindType
+{
+    None = 0,
+    OriginalSource = 1,
+    OriginalTarget = 2,
+    PreviousSource = 3,
+    PreviousTarget = 4,
+    CurrentPosition = 5
+}


### PR DESCRIPTION
This is the whole of our plot and skill work, in one PR because the pieces only make sense together — the crash fix keeps the server alive long enough to reach the conditions, and the conditions are what make the targeting matter.

> **Please read "Consequences" before merging.** Several of these changes make gates that previously always passed start actually gating. That is the point of them, but it means plot behaviour visibly changes, and a few decisions are deliberate deviations from the shipped data.

## 1. Server crash while casting a plot skill

Casting a plot skill took the server down with an `0xC0000005` inside ICU. `ClientSource` resolves the skill's text through ICU and handed it input it could not survive.

## 2. Condition kinds 19 and 20 never gated anything

`PlotConditionType` stopped at `ABLevel = 17`, so every kind the v10 data added fell into `Check`'s `_ => true` arm and passed unconditionally.

**Kind 19, `combat_resource`** — 233 shipped conditions. The clearest casualty is Malediction: Ghastly Pack (plot 5477) carries three of them on combat resource 15 — `(1,4)`, `(5,9)`, `(10,10)` — which are exactly the base / "5 Malice Charges" / "10 Malice Charges" tiers its tooltip advertises. With all three passing the plot always took its first branch, never reached the higher tiers, and never ran the `plot_effects` that spend the charges. Serpent Bite (plot 3524) is gated the same way. `param1`/`param2` are an inclusive range and `param3` is `combat_resources.id`, verified against `plot_conditions` 20966/20967/20968.

**Kind 20, `unit_reqs`** — after `buff_tag` and `dead` this is the most used gate in the shipped plots: 1605 conditions, of which 1504 own `unit_reqs` rows. It is the "may this unit do this here" test — stance, equipped weapon type, buff, zone, gear score, combat resource. All 1605 passed. It carries `plot_conditions.or_unit_reqs`: the rows pass when ANY holds (94 conditions) or only when ALL do (1511).

Kinds 18 and 21 remain unimplemented, but the default arm now warns once per kind instead of passing invisibly.

## 3. Area selection

**Line shapes (`enum_aoe_shape_kinds` 3) were computed as a cuboid.** A box centred on the aimed-at unit puts that unit exactly on the rectangle's diagonal, and `MathUtil.PointInTriangle` tests strictly (`Sign(...) < 0`), so a point on an edge is rejected. The search came back empty and every per-target edge behind it expanded to zero hits. Replaced with a real corridor: starts at the event's Source, runs `Value2` metres along the facing, `Value1` to each side, `±Value3` vertically.

**`aoe_shapes.area_target_kind_id` was never read.** For a line it names the unit the corridor is aimed at.

**Sphere cones were full 360° discs.** `value3 > 0` is a frontal cone (shotgun plots 5796/5604/5231); without the bearing filter `MaxTargets = 3` simply took whatever was nearest.

**`plot_aoe_conditions` did not gate Area and Random picks.** Crime Aura 40917 event 35070 requires BuffTag 894 (현상수배); without the filter every character in the 25m sphere counted as wanted — taunt, chip damage and the criminal bubble on a friendly Nuia guard.

## 4. Combat resources started every session at zero

`combat_resources.default_point` had never been read, so 죽음의 낙인 / 기쁨 / 슬픔 all began at 0 and the abilities gated on them could not reach their first tier. Pools are now seeded and their amounts broadcast so the client's bars follow.

## 5. One bad target cost an AoE the rest of its targets

An AoE that found five units damaged two and logged `Plot Effects Error` once. The nearest `try`/`catch` sat a level up in `PlotNode.Execute`, so anything thrown while applying target N dropped targets N..last of that effect.

The live cause: an item proc row with no template or no skill template built a `Skill` with a null `Template`, and `Skill.Use` dereferenced it on the first `Template.Id` read — inside `DamageEffect`'s `TakeDamageAny` roll, inside the per-target loop. `PlotEventEffect` now catches per target and names what it lost; `ItemProc` rejects such a row once per template id; `Skill.Use` returns `InvalidSkill` instead of an NRE.

## Consequences

**Plots that used to take their first branch will now branch properly.** That is the intent, but 1838 conditions across kinds 19 and 20 change from "always true" to "actually evaluated". Where our `unit_reqs` coverage is incomplete or the data means something we have not understood, a skill that appeared to work may now stop at a gate. The failures are visible in the log rather than silent, which is the trade we chose.

**Two deliberate deviations from the raw data:**

1. **The Range gate (kind 11) may be widened to the radius of the area search that selected the target.** The shipped data disagrees with itself: Backdraft (44200) selects with `aoe_shapes` 19754 (r 9.7) and then re-checks with Range 0..9, so a unit between 9.0 and 9.7 m is found, counted into the target list, and only then dropped — while the client, which draws the telegraph from the shape, shows it comfortably inside the cone. Left alone, the outer 0.7 m of every such cone is decorative. The widening is scoped to that contradiction: the gate only ever grows, only for a target an area search actually selected, and only up to that search's own radius. Blank shape rows are never recorded, so a placeholder can never become reach.

   One discrepancy remains after that widening, and we are leaving it alone: **the client draws the cone longer than its 9.7 m radius.** With six dummies placed inside the drawn telegraph, all six look to the player as though they are in the cone, while the server only considers those the shape actually covers. This is cosmetic — the server computes with what `aoe_shapes` 19754 specifies, and that is the number we trust. It is worth knowing about, because it is the shape of complaint ("it clearly hit them") that will come back from players.

2. **Blank sphere rows keep the historical 40 m guess.** ~497 shape rows carry `value1..3` all zero yet 502 plot events search them for up to 50 targets. There is no radius in the data to recover. It now warns once per shape, because a 40 m sweep is wide enough to explain an AoE that "hits things it shouldn't".

**One question is unresolved and deliberately left on the historical reading.** Whether `aoe_shapes.value3` on a sphere is the cone's half-angle (±value3) or its full sweep (±value3/2). 108 sphere rows carry exactly 360 — meaningless as a half-angle, exactly "omni" as a full sweep — but for those very rows both readings accept every bearing, so the difference is not observable there. Flipping it halves 215 cones that are in active use. The switch is a single `const` (`AreaShape.SphereConeValue3IsFullSweep`) with the experiment written next to it: stand roughly 40° off a caster's facing inside a `value3 = 60` cone (shape 19232, Crashing Wave's target picker) and see whether the hit lands.

**Diagnostics are opt-in.** `AAEMU_PLOT_AREA_DEBUG=1` logs one line per plot area search plus the neighbourhood of the origin, at `Debug`. Worth turning on when a plot AoE hits the wrong number of targets, because events without effects or conditions emit no `SCPlotEvent` — so an empty area search is otherwise indistinguishable from an event that never ran.

## Testing

`AAEmu.Game` builds clean against `client_version/zone-10.0.2_r575`.

Exercised in-game across the plot skills named above. Combat-resource tiering, the line corridor and the cone filter were each confirmed to change behaviour in the direction described; the full 1838-condition surface is obviously not covered by hand.

## Review fixes

Both findings from the automated review are addressed in the last commit:

- `InitializeCombatResources` and `SendAllCombatResources` were never called, so `default_point` was read into a method that never ran. Both now run at world entry, after `Spawn()` — the seeding applies each pool's bar buff and the point packet addresses the local player unit, neither of which exists earlier.
- `FilterTargets` evaluated `plot_aoe_conditions` twice per candidate. Beyond the wasted work, `Chance` and `CombatDiceResult` are not idempotent: they rolled a second time, shifting the odds and overwriting the dice result the rest of the plot reads.
- `UpdateRandomUnitTarget` enumerated the filtered sequence three times — `Count()`, `Any()`, `ElementAt()`. `FilterTargets` is lazy and now runs those same non-idempotent conditions, so each pass could see a different population, the rolls happened three times over, and the index could point past the end of the last one. The sequence is materialised once and the pick comes out of that snapshot.
- `AAEMU_PLOT_AREA_DEBUG` defaulted to on. It sits on the combat hot path — every area search materialises each filter stage, and a sphere search additionally runs a 40 m neighbourhood query and sorts it — so it is back to opt-in (`=1`) and logs at `Debug` instead of `Info`. That answers the "keep the diagnostic opt-in" note and supersedes the paragraph below.

## Notes

Deliberately **not** in this PR, to keep it to plot and skill: the equip-set-bonus crash fix (an `eiset_id` with no `equip_item_set_bonuses` row — ids 28 and 189 ship that way — throws out of `UpdateGearBonuses` and takes every other set bonus with it), the labor pool changes, and the character-sheet gear probe. Happy to send the equip-set one separately.
