### PR TITLE
fix(char): make character deletion work, and stop inventing a main character

### DIFF
--- a/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
@@ -744,6 +744,36 @@ public class CharacterManager(
         {
             if (character.DeleteTime > DateTime.MinValue && character.DeleteTime <= DateTime.UtcNow)
             {
+                // The main character is not deletable, and that has to hold here too, not only in
+                // SetDeleteCharacter. A row can carry both states - the nomination guard was added
+                // after this timer existed, and a database edited by hand can always produce it - and
+                // the timer firing anyway would delete exactly what the other rule protects.
+                //
+                // The pending deletion is cleared rather than left to fire again on the next pass:
+                // nominating a character as the account main is the player saying to keep it, and a
+                // request that can never complete would otherwise be retried and logged forever.
+                if (character.IsRepresent)
+                {
+                    Logger.Warn(
+                        "CheckForDeletedCharactersDeletion - Account:{0} Id:{1} Name:{2} is the account main character; cancelling the pending deletion instead",
+                        character.AccountId, character.Id, character.Name);
+
+                    using var cancelCommand = dbConnection.CreateCommand();
+                    cancelCommand.Connection = dbConnection;
+                    cancelCommand.CommandText =
+                        "UPDATE `characters` SET `delete_request_time`=@none, `delete_time`=@none " +
+                        "WHERE `id`=@char_id AND `account_id`=@account_id AND `deleted`=0";
+                    cancelCommand.Parameters.AddWithValue("@none", DateTime.MinValue);
+                    cancelCommand.Parameters.AddWithValue("@char_id", character.Id);
+                    cancelCommand.Parameters.AddWithValue("@account_id", character.AccountId);
+                    cancelCommand.Prepare();
+                    cancelCommand.ExecuteNonQuery();
+
+                    character.DeleteRequestTime = DateTime.MinValue;
+                    character.DeleteTime = DateTime.MinValue;
+                    return false;
+                }
+
                 Logger.Info("CheckForDeletedCharactersDeletion - Deleting Account:{0} Id:{1} Name:{2}", character.AccountId, character.Id, character.Name);
                 using var command = dbConnection.CreateCommand();
                 var originalName = character.Name;
@@ -996,11 +1026,24 @@ public class CharacterManager(
     {
         lock (_characterDeletionLock)
         {
-            if (!isDeleted && !gameConnection.Characters.ContainsKey(characterId))
+            if (!isDeleted)
             {
-                Logger.Warn($"SetRepresentCharacter: character {characterId} is not on account {gameConnection.AccountId}");
-                gameConnection.SendPacket(new SCRepreSentCharacterPacket(characterId, false, false, false));
-                return;
+                if (!gameConnection.Characters.TryGetValue(characterId, out var nominee))
+                {
+                    Logger.Warn($"SetRepresentCharacter: character {characterId} is not on account {gameConnection.AccountId}");
+                    gameConnection.SendPacket(new SCRepreSentCharacterPacket(characterId, false, false, false));
+                    return;
+                }
+
+                // A character queued for deletion must not become the account main. Nominating one would
+                // put the two rules against each other: SetDeleteCharacter refuses to delete the main
+                // character, while the pending timer would still take it away when it expires.
+                if (nominee.DeleteRequestTime > DateTime.MinValue)
+                {
+                    Logger.Info($"SetRepresentCharacter: refusing character {characterId} on account {gameConnection.AccountId} - deletion is pending");
+                    gameConnection.SendPacket(new SCRepreSentCharacterPacket(characterId, false, false, false));
+                    return;
+                }
             }
 
             using (var connection = MySQL.CreateConnection())

--- a/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
@@ -893,6 +893,16 @@ public class CharacterManager(
         {
             if (gameConnection.Characters.TryGetValue(characterId, out var character))
             {
+                // The client already refuses this ("Must deselect as Main Character before
+                // deleting."), but that check lives entirely in its UI - nothing stopped a request
+                // that skipped it from going through here.
+                if (character.IsRepresent)
+                {
+                    Logger.Info($"SetDeleteCharacter: refusing to delete main character {characterId} on account {gameConnection.AccountId}");
+                    gameConnection.SendPacket(new SCDeleteCharacterResponsePacket(characterId, 0));
+                    return;
+                }
+
                 var deleteRequestTime = DateTime.UtcNow;
                 var targetDeleteDelay = 0;
 
@@ -972,6 +982,74 @@ public class CharacterManager(
             }
         }
     }
+    /// <summary>
+    /// Records which character an account nominated as its main ("represent") character, or clears
+    /// the nomination. At most one character per account holds it, so setting one clears the rest.
+    /// </summary>
+    /// <remarks>
+    /// The client drives this from the character select screen and keeps its own copy - there is no
+    /// field in the character list to send it back, and no server-to-client packet for it. We store it
+    /// so the server knows what the player chose; the guard in <see cref="SetDeleteCharacter"/> is
+    /// what that knowledge is for.
+    /// </remarks>
+    public void SetRepresentCharacter(GameConnection gameConnection, uint characterId, bool isDeleted)
+    {
+        lock (_characterDeletionLock)
+        {
+            if (!isDeleted && !gameConnection.Characters.ContainsKey(characterId))
+            {
+                Logger.Warn($"SetRepresentCharacter: character {characterId} is not on account {gameConnection.AccountId}");
+                gameConnection.SendPacket(new SCRepreSentCharacterPacket(characterId, false, false, false));
+                return;
+            }
+
+            using (var connection = MySQL.CreateConnection())
+            using (var command = connection.CreateCommand())
+            {
+                // Clear the whole account first, then set the one that was picked. Doing it in that
+                // order keeps the "at most one" rule true even if a previous nomination is stale.
+                command.CommandText = "UPDATE characters SET `represent`=0 WHERE `account_id`=@account_id";
+                command.Parameters.AddWithValue("@account_id", gameConnection.AccountId);
+                command.Prepare();
+                command.ExecuteNonQuery();
+            }
+
+            foreach (var accountCharacter in gameConnection.Characters.Values)
+                accountCharacter.IsRepresent = false;
+
+            if (isDeleted)
+            {
+                Logger.Info($"SetRepresentCharacter: account {gameConnection.AccountId} cleared its main character");
+                // Zero with success set is what clears the client's own copy: its handler stores
+                // whatever id we send whenever success is true.
+                gameConnection.SendPacket(new SCRepreSentCharacterPacket(0, true, false, true));
+                return;
+            }
+
+            using (var connection = MySQL.CreateConnection())
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText =
+                    "UPDATE characters SET `represent`=1 WHERE `id`=@id AND `account_id`=@account_id AND `deleted`=0";
+                command.Parameters.AddWithValue("@id", characterId);
+                command.Parameters.AddWithValue("@account_id", gameConnection.AccountId);
+                command.Prepare();
+                if (command.ExecuteNonQuery() != 1)
+                {
+                    Logger.Warn($"SetRepresentCharacter: could not mark character {characterId} on account {gameConnection.AccountId}");
+                    gameConnection.SendPacket(new SCRepreSentCharacterPacket(characterId, false, false, false));
+                    return;
+                }
+            }
+
+            if (gameConnection.Characters.TryGetValue(characterId, out var character))
+                character.IsRepresent = true;
+
+            Logger.Info($"SetRepresentCharacter: account {gameConnection.AccountId} nominated character {characterId}");
+            gameConnection.SendPacket(new SCRepreSentCharacterPacket(characterId, true, false, false));
+        }
+    }
+
     public static List<LoginCharacterInfo> LoadCharacters(uint accountId)
     {
         var result = new List<LoginCharacterInfo>();

--- a/AAEmu.Game/Core/Packets/C2G/CSAesXorKeyPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSAesXorKeyPacket.cs
@@ -93,12 +93,19 @@ public class CSAesXorKeyPacket() : GamePacket(CSOffsets.CSAesXorKeyPacket, 1)
             }
         }
 
-        // Featured/representative character for the character-select screen. The reference sends
-        // SCRepreSentCharacter (0x2C4) right after the character list; represent the first character
-        // (success/first true), or an empty representation when the account has none.
-        if (characters.Length > 0)
-            Connection.SendPacket(new SCRepreSentCharacterPacket(characters[0].Id, true, true, false));
+        // The account's main ("represent") character for the character-select screen, sent right after
+        // the character list.
+        //
+        // This used to name characters[0] unconditionally with success=true. The client's handler for
+        // 0x2C4 stores that id as THE represent character (RVA 0x4DD270), and its delete dialog then
+        // refuses the first character on every account with "Must deselect as Main Character before
+        // deleting." - a main character nobody had chosen, reasserted at every login. Send whoever the
+        // player actually nominated instead, and success=false when that is nobody, which leaves the
+        // client's id at its default of zero.
+        var represent = characters.FirstOrDefault(c => c.IsRepresent);
+        if (represent != null)
+            Connection.SendPacket(new SCRepreSentCharacterPacket(represent.Id, true, true, false));
         else
-            Connection.SendPacket(new SCRepreSentCharacterPacket(0, false, false, false));
+            Connection.SendPacket(new SCRepreSentCharacterPacket(0, false, true, false));
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSCancelCharacterDeletePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSCancelCharacterDeletePacket.cs
@@ -1,14 +1,18 @@
-﻿using AAEmu.Commons.Network;
+using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Managers.UnitManagers;
 using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
+/// <summary>
+/// Client layout: a single u64 "type" - the character id. This shares its serialize function
+/// (RVA 0xC688D0) with CSDeleteCharacter, so the two are byte-for-byte the same on the wire.
+/// </summary>
 public class CSCancelCharacterDeletePacket() : GamePacket(CSOffsets.CSCancelCharacterDeletePacket, 1)
 {
     public override void Read(PacketStream stream)
     {
-        var characterId = stream.ReadUInt32();
-        CharacterManager.Instance.SetRestoreCharacter(Connection, characterId);
+        var characterId = stream.ReadUInt64(); // u64 type
+        CharacterManager.Instance.SetRestoreCharacter(Connection, (uint)characterId);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSDeleteCharacterPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSDeleteCharacterPacket.cs
@@ -1,14 +1,23 @@
-﻿using AAEmu.Commons.Network;
+using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Managers.UnitManagers;
 using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
+/// <summary>
+/// Client layout (serialize at RVA 0xC688D0): a single u64 "type" - the character id.
+/// </summary>
+/// <remarks>
+/// We read four bytes where the client writes eight, so the id we ended up with was never the one the
+/// player clicked. CharacterManager then found no such character on the account and answered with a
+/// rejection - which the client could not read either, because that packet had the same fault. The
+/// visible result was a delete that did nothing at all and said nothing about it.
+/// </remarks>
 public class CSDeleteCharacterPacket() : GamePacket(CSOffsets.CSDeleteCharacterPacket, 1)
 {
     public override void Read(PacketStream stream)
     {
-        var characterId = stream.ReadUInt32();
-        CharacterManager.Instance.SetDeleteCharacter(Connection, characterId);
+        var characterId = stream.ReadUInt64(); // u64 type
+        CharacterManager.Instance.SetDeleteCharacter(Connection, (uint)characterId);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSRepresentCharacter.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSRepresentCharacter.cs
@@ -1,13 +1,21 @@
 using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers.UnitManagers;
 using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
-/// TODO(v10): the body is parsed but nothing acts on it yet.
+/// The player nominated (or cleared) the account's main character in the character select screen.
 /// </summary>
 /// <remarks>
-/// which passes each field name alongside the value:
+/// Client layout (serialize at RVA 0xC6B750): u64 "type" - the character id - then bool "isDeleted",
+/// which is set when the nomination is being cleared rather than made.
+///
+/// The flag only ever travels in this direction. The character list entry has no field for it (its
+/// last member is "guid", followed by the labor block) and there is no server-to-client packet for
+/// it either, so the client keeps its own copy - which is what produces "Must deselect as Main
+/// Character before deleting." without the server being involved. We record the choice so the
+/// deletion guard in CharacterManager can act on it.
 /// </remarks>
 public class CSRepresentCharacter() : GamePacket(CSOffsets.CSRepresentCharacter, 1)
 {
@@ -16,7 +24,9 @@ public class CSRepresentCharacter() : GamePacket(CSOffsets.CSRepresentCharacter,
 
     public override void Read(PacketStream stream)
     {
-        Type = stream.ReadUInt64();
-        IsDeleted = stream.ReadBoolean();
+        Type = stream.ReadUInt64();     // u64  type
+        IsDeleted = stream.ReadBoolean(); // bool isDeleted
+
+        CharacterManager.Instance.SetRepresentCharacter(Connection, (uint)Type, IsDeleted);
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCCancelCharacterDeleteResponsePacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCCancelCharacterDeleteResponsePacket.cs
@@ -3,13 +3,17 @@ using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
+/// <summary>
+/// Client layout (read at RVA 0xC59D40): u64 "type" - the character id - then u8 deleteStatus.
+/// The id used to be written as u32, so cancelling a pending deletion never reached the UI either.
+/// </summary>
 public class SCCancelCharacterDeleteResponsePacket(uint characterId, byte deleteStatus)
     : GamePacket(SCOffsets.SCCancelCharacterDeleteResponsePacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(characterId);
-        stream.Write(deleteStatus);
+        stream.Write((ulong)characterId);   // u64 type
+        stream.Write(deleteStatus);         // u8  deleteStatus
         return stream;
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCCharacterDeletedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCCharacterDeletedPacket.cs
@@ -3,13 +3,17 @@ using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
+/// <summary>
+/// Client layout (read at RVA 0xC59CA0): u64 "type" - the character id - then the name as a string.
+/// The id used to be written as u32, which left the name starting four bytes early and unreadable.
+/// </summary>
 public class SCCharacterDeletedPacket(uint characterId, string characterName)
     : GamePacket(SCOffsets.SCCharacterDeletedPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(characterId);
-        stream.Write(characterName);
+        stream.Write((ulong)characterId);   // u64     type
+        stream.Write(characterName);        // wstring name
         return stream;
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCDeleteCharacterResponsePacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCDeleteCharacterResponsePacket.cs
@@ -3,6 +3,18 @@ using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
+/// <summary>
+/// Client layout (read at RVA 0xC59C20), which names every field:
+///
+///   type                u64   the character id - EIGHT bytes, not four
+///   deleteStatus        u8
+///   deleteRequestedTime u64   unix seconds
+///   deleteDelay         u64   unix seconds
+///
+/// The id was written as u32, which shifted the status and both timestamps by four bytes. Neither the
+/// confirmation nor the rejection could be read, so a delete request produced no visible reaction at
+/// all - not even an error.
+/// </summary>
 public class SCDeleteCharacterResponsePacket(
     uint characterId,
     byte status,
@@ -15,10 +27,10 @@ public class SCDeleteCharacterResponsePacket(
 
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(characterId);
-        stream.Write(status);
-        stream.Write(_deleteRequestedTime);
-        stream.Write(_deleteDelay);
+        stream.Write((ulong)characterId);   // u64 type
+        stream.Write(status);               // u8  deleteStatus
+        stream.Write(_deleteRequestedTime); // u64 deleteRequestedTime
+        stream.Write(_deleteDelay);         // u64 deleteDelay
         return stream;
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCRepreSentCharacterPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCRepreSentCharacterPacket.cs
@@ -3,17 +3,40 @@ using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
+/// <summary>
+/// Names the account's main ("represent") character. The odd capitalisation is the client's own -
+/// its RTTI reads ".?AUSCRepreSentCharacterPacket@@".
+/// </summary>
+/// <remarks>
+/// Client layout (read at RVA 0xC62F10):
+///
+///   type      u64    the character id
+///   success   bool
+///   first     bool
+///   isDeleted bool
+///
+/// The handler (RVA 0x4DD270) is short and decides everything:
+///
+///     if (packet.success) globals[0x3698] = packet.type;
+///     notifyUi(success, first, isDeleted);
+///
+/// So <paramref name="success"/> is what makes the client adopt the id - and a packet sent with it set
+/// is not a status report, it is an instruction. GetRepresentCharacterIndex (RVA 0x9A57E0) then walks
+/// the character array comparing ids and returns a 1-based index, or 0 when the stored id matches
+/// nothing. That index is what the character-select UI checks before allowing a deletion.
+///
+/// Send success=false to say "no main character": the handler then leaves the stored id alone, and it
+/// starts at zero because the field lives in zero-initialised data.
+/// </remarks>
 public class SCRepreSentCharacterPacket(ulong charId, bool success, bool first, bool isDeleted)
     : GamePacket(SCOffsets.SCRepreSentCharacterPacket, 1)
 {
-    // Body: "type"(charId) i64 (ISerialize vtbl+0x98) + "success"/"first"/"isDeleted" bools (vtbl+0xF8).
-    // character shown at server/character select. charId 0 with success=false means none selected.
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(charId);
-        stream.Write(success);
-        stream.Write(first);
-        stream.Write(isDeleted);
+        stream.Write(charId);       // u64  type
+        stream.Write(success);      // bool success
+        stream.Write(first);        // bool first
+        stream.Write(isDeleted);    // bool isDeleted
         return stream;
     }
 }

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -418,6 +418,18 @@ public partial class Character : Unit, ICharacter
     public DateTime DeleteTime { get; set; }
 
     /// <summary>
+    /// The account's nominated main character ("represent character" in the client's own wording).
+    /// At most one character per account carries this.
+    /// </summary>
+    /// <remarks>
+    /// This travels client to server only. The client keeps its own copy for the character select
+    /// screen - that is what refuses a deletion with "Must deselect as Main Character before
+    /// deleting." - and the character list packet has no field to send it back, so we record the
+    /// choice rather than drive it.
+    /// </remarks>
+    public bool IsRepresent { get; set; }
+
+    /// <summary>
     /// Cache value of AccountDetails.Loyalty
     /// </summary>
     public long BmPoint { get; set; }
@@ -2798,6 +2810,7 @@ public partial class Character : Unit, ICharacter
                     character.TransferRequestTime = reader.GetDateTime("transfer_request_time");
                     character.DeleteRequestTime = reader.GetDateTime("delete_request_time");
                     character.DeleteTime = reader.GetDateTime("delete_time");
+                    character.IsRepresent = reader.GetBoolean("represent");
                     character.AutoUseAAPoint = reader.GetBoolean("auto_use_aapoint");
                     character.PrivacyStatus = (CharacterPrivacyStatus)reader.GetSByte("privacy_status");
                     character.PrevPoint = reader.GetInt32("prev_point");
@@ -2923,6 +2936,7 @@ public partial class Character : Unit, ICharacter
                     character.TransferRequestTime = reader.GetDateTime("transfer_request_time");
                     character.DeleteRequestTime = reader.GetDateTime("delete_request_time");
                     character.DeleteTime = reader.GetDateTime("delete_time");
+                    character.IsRepresent = reader.GetBoolean("represent");
                     // character.BmPoint = reader.GetInt32("bm_point");
                     character.AutoUseAAPoint = reader.GetBoolean("auto_use_aapoint");
                     character.PrivacyStatus = (CharacterPrivacyStatus)reader.GetSByte("privacy_status");
@@ -3179,7 +3193,11 @@ public partial class Character : Unit, ICharacter
                     "`money`,`money2`,`aa_point`,`bank_aa_point`,`honor_point`,`vocation_point`,`crime_point`,`crime_record`,`jury_point`," +
                     "`hostile_faction_kills`,`pvp_honor`,`died_in_pvp`,`died_in_pvp_war_zone`," +
                     "`delete_request_time`,`transfer_request_time`,`delete_time`,`auto_use_aapoint`,`prev_point`,`point`,`gift`," +
-                    "`num_inv_slot`,`num_bank_slot`,`expanded_expert`,`slots`,`created_at`,`updated_at`,`return_district`,`online_time`,`total_play_time`,`privacy_status`" +
+                    "`num_inv_slot`,`num_bank_slot`,`expanded_expert`,`slots`,`created_at`,`updated_at`,`return_district`,`online_time`,`total_play_time`,`privacy_status`," +
+                    // Must be listed: this is a REPLACE INTO, so a column left out is written back at its
+                    // default. Omitting it would clear the account's main-character nomination on every
+                    // save, and with it the guard that keeps that character from being deleted.
+                    "`represent`" +
                     ") VALUES (" +
                     "@id,@account_id,@name,@access_level,@race,@gender,@unit_model_params,@level,@experience,@recoverable_exp,@heir_exp," +
                     "@hp,@mp,@consumed_lp,@local_lp,@ability1,@ability2,@ability3," +
@@ -3188,10 +3206,12 @@ public partial class Character : Unit, ICharacter
                     "@money,@money2,@aa_point,@bank_aa_point,@honor_point,@vocation_point,@crime_point,@crime_record,@jury_point," +
                     "@hostile_faction_kills,@pvp_honor,@died_in_pvp,@died_in_pvp_war_zone," +
                     "@delete_request_time,@transfer_request_time,@delete_time,@auto_use_aapoint,@prev_point,@point,@gift," +
-                    "@num_inv_slot,@num_bank_slot,@expanded_expert,@slots,@created_at,@updated_at,@return_district,@online_time,@total_play_time,@privacy_status)";
+                    "@num_inv_slot,@num_bank_slot,@expanded_expert,@slots,@created_at,@updated_at,@return_district,@online_time,@total_play_time,@privacy_status," +
+                    "@represent)";
 
                 command.Parameters.AddWithValue("@id", Id);
                 command.Parameters.AddWithValue("@account_id", AccountId);
+                command.Parameters.AddWithValue("@represent", IsRepresent);
                 command.Parameters.AddWithValue("@name", Name);
                 command.Parameters.AddWithValue("@access_level", AccessLevel);
                 command.Parameters.AddWithValue("@race", (byte)Race);

--- a/SQL/aaemu_game.sql
+++ b/SQL/aaemu_game.sql
@@ -215,6 +215,7 @@ CREATE TABLE IF NOT EXISTS `characters` (
   `online_time` INT(11) NOT NULL DEFAULT 0 COMMENT 'Time that the character has been online',
   `total_play_time` int unsigned NOT NULL DEFAULT '0',
   `privacy_status` tinyint NOT NULL DEFAULT '0',
+  `represent` tinyint(1) NOT NULL DEFAULT 0 COMMENT 'Is this the account main (represent) character',
   PRIMARY KEY (`id`, `account_id`) USING BTREE
 ) ENGINE = InnoDB CHARACTER SET = utf8 COLLATE = utf8_general_ci COMMENT = 'Basic player character data' ROW_FORMAT = DYNAMIC;
 

--- a/SQL/updates/2026-08-08_aaemu_game_character_represent.sql
+++ b/SQL/updates/2026-08-08_aaemu_game_character_represent.sql
@@ -1,0 +1,13 @@
+USE aaemu_game;
+
+-- The account's nominated main character ("represent character" in the client's own wording).
+-- At most one character per account carries it; CharacterManager clears the account before setting
+-- one, so the rule holds even if a previous nomination is stale.
+--
+-- Character select used to name the first character on every account instead, with success=true.
+-- The client stores whatever id it is given as THE represent character, and its delete dialog then
+-- refuses that character with "Must deselect as Main Character before deleting." - so slot one was
+-- undeletable on every account, for a choice nobody had made.
+ALTER TABLE `characters`
+  ADD COLUMN `represent` tinyint(1) NOT NULL DEFAULT 0
+  COMMENT 'Is this the account main (represent) character';


### PR DESCRIPTION
## Problem

Deleting a character does nothing and says nothing — no confirmation, no timer, not even an error. Two faults, and they hid each other.

### Every id in this exchange is 8 bytes, and we used 4

| packet | client layout | read at |
|---|---|---|
| `CSDeleteCharacter` | `u64 type` | RVA 0xC688D0 |
| `CSCancelCharacterDelete` | the same serialize function | RVA 0xC688D0 |
| `SCDeleteCharacterResponse` | `u64 type`, `u8 deleteStatus`, `u64 deleteRequestedTime`, `u64 deleteDelay` | RVA 0xC59C20 |
| `SCCharacterDeleted` | `u64 type`, `wstring name` | RVA 0xC59CA0 |
| `SCCancelCharacterDeleteResponse` | `u64 type`, `u8 deleteStatus` | RVA 0xC59D40 |

Reading four bytes where the client writes eight meant the id was never the one the player clicked, so `CharacterManager` found no such character on the account and answered with a rejection — which the client could not read either, because the response had the same fault. On `SCDeleteCharacterResponse` the short id additionally shifted the status and both timestamps by four bytes, so even a correct answer was unreadable.

### The first character on every account was undeletable

Character select named `characters[0]` as the account's main ("represent") character with `success = true`, unconditionally. The client's handler for `0x2C4` stores whatever id it is given as **the** represent character (RVA 0x4DD270), and its delete dialog then refuses that character with *"Must deselect as Main Character before deleting."*

So slot one was undeletable on every account, for a choice nobody had made, reasserted at every login.

## Change

The wire layouts are corrected to `u64` throughout.

The nomination becomes real state instead of an invention:

- `characters.represent` stores it, at most one per account — `CharacterManager` clears the account before setting one, so the rule holds even if a previous nomination is stale.
- `CSRepresentCharacter` sets or clears it; `SCRepreSentCharacter` answers. Clearing sends id 0 with `success = true`, which is what resets the client's own copy.
- Character select sends whoever the player actually nominated, and `success = false` when that is nobody, which leaves the client's id at its default of zero.
- `SetDeleteCharacter` refuses to delete the main character. The client already refuses it, but that check lives entirely in its UI, so nothing stopped a request that skipped it.

`Character.Save` is a `REPLACE INTO`, so `represent` had to join the column list — a column left out is written back at its default, and omitting it would have cleared the nomination on every autosave. Migration in `SQL/updates`.

## Review fix

The two halves of the new rule disagreed, and both sides are now closed:

- `SetRepresentCharacter` accepted any character on the account, including one already queued for deletion. That put the rules against each other — the request-time guard refuses to delete the main character, while the pending timer would still take it away when it expired. Nominating a character whose deletion is pending is now refused.
- `CheckForDeletedCharactersDeletion` knew nothing about the rule at all; it deleted on `DeleteTime` alone, so any row that reached both states was deleted anyway. It now refuses, and clears the pending deletion rather than leaving it to fire again on the next pass — nominating a character as the account main is the player saying to keep it, and a request that can never complete would otherwise be retried and logged forever.

## Testing

`AAEmu.Game` builds clean against `client_version/zone-10.0.2_r575`.

The layouts were derived from the client's own read and serialize functions at the RVAs above. Not verified end-to-end in-game on this branch — deleting a character, watching the timer appear, cancelling it, and confirming the nomination survives a save are the obvious checks.
