### PR TITLE
fix(labor): account-wide pools, and let memberships drive Patron state

### DIFF
--- a/AAEmu.Game/Configurations/CharacterSettings.json
+++ b/AAEmu.Game/Configurations/CharacterSettings.json
@@ -4,6 +4,8 @@
 		"AccessLevelFirstAccount": 100,
 		"AccessLevelFirstCharacter": 100,
 		"DeleteReleaseName": true,
+		// true grants every character the top premium_grades grade instead of deriving it from characters.point
+		"ForceMaxPremiumGrade": false,
 		"DeleteTimings": [
 			{
 				"Delay": 1,

--- a/AAEmu.Game/Core/Managers/AccountManager.cs
+++ b/AAEmu.Game/Core/Managers/AccountManager.cs
@@ -2,6 +2,7 @@
 using AAEmu.Commons.Utils;
 using AAEmu.Commons.Utils.DB;
 using AAEmu.Game.Core.Network.Connections;
+using AAEmu.Game.GameData;
 using AAEmu.Game.Models;
 using AAEmu.Game.Models.Account;
 
@@ -22,6 +23,71 @@ public class AccountManager(ITickManager tickManager, ITimedRewardsManager timed
     public void Initialize()
     {
         tickManager.OnTick.Subscribe(RemoveDeadConnections, TimeSpan.FromSeconds(30));
+    }
+
+    /// <summary>
+    /// The premium grade the ACCOUNT is at, for every path that runs without a character selected.
+    /// </summary>
+    /// <remarks>
+    /// Premium is account-wide, so the best point total any living character on it reached stands in
+    /// for the account.
+    ///
+    /// The character list cannot be the source here. The offline catch-up runs from <see cref="Add"/>,
+    /// which happens at authentication, while <c>GameConnection.LoadAccount</c> only fills
+    /// <c>Characters</c> later at CSAesXorKey - so reading the list would resolve every paid account as
+    /// the free tier for the single largest labor credit it ever gets. The loaded list is used when it
+    /// is there, to save a query, and the database answers when it is not.
+    ///
+    /// One method for lobby and reward tick both: the lobby tells the player which tier they are on and
+    /// the tick decides what that tier pays, and those two answering differently is how an account ends
+    /// up shown one thing and paid another.
+    /// </remarks>
+    public (int Point, uint Grade) GetAccountPremium(GameConnection connection)
+    {
+        if (AppConfiguration.Instance.Account?.ForceMaxPremiumGrade == true)
+        {
+            var forced = PremiumGameData.Instance.MaxGradeId;
+            if (forced > 0)
+                return (PremiumGameData.Instance.GetGrade(forced)?.Point ?? 0, forced);
+        }
+
+        var point = 0;
+        if (connection?.Characters is { Count: > 0 })
+        {
+            foreach (var character in connection.Characters.Values)
+                point = Math.Max(point, character.Point);
+        }
+        else if (connection != null)
+        {
+            point = GetMaxCharacterPoint(connection.AccountId);
+        }
+
+        return (point, PremiumGameData.Instance.GetGradeForPoint(point));
+    }
+
+    /// <summary>
+    /// Highest <c>characters.point</c> on the account, straight from the database.
+    /// </summary>
+    private static int GetMaxCharacterPoint(uint accountId)
+    {
+        try
+        {
+            using var connection = MySQL.CreateConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                "SELECT COALESCE(MAX(`point`), 0) FROM `characters` WHERE `account_id`=@account_id AND `deleted`=0";
+            command.Parameters.AddWithValue("@account_id", accountId);
+            command.Prepare();
+            var result = command.ExecuteScalar();
+            return result is null or DBNull ? 0 : Convert.ToInt32(result);
+        }
+        catch (Exception e)
+        {
+            // The free tier is the safe answer: it under-pays rather than handing out a grade the
+            // account may not hold, and it says so instead of failing silently.
+            Logger.Error($"GetMaxCharacterPoint: account {accountId} could not be read, assuming no premium: {e}");
+            return 0;
+        }
     }
 
     public void Add(GameConnection connection)

--- a/AAEmu.Game/Core/Managers/AccountManager.cs
+++ b/AAEmu.Game/Core/Managers/AccountManager.cs
@@ -78,6 +78,7 @@ public class AccountManager(ITickManager tickManager, ITimedRewardsManager timed
                 res.AccountId = reader.GetInt32("account_id");
                 res.AccessLevel = reader.GetInt32("access_level");
                 res.Labor = reader.GetInt16("labor");
+                res.LocalLabor = (int)reader.GetUInt32("local_labor");
                 res.Credits = reader.GetInt32("credits");
                 res.Loyalty = reader.GetInt32("loyalty");
                 res.LastUpdated = reader.GetDateTime("last_updated");
@@ -234,6 +235,40 @@ public class AccountManager(ITickManager tickManager, ITimedRewardsManager timed
                 command.CommandText = "UPDATE accounts SET labor = @labor WHERE account_id = @account_id";
                 command.Parameters.AddWithValue("@account_id", accountId);
                 command.Parameters.AddWithValue("@labor", laborPower);
+                command.Prepare();
+                command.ExecuteNonQuery();
+            }
+            catch (Exception e)
+            {
+                Logger.Error($"{e.Message}\n{e.StackTrace}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Persists the SERVER-LOCAL pool ("Online Labor"). Account-scoped, see
+    /// <see cref="AccountDetails.LocalLabor"/>.
+    /// </summary>
+    public void UpdateLocalLabor(uint accountId, int localLabor)
+    {
+        object accLock;
+        lock (_locks)
+        {
+            if (!_locks.TryGetValue(accountId, out accLock))
+            {
+                accLock = new object();
+                _locks.Add(accountId, accLock);
+            }
+        }
+        lock (accLock)
+        {
+            try
+            {
+                using var connection = MySQL.CreateConnection();
+                using var command = connection.CreateCommand();
+                command.CommandText = "UPDATE accounts SET local_labor = @local_labor WHERE account_id = @account_id";
+                command.Parameters.AddWithValue("@account_id", accountId);
+                command.Parameters.AddWithValue("@local_labor", Math.Max(0, localLabor));
                 command.Prepare();
                 command.ExecuteNonQuery();
             }

--- a/AAEmu.Game/Core/Managers/AccountMemberships.cs
+++ b/AAEmu.Game/Core/Managers/AccountMemberships.cs
@@ -1,0 +1,55 @@
+using AAEmu.Game.GameData;
+using AAEmu.Game.Models;
+using AAEmu.Game.Models.Game;
+using AAEmu.Game.Models.Game.Premium;
+
+namespace AAEmu.Game.Core.Managers;
+
+/// <summary>
+/// Which paid memberships an account currently holds, and what they add to its labor.
+/// </summary>
+/// <remarks>
+/// One place on purpose: the same list has to reach the client (as account attributes, which is the
+/// only thing it accepts as proof of membership - see <see cref="AccountMembership"/>) and the labor
+/// arithmetic. When the two drifted apart the client showed benefits the server never paid out.
+/// </remarks>
+public static class AccountMemberships
+{
+    /// <summary>
+    /// Membership ids active for an account: the account_buff attributes it holds, plus the ones
+    /// Account.ForceMaxPremiumGrade hands to everybody.
+    /// </summary>
+    public static List<uint> ActiveIds(uint accountId, uint worldId)
+    {
+        var ids = AccountAttributeManager.Instance
+            .Get(accountId, worldId)
+            .Where(a => a.KindId == (uint)AccountAttributeKind.AccountBuff)
+            .Select(a => a.KindValue)
+            .ToList();
+
+        if (AppConfiguration.Instance.Account?.ForceMaxPremiumGrade != true)
+            return ids;
+
+        foreach (var forced in ForcedIds)
+        {
+            if (!ids.Contains(forced))
+                ids.Add(forced);
+        }
+
+        return ids;
+    }
+
+    /// <summary>The memberships a forced max grade grants. Both, so nothing is held back.</summary>
+    public static IReadOnlyList<uint> ForcedIds { get; } =
+        [(uint)AccountMembership.Ancient, (uint)AccountMembership.Advanced];
+
+    /// <summary>
+    /// The grade's labor numbers with the account's memberships applied - the same sum the client
+    /// computes for its own display.
+    /// </summary>
+    public static LaborAllowance LaborFor(uint premiumGradeId, uint accountId, uint worldId)
+    {
+        var grade = PremiumGameData.Instance.GetGrade(premiumGradeId);
+        return AccountBuffsGameData.Instance.Apply(grade, ActiveIds(accountId, worldId));
+    }
+}

--- a/AAEmu.Game/Core/Managers/IAccountManager.cs
+++ b/AAEmu.Game/Core/Managers/IAccountManager.cs
@@ -14,6 +14,7 @@ public interface IAccountManager : IInitializable
     bool RemoveCredits(uint accountId, int credits);
     bool AddLoyalty(uint accountId, int loyaltyAmount);
     void UpdateLabor(uint accountId, short laborPower);
+    void UpdateLocalLabor(uint accountId, int localLabor);
     DateTime UpdateLoginTime(uint accountId, DateTime newTime);
     void UpdateTickTimes(uint accountId, DateTime newTime, bool updateLabor, bool updateCredits, bool updateLoyalty);
     void UpdateDivineClock(uint accountId, uint timeElapsed, uint timesTaken);

--- a/AAEmu.Game/Core/Managers/IAccountManager.cs
+++ b/AAEmu.Game/Core/Managers/IAccountManager.cs
@@ -10,6 +10,7 @@ public interface IAccountManager : IInitializable
     bool Contains(uint id);
     int Count();
     AccountDetails GetAccountDetails(uint accountId);
+    (int Point, uint Grade) GetAccountPremium(GameConnection connection);
     bool AddCredits(uint accountId, int creditsAmount);
     bool RemoveCredits(uint accountId, int credits);
     bool AddLoyalty(uint accountId, int loyaltyAmount);

--- a/AAEmu.Game/Core/Managers/TimedRewardsManager.cs
+++ b/AAEmu.Game/Core/Managers/TimedRewardsManager.cs
@@ -42,11 +42,34 @@ public class TimedRewardsManager(ITaskManager taskManager) : Singleton<TimedRewa
             var newLabor = (short)(currentLabor + addLabor);
             AccountManager.Instance.UpdateLabor(connection.AccountId, newLabor);
 
-            connection.ActiveChar?.SendPacket(new SCCharacterLaborPowerChangedPacket(addLabor, 0, 0, 0, 0, 0));
+            var activeChar = connection.ActiveChar;
+            activeChar?.SendPacket(new SCCharacterLaborPowerChangedPacket(addLabor, 0, 0, 0, 0, 0));
 
-            // Update cache if character was logged in
-            connection.ActiveChar?.InitializeLaborCache(newLabor, DateTime.UtcNow);
+            // Update cache if character was logged in. Only the account pool changed here - carry the
+            // local pool over unchanged, it is account-wide state too and this tick does not touch it.
+            activeChar?.InitializeLaborCache(newLabor, activeChar.LocalLaborPower, DateTime.UtcNow);
         }
+    }
+
+    /// <summary>
+    /// Adds to the SERVER-LOCAL pool ("Online Labor"), the one that fills while the player is logged
+    /// in. <see cref="Character.AddLocalLaborPower"/> clamps to the premium grade's max_local_labor and
+    /// emits the change in the packet's localAmount field, which is the counter the client adds it to.
+    /// Only runs with a character in the world - there is nothing to regenerate at character select.
+    /// </summary>
+    private static void DoAddLocalLabor(GameConnection connection, int addLabor)
+    {
+        if (addLabor <= 0)
+            return;
+
+        // Without a character in the world there is nothing to credit. Leave the tick time alone in
+        // that case, otherwise sitting at character select silently eats one tick after another.
+        var activeChar = connection.ActiveChar;
+        if (activeChar == null)
+            return;
+
+        AccountManager.Instance.UpdateTickTimes(connection.AccountId, DateTime.UtcNow, true, false, false);
+        activeChar.AddLocalLaborPower(addLabor);
     }
 
     public void DoTick()
@@ -58,11 +81,14 @@ public class TimedRewardsManager(ITaskManager taskManager) : Singleton<TimedRewa
             // Grab current values for last ticks
             var accountDetails = AccountManager.Instance.GetAccountDetails(connection.AccountId);
 
-            // Distribute Labor if needed (only for online labor)
+            // Online regeneration fills the SERVER-LOCAL pool, which the client labels "Online Labor" -
+            // its own ui_texts describe that one as restoring while you are logged in, and the account
+            // pool as restoring only while you are logged off. Crediting the account pool here is why
+            // "Online Labor" stayed at 0 forever while "Offline Labor" kept climbing.
             if (AppConfiguration.Instance.Labor.TickMinutes > 0 && accountDetails.LastLaborTick.AddMinutes(AppConfiguration.Instance.Labor.TickMinutes) <= DateTime.UtcNow)
             {
                 var addLabor = AppConfiguration.Instance.Labor.GetTickAmount(connection.Payment.PremiumState);
-                DoAddLabor(connection, accountDetails.Labor, addLabor);
+                DoAddLocalLabor(connection, addLabor);
             }
 
             // Distribute Credits if needed. 10.0.2.13 does not push the account balance on a timer (a live

--- a/AAEmu.Game/Core/Managers/TimedRewardsManager.cs
+++ b/AAEmu.Game/Core/Managers/TimedRewardsManager.cs
@@ -1,7 +1,9 @@
 ﻿using AAEmu.Commons.Utils;
 using AAEmu.Game.Core.Network.Connections;
 using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.GameData;
 using AAEmu.Game.Models;
+using AAEmu.Game.Models.Game.Premium;
 using AAEmu.Game.Models.Tasks.TimedRewards;
 
 namespace AAEmu.Game.Core.Managers;
@@ -25,6 +27,66 @@ public class TimedRewardsManager(ITaskManager taskManager) : Singleton<TimedRewa
     }
 
     /// <summary>
+    /// Cap of the ACCOUNT pool: premium_grades.max_labor plus whatever the account's memberships add.
+    /// This is the number the client puts behind the slash in its own labor display, so the two must not
+    /// disagree. Falls back to the flat constants for the free tier, which owns no account pool.
+    /// </summary>
+    public static int GetMaxLabor(uint premiumGradeId, bool isPremium, uint accountId)
+    {
+        var fromData = AccountMemberships.LaborFor(premiumGradeId, accountId, AppConfiguration.Instance.Id).MaxLabor;
+        return fromData > 0 ? fromData : GetMaxLabor(isPremium);
+    }
+
+    /// <summary>
+    /// Per-tick regeneration of the SERVER-LOCAL pool ("Online Labor").
+    /// </summary>
+    /// <remarks>
+    /// The game data is the authority here, not the config, because the client renders these exact
+    /// numbers itself - it reads premium_grades and account_buffs and adds them up for the Patron buff
+    /// tooltip ("Regenerates Online Labor +15 every 5 min", and 30 with both memberships active).
+    /// Paying out the config's rate instead made the server quietly contradict a promise the client had
+    /// already shown the player. The config still covers grades the data gives no rate of its own.
+    /// </remarks>
+    private static int GetOnlineLaborRate(GameConnection connection)
+    {
+        var fromData = LaborFor(connection).OnlineRate;
+        return fromData > 0
+            ? fromData
+            : AppConfiguration.Instance.Labor.GetTickAmount(connection.Payment.PremiumState);
+    }
+
+    /// <summary>
+    /// Per-tick catch-up of the ACCOUNT pool ("Offline Labor"). Same reasoning as
+    /// <see cref="GetOnlineLaborRate"/> - the buff tooltip promises "+10 every 5 min" per membership.
+    /// </summary>
+    private static int GetOfflineLaborRate(GameConnection connection)
+    {
+        var fromData = LaborFor(connection).OfflineRate;
+        return fromData > 0
+            ? fromData
+            : AppConfiguration.Instance.LaborOffline.GetTickAmount(connection.Payment.PremiumState);
+    }
+
+    private static LaborAllowance LaborFor(GameConnection connection) =>
+        AccountMemberships.LaborFor(
+            GradeIdOf(connection), connection?.AccountId ?? 0, AppConfiguration.Instance.Id);
+
+    /// <summary>
+    /// The premium grade to bill this connection at. The login catch-up runs before a character is
+    /// picked, so there is nobody to ask - a forced max grade still has to apply there.
+    /// </summary>
+    private static uint GradeIdOf(GameConnection connection)
+    {
+        var activeChar = connection?.ActiveChar;
+        if (activeChar != null)
+            return activeChar.PremiumGrade;
+
+        return AppConfiguration.Instance.Account?.ForceMaxPremiumGrade == true
+            ? PremiumGameData.Instance.MaxGradeId
+            : 0;
+    }
+
+    /// <summary>
     /// Adds labor, internal use only
     /// </summary>
     /// <param name="connection"></param>
@@ -32,7 +94,7 @@ public class TimedRewardsManager(ITaskManager taskManager) : Singleton<TimedRewa
     /// <param name="addLabor"></param>
     private void DoAddLabor(GameConnection connection, short currentLabor, int addLabor)
     {
-        var maxLaborToAdd = GetMaxLabor(connection.Payment.PremiumState) - currentLabor;
+        var maxLaborToAdd = GetMaxLabor(GradeIdOf(connection), connection.Payment.PremiumState, connection.AccountId) - currentLabor;
         if (maxLaborToAdd < 0)
             maxLaborToAdd = 0;
         addLabor = Math.Min(addLabor, maxLaborToAdd);
@@ -87,7 +149,7 @@ public class TimedRewardsManager(ITaskManager taskManager) : Singleton<TimedRewa
             // "Online Labor" stayed at 0 forever while "Offline Labor" kept climbing.
             if (AppConfiguration.Instance.Labor.TickMinutes > 0 && accountDetails.LastLaborTick.AddMinutes(AppConfiguration.Instance.Labor.TickMinutes) <= DateTime.UtcNow)
             {
-                var addLabor = AppConfiguration.Instance.Labor.GetTickAmount(connection.Payment.PremiumState);
+                var addLabor = GetOnlineLaborRate(connection);
                 DoAddLocalLabor(connection, addLabor);
             }
 
@@ -125,11 +187,20 @@ public class TimedRewardsManager(ITaskManager taskManager) : Singleton<TimedRewa
 
     public void AddOfflineLabor(GameConnection connection, DateTime lastLoginTime, short currentLabor)
     {
+        // A zero interval would divide by zero and hand Math.Floor an infinity that overflows the cast.
+        var tickMinutes = AppConfiguration.Instance.LaborOffline.TickMinutes;
+        if (tickMinutes <= 0)
+            return;
+
         var delta = DateTime.UtcNow - lastLoginTime;
-        var ticksToAdd = (int)Math.Floor(delta.TotalMinutes / AppConfiguration.Instance.LaborOffline.TickMinutes);
+        var ticksToAdd = (int)Math.Floor(delta.TotalMinutes / tickMinutes);
         if (ticksToAdd <= 0)
             return;
-        var addLabor = AppConfiguration.Instance.LaborOffline.GetTickAmount(connection.Payment.PremiumState) * ticksToAdd;
-        DoAddLabor(connection, currentLabor, addLabor);
+
+        var perTick = GetOfflineLaborRate(connection);
+        if (perTick <= 0)
+            return;
+
+        DoAddLabor(connection, currentLabor, perTick * ticksToAdd);
     }
 }

--- a/AAEmu.Game/Core/Managers/TimedRewardsManager.cs
+++ b/AAEmu.Game/Core/Managers/TimedRewardsManager.cs
@@ -81,9 +81,11 @@ public class TimedRewardsManager(ITaskManager taskManager) : Singleton<TimedRewa
         if (activeChar != null)
             return activeChar.PremiumGrade;
 
-        return AppConfiguration.Instance.Account?.ForceMaxPremiumGrade == true
-            ? PremiumGameData.Instance.MaxGradeId
-            : 0;
+        // No character picked yet - the login catch-up runs before that. Falling back to grade 0 here
+        // billed every offline catch-up at the free tier no matter what the account had paid for, which
+        // is the one tick where the difference is largest. Premium is account-wide, so resolve it the
+        // way the lobby does.
+        return PremiumGameData.Instance.GetAccountGrade(connection?.Characters?.Values);
     }
 
     /// <summary>

--- a/AAEmu.Game/Core/Managers/TimedRewardsManager.cs
+++ b/AAEmu.Game/Core/Managers/TimedRewardsManager.cs
@@ -81,11 +81,10 @@ public class TimedRewardsManager(ITaskManager taskManager) : Singleton<TimedRewa
         if (activeChar != null)
             return activeChar.PremiumGrade;
 
-        // No character picked yet - the login catch-up runs before that. Falling back to grade 0 here
-        // billed every offline catch-up at the free tier no matter what the account had paid for, which
-        // is the one tick where the difference is largest. Premium is account-wide, so resolve it the
-        // way the lobby does.
-        return PremiumGameData.Instance.GetAccountGrade(connection?.Characters?.Values);
+        // No character picked yet - the login catch-up runs before that, and before the character list
+        // is even loaded. Falling back to grade 0 here billed every offline catch-up at the free tier no
+        // matter what the account had paid for, which is the one tick where the difference is largest.
+        return AccountManager.Instance.GetAccountPremium(connection).Grade;
     }
 
     /// <summary>

--- a/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
@@ -539,7 +539,9 @@ public class CharacterManager(
         character.AccessLevel = useAccessLevel;
         // character.LaborPower = (short)AppConfiguration.Instance.Labor.Default;
         // character.LaborPowerModified = DateTime.UtcNow;
-        character.InitializeLaborCache(accountDetails.Labor, accountDetails.LastUpdated); // Initialize Labor cache, so we don't need to query the DB every time we need to read it
+        // Initialize the labor cache, so we don't need to query the DB every time we need to read it.
+        // A new character inherits both account-wide pools rather than starting either of them over.
+        character.InitializeLaborCache(accountDetails.Labor, accountDetails.LocalLabor, accountDetails.LastUpdated);
         character.NumInventorySlots = template.NumInventorySlot;
         character.NumBankSlots = template.NumBankSlot;
         character.Inventory = new Inventory(character);

--- a/AAEmu.Game/Core/Managers/World/SpecialtyManager.cs
+++ b/AAEmu.Game/Core/Managers/World/SpecialtyManager.cs
@@ -307,7 +307,8 @@ public class SpecialtyManager(IItemManager itemManager) : Singleton<SpecialtyMan
             (int)Math.Round(
                 AppConfiguration.Instance.Specialty.SellLaborCost * commerce.GetLaborCostMultiplier(),
                 MidpointRounding.AwayFromZero));
-        if (player.LaborPower < laborCost)
+        // Both pools pay; see Character.ChangeLabor.
+        if (player.LaborPower + player.LocalLaborPower < laborCost)
         {
             player.SendErrorMessage(ErrorMessageType.NotEnoughLaborPower);
             return false;

--- a/AAEmu.Game/Core/Network/Connections/AccountAttributePublisher.cs
+++ b/AAEmu.Game/Core/Network/Connections/AccountAttributePublisher.cs
@@ -1,0 +1,59 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models;
+using AAEmu.Game.Models.Game;
+
+namespace AAEmu.Game.Core.Network.Connections;
+
+/// <summary>
+/// Sends the account's attribute list, including the memberships a forced max grade grants.
+/// </summary>
+/// <remarks>
+/// Shared by the first handshake and by the return from world to character select. The client keeps its
+/// membership flags on an object that does not survive that trip - coming back from in-world dropped
+/// the account straight back to "Patron 0" - so the list has to go out on both paths, exactly like the
+/// character list itself.
+/// </remarks>
+public static class AccountAttributePublisher
+{
+    public static void Send(GameConnection connection)
+    {
+        if (connection == null)
+            return;
+
+        var worldId = AppConfiguration.Instance.Id;
+        var attributes = AccountAttributeManager.Instance.Get(connection.AccountId, worldId);
+
+        // Memberships are synthesised per session rather than stored, so clearing the setting takes
+        // effect on the next login and leaves no rows behind.
+        if (AppConfiguration.Instance.Account?.ForceMaxPremiumGrade == true)
+        {
+            foreach (var membership in AccountMemberships.ForcedIds)
+            {
+                if (attributes.Any(a => a.KindId == (uint)AccountAttributeKind.AccountBuff &&
+                                        a.KindValue == membership))
+                    continue;
+
+                attributes.Add(new AccountAttribute
+                {
+                    AccountId = connection.AccountId,
+                    KindId = (uint)AccountAttributeKind.AccountBuff,
+                    KindValue = membership,
+                    WorldId = 0,
+                    Count = 1,
+                    Starts = connection.Payment.StartTime,
+                    Expires = connection.Payment.EndTime
+                });
+            }
+        }
+
+        if (attributes.Count == 0)
+        {
+            connection.SendPacket(new SCAccountAttributeListPacket([]));
+            return;
+        }
+
+        foreach (var batch in attributes.Chunk(SCAccountAttributeListPacket.MaxAttributes))
+            connection.SendPacket(new SCAccountAttributeListPacket(batch));
+    }
+}

--- a/AAEmu.Game/Core/Packets/C2G/CSAesXorKeyPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSAesXorKeyPacket.cs
@@ -70,7 +70,13 @@ public class CSAesXorKeyPacket() : GamePacket(CSOffsets.CSAesXorKeyPacket, 1)
             (int)Connection.Payment.Method,
             Connection.Payment.Location,
             Connection.Payment.StartTime,
-            Connection.Payment.EndTime));
+            Connection.Payment.EndTime,
+            Connection.Payment.RealPayTimeSeconds,
+            Connection.Payment.BuyPremiumCount));
+
+        // The client's membership flags do not survive the trip back from in-world, so returning to
+        // character select showed "Patron 0" again until this went out a second time.
+        AccountAttributePublisher.Send(Connection);
 
         Connection.LoadAccount();
 

--- a/AAEmu.Game/Core/Packets/C2G/CSSpawnCharacterPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSSpawnCharacterPacket.cs
@@ -38,6 +38,15 @@ public class CSSpawnCharacterPacket() : GamePacket(CSOffsets.CSSpawnCharacterPac
 
         Connection.SendPacket(new SCDetailedTimeOfDayPacket(TimeManager.Instance.GetTime));
 
-        Logger.Info("CSSpawnCharacterPacket faction={0}", me.Faction?.Id);
+        // Deliberately no labor packet here. SCCharacterLaborPowerChanged is a delta - the handler does
+        // `add [mgr+0xE58], amount` and `add [mgr+0xE68], localAmount`, never a store - and the client
+        // already carries both balances into the world from the {lp, localLp, ...} block in the
+        // character-list record. Sending the totals once more would add them on top, so the in-world
+        // display reads exactly twice the stored balance. Only real changes belong on this packet.
+
+        // After SCUnitState, so the client has the unit before the buff-created packet references it.
+        me.ApplyPremiumGradeBuff();
+
+        Logger.Info("CSSpawnCharacterPacket faction={0} premiumGrade={1}", me.Faction?.Id, me.PremiumGrade);
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCAccountInfoPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCAccountInfoPacket.cs
@@ -3,7 +3,24 @@ using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCAccountInfoPacket(int payMethod, int payLocation, DateTime payStart, DateTime payEnd)
+/// <summary>
+/// Account payment state. Field order, offsets and widths verified against the 10.0.2.13 client's
+/// serializer at rva 0xc512a0, which names each value as it reads it:
+/// payMethod (+0x10, int32), payLocation (+0x14, int32), payStart (+0x18, DateTime),
+/// payEnd (+0x20, DateTime), realPayTime (+0x28, int64), buyPremiumCount (+0x30, int32).
+/// </summary>
+/// <remarks>
+/// payStart and payEnd go through the client's DateTime slot (0x78) while realPayTime goes through the
+/// plain int64 slot (0x98) - so realPayTime is a COUNT, not a timestamp, and it was hardcoded to zero
+/// along with buyPremiumCount. Both are now supplied by the caller.
+/// </remarks>
+public class SCAccountInfoPacket(
+    int payMethod,
+    int payLocation,
+    DateTime payStart,
+    DateTime payEnd,
+    long realPayTime = 0,
+    int buyPremiumCount = 0)
     : GamePacket(SCOffsets.SCAccountInfoPacket, 5)
 {
     public override PacketStream Write(PacketStream stream)
@@ -12,8 +29,8 @@ public class SCAccountInfoPacket(int payMethod, int payLocation, DateTime paySta
         stream.Write(payLocation);
         stream.Write(payStart);
         stream.Write(payEnd);
-        stream.Write((long)0); // realPayTime (+152, 8 bytes)
-        stream.Write((uint)0);
+        stream.Write(realPayTime);
+        stream.Write(buyPremiumCount);
         return stream;
     }
 }

--- a/AAEmu.Game/Core/Packets/Proxy/FinishStatePacket.cs
+++ b/AAEmu.Game/Core/Packets/Proxy/FinishStatePacket.cs
@@ -1,8 +1,11 @@
 using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Network.Connections;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.GameData;
 using AAEmu.Game.Models;
+using AAEmu.Game.Models.Game;
 
 namespace AAEmu.Game.Core.Packets.Proxy;
 
@@ -37,22 +40,14 @@ public class FinishStatePacket() : GamePacket(PPOffsets.FinishStatePacket, 2)
                         (int)Connection.Payment.Method,
                         Connection.Payment.Location,
                         Connection.Payment.StartTime,
-                        Connection.Payment.EndTime)
+                        Connection.Payment.EndTime,
+                        Connection.Payment.RealPayTimeSeconds,
+                        Connection.Payment.BuyPremiumCount)
                 );
                 Connection.SendPacket(new SCChatSpamDelayPacket());
                 Connection.SendPacket(new SCAccountAttributeConfigPacket());
 
-                var accountAttributes = AccountAttributeManager.Instance.Get(
-                    Connection.AccountId, AppConfiguration.Instance.Id);
-                if (accountAttributes.Count == 0)
-                {
-                    Connection.SendPacket(new SCAccountAttributeListPacket([]));
-                }
-                else
-                {
-                    foreach (var batch in accountAttributes.Chunk(SCAccountAttributeListPacket.MaxAttributes))
-                        Connection.SendPacket(new SCAccountAttributeListPacket(batch));
-                }
+                AccountAttributePublisher.Send(Connection);
 
                 Connection.SendPacket(new SCLevelRestrictionConfigPacket(AppConfiguration.Instance.LevelRestrictions));
 
@@ -78,11 +73,51 @@ public class FinishStatePacket() : GamePacket(PPOffsets.FinishStatePacket, 2)
                 Connection.SendPacket(new ChangeStatePacket(state + 1));
                 break;
             case 7:
-                Connection.SendPacket(new SCUpdatePremiumPointPacket(1, 1, 1));
+                // This carried a hardcoded (1, 1, 1). Grade 1 is the free tier and the client's Patron
+                // readout counts from zero - buff 7153 is named "grade 5" and hangs on grade_id 6 - so
+                // character select showed "Patron 0" for every account regardless of characters.point.
+                var (premiumPoint, premiumGrade) = ResolveAccountPremium(Connection);
+                Logger.Debug(
+                    "SCUpdatePremiumPoint point={0} grade={1} (forceMaxGrade={2}, maxGradeId={3}, chars={4})",
+                    premiumPoint, premiumGrade,
+                    AppConfiguration.Instance.Account?.ForceMaxPremiumGrade,
+                    PremiumGameData.Instance.MaxGradeId,
+                    Connection.Characters.Count);
+                // Wire format verified against x2game-dev.dll: the serializer at rva 0xc61e50 reads
+                // {int32 point, uint8 oldPg, uint8 pg} - point through the int32 vtable slot 0xA0, both
+                // grades through the one-byte slot 0x90 - so this packet is shaped correctly. Nothing is
+                // in flight at the handshake, so the old grade IS the current one; claiming a transition
+                // here would be a fabrication, and testing one changed nothing in the client anyway.
+                Connection.SendPacket(new SCUpdatePremiumPointPacket(
+                    premiumPoint, (byte)premiumGrade, (byte)premiumGrade));
                 break;
             default:
                 Logger.Info("Unknown state: {0}", state);
                 break;
         }
+    }
+
+    /// <summary>
+    /// Premium points and grade for the whole account. Premium is account-wide and the lobby has no
+    /// character selected yet, so the best grade any character on the account reached stands in for it.
+    /// </summary>
+    /// <remarks>
+    /// The character list may not be loaded yet at this point in the handshake; that only costs the
+    /// free tier, which is what the hardcoded value gave anyway. A forced max grade needs no characters.
+    /// </remarks>
+    private static (int Point, uint Grade) ResolveAccountPremium(GameConnection connection)
+    {
+        if (AppConfiguration.Instance.Account?.ForceMaxPremiumGrade == true)
+        {
+            var maxGrade = PremiumGameData.Instance.MaxGradeId;
+            if (maxGrade > 0)
+                return (Math.Max(0, PremiumGameData.Instance.GetGrade(maxGrade)?.Point ?? 0), maxGrade);
+        }
+
+        var point = 0;
+        foreach (var character in connection.Characters.Values)
+            point = Math.Max(point, character.Point);
+
+        return (point, PremiumGameData.Instance.GetGradeForPoint(point));
     }
 }

--- a/AAEmu.Game/Core/Packets/Proxy/FinishStatePacket.cs
+++ b/AAEmu.Game/Core/Packets/Proxy/FinishStatePacket.cs
@@ -107,18 +107,9 @@ public class FinishStatePacket() : GamePacket(PPOffsets.FinishStatePacket, 2)
     /// </remarks>
     private static (int Point, uint Grade) ResolveAccountPremium(GameConnection connection)
     {
-        if (AppConfiguration.Instance.Account?.ForceMaxPremiumGrade == true)
-        {
-            var maxGrade = PremiumGameData.Instance.MaxGradeId;
-            if (maxGrade > 0)
-                return (Math.Max(0, PremiumGameData.Instance.GetGrade(maxGrade)?.Point ?? 0), maxGrade);
-        }
-
-        var point = 0;
-        foreach (var character in connection.Characters.Values)
-            point = Math.Max(point, character.Point);
-
-        // Same resolution the reward tick uses, so the tier shown here is the tier that gets paid.
-        return (point, PremiumGameData.Instance.GetAccountGrade(connection.Characters.Values));
+        // Same resolution the reward tick uses, so the tier shown here is the tier that gets paid - and
+        // it falls back to the database, because this runs at a point in the handshake where the
+        // character list may not be loaded yet.
+        return AccountManager.Instance.GetAccountPremium(connection);
     }
 }

--- a/AAEmu.Game/Core/Packets/Proxy/FinishStatePacket.cs
+++ b/AAEmu.Game/Core/Packets/Proxy/FinishStatePacket.cs
@@ -118,6 +118,7 @@ public class FinishStatePacket() : GamePacket(PPOffsets.FinishStatePacket, 2)
         foreach (var character in connection.Characters.Values)
             point = Math.Max(point, character.Point);
 
-        return (point, PremiumGameData.Instance.GetGradeForPoint(point));
+        // Same resolution the reward tick uses, so the tier shown here is the tier that gets paid.
+        return (point, PremiumGameData.Instance.GetAccountGrade(connection.Characters.Values));
     }
 }

--- a/AAEmu.Game/GameData/AccountBuffsGameData.cs
+++ b/AAEmu.Game/GameData/AccountBuffsGameData.cs
@@ -1,0 +1,104 @@
+using AAEmu.Commons.Utils;
+using AAEmu.Game.GameData.Framework;
+using AAEmu.Game.Models.Game.Premium;
+using AAEmu.Game.Utils.DB;
+
+using Microsoft.Data.Sqlite;
+
+namespace AAEmu.Game.GameData;
+
+/// <summary>
+/// account_buffs — the paid memberships an account can hold, and the labor each adds on top of the
+/// premium grade. Row ids double as the <c>extraKind</c> of an account attribute.
+/// </summary>
+/// <remarks>
+/// Nothing loaded this table before, so the memberships contributed nothing server-side while the
+/// client added them to everything it displayed.
+/// </remarks>
+[GameData]
+public class AccountBuffsGameData : Singleton<AccountBuffsGameData>, IGameDataLoader
+{
+    private Dictionary<uint, AccountBuff> _buffs = [];
+
+    public AccountBuff Get(uint id) => _buffs.GetValueOrDefault(id);
+
+    /// <summary>
+    /// Adds the memberships to a grade's labor numbers exactly the way the client does: the caps always
+    /// accumulate, while a rate either accumulates or replaces the grade's own, per the row's
+    /// replace_premium_*_lp flag. A replacing membership wins over the grade but still stacks with the
+    /// other memberships, which is the only reading that keeps the sum order-independent.
+    /// </summary>
+    public LaborAllowance Apply(PremiumGrade grade, IEnumerable<uint> membershipIds)
+    {
+        var allowance = new LaborAllowance
+        {
+            OnlineRate = Math.Max(0, grade?.OnlineLabor ?? 0),
+            OfflineRate = Math.Max(0, grade?.OfflineLabor ?? 0),
+            MaxLabor = Math.Max(0, grade?.MaxLabor ?? 0),
+            MaxLocalLabor = Math.Max(0, grade?.MaxLocalLabor ?? 0)
+        };
+
+        if (membershipIds == null)
+            return allowance;
+
+        var replacedOnline = false;
+        var replacedOffline = false;
+
+        foreach (var id in membershipIds.Distinct())
+        {
+            var buff = Get(id);
+            if (buff == null)
+                continue;
+
+            if (buff.ReplacePremiumOnlineLp && !replacedOnline)
+            {
+                replacedOnline = true;
+                allowance.OnlineRate = 0;
+            }
+
+            if (buff.ReplacePremiumOfflineLp && !replacedOffline)
+            {
+                replacedOffline = true;
+                allowance.OfflineRate = 0;
+            }
+
+            allowance.OnlineRate += buff.OnlineLaborPower;
+            allowance.OfflineRate += buff.OfflineLaborPower;
+            allowance.MaxLabor += buff.AddMaxLp;
+            allowance.MaxLocalLabor += buff.AddMaxLocalLp;
+        }
+
+        return allowance;
+    }
+
+    public void Load(SqliteConnection connection)
+    {
+        _buffs = [];
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT * FROM account_buffs";
+        command.Prepare();
+        using var reader = new SQLiteWrapperReader(command.ExecuteReader());
+        while (reader.Read())
+        {
+            var buff = new AccountBuff
+            {
+                Id = reader.GetUInt32("id"),
+                Name = reader.GetString("name", string.Empty),
+                BuffId = reader.GetUInt32("buff_id", 0),
+                OnlineLaborPower = reader.GetInt32("online_laborpower", 0),
+                ReplacePremiumOnlineLp = reader.GetBoolean("replace_premium_online_lp", true),
+                OfflineLaborPower = reader.GetInt32("offline_laborpower", 0),
+                ReplacePremiumOfflineLp = reader.GetBoolean("replace_premium_offline_lp", true),
+                AddMaxLp = reader.GetInt32("add_max_lp", 0),
+                AddMaxLocalLp = reader.GetInt32("add_max_local_lp", 0)
+            };
+            _buffs[buff.Id] = buff;
+        }
+    }
+
+    public void PostLoad()
+    {
+        // Nothing to do here
+    }
+}

--- a/AAEmu.Game/GameData/PremiumGameData.cs
+++ b/AAEmu.Game/GameData/PremiumGameData.cs
@@ -42,6 +42,19 @@ public class PremiumGameData : Singleton<PremiumGameData>, IGameDataLoader
 
     public PremiumGrade GetGrade(uint gradeId) => _grades.FirstOrDefault(g => g.GradeId == gradeId);
 
+    /// <summary>
+    /// Highest grade premium_grades defines (6 on 10.0.2.13), or 0 when the table is empty. Used by
+    /// <see cref="Models.Game.Configurations.AccountConfig.ForceMaxPremiumGrade"/> rather than a
+    /// constant, so it follows the client data instead of going stale against it.
+    /// </summary>
+    public uint MaxGradeId => _grades.Count == 0 ? 0u : _grades.Max(g => g.GradeId);
+
+    /// <summary>
+    /// Every buff premium_grades attaches to a grade. Used to strip the buff of a grade a character no
+    /// longer holds before granting the current one. The free tier carries none, hence the filter.
+    /// </summary>
+    public IEnumerable<uint> GradeBuffIds => _grades.Where(g => g.BuffId > 0).Select(g => g.BuffId).Distinct();
+
     public PremiumConfig Config => _config;
 
     public void Load(SqliteConnection connection)

--- a/AAEmu.Game/GameData/PremiumGameData.cs
+++ b/AAEmu.Game/GameData/PremiumGameData.cs
@@ -44,28 +44,10 @@ public class PremiumGameData : Singleton<PremiumGameData>, IGameDataLoader
     public PremiumGrade GetGrade(uint gradeId) => _grades.FirstOrDefault(g => g.GradeId == gradeId);
 
     /// <summary>
-    /// The grade the ACCOUNT is at, for the paths that run without a character selected.
+    /// The account-wide grade lives in <c>AccountManager.GetAccountPremium</c>, which can reach the
+    /// database for the paths that run before the character list is loaded. This class stays a pure
+    /// lookup over the client data.
     /// </summary>
-    /// <remarks>
-    /// Premium is account-wide, so the best point total any character on the account reached stands in
-    /// for it, exactly as the lobby resolves it. One method on purpose: the lobby tells the player which
-    /// grade they are on and the reward tick decides what that grade pays, and those two answering
-    /// differently is precisely how an account ends up being shown one tier and paid another.
-    /// </remarks>
-    public uint GetAccountGrade(IEnumerable<Models.Game.Char.Character> characters)
-    {
-        if (AppConfiguration.Instance.Account?.ForceMaxPremiumGrade == true && MaxGradeId > 0)
-            return MaxGradeId;
-
-        var point = 0;
-        if (characters != null)
-        {
-            foreach (var character in characters)
-                point = Math.Max(point, character.Point);
-        }
-
-        return GetGradeForPoint(point);
-    }
 
     /// <summary>
     /// Highest grade premium_grades defines (6 on 10.0.2.13), or 0 when the table is empty. Used by

--- a/AAEmu.Game/GameData/PremiumGameData.cs
+++ b/AAEmu.Game/GameData/PremiumGameData.cs
@@ -1,5 +1,6 @@
 using AAEmu.Commons.Utils;
 using AAEmu.Game.GameData.Framework;
+using AAEmu.Game.Models;
 using AAEmu.Game.Models.Game.Premium;
 using AAEmu.Game.Utils.DB;
 
@@ -41,6 +42,30 @@ public class PremiumGameData : Singleton<PremiumGameData>, IGameDataLoader
     }
 
     public PremiumGrade GetGrade(uint gradeId) => _grades.FirstOrDefault(g => g.GradeId == gradeId);
+
+    /// <summary>
+    /// The grade the ACCOUNT is at, for the paths that run without a character selected.
+    /// </summary>
+    /// <remarks>
+    /// Premium is account-wide, so the best point total any character on the account reached stands in
+    /// for it, exactly as the lobby resolves it. One method on purpose: the lobby tells the player which
+    /// grade they are on and the reward tick decides what that grade pays, and those two answering
+    /// differently is precisely how an account ends up being shown one tier and paid another.
+    /// </remarks>
+    public uint GetAccountGrade(IEnumerable<Models.Game.Char.Character> characters)
+    {
+        if (AppConfiguration.Instance.Account?.ForceMaxPremiumGrade == true && MaxGradeId > 0)
+            return MaxGradeId;
+
+        var point = 0;
+        if (characters != null)
+        {
+            foreach (var character in characters)
+                point = Math.Max(point, character.Point);
+        }
+
+        return GetGradeForPoint(point);
+    }
 
     /// <summary>
     /// Highest grade premium_grades defines (6 on 10.0.2.13), or 0 when the table is empty. Used by

--- a/AAEmu.Game/Models/Account/AccountDetails.cs
+++ b/AAEmu.Game/Models/Account/AccountDetails.cs
@@ -5,6 +5,13 @@ public struct AccountDetails
     public int AccountId { get; set; }
     public int AccessLevel { get; set; }
     public short Labor { get; set; }
+
+    /// <summary>
+    /// The SERVER-LOCAL labor pool, which the client labels "Online Labor". Account-scoped like
+    /// <see cref="Labor"/>: the client keeps a single labor manager per session, so a per-character
+    /// balance can never be shown correctly in the character-select header.
+    /// </summary>
+    public int LocalLabor { get; set; }
     public int Credits { get; set; }
     public int Loyalty { get; set; }
     public DateTime LastUpdated { get; set; }

--- a/AAEmu.Game/Models/AccountPayment.cs
+++ b/AAEmu.Game/Models/AccountPayment.cs
@@ -11,8 +11,29 @@ public class AccountPayment(GameConnection connection)
     public PaymentMethodType Method { get; set; } = PaymentMethodType.Premium;
     public int Location { get; set; } = 1;
 
-    public DateTime StartTime { get; set; } = DateTime.MinValue;
+    /// <summary>
+    /// Start of the paid period. A fixed past date rather than DateTime.MinValue, which serializes to a
+    /// unix time of 0 and told the client the subscription began in 1970.
+    /// </summary>
+    public DateTime StartTime { get; set; } = new(2020, 1, 1);
     public DateTime EndTime { get; set; } = new(2030, 1, 1);
+
+    /// <summary>
+    /// Paid time left, in seconds. The client reads realPayTime through its plain int64 slot rather
+    /// than its DateTime slot (serializer at rva 0xc512a0), so this is a duration, not a timestamp -
+    /// and it was previously hardcoded to 0 on the wire.
+    /// </summary>
+    public long RealPayTimeSeconds
+    {
+        get
+        {
+            var remaining = EndTime - DateTime.UtcNow;
+            return remaining <= TimeSpan.Zero ? 0L : (long)remaining.TotalSeconds;
+        }
+    }
+
+    /// <summary>How many times premium was bought. No purchase records exist, so report one.</summary>
+    public int BuyPremiumCount { get; set; } = 1;
 
     /// <summary>
     /// Checks if Premium is currently active

--- a/AAEmu.Game/Models/Game/AccountMembership.cs
+++ b/AAEmu.Game/Models/Game/AccountMembership.cs
@@ -1,0 +1,28 @@
+namespace AAEmu.Game.Models.Game;
+
+/// <summary>
+/// The <c>extraKind</c> values the 10.0.2.13 client recognises on an
+/// <see cref="AccountAttributeKind.AccountBuff"/> attribute as a paid membership.
+/// </summary>
+/// <remarks>
+/// Read out of x2game-dev.dll at rva 0x154f00, which is the whole of the client's membership
+/// detection:
+/// <code>
+/// cmp dword ptr [rdx], 2      ; kind == AccountBuff
+/// mov eax, [rdx + 4]          ; extraKind
+/// cmp eax, 0x3e9              ; 1001 -> "[PremiumLog] Ancient membership activated, endTime=%llu"
+/// cmp eax, 0x3ea              ; 1002 -> "[PremiumLog] Advanced membership activated, endTime=%llu"
+/// </code>
+/// Nothing else sets those two flags. The premium grade the server sends in SCUpdatePremiumPoint and
+/// in UnitState is carried correctly on the wire (both layouts verified) but does not grant membership
+/// by itself, which is why an account with grade 6 still read "Patron 0" and the free tier's labor
+/// numbers while the attribute list went out empty.
+/// </remarks>
+public enum AccountMembership : uint
+{
+    /// <summary>上古会员 - the tier premium_grades attaches buff 7149 to.</summary>
+    Ancient = 1001,
+
+    /// <summary>The higher tier the client calls "Advanced membership".</summary>
+    Advanced = 1002
+}

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -2073,10 +2073,34 @@ public partial class Character : Unit, ICharacter
             AddExp(xpToAdd, true);
         }
 
-        LaborPower += change;
-        // amount = primary labor delta; local/recharged pools unused on our single-pool account labor.
+        // Spending draws on BOTH account-wide pools, offline ("Offline Labor", the account pool) first
+        // and only then online ("Online Labor", the local pool). Callers gate on the combined balance -
+        // Skill.Use and the unit_reqs labor margins both do - so charging the account pool alone drove
+        // it negative whenever the cost exceeded it while the local pool still had plenty.
+        //
+        // Granting stays on the account pool: the online tick has its own path in AddLocalLaborPower,
+        // which is the only thing that may raise the local pool, and it clamps to max_local_labor.
+        var accountDelta = change;
+        var localDelta = 0;
+        if (change < 0)
+        {
+            var cost = -(int)change;
+            var fromAccount = Math.Min(cost, Math.Max(0, (int)LaborPower));
+            var fromLocal = Math.Min(cost - fromAccount, Math.Max(0, LocalLaborPower));
+
+            accountDelta = (short)-fromAccount;
+            localDelta = -fromLocal;
+
+            if (fromLocal > 0)
+                LocalLaborPower -= fromLocal;
+        }
+
+        LaborPower += accountDelta;
+
+        // amount = account pool delta, localAmount = local pool delta. Both counters in the client's
+        // labor manager are accumulators, so each one has to carry its own share of the spend.
         SendPacket(new SCCharacterLaborPowerChangedPacket(
-            change, 0, 0, (uint)actabilityId, actabilityChange, actabilityStep));
+            accountDelta, localDelta, 0, (uint)actabilityId, actabilityChange, actabilityStep));
     }
 
     /// <summary>
@@ -2098,6 +2122,38 @@ public partial class Character : Unit, ICharacter
         LocalLaborPower = newAmount;
         SendPacket(new SCCharacterLaborPowerChangedPacket(0, applied, 0, 0, 0, 0));
         return applied;
+    }
+
+    /// <summary>Guards <see cref="SendLaborPowerSnapshot"/> against seeding the client twice.</summary>
+    private bool _laborSnapshotSent;
+
+    /// <summary>
+    /// Seeds the client's in-world labor counters with the current balances of both pools.
+    /// </summary>
+    /// <remarks>
+    /// Both counters are pure accumulators: the handler for SCCharacterLaborPowerChanged does
+    /// `add [mgr+0xE58], amount` and `add [mgr+0xE68], localAmount` and never stores an absolute
+    /// value, and no other packet writes them either. The absolute {lp, localLp, consumed, ...}
+    /// block the server sends is only parsed into the character-list entry and feeds the
+    /// character-select screen, never the in-world manager. So without this a fresh session starts
+    /// both counters at zero and the UI under-reports until the next tick happens to move them.
+    /// </remarks>
+    public void SendLaborPowerSnapshot()
+    {
+        // At most once per session. The counters are accumulators (`add`, never `mov`), so a second
+        // snapshot does not correct them - it doubles them. CSSpawnCharacter can legitimately arrive
+        // more than once for the same character, which is how Online Labor climbed past its own
+        // 5,000 cap to 5,529.
+        if (_laborSnapshotSent)
+            return;
+        _laborSnapshotSent = true;
+
+        var account = Math.Max(0, (int)LaborPower);
+        var local = Math.Max(0, LocalLaborPower);
+        if (account == 0 && local == 0)
+            return;
+
+        SendPacket(new SCCharacterLaborPowerChangedPacket(account, local, 0, 0, 0, 0));
     }
 
     public void ChangeGamePoints(GamePointKind kind, int change)

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Data;
 using System.Drawing;
 
@@ -345,9 +345,13 @@ public partial class Character : Unit, ICharacter
         }
     }
 
+    /// <summary>
+    /// Cap of the SERVER-LOCAL pool: premium_grades.max_local_labor plus what the account's memberships
+    /// add. The client sums the same two tables for its own display.
+    /// </summary>
     public int MaxLocalLaborPower => Math.Max(
         0,
-        PremiumGameData.Instance.GetGrade(PremiumGrade)?.MaxLocalLabor ?? 0);
+        AccountMemberships.LaborFor(PremiumGrade, AccountId, AppConfiguration.Instance.Id).MaxLocalLabor);
 
     /// <summary>
     /// Last time labor got updated
@@ -446,8 +450,41 @@ public partial class Character : Unit, ICharacter
 
     /// <summary>
     /// Premium grade resolved from <see cref="Point"/> against premium_grades. 0 is no premium.
+    /// Pinned to the highest grade when Account.ForceMaxPremiumGrade is set.
     /// </summary>
-    public uint PremiumGrade => PremiumGameData.Instance.GetGradeForPoint(Point);
+    public uint PremiumGrade
+    {
+        get
+        {
+            if (AppConfiguration.Instance.Account?.ForceMaxPremiumGrade == true)
+            {
+                var maxGrade = PremiumGameData.Instance.MaxGradeId;
+                if (maxGrade > 0)
+                    return maxGrade;
+            }
+
+            return PremiumGameData.Instance.GetGradeForPoint(Point);
+        }
+    }
+
+    /// <summary>
+    /// Premium points as the character-select record reports them. Normally <see cref="Point"/>, but a
+    /// forced max grade has no points behind it, so the lobby is given the top grade's threshold -
+    /// otherwise character select would still show the free tier for a character the world treats as a
+    /// full Patron.
+    /// </summary>
+    private uint LobbyPremiumPoint
+    {
+        get
+        {
+            var point = (uint)Math.Max(0, Point);
+            if (AppConfiguration.Instance.Account?.ForceMaxPremiumGrade != true)
+                return point;
+
+            var threshold = PremiumGameData.Instance.GetGrade(PremiumGameData.Instance.MaxGradeId)?.Point ?? 0;
+            return Math.Max(point, (uint)Math.Max(0, threshold));
+        }
+    }
 
     /// <summary>Cumulative heir exp (characters.heir_exp). heir_levels measures against the total.</summary>
     public long HeirExp { get; set; }
@@ -2124,36 +2161,40 @@ public partial class Character : Unit, ICharacter
         return applied;
     }
 
-    /// <summary>Guards <see cref="SendLaborPowerSnapshot"/> against seeding the client twice.</summary>
-    private bool _laborSnapshotSent;
-
     /// <summary>
-    /// Seeds the client's in-world labor counters with the current balances of both pools.
+    /// Grants the buff premium_grades attaches to this character's grade and strips the buffs of every
+    /// other grade.
     /// </summary>
     /// <remarks>
-    /// Both counters are pure accumulators: the handler for SCCharacterLaborPowerChanged does
-    /// `add [mgr+0xE58], amount` and `add [mgr+0xE68], localAmount` and never stores an absolute
-    /// value, and no other packet writes them either. The absolute {lp, localLp, consumed, ...}
-    /// block the server sends is only parsed into the character-list entry and feeds the
-    /// character-select screen, never the in-world manager. So without this a fresh session starts
-    /// both counters at zero and the UI under-reports until the next tick happens to move them.
+    /// premium_grades.buff_id was loaded into <see cref="Models.Game.Premium.PremiumGrade.BuffId"/> and
+    /// never used by anything. It is how ArcheAge carries Patron status on the character - grade 6 is
+    /// buff 7153, duration 0 (permanent) and flagged system - and the client evidently keys its Patron
+    /// readout off it rather than off the grade the server sends: with the grade correct in both
+    /// SCUpdatePremiumPoint and UnitState, the client still displayed the free tier's numbers.
+    /// The free tier has no buff of its own, so grade 1 only removes.
     /// </remarks>
-    public void SendLaborPowerSnapshot()
+    public void ApplyPremiumGradeBuff()
     {
-        // At most once per session. The counters are accumulators (`add`, never `mov`), so a second
-        // snapshot does not correct them - it doubles them. CSSpawnCharacter can legitimately arrive
-        // more than once for the same character, which is how Online Labor climbed past its own
-        // 5,000 cap to 5,529.
-        if (_laborSnapshotSent)
-            return;
-        _laborSnapshotSent = true;
+        var wanted = PremiumGameData.Instance.GetGrade(PremiumGrade)?.BuffId ?? 0;
 
-        var account = Math.Max(0, (int)LaborPower);
-        var local = Math.Max(0, LocalLaborPower);
-        if (account == 0 && local == 0)
+        foreach (var buffId in PremiumGameData.Instance.GradeBuffIds)
+        {
+            if (buffId == wanted)
+                continue;
+            if (Buffs.CheckBuff(buffId))
+                Buffs.RemoveBuff(buffId);
+        }
+
+        if (wanted == 0 || Buffs.CheckBuff(wanted))
             return;
 
-        SendPacket(new SCCharacterLaborPowerChangedPacket(account, local, 0, 0, 0, 0));
+        if (SkillManager.Instance.GetBuffTemplate(wanted) == null)
+        {
+            Logger.Warn("Premium grade {0} names buff {1}, which is not in the buff templates", PremiumGrade, wanted);
+            return;
+        }
+
+        Buffs.AddBuff(wanted, this);
     }
 
     public void ChangeGamePoints(GamePointKind kind, int change)
@@ -3529,9 +3570,13 @@ public partial class Character : Unit, ICharacter
         stream.Write(Money2);                                        // moneyAmount (bank)
         stream.Write(BankAaPoint);                                   // AA point amount (bank)
         stream.Write((byte)(AutoUseAAPoint ? 1 : 0));                 // autoUseAApoint (u8)
-        stream.Write((uint)0);                                        // prevPoint
-        stream.Write((uint)0);                                        // point
-        stream.Write((uint)0);                                        // gift
+        // Premium points. Hardcoded to 0, which is why character select read "Patron 0" for every
+        // character even when characters.point put them on a paid grade. LobbyPremiumPoint reports the
+        // grade threshold when Account.ForceMaxPremiumGrade is on, so the lobby agrees with the grade
+        // UnitState hands the client once it is in the world.
+        stream.Write((uint)Math.Max(0, PrevPoint));                   // prevPoint
+        stream.Write(LobbyPremiumPoint);                              // point
+        stream.Write((uint)Math.Max(0, Gift));                        // gift
         stream.Write(0L);                                            // updated
         stream.Write((byte)0);                                        // forceNameChange
         // guid: length-prefixed 16 bytes

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -329,8 +329,21 @@ public partial class Character : Unit, ICharacter
     }
 
     /// <summary>
+    /// Cached representation of the SERVER-LOCAL labor pool ("Online Labor"). Account-wide, exactly
+    /// like <see cref="LaborPower"/> - the client keeps one labor manager per session, so a
+    /// per-character balance shows up as whichever character the character-select header binds to.
     /// </summary>
-    public int LocalLaborPower { get; set; }
+    public int LocalLaborPower
+    {
+        get => _localLaborPower;
+        set
+        {
+            if (_localLaborPower == value)
+                return;
+            _localLaborPower = value;
+            AccountManager.Instance.UpdateLocalLabor(AccountId, value);
+        }
+    }
 
     public int MaxLocalLaborPower => Math.Max(
         0,
@@ -556,6 +569,7 @@ public partial class Character : Unit, ICharacter
     private bool _inParty;
     private bool _isOnline;
     private short _laborPower;
+    private int _localLaborPower;
     private DateTime _laborPowerModified;
 
     /// <summary>
@@ -568,9 +582,10 @@ public partial class Character : Unit, ICharacter
     public List<uint> AssaultedBy { get; } = [];
     public List<uint> AssaultOn { get; } = [];
 
-    public void InitializeLaborCache(short labor, DateTime newTime)
+    public void InitializeLaborCache(short labor, int localLabor, DateTime newTime)
     {
         _laborPower = labor;
+        _localLaborPower = localLabor;
         _laborPowerModified = newTime;
     }
 
@@ -2759,9 +2774,9 @@ public partial class Character : Unit, ICharacter
                     character._savedMp = character.Mp;
                     // character.LaborPower = reader.GetInt16("labor_power");
                     // character.LaborPowerModified = reader.GetDateTime("labor_power_modified");
-                    character.InitializeLaborCache(accountDetails.Labor, accountDetails.LastUpdated);
+                    // Both pools are account-wide, so neither comes from the character row.
+                    character.InitializeLaborCache(accountDetails.Labor, accountDetails.LocalLabor, accountDetails.LastUpdated);
                     character.ConsumedLaborPower = reader.GetInt32("consumed_lp");
-                    character.LocalLaborPower = reader.GetInt32("local_lp");
                     character.Ability1 = (AbilityType)reader.GetByte("ability1");
                     character.Ability2 = (AbilityType)reader.GetByte("ability2");
                     character.Ability3 = (AbilityType)reader.GetByte("ability3");
@@ -2882,11 +2897,9 @@ public partial class Character : Unit, ICharacter
                     character.Mp = reader.GetInt32("mp");
                     character._savedHp = character.Hp; // save for later
                     character._savedMp = character.Mp;
-                    character.InitializeLaborCache(accountDetails.Labor, accountDetails.LastUpdated);
-                    // character.LaborPower = reader.GetInt16("labor_power");
-                    // character.LaborPowerModified = reader.GetDateTime("labor_power_modified");
+                    // Both pools are account-wide, so neither comes from the character row.
+                    character.InitializeLaborCache(accountDetails.Labor, accountDetails.LocalLabor, accountDetails.LastUpdated);
                     character.ConsumedLaborPower = reader.GetInt32("consumed_lp");
-                    character.LocalLaborPower = reader.GetInt32("local_lp");
                     character.Ability1 = (AbilityType)reader.GetByte("ability1");
                     character.Ability2 = (AbilityType)reader.GetByte("ability2");
                     character.Ability3 = (AbilityType)reader.GetByte("ability3");
@@ -3173,7 +3186,9 @@ public partial class Character : Unit, ICharacter
                 command.CommandText =
                     "REPLACE INTO `characters` " +
                     "(`id`,`account_id`,`name`,`access_level`,`race`,`gender`,`unit_model_params`,`level`,`experience`,`recoverable_exp`,`heir_exp`," +
-                    "`hp`,`mp`,`consumed_lp`,`local_lp`,`ability1`,`ability2`,`ability3`," +
+                    // local_lp is deliberately absent: the local labor pool is account-wide and lives in
+                    // accounts.local_labor. REPLACE INTO resets the obsolete column to its default.
+                    "`hp`,`mp`,`consumed_lp`,`ability1`,`ability2`,`ability3`," +
                     "`world_id`,`zone_id`,`x`,`y`,`z`,`roll`,`pitch`,`yaw`," +
                     "`faction_id`,`faction_name`,`expedition_id`,`family`,`dead_count`,`dead_time`,`rez_wait_duration`,`rez_time`,`rez_penalty_duration`,`leave_time`," +
                     "`money`,`money2`,`aa_point`,`bank_aa_point`,`honor_point`,`vocation_point`,`crime_point`,`crime_record`,`jury_point`," +
@@ -3182,7 +3197,7 @@ public partial class Character : Unit, ICharacter
                     "`num_inv_slot`,`num_bank_slot`,`expanded_expert`,`slots`,`created_at`,`updated_at`,`return_district`,`online_time`,`total_play_time`,`privacy_status`" +
                     ") VALUES (" +
                     "@id,@account_id,@name,@access_level,@race,@gender,@unit_model_params,@level,@experience,@recoverable_exp,@heir_exp," +
-                    "@hp,@mp,@consumed_lp,@local_lp,@ability1,@ability2,@ability3," +
+                    "@hp,@mp,@consumed_lp,@ability1,@ability2,@ability3," +
                     "@world_id,@zone_id,@x,@y,@z,@yaw,@pitch,@roll," +
                     "@faction_id,@faction_name,@expedition_id,@family,@dead_count,@dead_time,@rez_wait_duration,@rez_time,@rez_penalty_duration,@leave_time," +
                     "@money,@money2,@aa_point,@bank_aa_point,@honor_point,@vocation_point,@crime_point,@crime_record,@jury_point," +
@@ -3204,7 +3219,6 @@ public partial class Character : Unit, ICharacter
                 command.Parameters.AddWithValue("@hp", Hp);
                 command.Parameters.AddWithValue("@mp", Mp);
                 command.Parameters.AddWithValue("@consumed_lp", ConsumedLaborPower);
-                command.Parameters.AddWithValue("@local_lp", LocalLaborPower);
                 command.Parameters.AddWithValue("@ability1", (byte)Ability1);
                 command.Parameters.AddWithValue("@ability2", (byte)Ability2);
                 command.Parameters.AddWithValue("@ability3", (byte)Ability3);
@@ -3470,7 +3484,11 @@ public partial class Character : Unit, ICharacter
         stream.Write((uint)Math.Max(0, LocalLaborPower));             // localLp
         stream.Write((uint)Math.Max(0, ConsumedLaborPower));          // consumed
         stream.Write(LaborPowerModified);                             // updated (unix DateTime)
-        stream.Write(0L);                                             // bmPoint
+        // Loyalty tokens ("Loyalty Token" in the char-select header). This was hardcoded to 0, which is
+        // why the header read 0 for every character while accounts.loyalty held the real balance. The
+        // labor fields right above it come from the same block and render correctly, so the block is
+        // parsed at the right offset - only the value was missing.
+        stream.Write(BmPoint);                                        // bmPoint
         stream.Write(0u);                                             // rechargedLp
         stream.Write(0L);                                             // rechargeResetTime
         return stream;

--- a/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
@@ -125,7 +125,8 @@ public class CharacterCraft(Character owner)
             return;
         }
 
-        if (Owner.LaborPower < ConsumeLaborPower)
+        // Both pools pay: ChangeLabor spends the account pool first and the local one for the rest.
+        if (Owner.LaborPower + Owner.LocalLaborPower < ConsumeLaborPower)
         {
             Owner.SendDebugMessage("|cFFFFFF00[Craft] Not enough Labor Powers for crafting! Performing a fictitious crafting step...|r");
             Owner.SendErrorMessage(ErrorMessageType.CraftCantActAnyMore, ErrorMessageType.NotEnoughLaborPower, 0, false);

--- a/AAEmu.Game/Models/Game/Char/CharacterMails.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterMails.cs
@@ -315,7 +315,8 @@ public class CharacterMails
             var tookMoney = false;
             if (thisMail.MailType == MailType.AucOffSuccess && thisMail.Body.CopperCoins > 0 && takeMoney)
             {
-                if (Self.LaborPower < 1)
+                // Both pools pay; see Character.ChangeLabor.
+                if (Self.LaborPower + Self.LocalLaborPower < 1)
                 {
                     Self.SendErrorMessage(ErrorMessageType.NotEnoughLaborPower);
                     takeMoney = false;

--- a/AAEmu.Game/Models/Game/Configurations.cs
+++ b/AAEmu.Game/Models/Game/Configurations.cs
@@ -246,6 +246,18 @@ public class AccountConfig
     /// Access-Level that should be used for the first created character on the server regardless of other settings
     /// </summary>
     public int AccessLevelFirstCharacter { get; set; } = 100;
+
+    /// <summary>
+    /// Grants every character the highest grade in premium_grades instead of deriving it from
+    /// characters.point. Off by default, so the point thresholds (1, 50, 125, 225, 400) keep deciding.
+    /// </summary>
+    /// <remarks>
+    /// Turning this on is what "everyone is a max Patron" means: it moves the whole account off the
+    /// free tier (grade 1, which premium_grades gives max_labor = 0, so the account/"Offline" pool
+    /// does not exist for it) onto the top grade and its 6000/5000 caps and 15/10 regeneration.
+    /// The grade also travels in UnitState, so the client's own labor cap display follows it.
+    /// </remarks>
+    public bool ForceMaxPremiumGrade { get; set; } = false;
 }
 
 public class CurrencyValuesConfig

--- a/AAEmu.Game/Models/Game/Premium/AccountBuff.cs
+++ b/AAEmu.Game/Models/Game/Premium/AccountBuff.cs
@@ -1,0 +1,45 @@
+namespace AAEmu.Game.Models.Game.Premium;
+
+/// <summary>
+/// Row of <c>account_buffs</c> - a paid membership and the labor it adds on top of the premium grade.
+/// The row id is the <c>extraKind</c> the client matches an account attribute against, see
+/// <see cref="AccountMembership"/>.
+/// </summary>
+/// <remarks>
+/// The client sums these onto premium_grades itself. With memberships 1001 (上古会员, +10 online,
+/// +10 offline, +3000 max) and 1002 (生活会员, +5 online) both active on a grade-6 account it displays
+/// a rate of 15+10+5 = 30 and an account pool cap of 6000+3000+0 = 9000, which is exactly what the
+/// live client shows. The server has to do the same arithmetic or it pays out less than the client
+/// promises.
+/// </remarks>
+public class AccountBuff
+{
+    public uint Id { get; set; }
+    public string Name { get; set; }
+    public uint BuffId { get; set; }
+
+    /// <summary>Added to (or, with <see cref="ReplacePremiumOnlineLp"/>, substituted for) the grade's online rate.</summary>
+    public int OnlineLaborPower { get; set; }
+    public bool ReplacePremiumOnlineLp { get; set; }
+
+    /// <summary>Added to (or, with <see cref="ReplacePremiumOfflineLp"/>, substituted for) the grade's offline rate.</summary>
+    public int OfflineLaborPower { get; set; }
+    public bool ReplacePremiumOfflineLp { get; set; }
+
+    /// <summary>Raises the ACCOUNT pool cap ("Offline Labor").</summary>
+    public int AddMaxLp { get; set; }
+
+    /// <summary>Raises the SERVER-LOCAL pool cap ("Online Labor").</summary>
+    public int AddMaxLocalLp { get; set; }
+}
+
+/// <summary>
+/// The labor numbers a premium grade and the account's active memberships add up to.
+/// </summary>
+public class LaborAllowance
+{
+    public int OnlineRate { get; set; }
+    public int OfflineRate { get; set; }
+    public int MaxLabor { get; set; }
+    public int MaxLocalLabor { get; set; }
+}

--- a/AAEmu.Game/Models/Game/Skills/Effects/RecoverExpEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/RecoverExpEffect.cs
@@ -62,7 +62,8 @@ public class RecoverExpEffect : EffectTemplate
 
         if (NeedLaborPower)
         {
-            if (character.LaborPower < ExpRecoveryLabor)
+            // Both pools pay; see Character.ChangeLabor.
+            if (character.LaborPower + character.LocalLaborPower < ExpRecoveryLabor)
             {
                 character.SendErrorMessage(ErrorMessageType.NotEnoughLaborPower);
                 return;

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -1556,7 +1556,12 @@ public class Skill
             if (Template.ConsumeLaborPower > 0 && laborCost < 1)
                 laborCost = 1;
 
-            if (laborCost > 0 && !Cancelled && character.LaborPower >= laborCost)
+            // Both pools pay, so both have to be counted here. ChangeLabor charges the account pool
+            // first and the local pool for the rest; gating on the account pool alone let a skill whose
+            // cost exceeded it run without being charged at all, while the player still held plenty of
+            // Online Labor. The other labor gates - crafting, the auction fee, specialty selling, exp
+            // recovery - all read the combined balance.
+            if (laborCost > 0 && !Cancelled && character.LaborPower + character.LocalLaborPower >= laborCost)
             {
                 // Consume labor only if there is enough of it
                 character.ChangeLabor((short)-laborCost, Template.ActabilityGroupId);

--- a/AAEmu.Game/Models/Game/Units/UnitReqs.cs
+++ b/AAEmu.Game/Models/Game/Units/UnitReqs.cs
@@ -384,9 +384,13 @@ public class UnitReqs
             // case UnitReqsKindType.ManaMargin:
 
             case UnitReqsKindType.LaborPowerMargin:
-                var remainingLaborMargin =
-                    TimedRewardsManager.GetMaxLabor(player?.Connection?.Payment?.PremiumState ?? false) -
-                    player?.LaborPower ?? 0;
+                // Headroom across BOTH pools: the account cap plus the local cap, minus what is held in
+                // either. Both pools are account-wide, so the margin the client shows spans both.
+                var remainingLaborMargin = player == null
+                    ? 0
+                    : TimedRewardsManager.GetMaxLabor(player.PremiumGrade, player.Connection?.Payment?.PremiumState ?? false, player.AccountId) +
+                      player.MaxLocalLaborPower -
+                      (player.LaborPower + player.LocalLaborPower);
                 return RetWithValue(SkillResultKeys.skill_urk_labor_power_margin, Value1, Value1 <= remainingLaborMargin);
 
             case UnitReqsKindType.LaborPowerMarginLocal:
@@ -499,10 +503,13 @@ public class UnitReqs
                     unit?.Cooldowns.CheckCooldown(Value1) ?? false);
 
             case UnitReqsKindType.FullRechargedLaborPower:
-                var maximumLabor = TimedRewardsManager.GetMaxLabor(
-                    player?.Connection?.Payment?.PremiumState ?? false);
+                var maximumLabor = player == null
+                    ? 0
+                    : TimedRewardsManager.GetMaxLabor(player.PremiumGrade, player.Connection?.Payment?.PremiumState ?? false, player.AccountId) +
+                      player.MaxLocalLaborPower;
+                // Both pools count towards "fully recharged", because maximumLabor is both caps added up.
                 return Ret(SkillResultKeys.skill_urk_full_recharged_labor_power,
-                    player?.LaborPower >= maximumLabor);
+                    player != null && player.LaborPower + player.LocalLaborPower >= maximumLabor);
 
             case UnitReqsKindType.ExpeditionMemberNot:
                 return Ret(SkillResultKeys.skill_urk_expedition_member_not,

--- a/SQL/aaemu_game.sql
+++ b/SQL/aaemu_game.sql
@@ -22,6 +22,7 @@ CREATE TABLE IF NOT EXISTS `accounts` (
   `account_id` INT(11) NOT NULL,
   `access_level` INT(11) NOT NULL DEFAULT '0',
   `labor` INT(11) NOT NULL DEFAULT '0',
+  `local_labor` INT UNSIGNED NOT NULL DEFAULT '0',
   `credits` INT(11) NOT NULL DEFAULT '0',
   `loyalty` INT(11) NOT NULL DEFAULT '0',
   `last_updated` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/SQL/updates/2026-08-08_aaemu_game_account_local_labor.sql
+++ b/SQL/updates/2026-08-08_aaemu_game_account_local_labor.sql
@@ -1,0 +1,21 @@
+USE aaemu_game;
+
+-- The LOCAL ("Online"/server) labor pool belongs to the account, not to a single character.
+-- 10.0.2.13 carries it inside the per-character lobby record only because that record is a full
+-- snapshot; at runtime the client keeps ONE labor manager per session with two counters
+-- (account +0xE58, local +0xE68). Keeping the pool in characters.local_lp made the character-select
+-- header show whichever character the client happened to bind - in practice always the first one,
+-- so an account whose first character had never gathered any read "Online Labor 0" for every slot.
+ALTER TABLE `accounts`
+  ADD COLUMN `local_labor` INT UNSIGNED NOT NULL DEFAULT 0 AFTER `labor`;
+
+-- Carry the existing balances over. The pool is shared, so the largest per-character balance is the
+-- one the account actually earned; summing would hand out labor that was never granted.
+UPDATE `accounts` a
+  SET a.`local_labor` = COALESCE((
+    SELECT MAX(c.`local_lp`) FROM `characters` c WHERE c.`account_id` = a.`account_id`
+  ), 0);
+
+-- characters.local_lp is left in place so this migration stays reversible, but nothing reads or
+-- writes it any more. Character saves use REPLACE INTO, so each character resets it to 0 the first
+-- time it is saved after this update - the balances above are the ones that carry over.


### PR DESCRIPTION
Labor and paid memberships, which turn out to be one subject: the client computes its labor display from the memberships it believes the account holds, so a server that disagrees about either ends up paying out something other than what the player was shown.

> **See "Coupling I would rather split" before merging** — one switch in here does three things, and I do not think it should.

## 1. The local pool was per-character

"Online Labor" lived in `characters.local_lp`. 10.0.2.13 carries it inside the per-character lobby record only because that record is a full snapshot; at runtime the client keeps **one** labor manager per session with two counters (account `+0xE58`, local `+0xE68`).

A per-character balance therefore surfaces as whichever character the character-select header happens to bind to — in practice always the first — so an account whose first character had never gathered read "Online Labor 0" for every slot. It now lives in `accounts.local_labor`. The migration takes the largest existing per-character balance rather than the sum, which would hand out labor that was never granted. `characters.local_lp` stays in place so the migration is reversible; nothing reads or writes it any more.

## 2. The online tick filled the wrong pool

The client's own `ui_texts` describe the local pool as the one that restores while logged in, and the account pool as restoring only while logged off. We credited the account pool on the online tick — which is why "Online Labor" stayed at 0 forever while "Offline Labor" kept climbing.

Without a character in the world the tick time is now left alone, so sitting at character select no longer silently eats tick after tick.

## 3. Spending charged one pool while every caller checked both

`ChangeLabor` charged the account pool alone. With 5 account labor and 100 local, a 50-cost action passed the gate and drove the account pool to −45. Spending now takes the account pool first and the local pool for the rest, and reports each pool's share in its own field of `SCCharacterLaborPowerChanged`, because both client counters are accumulators. Four gates that still read the account pool alone follow: crafting, the auction fee, specialty selling, and exp recovery.

## 4. Premium grade never granted membership

An account at grade 6 still read "Patron 0" and regenerated at the free tier's rate.

The client's entire membership detection is one function (RVA 0x154F00): it walks the **account attribute** list, matches `kind == AccountBuff`, and reads `extraKind` — 1001 activates the Ancient membership, 1002 the Advanced one. Nothing else sets those flags. The grade we send in `SCUpdatePremiumPoint` and in the unit state is carried correctly on the wire; the client simply does not read membership out of it. With the attribute list going out empty, every account stayed on the free tier no matter what the grade said.

`SCUpdatePremiumPoint` also carried a hardcoded `(1, 1, 1)`. Grade 1 is the free tier and the client's Patron readout counts from zero — buff 7153 is named "grade 5" and hangs on `grade_id` 6 — so character select showed "Patron 0" for every account regardless of `characters.point`.

The attributes did not survive the trip back from in-world either, so returning to character select reverted to "Patron 0" until they were published again.

## 5. The labor numbers now come from the game data

The client renders these numbers itself: it reads `premium_grades` and `account_buffs` and adds them up for the Patron tooltip. With memberships 1001 (+10 online, +10 offline, +3000 max) and 1002 (+5 online) on a grade-6 account it shows a rate of 15 + 10 + 5 = 30 and an account cap of 6000 + 3000 = 9000.

Paying out the config's rate instead made the server quietly contradict a promise the player had already been shown. `AccountMemberships` is the single place that answers "which memberships does this account hold", and both the attribute list and the labor arithmetic read it — keeping those apart is exactly what let the client advertise benefits the server never paid. The config still covers grades the data gives no rate of its own.

## Coupling I would rather split

`Account.ForceMaxPremiumGrade` currently does **three** things: it pins the premium grade, it drives the lobby's premium points, and it gifts both memberships to everybody.

Only the first is an operator decision. The `account_buffs` evaluation and republishing the attributes on the way back are plain bug fixes and should not depend on a "everyone is Patron" switch at all. If you would prefer this PR split along that line — the fixes on their own, the convenience switch separately — say so and I will resend it that way.

## Review fixes

Both findings are addressed in the last commit.

**The offline catch-up was billed at the free tier.** The login catch-up runs before a character is picked, and the grade lookup fell back to 0 in that case — so it paid the free rate no matter what the account held. That is the one tick where the difference is largest, since it covers the whole time the player was away.

The first attempt at this read `connection.Characters`, which was still wrong: the catch-up runs from `AccountManager.Add` at authentication, while `GameConnection.LoadAccount` only fills that list later at `CSAesXorKey`, so paid accounts still resolved as grade 0. `FinishStatePacket.ResolveAccountPremium` had the same ordering problem. Both now call `AccountManager.GetAccountPremium`, which uses the loaded character list when it is there and asks the database when it is not:

```sql
SELECT COALESCE(MAX(point), 0) FROM characters
 WHERE account_id = @account_id AND deleted = 0
```

A failed read logs and answers with the free tier, which under-pays rather than handing out a grade the account may not hold. One method for both callers, in `AccountManager` because that owns account state and can reach the database; `PremiumGameData` goes back to being a pure lookup over the client data.

**A skill could consume nothing.** `Skill.Use` gated on the account pool alone while `ChangeLabor` charges both. A skill whose cost exceeded the account pool ran without being charged at all, even with plenty of Online Labor left — the gate failed, so `ChangeLabor` was never reached, and nothing stopped the cast. It now reads the combined balance, like every other labor gate. This was a regression introduced by this PR itself: before it, `ChangeLabor` only ever touched the account pool, so the gate and the charge agreed.

## Notes

- The offline catch-up tick now guards a zero interval, which divided by zero and handed `Math.Floor` an infinity that overflowed the cast.
- The char-select record hardcoded `bmPoint` to 0, so the Loyalty Token count read 0 while `accounts.loyalty` held the real balance. The labor fields immediately above it come from the same block and rendered correctly, so the block was parsed at the right offset — only the value was missing.
- One commit in here adds a labor snapshot at spawn and a later one removes it again. It is worth knowing why: `SCCharacterLaborPowerChanged` is a delta — the handler does `add [mgr+0xE58], amount`, never a store — and the client already carries both balances into the world from the `{lp, localLp, ...}` block of the character-list record. Sending the totals once more added them on top, so the in-world display read exactly twice the stored balance (10,360 against 2,551 + 2,659) and Online Labor sat above its own 5,000 cap.

## Testing

`AAEmu.Game` builds clean against `client_version/zone-10.0.2_r575`.

The membership detection, the tooltip arithmetic and the doubled counters were each read off a live 10.0.2.13 client and its data. Not re-verified end to end on this branch — the checks worth running are the Patron readout at character select, the same readout after returning from in-world, and the in-world labor display matching the stored balance rather than twice it.
