### PR TITLE
feat(quests): daily schedule (Path of Destiny) contracts

### DIFF
--- a/AAEmu.Game/Core/Managers/QuestManager.cs
+++ b/AAEmu.Game/Core/Managers/QuestManager.cs
@@ -862,6 +862,23 @@ public partial class QuestManager(ITaskManager taskManager, IZoneManager zoneMan
         }
         using (var command = connection.CreateCommand())
         {
+            command.CommandText = "SELECT * FROM quest_act_con_accept_uis";
+            command.Prepare();
+            using (var reader = new SQLiteWrapperReader(command.ExecuteReader()))
+            {
+                while (reader.Read())
+                {
+                    var actId = reader.GetUInt32("id");
+                    var parentComponent = GetComponentByActTemplate("QuestActConAcceptUi", actId);
+                    if (parentComponent == null)
+                        continue;
+                    var template = new QuestActConAcceptUi(parentComponent) { DetailId = actId };
+                    AddActTemplate(template);
+                }
+            }
+        }
+        using (var command = connection.CreateCommand())
+        {
             command.CommandText = "SELECT * FROM quest_act_con_auto_completes";
             command.Prepare();
             using (var reader = new SQLiteWrapperReader(command.ExecuteReader()))
@@ -1370,6 +1387,31 @@ public partial class QuestManager(ITaskManager taskManager, IZoneManager zoneMan
                     var template = new QuestActObjLevel(parentComponent)
                     {
                         DetailId = actId, Level = reader.GetByte("level"), UseAlias = reader.GetBoolean("use_alias", true),
+                        QuestActObjAliasId = reader.GetUInt32("quest_act_obj_alias_id", 0)
+                    };
+                    AddActTemplate(template);
+                }
+            }
+        }
+
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = "SELECT * FROM quest_act_obj_labor_powers";
+            command.Prepare();
+            using (var reader = new SQLiteWrapperReader(command.ExecuteReader()))
+            {
+                while (reader.Read())
+                {
+                    var actId = reader.GetUInt32("id");
+                    var parentComponent = GetComponentByActTemplate("QuestActObjLaborPower", actId);
+                    if (parentComponent == null)
+                        continue;
+                    var template = new QuestActObjLaborPower(parentComponent)
+                    {
+                        DetailId = actId,
+                        Count = reader.GetInt32("count"),
+                        ActabilityGroupId = reader.GetUInt32("actability_group_id", 0),
+                        UseAlias = reader.GetBoolean("use_alias", true),
                         QuestActObjAliasId = reader.GetUInt32("quest_act_obj_alias_id", 0)
                     };
                     AddActTemplate(template);

--- a/AAEmu.Game/Core/Managers/TodayAssignmentManager.cs
+++ b/AAEmu.Game/Core/Managers/TodayAssignmentManager.cs
@@ -14,8 +14,10 @@ using NLog;
 namespace AAEmu.Game.Core.Managers;
 
 /// <summary>
-/// Daily schedule (today_quest_* tables): unlock, accept, re-roll, and completion.
-/// Progress is stored per character and day in character_today_assignments.
+/// Daily schedule (today_quest_* tables).
+/// Client visuals for Locked: grey until level+cost item (client); green when satisfy.
+/// Flow: LOCKED → Unlock → READY (blue, no quest) → Accept → PROGRESS → DONE.
+/// Paid steps (item cost): unlock once per character; each new day seeds READY again.
 /// </summary>
 public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
 {
@@ -37,8 +39,17 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
     /// <summary>characterId → free re-rolls used today (0..MaxDailyResets).</summary>
     private readonly Dictionary<uint, uint> _resetsUsed = [];
 
-    /// <summary>Characters whose rows for today have been loaded this process lifetime.</summary>
-    private readonly HashSet<uint> _loadedOwners = [];
+    /// <summary>
+    /// Paid slot unlocks that survive across days (item cost paid once per character).
+    /// Free steps (no item cost) are not stored here.
+    /// </summary>
+    private readonly Dictionary<uint, HashSet<uint>> _lifetimeUnlocks = [];
+
+    /// <summary>
+    /// Characters loaded for a specific local calendar day. If the day changes while online,
+    /// EnsureLoaded reloads so assignment/reroll state does not carry across midnight.
+    /// </summary>
+    private readonly Dictionary<uint, DateTime> _loadedDay = [];
 
     private sealed class ActiveTodayAssignment
     {
@@ -50,6 +61,9 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
     }
 
     private static DateTime TodayKey => DateTime.Today;
+
+    private static bool IsPaidStep(TodayQuestStepTemplate step)
+        => step != null && step.ItemId != 0 && step.ItemNum > 0;
 
     public void SendResetCount(Character character)
     {
@@ -101,18 +115,7 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
             return;
         }
 
-        if (!UnitRequirementsGameData.Instance.MeetOwnerRequirements(
-                "TodayQuestStep", step.Id, step.OrUnitReqs, character))
-        {
-            Logger.Info(
-                "TodayAssignment: step reqs failed realStep={0} stepId={1} for {2}",
-                realStep, step.Id, character.Name);
-            return;
-        }
-
-        if (step.LevelMin > 0 && character.Level < step.LevelMin)
-            return;
-        if (step.LevelMax > 0 && character.Level > step.LevelMax)
+        if (!MeetsStepEligibility(character, step, realStep, log: true))
             return;
 
         switch (request)
@@ -231,7 +234,9 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
         SetActive(character.Id, realStep, state);
         Persist(character.Id, realStep, state);
 
-        _resetsUsed[character.Id] = used + 1;
+        var newUsed = used + 1;
+        _resetsUsed[character.Id] = newUsed;
+        PersistResetsUsed(character.Id, newUsed);
 
         SendState(character, realStep, state, init: false);
         SendResetCount(character);
@@ -239,7 +244,7 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
         Logger.Info(
             "TodayAssignment reset ok {0}: realStep={1} group {2}→{3} quest {4}→{5} used={6}/{7}",
             character.Name, realStep, oldGroupId, newGroup.Id, oldQuestId, newQuestId,
-            used + 1, MaxDailyResets);
+            newUsed, MaxDailyResets);
     }
 
     public void HandleAcceptAll(Character character, sbyte todayType, IReadOnlyList<uint> realSteps)
@@ -263,7 +268,9 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
                     if (state.Unlocked && !state.Accepted && state.Status != TodayAssignmentStatus.Done)
                     {
                         var step = TodayQuestGameData.Instance.GetStepByRealStep(realStep);
-                        if (step == null || !Accept(character, step, realStep))
+                        if (step == null
+                            || !MeetsStepEligibility(character, step, realStep, log: true)
+                            || !Accept(character, step, realStep))
                             ok = false;
                     }
                 }
@@ -275,6 +282,13 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
             {
                 var step = TodayQuestGameData.Instance.GetStepByRealStep(realStep);
                 if (step == null)
+                {
+                    ok = false;
+                    continue;
+                }
+
+                // Same step-level gates as CSRequestTodayAssignment — bulk list is client-controlled.
+                if (!MeetsStepEligibility(character, step, realStep, log: true))
                 {
                     ok = false;
                     continue;
@@ -295,7 +309,38 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
     {
         _active.Remove(characterId);
         _resetsUsed.Remove(characterId);
-        _loadedOwners.Remove(characterId);
+        _lifetimeUnlocks.Remove(characterId);
+        _loadedDay.Remove(characterId);
+    }
+
+    /// <summary>
+    /// Step unit_reqs + level bounds shared by single-step requests and AcceptAll bulk unlock.
+    /// </summary>
+    private static bool MeetsStepEligibility(
+        Character character,
+        TodayQuestStepTemplate step,
+        uint realStep,
+        bool log)
+    {
+        if (!UnitRequirementsGameData.Instance.MeetOwnerRequirements(
+                "TodayQuestStep", step.Id, step.OrUnitReqs, character))
+        {
+            if (log)
+            {
+                Logger.Info(
+                    "TodayAssignment: step reqs failed realStep={0} stepId={1} for {2}",
+                    realStep, step.Id, character.Name);
+            }
+
+            return false;
+        }
+
+        if (step.LevelMin > 0 && character.Level < step.LevelMin)
+            return false;
+        if (step.LevelMax > 0 && character.Level > step.LevelMax)
+            return false;
+
+        return true;
     }
 
     public void NotifyQuestCompleted(Character character, uint questContextId)
@@ -397,9 +442,6 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
                 return;
             }
 
-            if (TryRecoverDoneFromCompletedQuests(character, realStep, existing))
-                return;
-
             // Re-click on an unlocked, not-yet-accepted slot completes accept (no second charge).
             if (existing.Status == TodayAssignmentStatus.Ready || !existing.Accepted)
             {
@@ -420,34 +462,16 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
             return;
         }
 
-        // If player already completed a quest for this group today (DB completed_quests), stay Done.
-        // No item charge — cost was (or would have been) paid before completion.
-        foreach (var qid in group.QuestContextIds)
+        // Green unlock → blue Ready only (no quest start). Item cost once for paid slots.
+        if (IsPaidStep(step))
         {
-            if (!character.Quests.HasQuestCompleted(qid))
-                continue;
-
-            var doneState = new ActiveTodayAssignment
+            if (!HasLifetimeUnlock(character.Id, realStep))
             {
-                GroupId = group.Id,
-                QuestContextId = qid,
-                Unlocked = true,
-                Accepted = true,
-                Status = TodayAssignmentStatus.Done
-            };
-            SetActive(character.Id, realStep, doneState);
-            Persist(character.Id, realStep, doneState);
-            DropSiblingQuests(character, group.Id, keepQuestId: qid);
-            SendState(character, realStep, doneState, init: false);
-            Logger.Info(
-                "TodayAssignment unlock recovered Done {0}: realStep={1} quest={2}",
-                character.Name, realStep, qid);
-            return;
+                if (!TryConsumeUnlockCost(character, step, realStep))
+                    return;
+                GrantLifetimeUnlock(character.Id, realStep);
+            }
         }
-
-        // Paid unlocks (e.g. Blue Salt Hammer / Evenstone) charge bag once at unlock.
-        if (!TryConsumeUnlockCost(character, step, realStep))
-            return;
 
         var state = new ActiveTodayAssignment
         {
@@ -461,15 +485,12 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
         Persist(character.Id, realStep, state);
 
         Logger.Info(
-            "TodayAssignment unlocked {0}: realStep={1} group={2} costItem={3}x{4}",
-            character.Name, realStep, group.Id, step.ItemId, step.ItemNum);
+            "TodayAssignment unlocked→Ready {0}: realStep={1} group={2} costItem={3}x{4} lifetime={5}",
+            character.Name, realStep, group.Id, step.ItemId, step.ItemNum,
+            IsPaidStep(step) && HasLifetimeUnlock(character.Id, realStep));
 
-        // Paid unlocks auto-accept so the slot immediately enters Progress.
-        if (!Accept(character, step, realStep))
-        {
-            SendState(character, realStep, state, init: false);
-            SendResetCount(character);
-        }
+        SendState(character, realStep, state, init: false);
+        SendResetCount(character);
     }
 
     /// <summary>
@@ -511,11 +532,13 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
 
     private bool Accept(Character character, TodayQuestStepTemplate step, uint realStep)
     {
+        // Not unlocked yet: unlock only (Ready/blue). Client must click Accept/unlock again for Progress.
         if (!TryGetActive(character.Id, realStep, out var state) || !state.Unlocked)
         {
             Unlock(character, step, realStep);
-            if (!TryGetActive(character.Id, realStep, out state) || !state.Unlocked)
-                return false;
+            return TryGetActive(character.Id, realStep, out state)
+                   && state.Unlocked
+                   && state.Status == TodayAssignmentStatus.Ready;
         }
 
         if (state.Status == TodayAssignmentStatus.Done)
@@ -524,9 +547,6 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
             SendState(character, realStep, state, init: false);
             return true;
         }
-
-        if (TryRecoverDoneFromCompletedQuests(character, realStep, state))
-            return true;
 
         if (state.Accepted)
         {
@@ -554,12 +574,6 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
         uint primaryQuestId = 0;
         foreach (var questId in group.QuestContextIds)
         {
-            if (character.Quests.HasQuestCompleted(questId))
-            {
-                CompleteStep(character, realStep, state, questId);
-                return true;
-            }
-
             if (character.Quests.HasQuest(questId))
             {
                 startedAny = true;
@@ -568,7 +582,7 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
             }
         }
 
-        // Start only the first incomplete group quest (not all three) so one kill pool tracks one contract.
+        // Start only the first group quest that can still be started (repeatables ok on later days).
         if (!startedAny)
         {
             foreach (var questId in group.QuestContextIds)
@@ -613,35 +627,6 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
             "TodayAssignment accepted {0}: realStep={1} group={2} quest={3}",
             character.Name, realStep, group.Id, primaryQuestId);
         return true;
-    }
-
-    private bool TryRecoverDoneFromCompletedQuests(
-        Character character,
-        uint realStep,
-        ActiveTodayAssignment state)
-    {
-        var group = TodayQuestGameData.Instance.GetGroup(state.GroupId);
-        if (group == null)
-        {
-            var stepTemplate = TodayQuestGameData.Instance.GetStepByRealStep(realStep);
-            if (stepTemplate != null)
-                group = PickEligibleGroup(character, stepTemplate);
-        }
-
-        if (group == null)
-            return false;
-
-        foreach (var qid in group.QuestContextIds)
-        {
-            if (!character.Quests.HasQuestCompleted(qid))
-                continue;
-
-            state.GroupId = group.Id;
-            CompleteStep(character, realStep, state, qid);
-            return true;
-        }
-
-        return false;
     }
 
     private void Resync(Character character, uint realStep)
@@ -756,11 +741,49 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
     {
         if (character == null)
             return;
-        if (_loadedOwners.Contains(character.Id))
+
+        var today = TodayKey;
+        if (_loadedDay.TryGetValue(character.Id, out var loadedDay) && loadedDay == today)
             return;
 
+        // Midnight crossed while still online (or first load this process).
+        var dayRolledOver = loadedDay != default && loadedDay != today;
+        if (dayRolledOver)
+        {
+            Logger.Info(
+                "TodayAssignment day rollover owner={0} was={1:yyyy-MM-dd} now={2:yyyy-MM-dd}",
+                character.Id, loadedDay, today);
+            _active.Remove(character.Id);
+            _resetsUsed.Remove(character.Id);
+        }
+
         LoadFromDb(character);
-        _loadedOwners.Add(character.Id);
+        _loadedDay[character.Id] = today;
+
+        // Refresh client UI so yesterday's Done/Progress does not stick after midnight.
+        if (dayRolledOver)
+            PushDayRolloverUi(character);
+    }
+
+    private void PushDayRolloverUi(Character character)
+    {
+        SendResetCount(character);
+
+        foreach (var step in TodayQuestGameData.Instance.AllSteps)
+        {
+            if (TryGetActive(character.Id, step.RealStep, out var state))
+            {
+                SendState(character, step.RealStep, state, init: true);
+                continue;
+            }
+
+            character.SendPacket(new SCTodayAssignmentChangedPacket(
+                (int)step.Id,
+                0,
+                0,
+                (sbyte)TodayAssignmentStatus.Locked,
+                init: true));
+        }
     }
 
     private void LoadFromDb(Character character)
@@ -802,6 +825,11 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
                     Accepted = status >= TodayAssignmentStatus.Progress
                 };
                 SetActive(character.Id, realStep, state);
+
+                // Any paid step used today is also a lifetime unlock.
+                var stepTpl = TodayQuestGameData.Instance.GetStepByRealStep(realStep);
+                if (IsPaidStep(stepTpl) && status >= TodayAssignmentStatus.Ready)
+                    RememberLifetimeUnlock(character.Id, realStep);
             }
         }
         catch (MySqlException ex) when (ex.Number is 1146 or 1054)
@@ -815,38 +843,218 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
             Logger.Error(ex, "TodayAssignment LoadFromDb failed for {0}", character.Id);
         }
 
-        // Recover Done from completed_quests even when the row was never saved (pre-persist sessions).
-        foreach (var step in TodayQuestGameData.Instance.AllSteps)
+        LoadLifetimeUnlocksFromDb(character);
+        BackfillLifetimeUnlocksFromHistory(character);
+        SeedReadyForLifetimeUnlocks(character);
+        LoadResetsUsedFromDb(character);
+    }
+
+    private bool HasLifetimeUnlock(uint characterId, uint realStep)
+        => _lifetimeUnlocks.TryGetValue(characterId, out var set) && set.Contains(realStep);
+
+    private void RememberLifetimeUnlock(uint characterId, uint realStep)
+    {
+        if (!_lifetimeUnlocks.TryGetValue(characterId, out var set))
         {
-            if (TryGetActive(character.Id, step.RealStep, out var existing)
-                && existing.Status == TodayAssignmentStatus.Done)
+            set = [];
+            _lifetimeUnlocks[characterId] = set;
+        }
+
+        set.Add(realStep);
+    }
+
+    private void GrantLifetimeUnlock(uint characterId, uint realStep)
+    {
+        RememberLifetimeUnlock(characterId, realStep);
+        PersistLifetimeUnlock(characterId, realStep);
+    }
+
+    private void LoadLifetimeUnlocksFromDb(Character character)
+    {
+        try
+        {
+            using var connection = MySQL.CreateConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                """
+                SELECT real_step
+                FROM character_today_step_unlocks
+                WHERE owner = @owner
+                """;
+            command.Parameters.AddWithValue("@owner", character.Id);
+            command.Prepare();
+
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+                RememberLifetimeUnlock(character.Id, reader.GetUInt32("real_step"));
+        }
+        catch (MySqlException ex) when (ex.Number is 1146 or 1054)
+        {
+            Logger.Warn(
+                "TodayAssignment step-unlocks table missing — run SQL/updates/2026-08-09_aaemu_game_character_today_step_unlocks.sql ({0})",
+                ex.Message);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "TodayAssignment LoadLifetimeUnlocks failed for {0}", character.Id);
+        }
+    }
+
+    /// <summary>
+    /// One-time migration: any past daily row for a paid step implies the character already paid.
+    /// </summary>
+    private void BackfillLifetimeUnlocksFromHistory(Character character)
+    {
+        try
+        {
+            using var connection = MySQL.CreateConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                """
+                SELECT DISTINCT real_step
+                FROM character_today_assignments
+                WHERE owner = @owner AND status >= 1
+                """;
+            command.Parameters.AddWithValue("@owner", character.Id);
+            command.Prepare();
+
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                var realStep = reader.GetUInt32("real_step");
+                var step = TodayQuestGameData.Instance.GetStepByRealStep(realStep);
+                if (!IsPaidStep(step) || HasLifetimeUnlock(character.Id, realStep))
+                    continue;
+
+                RememberLifetimeUnlock(character.Id, realStep);
+                PersistLifetimeUnlock(character.Id, realStep);
+                Logger.Info(
+                    "TodayAssignment backfilled lifetime unlock {0} realStep={1}",
+                    character.Name, realStep);
+            }
+        }
+        catch (MySqlException ex) when (ex.Number is 1146 or 1054)
+        {
+            // assignments or unlocks table missing — ignore
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "TodayAssignment BackfillLifetimeUnlocks failed for {0}", character.Id);
+        }
+    }
+
+    /// <summary>
+    /// After midnight / first login of the day: paid slots already unlocked sit Ready (blue), not Locked.
+    /// </summary>
+    private void SeedReadyForLifetimeUnlocks(Character character)
+    {
+        if (!_lifetimeUnlocks.TryGetValue(character.Id, out var unlockedSteps) || unlockedSteps.Count == 0)
+            return;
+
+        foreach (var realStep in unlockedSteps)
+        {
+            if (TryGetActive(character.Id, realStep, out _))
+                continue;
+
+            var step = TodayQuestGameData.Instance.GetStepByRealStep(realStep);
+            if (step == null || !IsPaidStep(step))
+                continue;
+
+            if (!MeetsStepEligibility(character, step, realStep, log: false))
                 continue;
 
             var group = PickEligibleGroup(character, step);
             if (group == null)
                 continue;
 
-            foreach (var qid in group.QuestContextIds)
+            var state = new ActiveTodayAssignment
             {
-                if (!character.Quests.HasQuestCompleted(qid))
-                    continue;
+                GroupId = group.Id,
+                QuestContextId = 0,
+                Unlocked = true,
+                Accepted = false,
+                Status = TodayAssignmentStatus.Ready
+            };
+            SetActive(character.Id, realStep, state);
+            Persist(character.Id, realStep, state);
+            Logger.Info(
+                "TodayAssignment seeded Ready for lifetime unlock {0} realStep={1} group={2}",
+                character.Name, realStep, group.Id);
+        }
+    }
 
-                var state = new ActiveTodayAssignment
-                {
-                    GroupId = group.Id,
-                    QuestContextId = qid,
-                    Unlocked = true,
-                    Accepted = true,
-                    Status = TodayAssignmentStatus.Done
-                };
-                SetActive(character.Id, step.RealStep, state);
-                Persist(character.Id, step.RealStep, state);
-                DropSiblingQuests(character, group.Id, keepQuestId: qid);
-                Logger.Info(
-                    "TodayAssignment recovered Done from completed_quests {0}: realStep={1} quest={2}",
-                    character.Name, step.RealStep, qid);
-                break;
+    private void PersistLifetimeUnlock(uint ownerId, uint realStep)
+    {
+        try
+        {
+            using var connection = MySQL.CreateConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                """
+                INSERT IGNORE INTO character_today_step_unlocks (owner, real_step)
+                VALUES (@owner, @realStep)
+                """;
+            command.Parameters.AddWithValue("@owner", ownerId);
+            command.Parameters.AddWithValue("@realStep", realStep);
+            command.Prepare();
+            command.ExecuteNonQuery();
+        }
+        catch (MySqlException ex) when (ex.Number is 1146 or 1054)
+        {
+            Logger.Warn(
+                "TodayAssignment PersistLifetimeUnlock skipped (table missing): owner={0} realStep={1}",
+                ownerId, realStep);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(
+                ex, "TodayAssignment PersistLifetimeUnlock failed owner={0} realStep={1}", ownerId, realStep);
+        }
+    }
+
+    private void LoadResetsUsedFromDb(Character character)
+    {
+        try
+        {
+            using var connection = MySQL.CreateConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                """
+                SELECT resets_used, day_key
+                FROM character_today_reset_counts
+                WHERE owner = @owner
+                """;
+            command.Parameters.AddWithValue("@owner", character.Id);
+            command.Prepare();
+
+            using var reader = command.ExecuteReader();
+            if (!reader.Read())
+            {
+                _resetsUsed.Remove(character.Id);
+                return;
             }
+
+            var dayKey = reader.GetDateTime("day_key").Date;
+            if (dayKey != TodayKey)
+            {
+                _resetsUsed.Remove(character.Id);
+                return;
+            }
+
+            var used = reader.GetUInt32("resets_used");
+            if (used > MaxDailyResets)
+                used = MaxDailyResets;
+            _resetsUsed[character.Id] = used;
+        }
+        catch (MySqlException ex) when (ex.Number is 1146 or 1054)
+        {
+            Logger.Warn(
+                "TodayAssignment reset-count table missing — run SQL/updates/2026-08-09_aaemu_game_character_today_assignments.sql ({0})",
+                ex.Message);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "TodayAssignment LoadResetsUsed failed for {0}", character.Id);
         }
     }
 
@@ -881,6 +1089,37 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
         catch (Exception ex)
         {
             Logger.Error(ex, "TodayAssignment Persist failed owner={0} realStep={1}", ownerId, realStep);
+        }
+    }
+
+    private void PersistResetsUsed(uint ownerId, uint used)
+    {
+        try
+        {
+            using var connection = MySQL.CreateConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                """
+                REPLACE INTO character_today_reset_counts
+                    (owner, day_key, resets_used)
+                VALUES
+                    (@owner, @dayKey, @used)
+                """;
+            command.Parameters.AddWithValue("@owner", ownerId);
+            command.Parameters.AddWithValue("@dayKey", TodayKey.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+            command.Parameters.AddWithValue("@used", used);
+            command.Prepare();
+            command.ExecuteNonQuery();
+        }
+        catch (MySqlException ex) when (ex.Number is 1146 or 1054)
+        {
+            Logger.Warn(
+                "TodayAssignment PersistResetsUsed skipped (table missing): owner={0}",
+                ownerId);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "TodayAssignment PersistResetsUsed failed owner={0}", ownerId);
         }
     }
 

--- a/AAEmu.Game/Core/Managers/TodayAssignmentManager.cs
+++ b/AAEmu.Game/Core/Managers/TodayAssignmentManager.cs
@@ -1,0 +1,932 @@
+using System.Globalization;
+using AAEmu.Commons.Utils;
+using AAEmu.Commons.Utils.DB;
+using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.GameData;
+using AAEmu.Game.Models.Game;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Items;
+using AAEmu.Game.Models.Game.Items.Actions;
+using AAEmu.Game.Models.Game.TodayAssignment;
+using MySql.Data.MySqlClient;
+using NLog;
+
+namespace AAEmu.Game.Core.Managers;
+
+/// <summary>
+/// Daily schedule (today_quest_* tables): unlock, accept, re-roll, and completion.
+/// Progress is stored per character and day in character_today_assignments.
+/// </summary>
+public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
+{
+    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
+
+    private const sbyte RequestQuery = 0;
+    private const sbyte RequestUnlock = 1;
+    private const sbyte RequestAccept = 2;
+
+    /// <summary>Free mission re-rolls allowed per calendar day.</summary>
+    private const uint MaxDailyResets = 3;
+
+    /// <summary>SCTodayAssignmentResetCount countType for personal daily schedule.</summary>
+    private const uint PersonalResetCountType = 0x0B;
+
+    /// <summary>characterId → realStep → assignment (today only).</summary>
+    private readonly Dictionary<uint, Dictionary<uint, ActiveTodayAssignment>> _active = [];
+
+    /// <summary>characterId → free re-rolls used today (0..MaxDailyResets).</summary>
+    private readonly Dictionary<uint, uint> _resetsUsed = [];
+
+    /// <summary>Characters whose rows for today have been loaded this process lifetime.</summary>
+    private readonly HashSet<uint> _loadedOwners = [];
+
+    private sealed class ActiveTodayAssignment
+    {
+        public uint GroupId { get; set; }
+        public uint QuestContextId { get; set; }
+        public bool Unlocked { get; set; }
+        public bool Accepted { get; set; }
+        public TodayAssignmentStatus Status { get; set; }
+    }
+
+    private static DateTime TodayKey => DateTime.Today;
+
+    public void SendResetCount(Character character)
+    {
+        if (character == null)
+            return;
+
+        var used = _resetsUsed.GetValueOrDefault(character.Id, 0u);
+        character.SendPacket(new SCTodayAssignmentResetCountPacket(used, PersonalResetCountType));
+    }
+
+    /// <summary>
+    /// Load today's assignments from MySQL and push SC to the client (NotifyInGame).
+    /// </summary>
+    public void OnCharacterEnterWorld(Character character)
+    {
+        if (character == null)
+            return;
+
+        EnsureLoaded(character);
+        SendResetCount(character);
+
+        if (!TryGetCharState(character.Id, out var byStep) || byStep.Count == 0)
+            return;
+
+        foreach (var (realStep, state) in byStep)
+        {
+            // Do not re-fire complete-toast on login.
+            SendState(character, realStep, state, init: true);
+            if (state.Status == TodayAssignmentStatus.Done)
+                DropSiblingQuests(character, state.GroupId, keepQuestId: state.QuestContextId);
+        }
+    }
+
+    public void HandleRequest(Character character, uint realStep, sbyte request)
+    {
+        if (character == null)
+            return;
+
+        EnsureLoaded(character);
+
+        Logger.Info(
+            "TodayAssignment request {0} ({1}) realStep={2} request={3}",
+            character.Name, character.Id, realStep, request);
+
+        var step = TodayQuestGameData.Instance.GetStepByRealStep(realStep);
+        if (step == null)
+        {
+            Logger.Warn("TodayAssignment: unknown realStep={0} for {1}", realStep, character.Name);
+            return;
+        }
+
+        if (!UnitRequirementsGameData.Instance.MeetOwnerRequirements(
+                "TodayQuestStep", step.Id, step.OrUnitReqs, character))
+        {
+            Logger.Info(
+                "TodayAssignment: step reqs failed realStep={0} stepId={1} for {2}",
+                realStep, step.Id, character.Name);
+            return;
+        }
+
+        if (step.LevelMin > 0 && character.Level < step.LevelMin)
+            return;
+        if (step.LevelMax > 0 && character.Level > step.LevelMax)
+            return;
+
+        switch (request)
+        {
+            case RequestQuery:
+                Resync(character, realStep);
+                SendResetCount(character);
+                break;
+            case RequestUnlock:
+                Unlock(character, step, realStep);
+                break;
+            case RequestAccept:
+                Accept(character, step, realStep);
+                break;
+            default:
+                Logger.Warn(
+                    "TodayAssignment: unhandled request={0} realStep={1} for {2}",
+                    request, realStep, character.Name);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Change Mission: re-roll an in-progress step. Free while under MaxDailyResets;
+    /// charges inventory gold when moneyAmount is greater than zero.
+    /// </summary>
+    public void HandleReset(Character character, uint realStep, ulong moneyAmount)
+    {
+        if (character == null)
+            return;
+
+        EnsureLoaded(character);
+
+        Logger.Info(
+            "TodayAssignment reset {0} ({1}) realStep={2} money={3}",
+            character.Name, character.Id, realStep, moneyAmount);
+
+        var step = TodayQuestGameData.Instance.GetStepByRealStep(realStep);
+        if (step == null)
+        {
+            Logger.Warn("TodayAssignment: reset unknown realStep={0} for {1}", realStep, character.Name);
+            return;
+        }
+
+        if (!TryGetActive(character.Id, realStep, out var state)
+            || !state.Accepted
+            || state.Status != TodayAssignmentStatus.Progress)
+        {
+            Logger.Info(
+                "TodayAssignment: reset refused (not in Progress) realStep={0} for {1}",
+                realStep, character.Name);
+            return;
+        }
+
+        var used = _resetsUsed.GetValueOrDefault(character.Id, 0u);
+        if (used >= MaxDailyResets)
+        {
+            Logger.Info(
+                "TodayAssignment: reset limit reached ({0}/{1}) for {2}",
+                used, MaxDailyResets, character.Name);
+            SendResetCount(character);
+            return;
+        }
+
+        if (moneyAmount > 0)
+        {
+            if (moneyAmount > (ulong)long.MaxValue
+                || !character.ChangeMoney(
+                    SlotType.Inventory,
+                    SlotType.None,
+                    (long)moneyAmount,
+                    ItemTaskType.StoreBuy))
+            {
+                character.SendErrorMessage(ErrorMessageType.NotEnoughMoney);
+                return;
+            }
+        }
+
+        var oldGroupId = state.GroupId;
+        var oldQuestId = state.QuestContextId;
+
+        if (!TryPickReplacement(character, step, oldGroupId, oldQuestId, out var newGroup, out var newQuestId))
+        {
+            Logger.Warn(
+                "TodayAssignment: reset no alternate quest realStep={0} for {1} (group={2} quest={3})",
+                realStep, character.Name, oldGroupId, oldQuestId);
+            // Refund gold if we charged but cannot re-roll.
+            if (moneyAmount > 0)
+                character.ChangeMoney(SlotType.None, SlotType.Inventory, (long)moneyAmount, ItemTaskType.StoreBuy);
+            return;
+        }
+
+        // Drop every active quest in the old group, then start the replacement.
+        DropSiblingQuests(character, oldGroupId, keepQuestId: 0);
+        if (newGroup.Id != oldGroupId)
+            DropSiblingQuests(character, newGroup.Id, keepQuestId: 0);
+
+        if (!character.Quests.AddQuest(newQuestId))
+        {
+            Logger.Warn(
+                "TodayAssignment: reset failed to start quest={0} realStep={1} for {2}",
+                newQuestId, realStep, character.Name);
+            if (moneyAmount > 0)
+                character.ChangeMoney(SlotType.None, SlotType.Inventory, (long)moneyAmount, ItemTaskType.StoreBuy);
+            // Try to restore the previous contract if it still exists as a template.
+            if (oldQuestId != 0 && !character.Quests.HasQuestCompleted(oldQuestId))
+                character.Quests.AddQuest(oldQuestId);
+            return;
+        }
+
+        state.GroupId = newGroup.Id;
+        state.QuestContextId = newQuestId;
+        state.Unlocked = true;
+        state.Accepted = true;
+        state.Status = TodayAssignmentStatus.Progress;
+        SetActive(character.Id, realStep, state);
+        Persist(character.Id, realStep, state);
+
+        _resetsUsed[character.Id] = used + 1;
+
+        SendState(character, realStep, state, init: false);
+        SendResetCount(character);
+
+        Logger.Info(
+            "TodayAssignment reset ok {0}: realStep={1} group {2}→{3} quest {4}→{5} used={6}/{7}",
+            character.Name, realStep, oldGroupId, newGroup.Id, oldQuestId, newQuestId,
+            used + 1, MaxDailyResets);
+    }
+
+    public void HandleAcceptAll(Character character, sbyte todayType, IReadOnlyList<uint> realSteps)
+    {
+        if (character == null)
+            return;
+
+        EnsureLoaded(character);
+
+        Logger.Info(
+            "TodayAssignment AcceptAll {0} ({1}) todayType={2} steps=[{3}]",
+            character.Name, character.Id, todayType, string.Join(",", realSteps ?? []));
+
+        var ok = true;
+        if (realSteps == null || realSteps.Count == 0)
+        {
+            if (TryGetCharState(character.Id, out var byStep))
+            {
+                foreach (var (realStep, state) in byStep.ToList())
+                {
+                    if (state.Unlocked && !state.Accepted && state.Status != TodayAssignmentStatus.Done)
+                    {
+                        var step = TodayQuestGameData.Instance.GetStepByRealStep(realStep);
+                        if (step == null || !Accept(character, step, realStep))
+                            ok = false;
+                    }
+                }
+            }
+        }
+        else
+        {
+            foreach (var realStep in realSteps)
+            {
+                var step = TodayQuestGameData.Instance.GetStepByRealStep(realStep);
+                if (step == null)
+                {
+                    ok = false;
+                    continue;
+                }
+
+                if (!TryGetActive(character.Id, realStep, out var state) || !state.Unlocked)
+                    Unlock(character, step, realStep);
+
+                if (!Accept(character, step, realStep))
+                    ok = false;
+            }
+        }
+
+        character.SendPacket(new SCTodayAssignmentAcceptAllPacket(ok ? (ushort)0 : (ushort)1));
+    }
+
+    public void OnCharacterLogout(uint characterId)
+    {
+        _active.Remove(characterId);
+        _resetsUsed.Remove(characterId);
+        _loadedOwners.Remove(characterId);
+    }
+
+    public void NotifyQuestCompleted(Character character, uint questContextId)
+    {
+        if (character == null || questContextId == 0)
+            return;
+
+        EnsureLoaded(character);
+
+        if (!TryGetCharState(character.Id, out var byStep) || byStep.Count == 0)
+        {
+            TryCompleteFromQuestId(character, questContextId);
+            return;
+        }
+
+        foreach (var (realStep, state) in byStep.ToList())
+        {
+            if (state.Status == TodayAssignmentStatus.Done)
+                continue;
+            if (!state.Accepted && !state.Unlocked)
+                continue;
+
+            var group = TodayQuestGameData.Instance.GetGroup(state.GroupId);
+            if (group == null)
+                continue;
+
+            if (!group.QuestContextIds.Contains(questContextId)
+                && state.QuestContextId != questContextId)
+                continue;
+
+            CompleteStep(character, realStep, state, questContextId);
+            return;
+        }
+
+        TryCompleteFromQuestId(character, questContextId);
+    }
+
+    private void TryCompleteFromQuestId(Character character, uint questContextId)
+    {
+        var group = TodayQuestGameData.Instance.FindGroupByQuestId(questContextId);
+        if (group == null)
+            return;
+
+        var step = TodayQuestGameData.Instance.GetStepById(group.StepId);
+        if (step == null)
+            return;
+
+        if (!TryGetActive(character.Id, step.RealStep, out var state))
+        {
+            state = new ActiveTodayAssignment
+            {
+                GroupId = group.Id,
+                Unlocked = true,
+                Accepted = true
+            };
+            SetActive(character.Id, step.RealStep, state);
+        }
+        else
+        {
+            state.GroupId = group.Id;
+        }
+
+        CompleteStep(character, step.RealStep, state, questContextId);
+    }
+
+    private void CompleteStep(
+        Character character,
+        uint realStep,
+        ActiveTodayAssignment state,
+        uint completedQuestId)
+    {
+        state.GroupId = state.GroupId != 0
+            ? state.GroupId
+            : TodayQuestGameData.Instance.FindGroupByQuestId(completedQuestId)?.Id ?? 0;
+        state.QuestContextId = completedQuestId;
+        state.Unlocked = true;
+        state.Accepted = true;
+        state.Status = TodayAssignmentStatus.Done;
+        SetActive(character.Id, realStep, state);
+        Persist(character.Id, realStep, state);
+
+        SendState(character, realStep, state, init: false);
+        DropSiblingQuests(character, state.GroupId, keepQuestId: completedQuestId);
+
+        Logger.Info(
+            "TodayAssignment done {0}: realStep={1} group={2} quest={3}",
+            character.Name, realStep, state.GroupId, completedQuestId);
+    }
+
+    private void Unlock(Character character, TodayQuestStepTemplate step, uint realStep)
+    {
+        if (TryGetActive(character.Id, realStep, out var existing) && existing.Unlocked)
+        {
+            // Done/progress for today must not be reset to Ready by a re-unlock click.
+            if (existing.Status == TodayAssignmentStatus.Done)
+            {
+                DropSiblingQuests(character, existing.GroupId, keepQuestId: existing.QuestContextId);
+                SendState(character, realStep, existing, init: false);
+                return;
+            }
+
+            if (TryRecoverDoneFromCompletedQuests(character, realStep, existing))
+                return;
+
+            // Re-click on an unlocked, not-yet-accepted slot completes accept (no second charge).
+            if (existing.Status == TodayAssignmentStatus.Ready || !existing.Accepted)
+            {
+                Accept(character, step, realStep);
+                return;
+            }
+
+            SendState(character, realStep, existing, init: false);
+            return;
+        }
+
+        var group = PickEligibleGroup(character, step);
+        if (group == null)
+        {
+            Logger.Warn(
+                "TodayAssignment: unlock no eligible group realStep={0} for {1} (level={2} race={3})",
+                realStep, character.Name, character.Level, character.Race);
+            return;
+        }
+
+        // If player already completed a quest for this group today (DB completed_quests), stay Done.
+        // No item charge — cost was (or would have been) paid before completion.
+        foreach (var qid in group.QuestContextIds)
+        {
+            if (!character.Quests.HasQuestCompleted(qid))
+                continue;
+
+            var doneState = new ActiveTodayAssignment
+            {
+                GroupId = group.Id,
+                QuestContextId = qid,
+                Unlocked = true,
+                Accepted = true,
+                Status = TodayAssignmentStatus.Done
+            };
+            SetActive(character.Id, realStep, doneState);
+            Persist(character.Id, realStep, doneState);
+            DropSiblingQuests(character, group.Id, keepQuestId: qid);
+            SendState(character, realStep, doneState, init: false);
+            Logger.Info(
+                "TodayAssignment unlock recovered Done {0}: realStep={1} quest={2}",
+                character.Name, realStep, qid);
+            return;
+        }
+
+        // Paid unlocks (e.g. Blue Salt Hammer / Evenstone) charge bag once at unlock.
+        if (!TryConsumeUnlockCost(character, step, realStep))
+            return;
+
+        var state = new ActiveTodayAssignment
+        {
+            GroupId = group.Id,
+            QuestContextId = 0,
+            Unlocked = true,
+            Accepted = false,
+            Status = TodayAssignmentStatus.Ready
+        };
+        SetActive(character.Id, realStep, state);
+        Persist(character.Id, realStep, state);
+
+        Logger.Info(
+            "TodayAssignment unlocked {0}: realStep={1} group={2} costItem={3}x{4}",
+            character.Name, realStep, group.Id, step.ItemId, step.ItemNum);
+
+        // Paid unlocks auto-accept so the slot immediately enters Progress.
+        if (!Accept(character, step, realStep))
+        {
+            SendState(character, realStep, state, init: false);
+            SendResetCount(character);
+        }
+    }
+
+    /// <summary>
+    /// Consumes today_quest_steps item cost from bag inventory when unlocking a paid step.
+    /// </summary>
+    private static bool TryConsumeUnlockCost(Character character, TodayQuestStepTemplate step, uint realStep)
+    {
+        if (step.ItemId == 0 || step.ItemNum <= 0)
+            return true;
+
+        if (!character.Inventory.CheckItems(SlotType.Inventory, step.ItemId, step.ItemNum))
+        {
+            character.SendErrorMessage(ErrorMessageType.NotEnoughItem);
+            Logger.Info(
+                "TodayAssignment: unlock cost missing {0} realStep={1} item={2} need={3}",
+                character.Name, realStep, step.ItemId, step.ItemNum);
+            return false;
+        }
+
+        var consumed = character.Inventory.Bag.ConsumeItem(
+            ItemTaskType.Destroy,
+            step.ItemId,
+            step.ItemNum,
+            null);
+        if (consumed < step.ItemNum)
+        {
+            character.SendErrorMessage(ErrorMessageType.NotEnoughItem);
+            Logger.Warn(
+                "TodayAssignment: unlock consume short {0} realStep={1} item={2} need={3} got={4}",
+                character.Name, realStep, step.ItemId, step.ItemNum, consumed);
+            return false;
+        }
+
+        Logger.Info(
+            "TodayAssignment: unlock consumed {0}×{1} from {2} realStep={3}",
+            step.ItemId, step.ItemNum, character.Name, realStep);
+        return true;
+    }
+
+    private bool Accept(Character character, TodayQuestStepTemplate step, uint realStep)
+    {
+        if (!TryGetActive(character.Id, realStep, out var state) || !state.Unlocked)
+        {
+            Unlock(character, step, realStep);
+            if (!TryGetActive(character.Id, realStep, out state) || !state.Unlocked)
+                return false;
+        }
+
+        if (state.Status == TodayAssignmentStatus.Done)
+        {
+            DropSiblingQuests(character, state.GroupId, keepQuestId: state.QuestContextId);
+            SendState(character, realStep, state, init: false);
+            return true;
+        }
+
+        if (TryRecoverDoneFromCompletedQuests(character, realStep, state))
+            return true;
+
+        if (state.Accepted)
+        {
+            if (state.QuestContextId != 0 && state.Status < TodayAssignmentStatus.Progress)
+                state.Status = TodayAssignmentStatus.Progress;
+            Persist(character.Id, realStep, state);
+            SendState(character, realStep, state, init: false);
+            return true;
+        }
+
+        var group = TodayQuestGameData.Instance.GetGroup(state.GroupId)
+                    ?? PickEligibleGroup(character, step);
+        if (group == null || group.QuestContextIds.Count == 0)
+        {
+            Logger.Warn(
+                "TodayAssignment: accept no group/quests realStep={0} for {1}",
+                realStep, character.Name);
+            return false;
+        }
+
+        state.GroupId = group.Id;
+
+        // Prefer a single active difficulty: if several already exist from older bugs, keep the first.
+        var startedAny = false;
+        uint primaryQuestId = 0;
+        foreach (var questId in group.QuestContextIds)
+        {
+            if (character.Quests.HasQuestCompleted(questId))
+            {
+                CompleteStep(character, realStep, state, questId);
+                return true;
+            }
+
+            if (character.Quests.HasQuest(questId))
+            {
+                startedAny = true;
+                if (primaryQuestId == 0)
+                    primaryQuestId = questId;
+            }
+        }
+
+        // Start only the first incomplete group quest (not all three) so one kill pool tracks one contract.
+        if (!startedAny)
+        {
+            foreach (var questId in group.QuestContextIds)
+            {
+                if (character.Quests.AddQuest(questId))
+                {
+                    primaryQuestId = questId;
+                    startedAny = true;
+                    break;
+                }
+            }
+        }
+        else
+        {
+            // Drop extra active variants so progress is not split across 10/20/30 tracks.
+            foreach (var questId in group.QuestContextIds)
+            {
+                if (questId == primaryQuestId)
+                    continue;
+                if (character.Quests.HasQuest(questId))
+                    character.Quests.DropQuest(questId, true, false);
+            }
+        }
+
+        if (!startedAny || primaryQuestId == 0)
+        {
+            Logger.Warn(
+                "TodayAssignment: accept failed to start quests realStep={0} group={1} for {2}",
+                realStep, group.Id, character.Name);
+            return false;
+        }
+
+        state.QuestContextId = primaryQuestId;
+        state.Accepted = true;
+        state.Status = TodayAssignmentStatus.Progress;
+        SetActive(character.Id, realStep, state);
+        Persist(character.Id, realStep, state);
+        SendState(character, realStep, state, init: false);
+        SendResetCount(character);
+
+        Logger.Info(
+            "TodayAssignment accepted {0}: realStep={1} group={2} quest={3}",
+            character.Name, realStep, group.Id, primaryQuestId);
+        return true;
+    }
+
+    private bool TryRecoverDoneFromCompletedQuests(
+        Character character,
+        uint realStep,
+        ActiveTodayAssignment state)
+    {
+        var group = TodayQuestGameData.Instance.GetGroup(state.GroupId);
+        if (group == null)
+        {
+            var stepTemplate = TodayQuestGameData.Instance.GetStepByRealStep(realStep);
+            if (stepTemplate != null)
+                group = PickEligibleGroup(character, stepTemplate);
+        }
+
+        if (group == null)
+            return false;
+
+        foreach (var qid in group.QuestContextIds)
+        {
+            if (!character.Quests.HasQuestCompleted(qid))
+                continue;
+
+            state.GroupId = group.Id;
+            CompleteStep(character, realStep, state, qid);
+            return true;
+        }
+
+        return false;
+    }
+
+    private void Resync(Character character, uint realStep)
+    {
+        if (TryGetActive(character.Id, realStep, out var state))
+            SendState(character, realStep, state, init: false);
+    }
+
+    private static void DropSiblingQuests(Character character, uint groupId, uint keepQuestId)
+    {
+        if (groupId == 0)
+            return;
+
+        var group = TodayQuestGameData.Instance.GetGroup(groupId);
+        if (group == null)
+            return;
+
+        foreach (var otherId in group.QuestContextIds)
+        {
+            // Drop every still-active variant once the contract is done (including the finished one
+            // if DropQuest hasn't run yet — caller may remove keepQuestId after CompleteStep).
+            if (character.Quests.HasQuest(otherId))
+                character.Quests.DropQuest(otherId, true, false);
+        }
+
+        // Silence unused parameter if we always drop all actives for Done.
+        _ = keepQuestId;
+    }
+
+    private static TodayQuestGroupTemplate PickEligibleGroup(Character character, TodayQuestStepTemplate step)
+    {
+        var eligible = GetEligibleGroups(character, step);
+        return eligible.Count > 0 ? eligible[0] : null;
+    }
+
+    private static List<TodayQuestGroupTemplate> GetEligibleGroups(Character character, TodayQuestStepTemplate step)
+    {
+        var list = new List<TodayQuestGroupTemplate>();
+        foreach (var group in step.Groups)
+        {
+            if (!UnitRequirementsGameData.Instance.MeetOwnerRequirements(
+                    "TodayQuestGroup", group.Id, group.OrUnitReqs, character))
+                continue;
+            list.Add(group);
+        }
+
+        return list;
+    }
+
+    /// <summary>
+    /// Prefer a different eligible group, then a different incomplete quest in any eligible group.
+    /// Falls back to the current quest only if nothing else is available.
+    /// </summary>
+    private static bool TryPickReplacement(
+        Character character,
+        TodayQuestStepTemplate step,
+        uint oldGroupId,
+        uint oldQuestId,
+        out TodayQuestGroupTemplate newGroup,
+        out uint newQuestId)
+    {
+        newGroup = null;
+        newQuestId = 0;
+
+        var eligible = GetEligibleGroups(character, step);
+        if (eligible.Count == 0)
+            return false;
+
+        // Candidates: (group, quest) that are incomplete and not the current pair.
+        var alternates = new List<(TodayQuestGroupTemplate Group, uint QuestId)>();
+        var sameAsCurrent = ((TodayQuestGroupTemplate Group, uint QuestId)?)null;
+
+        foreach (var group in eligible)
+        {
+            foreach (var questId in group.QuestContextIds)
+            {
+                if (character.Quests.HasQuestCompleted(questId))
+                    continue;
+
+                if (group.Id == oldGroupId && questId == oldQuestId)
+                {
+                    sameAsCurrent = (group, questId);
+                    continue;
+                }
+
+                alternates.Add((group, questId));
+            }
+        }
+
+        // Prefer a different group when several are eligible.
+        var otherGroups = alternates.Where(c => c.Group.Id != oldGroupId).ToList();
+        var pool = otherGroups.Count > 0
+            ? otherGroups
+            : alternates;
+
+        if (pool.Count == 0)
+        {
+            if (sameAsCurrent == null)
+                return false;
+            newGroup = sameAsCurrent.Value.Group;
+            newQuestId = sameAsCurrent.Value.QuestId;
+            return true;
+        }
+
+        var pick = pool[Random.Shared.Next(pool.Count)];
+        newGroup = pick.Group;
+        newQuestId = pick.QuestId;
+        return true;
+    }
+
+    private void EnsureLoaded(Character character)
+    {
+        if (character == null)
+            return;
+        if (_loadedOwners.Contains(character.Id))
+            return;
+
+        LoadFromDb(character);
+        _loadedOwners.Add(character.Id);
+    }
+
+    private void LoadFromDb(Character character)
+    {
+        try
+        {
+            using var connection = MySQL.CreateConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                """
+                SELECT real_step, group_id, quest_context_id, status, day_key
+                FROM character_today_assignments
+                WHERE owner = @owner
+                """;
+            command.Parameters.AddWithValue("@owner", character.Id);
+            command.Prepare();
+
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                var dayKey = reader.GetDateTime("day_key").Date;
+                var realStep = reader.GetUInt32("real_step");
+                if (dayKey != TodayKey)
+                {
+                    // Stale day — leave row; Persist will overwrite when used; ignore for load.
+                    continue;
+                }
+
+                var status = (TodayAssignmentStatus)reader.GetByte("status");
+                if (status is < TodayAssignmentStatus.Ready or > TodayAssignmentStatus.Done)
+                    continue;
+
+                var state = new ActiveTodayAssignment
+                {
+                    GroupId = reader.GetUInt32("group_id"),
+                    QuestContextId = reader.GetUInt32("quest_context_id"),
+                    Status = status,
+                    Unlocked = status >= TodayAssignmentStatus.Ready,
+                    Accepted = status >= TodayAssignmentStatus.Progress
+                };
+                SetActive(character.Id, realStep, state);
+            }
+        }
+        catch (MySqlException ex) when (ex.Number is 1146 or 1054)
+        {
+            Logger.Warn(
+                "TodayAssignment table missing — run SQL/updates/2026-08-09_aaemu_game_character_today_assignments.sql ({0})",
+                ex.Message);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "TodayAssignment LoadFromDb failed for {0}", character.Id);
+        }
+
+        // Recover Done from completed_quests even when the row was never saved (pre-persist sessions).
+        foreach (var step in TodayQuestGameData.Instance.AllSteps)
+        {
+            if (TryGetActive(character.Id, step.RealStep, out var existing)
+                && existing.Status == TodayAssignmentStatus.Done)
+                continue;
+
+            var group = PickEligibleGroup(character, step);
+            if (group == null)
+                continue;
+
+            foreach (var qid in group.QuestContextIds)
+            {
+                if (!character.Quests.HasQuestCompleted(qid))
+                    continue;
+
+                var state = new ActiveTodayAssignment
+                {
+                    GroupId = group.Id,
+                    QuestContextId = qid,
+                    Unlocked = true,
+                    Accepted = true,
+                    Status = TodayAssignmentStatus.Done
+                };
+                SetActive(character.Id, step.RealStep, state);
+                Persist(character.Id, step.RealStep, state);
+                DropSiblingQuests(character, group.Id, keepQuestId: qid);
+                Logger.Info(
+                    "TodayAssignment recovered Done from completed_quests {0}: realStep={1} quest={2}",
+                    character.Name, step.RealStep, qid);
+                break;
+            }
+        }
+    }
+
+    private void Persist(uint ownerId, uint realStep, ActiveTodayAssignment state)
+    {
+        try
+        {
+            using var connection = MySQL.CreateConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                """
+                REPLACE INTO character_today_assignments
+                    (owner, real_step, group_id, quest_context_id, status, day_key)
+                VALUES
+                    (@owner, @realStep, @groupId, @questId, @status, @dayKey)
+                """;
+            command.Parameters.AddWithValue("@owner", ownerId);
+            command.Parameters.AddWithValue("@realStep", realStep);
+            command.Parameters.AddWithValue("@groupId", state.GroupId);
+            command.Parameters.AddWithValue("@questId", state.QuestContextId);
+            command.Parameters.AddWithValue("@status", (sbyte)state.Status);
+            command.Parameters.AddWithValue("@dayKey", TodayKey.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+            command.Prepare();
+            command.ExecuteNonQuery();
+        }
+        catch (MySqlException ex) when (ex.Number is 1146 or 1054)
+        {
+            Logger.Warn(
+                "TodayAssignment Persist skipped (table missing): owner={0} realStep={1}",
+                ownerId, realStep);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "TodayAssignment Persist failed owner={0} realStep={1}", ownerId, realStep);
+        }
+    }
+
+    private bool TryGetCharState(uint characterId, out Dictionary<uint, ActiveTodayAssignment> byStep)
+        => _active.TryGetValue(characterId, out byStep);
+
+    private bool TryGetActive(uint characterId, uint realStep, out ActiveTodayAssignment active)
+    {
+        active = null;
+        if (!_active.TryGetValue(characterId, out var byStep))
+            return false;
+        return byStep.TryGetValue(realStep, out active);
+    }
+
+    private void SetActive(uint characterId, uint realStep, ActiveTodayAssignment active)
+    {
+        if (!_active.TryGetValue(characterId, out var byStep))
+        {
+            byStep = [];
+            _active[characterId] = byStep;
+        }
+
+        byStep[realStep] = active;
+    }
+
+    private static void SendState(
+        Character character,
+        uint realStep,
+        ActiveTodayAssignment state,
+        bool init)
+    {
+        // First packet field is today_quest_steps.id (catalog key), not real_step.
+        var step = TodayQuestGameData.Instance.GetStepByRealStep(realStep);
+        if (step == null)
+        {
+            Logger.Warn(
+                "TodayAssignment SendState: no step for realStep={0} char={1}",
+                realStep, character?.Name);
+            return;
+        }
+
+        character.SendPacket(new SCTodayAssignmentChangedPacket(
+            (int)step.Id,
+            (int)state.GroupId,
+            (int)state.QuestContextId,
+            (sbyte)state.Status,
+            init));
+    }
+}

--- a/AAEmu.Game/Core/Managers/TodayAssignmentManager.cs
+++ b/AAEmu.Game/Core/Managers/TodayAssignmentManager.cs
@@ -351,16 +351,12 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
         EnsureLoaded(character);
 
         if (!TryGetCharState(character.Id, out var byStep) || byStep.Count == 0)
-        {
-            TryCompleteFromQuestId(character, questContextId);
             return;
-        }
 
         foreach (var (realStep, state) in byStep.ToList())
         {
-            if (state.Status == TodayAssignmentStatus.Done)
-                continue;
-            if (!state.Accepted && !state.Unlocked)
+            // Only Progress contracts can complete. Orphan / previous-day quests must not invent Done.
+            if (state.Status != TodayAssignmentStatus.Progress || !state.Accepted)
                 continue;
 
             var group = TodayQuestGameData.Instance.GetGroup(state.GroupId);
@@ -374,36 +370,6 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
             CompleteStep(character, realStep, state, questContextId);
             return;
         }
-
-        TryCompleteFromQuestId(character, questContextId);
-    }
-
-    private void TryCompleteFromQuestId(Character character, uint questContextId)
-    {
-        var group = TodayQuestGameData.Instance.FindGroupByQuestId(questContextId);
-        if (group == null)
-            return;
-
-        var step = TodayQuestGameData.Instance.GetStepById(group.StepId);
-        if (step == null)
-            return;
-
-        if (!TryGetActive(character.Id, step.RealStep, out var state))
-        {
-            state = new ActiveTodayAssignment
-            {
-                GroupId = group.Id,
-                Unlocked = true,
-                Accepted = true
-            };
-            SetActive(character.Id, step.RealStep, state);
-        }
-        else
-        {
-            state.GroupId = group.Id;
-        }
-
-        CompleteStep(character, step.RealStep, state, questContextId);
     }
 
     private void CompleteStep(
@@ -753,6 +719,8 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
             Logger.Info(
                 "TodayAssignment day rollover owner={0} was={1:yyyy-MM-dd} now={2:yyyy-MM-dd}",
                 character.Id, loadedDay, today);
+            // Yesterday's active contracts are abandoned — partial progress is lost.
+            DropAllTodayAssignmentQuests(character);
             _active.Remove(character.Id);
             _resetsUsed.Remove(character.Id);
         }
@@ -847,6 +815,81 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
         BackfillLifetimeUnlocksFromHistory(character);
         SeedReadyForLifetimeUnlocks(character);
         LoadResetsUsedFromDb(character);
+        // Drop daily-contract quests that do not belong to today's Progress (incl. leftover from prior days).
+        DropOrphanTodayAssignmentQuests(character);
+    }
+
+    /// <summary>
+    /// Drops every active quest from the today_quest catalog (used on calendar rollover).
+    /// Partial progress does not carry; player re-accepts from Ready for a fresh pool.
+    /// </summary>
+    private static void DropAllTodayAssignmentQuests(Character character)
+    {
+        if (character?.Quests == null)
+            return;
+
+        foreach (var group in TodayQuestGameData.Instance.AllGroups)
+        {
+            foreach (var questId in group.QuestContextIds)
+            {
+                if (character.Quests.HasQuest(questId))
+                    character.Quests.DropQuest(questId, true, false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Keep only quests tied to this character's Progress assignments for the current day.
+    /// Everything else from the daily-contract catalog is dropped (no silent Done invent).
+    /// </summary>
+    private void DropOrphanTodayAssignmentQuests(Character character)
+    {
+        if (character?.Quests == null)
+            return;
+
+        var keep = new HashSet<uint>();
+        if (TryGetCharState(character.Id, out var byStep))
+        {
+            foreach (var state in byStep.Values)
+            {
+                if (state.Status != TodayAssignmentStatus.Progress || !state.Accepted)
+                    continue;
+
+                if (state.QuestContextId != 0)
+                {
+                    keep.Add(state.QuestContextId);
+                    continue;
+                }
+
+                // No primary stored — keep at most one still-active variant from the group.
+                var group = TodayQuestGameData.Instance.GetGroup(state.GroupId);
+                if (group == null)
+                    continue;
+                foreach (var qid in group.QuestContextIds)
+                {
+                    if (!character.Quests.HasQuest(qid))
+                        continue;
+                    keep.Add(qid);
+                    break;
+                }
+            }
+        }
+
+        foreach (var group in TodayQuestGameData.Instance.AllGroups)
+        {
+            foreach (var questId in group.QuestContextIds)
+            {
+                if (keep.Contains(questId))
+                    continue;
+                if (!character.Quests.HasQuest(questId))
+                    continue;
+
+                character.Quests.DropQuest(questId, true, false);
+                Logger.Info(
+                    "TodayAssignment dropped orphan daily quest {0} for {1}",
+                    questId, character.Name);
+            }
+        }
     }
 
     private bool HasLifetimeUnlock(uint characterId, uint realStep)

--- a/AAEmu.Game/Core/Network/Game/GameNetwork.cs
+++ b/AAEmu.Game/Core/Network/Game/GameNetwork.cs
@@ -348,6 +348,7 @@ public class GameNetwork : Singleton<GameNetwork>
         RegisterPacket(CSOffsets.CSEditorRemoveGimmickPacket, 1, typeof(CSEditorRemoveGimmickPacket));
         RegisterPacket(CSOffsets.CSInteractGimmickPacket, 1, typeof(CSInteractGimmickPacket));
         RegisterPacket(CSOffsets.CSRequestTodayAssignmentPacket, 1, typeof(CSRequestTodayAssignmentPacket));
+        RegisterPacket(CSOffsets.CSResetTodayAssignmentPacket, 1, typeof(CSResetTodayAssignmentPacket));
         RegisterPacket(CSOffsets.CSEnterInstantGamePacket, 1, typeof(CSEnterInstantGamePacket));
         RegisterPacket(CSOffsets.CSInstantLeaveUserListRequest, 1, typeof(CSInstantLeaveUserListRequest));
         RegisterPacket(CSOffsets.CSBanVoteRequestPacket, 1, typeof(CSBanVoteRequestPacket));

--- a/AAEmu.Game/Core/Packets/C2G/CSNotifyInGamePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSNotifyInGamePacket.cs
@@ -109,6 +109,9 @@ public class CSNotifyInGamePacket() : GamePacket(CSOffsets.CSNotifyInGamePacket,
         // The reference emits 0x038A ~4s after NotifyInGame, never in the select burst.
         Connection.ActiveChar.SendPacket(new SCWorldLevelInfoPacket());
 
+        // Daily schedule: load persisted contracts for today, then reset-count budget.
+        TodayAssignmentManager.Instance.OnCharacterEnterWorld(Connection.ActiveChar);
+
         // Mirror interest armed on NotifyInGameCompleted — not here during load.
         Logger.Info($"NotifyInGame: {Connection.ActiveChar?.Name} ({Connection.ActiveChar?.Id}) zoneAuth={WorldIntegration.ZoneAuthority}");
     }

--- a/AAEmu.Game/Core/Packets/C2G/CSRequestTodayAssignmentPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSRequestTodayAssignmentPacket.cs
@@ -1,14 +1,9 @@
 using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
-/// <summary>
-/// TODO(v10): the body is parsed but nothing acts on it yet.
-/// </summary>
-/// <remarks>
-/// which passes each field name alongside the value:
-/// </remarks>
 public class CSRequestTodayAssignmentPacket() : GamePacket(CSOffsets.CSRequestTodayAssignmentPacket, 1)
 {
     public uint RealStep { get; private set; }
@@ -18,5 +13,10 @@ public class CSRequestTodayAssignmentPacket() : GamePacket(CSOffsets.CSRequestTo
     {
         RealStep = stream.ReadUInt32();
         Request = stream.ReadSByte();
+    }
+
+    public override void Execute()
+    {
+        TodayAssignmentManager.Instance.HandleRequest(Connection.ActiveChar, RealStep, Request);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSResetTodayAssignmentPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSResetTodayAssignmentPacket.cs
@@ -1,15 +1,13 @@
 using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
-/// TODO: the body is parsed but nothing acts on it yet.
+/// Daily schedule Change Mission: re-roll an in-progress real_step.
+/// moneyAmount is bag copper charged for paid re-rolls (0 while free budget remains).
 /// </summary>
-/// <remarks>
-/// Field order, widths and names come from the 10.0.2.13 client's serializer, which passes each
-/// value's name alongside the value:
-/// </remarks>
 public class CSResetTodayAssignmentPacket() : GamePacket(CSOffsets.CSResetTodayAssignmentPacket, 1)
 {
     public uint RealStep { get; private set; }
@@ -19,5 +17,13 @@ public class CSResetTodayAssignmentPacket() : GamePacket(CSOffsets.CSResetTodayA
     {
         RealStep = stream.ReadUInt32();
         MoneyAmount = stream.ReadUInt64();
+    }
+
+    public override void Execute()
+    {
+        TodayAssignmentManager.Instance.HandleReset(
+            Connection.ActiveChar,
+            RealStep,
+            MoneyAmount);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSTodayAssignmentAcceptAllPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSTodayAssignmentAcceptAllPacket.cs
@@ -1,23 +1,27 @@
+using System.Collections.Generic;
 using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
-/// <summary>
-/// TODO(v10): the body is parsed but nothing acts on it yet.
-/// </summary>
-/// <remarks>
-/// which passes each field name alongside the value:
-/// sbyte todayType, uint count
-/// </remarks>
 public class CSTodayAssignmentAcceptAllPacket() : GamePacket(CSOffsets.CSTodayAssignmentAcceptAllPacket, 1)
 {
     public sbyte TodayType { get; private set; }
     public uint Count { get; private set; }
+    public List<uint> RealSteps { get; } = [];
 
     public override void Read(PacketStream stream)
     {
         TodayType = stream.ReadSByte();
         Count = stream.ReadUInt32();
+        RealSteps.Clear();
+        for (var i = 0; i < Count && i < 64; i++)
+            RealSteps.Add(stream.ReadUInt32());
+    }
+
+    public override void Execute()
+    {
+        TodayAssignmentManager.Instance.HandleAcceptAll(Connection.ActiveChar, TodayType, RealSteps);
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCOffsets.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCOffsets.cs
@@ -739,6 +739,7 @@ public static class SCOffsets
     public const ushort SCTodayAssignmentGoalPacket = 0x286;
     public const ushort SCTodayAssignmentItemSentPacket = 0x284;
     public const ushort SCTodayAssignmentResetCountPacket = 0x328;
+    public const ushort SCTodayAssignmentAcceptAllPacket = 0x329;
     public const ushort SCUlcNeedSquadNoticePacket = 0x31E;
     public const ushort SCUnitCollisionResultPacket = 0x18A;
     public const ushort SCUnlockLearnSkillPacket = 0x146;

--- a/AAEmu.Game/Core/Packets/G2C/SCTodayAssignmentAcceptAllPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCTodayAssignmentAcceptAllPacket.cs
@@ -1,0 +1,14 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Network.Game;
+
+namespace AAEmu.Game.Core.Packets.G2C;
+
+public class SCTodayAssignmentAcceptAllPacket(ushort errorMessage)
+    : GamePacket(SCOffsets.SCTodayAssignmentAcceptAllPacket, 1)
+{
+    public override PacketStream Write(PacketStream stream)
+    {
+        stream.Write(errorMessage);
+        return stream;
+    }
+}

--- a/AAEmu.Game/Core/Packets/G2C/SCTodayAssignmentChangedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCTodayAssignmentChangedPacket.cs
@@ -4,20 +4,18 @@ using AAEmu.Game.Core.Network.Game;
 namespace AAEmu.Game.Core.Packets.G2C;
 
 /// <summary>
-/// TODO: nothing constructs this packet yet.
+/// Updates a daily-schedule slot: stepId, groupId, questContextId, status, init.
+/// stepId is today_quest_steps.id (not real_step).
 /// </summary>
-/// <remarks>
-/// Field order, widths and names come from the 10.0.2.13 client's serializer, which passes each
-/// value's name alongside the value:
-/// </remarks>
-public class SCTodayAssignmentChangedPacket(int @type, int @type2, int @type3, sbyte unnamed1, bool init) : GamePacket(SCOffsets.SCTodayAssignmentChangedPacket, 1)
+public class SCTodayAssignmentChangedPacket(int stepId, int groupId, int questContextId, sbyte status, bool init)
+    : GamePacket(SCOffsets.SCTodayAssignmentChangedPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(@type);
-        stream.Write(@type2);
-        stream.Write(@type3);
-        stream.Write(unnamed1);
+        stream.Write(stepId);
+        stream.Write(groupId);
+        stream.Write(questContextId);
+        stream.Write(status);
         stream.Write(init);
         return stream;
     }

--- a/AAEmu.Game/Core/Packets/G2C/SCTodayAssignmentResetCountPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCTodayAssignmentResetCountPacket.cs
@@ -4,13 +4,10 @@ using AAEmu.Game.Core.Network.Game;
 namespace AAEmu.Game.Core.Packets.G2C;
 
 /// <summary>
-/// TODO: nothing constructs this packet yet.
+/// Reports how many free mission re-rolls have been used (count) for a schedule sort (countType).
 /// </summary>
-/// <remarks>
-/// Field order, widths and names come from the 10.0.2.13 client's serializer, which passes each
-/// value's name alongside the value:
-/// </remarks>
-public class SCTodayAssignmentResetCountPacket(uint count, uint countType) : GamePacket(SCOffsets.SCTodayAssignmentResetCountPacket, 1)
+public class SCTodayAssignmentResetCountPacket(uint count, uint countType)
+    : GamePacket(SCOffsets.SCTodayAssignmentResetCountPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {

--- a/AAEmu.Game/GameData/TodayQuestGameData.cs
+++ b/AAEmu.Game/GameData/TodayQuestGameData.cs
@@ -91,6 +91,8 @@ public class TodayQuestGameData : Singleton<TodayQuestGameData>, IGameDataLoader
 
     public IEnumerable<TodayQuestStepTemplate> AllSteps => _stepsById.Values;
 
+    public IEnumerable<TodayQuestGroupTemplate> AllGroups => _groupsById.Values;
+
     public TodayQuestStepTemplate GetStepByRealStep(uint realStep)
     {
         return _stepsByRealStep.GetValueOrDefault(realStep);

--- a/AAEmu.Game/GameData/TodayQuestGameData.cs
+++ b/AAEmu.Game/GameData/TodayQuestGameData.cs
@@ -1,0 +1,119 @@
+using AAEmu.Commons.Utils;
+using AAEmu.Game.GameData.Framework;
+using AAEmu.Game.Models.Game.TodayAssignment;
+using AAEmu.Game.Utils.DB;
+using Microsoft.Data.Sqlite;
+using NLog;
+
+namespace AAEmu.Game.GameData;
+
+[GameData]
+public class TodayQuestGameData : Singleton<TodayQuestGameData>, IGameDataLoader
+{
+    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
+
+    private Dictionary<uint, TodayQuestStepTemplate> _stepsById = [];
+    private Dictionary<uint, TodayQuestStepTemplate> _stepsByRealStep = [];
+    private Dictionary<uint, TodayQuestGroupTemplate> _groupsById = [];
+
+    public void Load(SqliteConnection connection)
+    {
+        _stepsById = [];
+        _stepsByRealStep = [];
+        _groupsById = [];
+
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = "SELECT * FROM today_quest_steps";
+            command.Prepare();
+            using var sqliteReader = command.ExecuteReader();
+            using var reader = new SQLiteWrapperReader(sqliteReader);
+            while (reader.Read())
+            {
+                var step = new TodayQuestStepTemplate
+                {
+                    Id = reader.GetUInt32("id"),
+                    RealStep = reader.GetUInt32("real_step"),
+                    ItemId = reader.GetUInt32("item_id", 0),
+                    ItemNum = reader.GetInt32("item_num", 0),
+                    OrUnitReqs = reader.GetBoolean("or_unit_reqs", true),
+                    LevelMin = reader.GetInt32("level_min", 0),
+                    LevelMax = reader.GetInt32("level_max", 0)
+                };
+                _stepsById[step.Id] = step;
+                // Prefer the first mapped row when real_step collides (should not in shipped data).
+                _stepsByRealStep.TryAdd(step.RealStep, step);
+            }
+        }
+
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = "SELECT * FROM today_quest_groups";
+            command.Prepare();
+            using var sqliteReader = command.ExecuteReader();
+            using var reader = new SQLiteWrapperReader(sqliteReader);
+            while (reader.Read())
+            {
+                var group = new TodayQuestGroupTemplate
+                {
+                    Id = reader.GetUInt32("id"),
+                    StepId = reader.GetUInt32("step_id"),
+                    OrUnitReqs = reader.GetBoolean("or_unit_reqs", true),
+                    AutomaticRestart = reader.GetBoolean("automatic_restart", true)
+                };
+                _groupsById[group.Id] = group;
+                if (_stepsById.TryGetValue(group.StepId, out var step))
+                    step.Groups.Add(group);
+            }
+        }
+
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = "SELECT * FROM today_quest_group_quests ORDER BY id";
+            command.Prepare();
+            using var sqliteReader = command.ExecuteReader();
+            using var reader = new SQLiteWrapperReader(sqliteReader);
+            while (reader.Read())
+            {
+                var groupId = reader.GetUInt32("today_quest_group_id");
+                var questId = reader.GetUInt32("quest_context_id");
+                if (_groupsById.TryGetValue(groupId, out var group))
+                    group.QuestContextIds.Add(questId);
+            }
+        }
+
+        Logger.Info("Loaded {0} today_quest steps, {1} groups", _stepsById.Count, _groupsById.Count);
+    }
+
+    public void PostLoad()
+    {
+    }
+
+    public IEnumerable<TodayQuestStepTemplate> AllSteps => _stepsById.Values;
+
+    public TodayQuestStepTemplate GetStepByRealStep(uint realStep)
+    {
+        return _stepsByRealStep.GetValueOrDefault(realStep);
+    }
+
+    public TodayQuestStepTemplate GetStepById(uint stepId)
+    {
+        return _stepsById.GetValueOrDefault(stepId);
+    }
+
+    public TodayQuestGroupTemplate GetGroup(uint groupId)
+    {
+        return _groupsById.GetValueOrDefault(groupId);
+    }
+
+    public TodayQuestGroupTemplate FindGroupByQuestId(uint questContextId)
+    {
+        foreach (var group in _groupsById.Values)
+        {
+            if (group.QuestContextIds.Contains(questContextId))
+                return group;
+        }
+
+        return null;
+    }
+}

--- a/AAEmu.Game/GameData/UnitRequirementsGameData.cs
+++ b/AAEmu.Game/GameData/UnitRequirementsGameData.cs
@@ -334,28 +334,42 @@ public class UnitRequirementsGameData : Singleton<UnitRequirementsGameData>, IGa
 
     public bool CanComponentRun(QuestComponentTemplate questComponent, BaseUnit ownerUnit)
     {
-        var reqs = GetQuestComponentRequirements(questComponent.Id);
+        return MeetOwnerRequirements(
+            "QuestComponent",
+            questComponent.Id,
+            questComponent.OrUnitReqs,
+            ownerUnit);
+    }
+
+    /// <summary>
+    /// Validates unit_reqs rows for a (owner_type, owner_id) pair using the same AND/OR rule as components.
+    /// </summary>
+    public bool MeetOwnerRequirements(string ownerType, uint ownerId, bool orUnitReqs, BaseUnit ownerUnit)
+    {
+        var reqs = GetRequirement(ownerType, ownerId).ToList();
         if (reqs.Count == 0)
-            return true; // No requirements, we're good
+            return true;
+
         var target = (ownerUnit as Unit)?.CurrentTarget ?? ownerUnit;
-        var res = !questComponent.OrUnitReqs;
+        var res = !orUnitReqs;
         foreach (var unitReq in reqs)
         {
             var validateRes = unitReq.Validate(ownerUnit, target);
             var reqRes = validateRes.ResultKey == SkillResultKeys.ok;
 
-            if (questComponent.OrUnitReqs && reqRes)
+            if (orUnitReqs && reqRes)
             {
                 res = true;
                 break;
             }
 
-            if (!questComponent.OrUnitReqs && !reqRes)
+            if (!orUnitReqs && !reqRes)
             {
                 res = false;
                 break;
             }
         }
+
         return res;
     }
 }

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -2162,6 +2162,20 @@ public partial class Character : Unit, ICharacter
         // labor manager are accumulators, so each one has to carry its own share of the spend.
         SendPacket(new SCCharacterLaborPowerChangedPacket(
             accountDelta, localDelta, 0, (uint)actabilityId, actabilityChange, actabilityStep));
+
+        // Quest objectives (QuestActObjLaborPower) track labor spent after accept only.
+        if (change < 0)
+        {
+            var spent = -(accountDelta + localDelta);
+            if (spent > 0)
+            {
+                Events.OnLaborPower.Invoke(this, new OnLaborPowerArgs
+                {
+                    LaborUsed = spent,
+                    ActabilityGroupId = (uint)Math.Max(0, actabilityId)
+                });
+            }
+        }
     }
 
     /// <summary>

--- a/AAEmu.Game/Models/Game/Quests/Acts/QuestActConAcceptUi.cs
+++ b/AAEmu.Game/Models/Game/Quests/Acts/QuestActConAcceptUi.cs
@@ -1,0 +1,17 @@
+using AAEmu.Game.Models.Game.Quests.Templates;
+
+namespace AAEmu.Game.Models.Game.Quests.Acts;
+
+/// <summary>
+/// Quest start gate used by UI-accepted quests (daily schedule / Path of Destiny).
+/// </summary>
+public class QuestActConAcceptUi(QuestComponentTemplate parentComponent) : QuestActTemplate(parentComponent)
+{
+    public override bool RunAct(Quest quest, QuestAct questAct, int currentObjectiveCount)
+    {
+        Logger.Trace(
+            "{0}({1}).RunAct: Quest: {2}, Owner {3} ({4})",
+            QuestActTemplateName, DetailId, quest.TemplateId, quest.Owner.Name, quest.Owner.Id);
+        return true;
+    }
+}

--- a/AAEmu.Game/Models/Game/Quests/Acts/QuestActObjLaborPower.cs
+++ b/AAEmu.Game/Models/Game/Quests/Acts/QuestActObjLaborPower.cs
@@ -1,0 +1,58 @@
+using AAEmu.Game.Models.Game.Quests.Templates;
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.Game.Models.Game.Quests.Acts;
+
+/// <summary>
+/// Progress objective: spend labor after the quest is accepted.
+/// Does not credit labor spent before accept (no retroactive / lifetime total).
+/// </summary>
+public class QuestActObjLaborPower(QuestComponentTemplate parentComponent) : QuestActTemplate(parentComponent)
+{
+    public override bool CountsAsAnObjective => true;
+
+    /// <summary>Optional actability group filter; 0 = any labor spend counts.</summary>
+    public uint ActabilityGroupId { get; set; }
+
+    public bool UseAlias { get; set; }
+    public uint QuestActObjAliasId { get; set; }
+
+    public override bool RunAct(Quest quest, QuestAct questAct, int currentObjectiveCount)
+    {
+        Logger.Debug(
+            $"{QuestActTemplateName}({DetailId}).RunAct: Quest: {quest.TemplateId}, Owner {quest.Owner.Name} ({quest.Owner.Id}), " +
+            $"Labor {currentObjectiveCount}/{Count}, ActabilityGroupId {ActabilityGroupId}");
+
+        return ParentQuestTemplate.Score > 0
+            ? currentObjectiveCount * Count > ParentQuestTemplate.Score
+            : currentObjectiveCount >= Count;
+    }
+
+    public override void InitializeAction(Quest quest, QuestAct questAct)
+    {
+        base.InitializeAction(quest, questAct);
+        quest.Owner.Events.OnLaborPower += questAct.OnLaborPower;
+    }
+
+    public override void FinalizeAction(Quest quest, QuestAct questAct)
+    {
+        quest.Owner.Events.OnLaborPower -= questAct.OnLaborPower;
+        base.FinalizeAction(quest, questAct);
+    }
+
+    public override void OnLaborPower(QuestAct questAct, object sender, OnLaborPowerArgs e)
+    {
+        if (questAct.Template.ActId != ActId)
+            return;
+        if (e.LaborUsed <= 0)
+            return;
+        if (ActabilityGroupId != 0 && e.ActabilityGroupId != ActabilityGroupId)
+            return;
+
+        Logger.Debug(
+            $"{QuestActTemplateName}({DetailId}).OnLaborPower: Quest: {questAct.QuestComponent.Parent.Parent.TemplateId}, " +
+            $"Owner {questAct.QuestComponent.Parent.Parent.Owner.Name}, used {e.LaborUsed}, group {e.ActabilityGroupId}");
+
+        AddObjective(questAct, e.LaborUsed);
+    }
+}

--- a/AAEmu.Game/Models/Game/Quests/Acts/QuestActObjZoneKill.cs
+++ b/AAEmu.Game/Models/Game/Quests/Acts/QuestActObjZoneKill.cs
@@ -59,6 +59,10 @@ public class QuestActObjZoneKill(QuestComponentTemplate parentComponent) : Quest
         if (questAct.Id != ActId)
             return;
 
+        // zone_id column is zone_group id (same as QuestActObjZoneMonsterHunt).
+        if (ZoneId != 0 && args.ZoneGroupId != ZoneId)
+            return;
+
         var player = questAct.QuestComponent.Parent.Parent.Owner;
 
         // If Party kills is not allowed, only allow kills from self
@@ -77,16 +81,20 @@ public class QuestActObjZoneKill(QuestComponentTemplate parentComponent) : Quest
 
         if (CountNpc > 0 && victimNpc != null)
         {
-            // NPC kills
+            // No faction gate → any NPC. Most today-assignment / clear-zone acts ship 0/null.
             if (NpcFactionId > 0)
             {
-                if (NpcFactionExclusive && victimNpc.Faction.Id != NpcFactionId)
-                    valid = true;
-                if (!NpcFactionExclusive && victimNpc.Faction.Id == NpcFactionId)
-                    valid = true;
+                valid = NpcFactionExclusive
+                    ? victimNpc.Faction.Id != NpcFactionId
+                    : victimNpc.Faction.Id == NpcFactionId;
+            }
+            else
+            {
+                valid = true;
             }
 
-            if (victimNpc.Level < LvlMinNpc || victimNpc.Level > LvlMaxNpc)
+            // 0/0 means unlimited. max=0 with min>0 means minimum only.
+            if (valid && !MeetsLevelRange(victimNpc.Level, LvlMinNpc, LvlMaxNpc))
                 valid = false;
         }
 
@@ -94,14 +102,16 @@ public class QuestActObjZoneKill(QuestComponentTemplate parentComponent) : Quest
         {
             if (PcFactionId > 0)
             {
-                // Player kills
-                if (PcFactionExclusive && victimPc.Faction.Id != PcFactionId)
-                    valid = true;
-                if (!PcFactionExclusive && victimPc.Faction.Id == PcFactionId)
-                    valid = true;
+                valid = PcFactionExclusive
+                    ? victimPc.Faction.Id != PcFactionId
+                    : victimPc.Faction.Id == PcFactionId;
+            }
+            else
+            {
+                valid = true;
             }
 
-            if (victimPc.Level < LvlMin || victimPc.Level > LvlMax)
+            if (valid && !MeetsLevelRange(victimPc.Level, LvlMin, LvlMax))
                 valid = false;
         }
 
@@ -133,5 +143,19 @@ public class QuestActObjZoneKill(QuestComponentTemplate parentComponent) : Quest
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Level filter for zone-kill acts. max == 0 means no upper bound (and with min == 0, no filter).
+    /// </summary>
+    private static bool MeetsLevelRange(byte level, int min, int max)
+    {
+        if (min <= 0 && max <= 0)
+            return true;
+        if (min > 0 && level < min)
+            return false;
+        if (max > 0 && level > max)
+            return false;
+        return true;
     }
 }

--- a/AAEmu.Game/Models/Game/Quests/IQuestAct.cs
+++ b/AAEmu.Game/Models/Game/Quests/IQuestAct.cs
@@ -69,6 +69,7 @@ public interface IQuestAct
     void OnInteraction(object sender, OnInteractionArgs args);
     void OnDoodadPhaseCheck(object sender, OnDoodadPhaseCheckArgs args);
     void OnCraft(object sender, OnCraftArgs args);
+    void OnLaborPower(object sender, OnLaborPowerArgs args);
     void OnExpressFire(object sender, OnExpressFireArgs args);
     void OnLevelUp(object sender, OnLevelUpArgs args);
     void OnMateLevelUp(object sender, OnMateLevelUpArgs args);

--- a/AAEmu.Game/Models/Game/Quests/NewQuestCode.cs
+++ b/AAEmu.Game/Models/Game/Quests/NewQuestCode.cs
@@ -1,4 +1,6 @@
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Quests.Static;
 using AAEmu.Game.Models.Game.Units;
 
@@ -151,6 +153,10 @@ public partial class Quest
                     // copy body data for packet
                     var body = new byte[8];
                     completedBlock.Body.CopyTo(body, 0);
+
+                    // Daily Contracts: push A_TODAY_STATUS.DONE before remove so the UI still has questType.
+                    if (Owner is Character character)
+                        TodayAssignmentManager.Instance.NotifyQuestCompleted(character, TemplateId);
 
                     Owner.Quests.DropQuest(TemplateId, false, false);
                     Owner.SendPacket(new SCQuestContextCompletedPacket(TemplateId, 0));

--- a/AAEmu.Game/Models/Game/Quests/NewQuestCode.cs
+++ b/AAEmu.Game/Models/Game/Quests/NewQuestCode.cs
@@ -154,7 +154,7 @@ public partial class Quest
                     var body = new byte[8];
                     completedBlock.Body.CopyTo(body, 0);
 
-                    // Daily Contracts: push A_TODAY_STATUS.DONE before remove so the UI still has questType.
+                    // Daily schedule: push Done status before remove so the UI still has questType.
                     if (Owner is Character character)
                         TodayAssignmentManager.Instance.NotifyQuestCompleted(character, TemplateId);
 

--- a/AAEmu.Game/Models/Game/Quests/QuestAct.cs
+++ b/AAEmu.Game/Models/Game/Quests/QuestAct.cs
@@ -180,6 +180,11 @@ public class QuestAct(QuestComponent parentComponent, QuestActTemplate template)
         Template.OnCraft(this, sender, args);
     }
 
+    public virtual void OnLaborPower(object sender, OnLaborPowerArgs args)
+    {
+        Template.OnLaborPower(this, sender, args);
+    }
+
     /// <summary>
     /// OnExpressFire 
     /// </summary>

--- a/AAEmu.Game/Models/Game/Quests/Templates/QuestActTemplate.cs
+++ b/AAEmu.Game/Models/Game/Quests/Templates/QuestActTemplate.cs
@@ -332,6 +332,11 @@ public class QuestActTemplate(QuestComponentTemplate parentComponent)
         //
     }
 
+    public virtual void OnLaborPower(QuestAct questAct, object sender, OnLaborPowerArgs args)
+    {
+        //
+    }
+
     /// <summary>
     /// OnExpressFire 
     /// </summary>

--- a/AAEmu.Game/Models/Game/TodayAssignment/TodayAssignmentStatus.cs
+++ b/AAEmu.Game/Models/Game/TodayAssignment/TodayAssignmentStatus.cs
@@ -1,0 +1,12 @@
+namespace AAEmu.Game.Models.Game.TodayAssignment;
+
+/// <summary>
+/// Daily schedule slot status: Locked → Ready → Progress → Done.
+/// </summary>
+public enum TodayAssignmentStatus : sbyte
+{
+    Locked = 0,
+    Ready = 1,
+    Progress = 2,
+    Done = 3
+}

--- a/AAEmu.Game/Models/Game/TodayAssignment/TodayQuestGroupTemplate.cs
+++ b/AAEmu.Game/Models/Game/TodayAssignment/TodayQuestGroupTemplate.cs
@@ -1,0 +1,10 @@
+namespace AAEmu.Game.Models.Game.TodayAssignment;
+
+public class TodayQuestGroupTemplate
+{
+    public uint Id { get; set; }
+    public uint StepId { get; set; }
+    public bool OrUnitReqs { get; set; }
+    public bool AutomaticRestart { get; set; }
+    public List<uint> QuestContextIds { get; } = [];
+}

--- a/AAEmu.Game/Models/Game/TodayAssignment/TodayQuestStepTemplate.cs
+++ b/AAEmu.Game/Models/Game/TodayAssignment/TodayQuestStepTemplate.cs
@@ -4,7 +4,7 @@ public class TodayQuestStepTemplate
 {
     public uint Id { get; set; }
     public uint RealStep { get; set; }
-    /// <summary>Optional bag cost to unlock this step (e.g. Blue Salt Hammer 8329).</summary>
+    /// <summary>Optional bag cost to unlock this step (from today_quest_steps.item_id / item_num).</summary>
     public uint ItemId { get; set; }
     public int ItemNum { get; set; }
     public bool OrUnitReqs { get; set; }

--- a/AAEmu.Game/Models/Game/TodayAssignment/TodayQuestStepTemplate.cs
+++ b/AAEmu.Game/Models/Game/TodayAssignment/TodayQuestStepTemplate.cs
@@ -1,0 +1,14 @@
+namespace AAEmu.Game.Models.Game.TodayAssignment;
+
+public class TodayQuestStepTemplate
+{
+    public uint Id { get; set; }
+    public uint RealStep { get; set; }
+    /// <summary>Optional bag cost to unlock this step (e.g. Blue Salt Hammer 8329).</summary>
+    public uint ItemId { get; set; }
+    public int ItemNum { get; set; }
+    public bool OrUnitReqs { get; set; }
+    public int LevelMin { get; set; }
+    public int LevelMax { get; set; }
+    public List<TodayQuestGroupTemplate> Groups { get; } = [];
+}

--- a/AAEmu.Game/Models/Game/Units/UnitEvents.cs
+++ b/AAEmu.Game/Models/Game/Units/UnitEvents.cs
@@ -58,6 +58,7 @@ public class UnitEvents
     public EventHandler<OnEnterSphereArgs> OnEnterSphere = delegate { };
     public EventHandler<OnExitSphereArgs> OnExitSphere = delegate { };
     public EventHandler<OnCraftArgs> OnCraft = delegate { };
+    public EventHandler<OnLaborPowerArgs> OnLaborPower = delegate { };
     public EventHandler<OnZoneKillArgs> OnZoneKill = delegate { };
     // public EventHandler<OnZoneMonsterHuntArgs> OnZoneMonsterHunt = delegate { }; // Integrated into OnZoneKill
     public EventHandler<OnCinemaStartedArgs> OnCinemaStarted = delegate { };
@@ -161,6 +162,15 @@ public class OnDoodadPhaseCheckArgs : EventArgs
 public class OnCraftArgs : EventArgs
 {
     public uint CraftId { get; set; }
+}
+
+public class OnLaborPowerArgs : EventArgs
+{
+    /// <summary>Positive amount of labor spent in this change.</summary>
+    public int LaborUsed { get; set; }
+
+    /// <summary>Actability group for the spend (0 if untagged).</summary>
+    public uint ActabilityGroupId { get; set; }
 }
 
 public class OnExpressFireArgs : EventArgs

--- a/SQL/updates/2026-08-09_aaemu_game_character_today_assignments.sql
+++ b/SQL/updates/2026-08-09_aaemu_game_character_today_assignments.sql
@@ -1,7 +1,6 @@
 USE aaemu_game;
 
--- Path of Destiny / Daily Contracts per-character state for the current day.
--- day_key resets at local midnight: rows with an older day_key are ignored and replaced.
+-- Daily assignment progress (Ready / Progress / Done for local calendar day).
 CREATE TABLE IF NOT EXISTS `character_today_assignments` (
   `owner` int unsigned NOT NULL,
   `real_step` int unsigned NOT NULL,
@@ -12,4 +11,22 @@ CREATE TABLE IF NOT EXISTS `character_today_assignments` (
   `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`owner`, `real_step`),
   KEY `idx_owner_day` (`owner`, `day_key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Free Change Mission re-rolls used today.
+CREATE TABLE IF NOT EXISTS `character_today_reset_counts` (
+  `owner` int unsigned NOT NULL,
+  `day_key` date NOT NULL,
+  `resets_used` tinyint unsigned NOT NULL DEFAULT 0,
+  `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`owner`),
+  KEY `idx_day` (`day_key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Paid today_quest_steps: unlock once per character (item cost). After that, each day starts Ready.
+CREATE TABLE IF NOT EXISTS `character_today_step_unlocks` (
+  `owner` int unsigned NOT NULL,
+  `real_step` int unsigned NOT NULL,
+  `unlocked_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`owner`, `real_step`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/SQL/updates/2026-08-09_aaemu_game_character_today_assignments.sql
+++ b/SQL/updates/2026-08-09_aaemu_game_character_today_assignments.sql
@@ -1,0 +1,15 @@
+USE aaemu_game;
+
+-- Path of Destiny / Daily Contracts per-character state for the current day.
+-- day_key resets at local midnight: rows with an older day_key are ignored and replaced.
+CREATE TABLE IF NOT EXISTS `character_today_assignments` (
+  `owner` int unsigned NOT NULL,
+  `real_step` int unsigned NOT NULL,
+  `group_id` int unsigned NOT NULL DEFAULT 0,
+  `quest_context_id` int unsigned NOT NULL DEFAULT 0,
+  `status` tinyint NOT NULL DEFAULT 0 COMMENT '1=Ready 2=Progress 3=Done (A_TODAY_STATUS)',
+  `day_key` date NOT NULL,
+  `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`owner`, `real_step`),
+  KEY `idx_owner_day` (`owner`, `day_key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/SQL/updates/2026-08-09_aaemu_game_character_today_reset_counts.sql
+++ b/SQL/updates/2026-08-09_aaemu_game_character_today_reset_counts.sql
@@ -1,0 +1,11 @@
+USE aaemu_game;
+
+-- Additive table for installs that already applied character_today_assignments only.
+CREATE TABLE IF NOT EXISTS `character_today_reset_counts` (
+  `owner` int unsigned NOT NULL,
+  `day_key` date NOT NULL,
+  `resets_used` tinyint unsigned NOT NULL DEFAULT 0,
+  `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`owner`),
+  KEY `idx_day` (`day_key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/SQL/updates/2026-08-09_aaemu_game_character_today_step_unlocks.sql
+++ b/SQL/updates/2026-08-09_aaemu_game_character_today_step_unlocks.sql
@@ -1,0 +1,9 @@
+USE aaemu_game;
+
+-- Additive for installs that already created character_today_assignments only.
+CREATE TABLE IF NOT EXISTS `character_today_step_unlocks` (
+  `owner` int unsigned NOT NULL,
+  `real_step` int unsigned NOT NULL,
+  `unlocked_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`owner`, `real_step`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Summary
- Implement Path of Destiny / daily schedule (`today_quest_*`): unlock, accept, progress, completion, and Change Mission re-roll.
- SC status uses `today_quest_steps.id` as the catalog key; free re-roll budget uses personal reset-count type `0x0B`.
- Add labor spend objectives (`QuestActObjLaborPower`), UI-accept gate, zone-kill progress fixes, and day-keyed MySQL persistence (`character_today_assignments`).

## Test plan
- [ ] Apply `SQL/updates/2026-08-09_aaemu_game_character_today_assignments.sql` on `aaemu_game`
- [ ] Enter world → daily contracts load; free steps unlock/accept; kill/labor progress works
- [ ] Paid unlocks (hammer / evenstone / Delphinad stars) consume items and show Progress (not padlock)
- [ ] Change Mission re-rolls in-progress slots; UI shows used/max (e.g. 1/3…3/3); free limit enforced
- [ ] Relog same day: state persists; optional next-calendar-day rows load cleanly via `day_key`

Made with [Cursor](https://cursor.com)