### PR TITLE
fix(game): resolve NPC movement, sprint, and teleport issues for zone-10.0.2_r575

### DIFF
--- a/AAEmu.Game/Models/Game/NPChar/Npc.cs
+++ b/AAEmu.Game/Models/Game/NPChar/Npc.cs
@@ -144,6 +144,9 @@ public partial class Npc : Unit
             _currentGameStance = value;
         }
     }
+
+    /// <summary>Stance the client should use for animations: Relaxed when idle, otherwise CurrentGameStance.</summary>
+    public GameStanceType VisualStance => CurrentGameStance == GameStanceType.Combat && !IsInBattle ? GameStanceType.Relaxed : CurrentGameStance;
     public MoveTypeAlertness CurrentAlertness { get; set; }
 
     #region Attributes
@@ -1276,7 +1279,7 @@ public partial class Npc : Unit
         moveType.DeltaMovement[0] = 0;
         moveType.DeltaMovement[1] = 127;
         moveType.DeltaMovement[2] = 0;
-        moveType.Stance = CurrentGameStance;    // COMBAT = 0x0, IDLE = 0x1
+        moveType.Stance = VisualStance;    // COMBAT = 0x0, IDLE = 0x1
         moveType.Alertness = CurrentAlertness;
         moveType.Time = (uint)(DateTime.UtcNow - DateTime.UtcNow.Date).TotalMilliseconds;
 
@@ -1347,7 +1350,7 @@ public partial class Npc : Unit
         moveType.DeltaMovement[0] = 0;
         moveType.DeltaMovement[1] = 0;
         moveType.DeltaMovement[2] = 0;
-        moveType.Stance = CurrentGameStance;// (sbyte)(CurrentAggroTarget?.ObjId > 0 ? 0 : 1);    // COMBAT = 0x0, IDLE = 0x1
+        moveType.Stance = VisualStance;// (sbyte)(CurrentAggroTarget?.ObjId > 0 ? 0 : 1);    // COMBAT = 0x0, IDLE = 0x1
         moveType.Alertness = CurrentAlertness;
         moveType.Time = (uint)(DateTime.UtcNow - DateTime.UtcNow.Date).TotalMilliseconds;
         BroadcastPacket(new SCOneUnitMovementPacket(ObjId, moveType), false);
@@ -1374,7 +1377,7 @@ public partial class Npc : Unit
         moveType.RotationZ = Transform.Local.ToRollPitchYawSBytesMovement().Item3;
         moveType.Flags = MoveTypeFlags.Stopping | (IsInBattle ? MoveTypeFlags.InCombat : 0);
         moveType.DeltaMovement = new sbyte[3];
-        moveType.Stance = CurrentGameStance;
+        moveType.Stance = VisualStance;
         moveType.Alertness = CurrentAlertness;
         moveType.Time = time;
         return moveType;

--- a/AAEmu.Game/Models/Game/NPChar/Npc.cs
+++ b/AAEmu.Game/Models/Game/NPChar/Npc.cs
@@ -52,6 +52,9 @@ public partial class Npc : Unit
     {
         get
         {
+            if (_overrideAnimActionId.HasValue)
+                return _overrideAnimActionId.Value;
+
             switch (Template.NpcPostureSets.Count)
             {
                 // If no postures, just return 0
@@ -68,7 +71,10 @@ public partial class Npc : Unit
                     }
             }
         }
+        set => _overrideAnimActionId = value;
     }
+
+    private uint? _overrideAnimActionId;
 
     public override float Scale => Template.Scale;
 

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/Return.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/Return.cs
@@ -1,4 +1,5 @@
 ﻿using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Teleport;
@@ -48,10 +49,12 @@ public class Return : SpecialEffectAction
         if (trp != null)
         {
             // return to main_world
+            var mainWorldInstanceId = WorldManager.DefaultInstanceId;
+            var mainWorldTemplateId = WorldManager.DefaultWorldTemplateId;
             character.DisabledSetPosition = true;
             character.SendPacket(
                 new SCLoadInstancePacket(
-                    1,
+                    mainWorldTemplateId,
                     trp.ZoneId,
                     trp.X,
                     trp.Y,
@@ -66,7 +69,7 @@ public class Return : SpecialEffectAction
                 character,
                 null,
                 trp.ZoneId,
-                0,
+                mainWorldInstanceId,
                 trp.X,
                 trp.Y,
                 trp.Z,

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -425,8 +425,10 @@ public class Skill
             return null;
 
         // HACKFIX : Mounts and Turbulence
+        // Some client-initiated self casts (e.g. sprint/double-W) may carry caster objId before
+        // the world unit lookup is fully in sync; falling back to caster avoids false NoTarget.
         if (skillCaster.Type == SkillCasterType.Mount || skillCaster.Type == SkillCasterType.Unit)
-            target = caster.ParentWorld.GetUnit(skillCaster.ObjId);
+            target = caster.ParentWorld.GetUnit(skillCaster.ObjId) ?? caster;
 
         switch (Template.TargetType)
         {

--- a/AAEmu.Game/WorldIntegration.cs
+++ b/AAEmu.Game/WorldIntegration.cs
@@ -1057,6 +1057,13 @@ public static class WorldIntegration
 
             npc.IsZoneMirror = true;
 
+            // Zone-mirror NPCs that use the attention idle pose get their posture cleared
+            // so the walk movement from the native zone isn't overridden by a full-body idle pose.
+            if (npc.AnimActionId == 109)
+            {
+                npc.AnimActionId = 0;
+            }
+
             var worldPos = ZoneManager.Instance.ConvertToWorldCoordinates(zoneId, new System.Numerics.Vector3(x, y, z));
             npc.Transform.ZoneId = zoneId;
             npc.Transform.Local.SetPosition(worldPos.X, worldPos.Y, worldPos.Z, 0f, 0f, zRot);


### PR DESCRIPTION
## Summary
This PR contains fixes for the `client_version/zone-10.0.2_r575` branch:
 
- **Sprint NoTarget** and **Arch mall teleport** issues were addressed in previous commits.
- **Zone-mirror NPC idle pose overriding walk movement** was fixed. The full-body attention pose (`AnimActionId=109`) was being broadcast in `SCUnitState`, overriding the Relaxed/walk movement from the native ZoneHost and causing the NPC to slide.
 
## Changes
- Added per-instance `AnimActionId` override support to `Npc`.
- In `WorldIntegration.MirrorZoneNpcSpawn`, clear `AnimActionId` for zone-mirror NPCs that use the attention idle pose (`AnimActionId == 109`) so `UnitModelPostureSerializer` sends no full-body action.
 
## Result
NPCs that use the attention idle pose now play the correct walk animation from the zone host instead of sliding.