### PR TITLE
fix(world): stabilize doodad seat bond under zone authority

### DIFF
--- a/AAEmu.Game/Core/Packets/C2G/CSMoveUnitPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSMoveUnitPacket.cs
@@ -3,6 +3,7 @@ using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.DoodadObj.Static;
 using AAEmu.Game.Models.Game.Skills.Buffs;
 using AAEmu.Game.Models.Game.Skills.SkillControllers;
@@ -87,27 +88,14 @@ public class CSMoveUnitPacket() : GamePacket(CSOffsets.CSMoveUnitPacket, 1)
                 character.PhysTimeAnchor = _moveType.Time;
                 character.PhysTimeAnchorTick = Environment.TickCount64;
 
-                // Sit/bond (buff 4645 remove_on_move, chair DoodadFuncAttachment): ZoneAuthority used to
-                // return before RemoveEffects / unbond, so move never cleared the sit state → stuck.
-                RemoveEffects(character, _moveType);
-                if (character.Bonding != null &&
-                    (_moveType.VelX != 0 || _moveType.VelY != 0 || _moveType.VelZ != 0))
+                // Seats under zone authority: clear remove_on_move only when not bonded, or when
+                // the move is leave (walk/jump). Residual settle velocity must not unseat.
+                if (character.Bonding == null)
+                    RemoveEffects(character, _moveType);
+                else if (BondDoodad.IsIntentionalSeatLeave(umt.Flags, umt.ActorFlags))
                 {
-                    var bonding = character.Bonding;
-                    var bondedDoodad = bonding.GetOwner();
-                    var doodadObjId = bonding.ObjId;
-                    bondedDoodad?.Seat.UnLoadPassenger(character, doodadObjId);
-                    character.Bonding.SetOwner(null);
-                    character.Bonding = null;
-                    character.Transform.Parent = null;
-                    character.Transform.StickyParent = null;
-                    character.BroadcastPacket(
-                        new SCUnbondDoodadPacket(character.ObjId, character.Id, doodadObjId), true);
-                    WorldIntegration.RelayBondDoodadToZone?.Invoke(character.ObjId, bonding, false);
-                    // Sit buff 4645 has remove_on_unbond + remove_on_move; RemoveEffects above
-                    // covers move. Explicitly drop sit buff if still present after unbond.
-                    if (character.Buffs.CheckBuff(4645))
-                        character.Buffs.RemoveBuff(4645);
+                    RemoveEffects(character, _moveType);
+                    BondDoodad.TryRelease(character);
                 }
 
                 // Mast / ladder hang (StickyParent) and BindSlave seats: ZoneAuthority used to
@@ -128,6 +116,10 @@ public class CSMoveUnitPacket() : GamePacket(CSOffsets.CSMoveUnitPacket, 1)
                     ClearHang(character, reason: 0); // climbed off
 
                 ApplyGroundContact(character, umt);
+
+                // Never apply CSMove world XYZ as local under a seat doodad (AOI thrash).
+                if (character.Bonding != null && character.Transform.Parent?.GameObject is Doodad)
+                    character.Transform.Parent = null;
 
                 character.Transform.Local.SetPosition(
                     umt.X, umt.Y, umt.Z,

--- a/AAEmu.Game/Core/Packets/C2G/CSMoveUnitPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSMoveUnitPacket.cs
@@ -117,16 +117,27 @@ public class CSMoveUnitPacket() : GamePacket(CSOffsets.CSMoveUnitPacket, 1)
 
                 ApplyGroundContact(character, umt);
 
-                // Never apply CSMove world XYZ as local under a seat doodad (AOI thrash).
+                // Free seats: never parent under the doodad (world CSMove as Local → AOI thrash).
+                // Carrier seats (transfer/slave): parent stays the unit; skip position overwrite so
+                // world XYZ is not applied as local under a moving parent.
                 if (character.Bonding != null && character.Transform.Parent?.GameObject is Doodad)
                     character.Transform.Parent = null;
 
-                character.Transform.Local.SetPosition(
-                    umt.X, umt.Y, umt.Z,
-                    (float)MathUtil.ConvertDirectionToRadian(umt.RotationX),
-                    (float)MathUtil.ConvertDirectionToRadian(umt.RotationY),
-                    (float)MathUtil.ConvertDirectionToRadian(umt.RotationZ));
-                character.Transform.FinalizeTransform();
+                if (character.Bonding != null &&
+                    character.Transform.Parent?.GameObject is BaseUnit and not Doodad)
+                {
+                    character.Transform.FinalizeTransform();
+                }
+                else
+                {
+                    character.Transform.Local.SetPosition(
+                        umt.X, umt.Y, umt.Z,
+                        (float)MathUtil.ConvertDirectionToRadian(umt.RotationX),
+                        (float)MathUtil.ConvertDirectionToRadian(umt.RotationY),
+                        (float)MathUtil.ConvertDirectionToRadian(umt.RotationZ));
+                    character.Transform.FinalizeTransform();
+                }
+
                 character.SetPlayerMoved();
 
                 // Fan this player's movement out to everyone around them.

--- a/AAEmu.Game/Core/Packets/C2G/CSUnbondDoodadPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSUnbondDoodadPacket.cs
@@ -1,7 +1,6 @@
 ﻿using AAEmu.Commons.Network;
-using AAEmu.Game;
 using AAEmu.Game.Core.Network.Game;
-using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.DoodadObj;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
@@ -12,18 +11,9 @@ public class CSUnbondDoodadPacket() : GamePacket(CSOffsets.CSUnbondDoodadPacket,
         var characterObjId = stream.ReadBc();
         var doodadObjId = stream.ReadBc();
 
-        if (Connection.ActiveChar.ObjId != characterObjId || Connection.ActiveChar.Bonding == null || Connection.ActiveChar.Bonding.ObjId != doodadObjId)
+        if (Connection.ActiveChar.ObjId != characterObjId)
             return;
 
-        var doodad = Connection.ActiveChar.Bonding.GetOwner();
-        doodad.Seat.UnLoadPassenger(Connection.ActiveChar, doodad.ObjId); // we free up the place where we were sitting
-
-        var bonding = Connection.ActiveChar.Bonding;
-        Connection.ActiveChar.Bonding.SetOwner(null);
-        Connection.ActiveChar.Bonding = null;
-        Connection.ActiveChar.Transform.Parent = null;
-
-        Connection.ActiveChar.BroadcastPacket(new SCUnbondDoodadPacket(Connection.ActiveChar.ObjId, Connection.ActiveChar.Id, doodadObjId), true);
-        WorldIntegration.RelayBondDoodadToZone?.Invoke(Connection.ActiveChar.ObjId, bonding, false);
+        BondDoodad.TryRelease(Connection.ActiveChar, doodadObjId);
     }
 }

--- a/AAEmu.Game/Models/Game/DoodadObj/BondDoodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/BondDoodad.cs
@@ -1,5 +1,11 @@
 using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers.Id;
+using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.DoodadObj.Static;
+using AAEmu.Game.Models.Game.Skills.Buffs;
+using AAEmu.Game.Models.Game.World;
+using AAEmu.Game.Models.StaticValues;
 
 namespace AAEmu.Game.Models.Game.DoodadObj;
 
@@ -45,8 +51,77 @@ public class BondDoodad : PacketMarshaler
     }
 
     /// <summary>
+    /// Whether a CS move should stand the unit up from a bond.
+    /// Seat-settle packets often still report residual velocity; only Moving / Jumping mean leave.
+    /// CSUnbond is always leave and does not use this.
+    /// </summary>
+    public static bool IsIntentionalSeatLeave(MoveTypeFlags flags, ushort actorFlags)
+    {
+        if (((MoveTypeActorFlags)actorFlags).HasFlag(MoveTypeActorFlags.Jumping))
+            return true;
+        // Moving (0x02) and Jumping combo (Moving|Stopping).
+        return flags.HasFlag(MoveTypeFlags.Moving);
+    }
+
+    /// <summary>
+    /// Clears seat occupancy, transform parenting, SCUnbond, zone unbond, and remove_on_unbond buffs.
+    /// No-op when not bonded. When <paramref name="expectedDoodadObjId"/> is set, requires a match.
+    /// </summary>
+    public static bool TryRelease(Character character, uint? expectedDoodadObjId = null)
+    {
+        if (character?.Bonding == null)
+            return false;
+
+        var bonding = character.Bonding;
+        var doodadObjId = bonding.ObjId;
+        if (expectedDoodadObjId is { } expect && doodadObjId != expect)
+            return false;
+
+        var doodad = bonding.GetOwner();
+        if (doodad != null)
+            doodad.Seat.UnLoadPassenger(character, doodad.ObjId);
+
+        bonding.SetOwner(null);
+        character.Bonding = null;
+        character.Transform.Parent = null;
+        character.Transform.StickyParent = null;
+
+        character.BroadcastPacket(new SCUnbondDoodadPacket(character.ObjId, character.Id, doodadObjId), true);
+        WorldIntegration.RelayBondDoodadToZone?.Invoke(character.ObjId, bonding, false);
+        character.Buffs.TriggerRemoveOn(BuffRemoveOn.Unbond);
+        return true;
+    }
+
+    /// <summary>
+    /// Trailing root on WZUnitBondToDoodad must be a zone unit ObjId (or 0), never the seat doodad.
+    /// Free-world furniture has no house/slave parent → root 0.
+    /// </summary>
+    public static uint ResolveZoneRootUnitId(Doodad seat)
+    {
+        if (seat == null)
+            return 0;
+
+        for (GameObject cur = seat.ParentObj; cur != null; cur = cur.ParentObj)
+        {
+            if (ObjectIdManager.IsZoneUnitId(cur.ObjId))
+                return cur.ObjId;
+        }
+
+        if (ObjectIdManager.IsZoneUnitId(seat.ParentObjId))
+            return seat.ParentObjId;
+
+        for (var t = seat.Transform?.StickyParent; t != null; t = t.StickyParent)
+        {
+            var go = t.GameObject;
+            if (go != null && ObjectIdManager.IsZoneUnitId(go.ObjId))
+                return go.ObjId;
+        }
+
+        return 0;
+    }
+
+    /// <summary>
     /// point u8, doodad bc(3), space s32, spot s32, type u32 (BondKind).
-    /// Older AAEmu wrote kind before space/spot as u8 — client never bonded → no sit.
     /// </summary>
     public override PacketStream Write(PacketStream stream)
     {

--- a/AAEmu.Game/Models/Game/DoodadObj/BondDoodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/BondDoodad.cs
@@ -4,6 +4,7 @@ using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.DoodadObj.Static;
 using AAEmu.Game.Models.Game.Skills.Buffs;
+using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.World;
 using AAEmu.Game.Models.StaticValues;
 
@@ -93,6 +94,43 @@ public class BondDoodad : PacketMarshaler
     }
 
     /// <summary>
+    /// Live unit the seat rides on (transfer, slave, house, …), or null for free-world furniture.
+    /// Transfer seat doodads often only set ParentObjId + Transform.Parent (ParentObj may be null).
+    /// </summary>
+    public static BaseUnit ResolveCarrierUnit(Doodad seat)
+    {
+        if (seat == null)
+            return null;
+
+        for (var cur = seat.ParentObj; cur != null; cur = cur.ParentObj)
+        {
+            if (cur is BaseUnit unit and not Doodad)
+                return unit;
+        }
+
+        if (ObjectIdManager.IsZoneUnitId(seat.ParentObjId))
+        {
+            var byId = seat.ParentWorld?.GetBaseUnit(seat.ParentObjId);
+            if (byId is not null and not Doodad)
+                return byId;
+        }
+
+        for (var t = seat.Transform?.Parent; t != null; t = t.Parent)
+        {
+            if (t.GameObject is BaseUnit unit and not Doodad)
+                return unit;
+        }
+
+        for (var t = seat.Transform?.StickyParent; t != null; t = t.StickyParent)
+        {
+            if (t.GameObject is BaseUnit unit and not Doodad)
+                return unit;
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Trailing root on WZUnitBondToDoodad must be a zone unit ObjId (or 0), never the seat doodad.
     /// Free-world furniture has no house/slave parent → root 0.
     /// </summary>
@@ -101,21 +139,13 @@ public class BondDoodad : PacketMarshaler
         if (seat == null)
             return 0;
 
-        for (GameObject cur = seat.ParentObj; cur != null; cur = cur.ParentObj)
-        {
-            if (ObjectIdManager.IsZoneUnitId(cur.ObjId))
-                return cur.ObjId;
-        }
+        var carrier = ResolveCarrierUnit(seat);
+        if (carrier != null && ObjectIdManager.IsZoneUnitId(carrier.ObjId))
+            return carrier.ObjId;
 
+        // ParentObjId alone when the carrier is not resolved in-memory (tests / load order).
         if (ObjectIdManager.IsZoneUnitId(seat.ParentObjId))
             return seat.ParentObjId;
-
-        for (var t = seat.Transform?.StickyParent; t != null; t = t.StickyParent)
-        {
-            var go = t.GameObject;
-            if (go != null && ObjectIdManager.IsZoneUnitId(go.ObjId))
-                return go.ObjId;
-        }
 
         return 0;
     }

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncAttachment.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncAttachment.cs
@@ -30,8 +30,10 @@ public class DoodadFuncAttachment : DoodadFuncTemplate
                 character.Bonding = new BondDoodad(owner, AttachPointId, BondKindId, Space, spot);
                 character.BroadcastPacket(new SCBondDoodadPacket(caster.ObjId, character.Bonding), true);
                 WorldIntegration.RelayBondDoodadToZone?.Invoke(character.ObjId, character.Bonding, true);
-                character.Transform.StickyParent = owner.Transform.StickyParent;
-                character.Transform.Parent = owner.Transform;
+                // Sit attach is SCBond; keep free chairs unparented so CSMove world coords stay world-space.
+                // Parent only when the seat is on a unit carrier (house/slave).
+                if (owner.ParentObj is BaseUnit carrierUnit)
+                    character.Transform.Parent = carrierUnit.Transform;
             }
             // Ships // TODO Check how sit on the ship
             else

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncAttachment.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncAttachment.cs
@@ -30,10 +30,11 @@ public class DoodadFuncAttachment : DoodadFuncTemplate
                 character.Bonding = new BondDoodad(owner, AttachPointId, BondKindId, Space, spot);
                 character.BroadcastPacket(new SCBondDoodadPacket(caster.ObjId, character.Bonding), true);
                 WorldIntegration.RelayBondDoodadToZone?.Invoke(character.ObjId, character.Bonding, true);
-                // Sit attach is SCBond; keep free chairs unparented so CSMove world coords stay world-space.
-                // Parent only when the seat is on a unit carrier (house/slave).
-                if (owner.ParentObj is BaseUnit carrierUnit)
-                    character.Transform.Parent = carrierUnit.Transform;
+                // SCBond is the client attach. Free seats stay unparented (CSMove world-space).
+                // Transfer/slave/house seats parent to the resolved carrier (not the seat doodad).
+                var carrier = BondDoodad.ResolveCarrierUnit(owner);
+                if (carrier != null)
+                    character.Transform.Parent = carrier.Transform;
             }
             // Ships // TODO Check how sit on the ship
             else

--- a/AAEmu.Game/Models/Game/DoodadObj/VehicleSeat.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/VehicleSeat.cs
@@ -16,6 +16,18 @@ public class VehicleSeat(BaseUnit parentVehicle)
     // Space = 1-means that there is one place (a chair), Space = 2-means that there are two places to sit (a bench on transport)
     // Spot = 0 sit left, = 1 sit right on the bench
 
+    /// <summary>
+    /// Seats are owned by a doodad (`new VehicleSeat(this)`), not the transfer. Resolve any unit carrier.
+    /// </summary>
+    private BaseUnit ResolveCarrier()
+    {
+        if (parentVehicle is Transfer or Slave)
+            return parentVehicle;
+        if (parentVehicle is Doodad seat)
+            return BondDoodad.ResolveCarrierUnit(seat);
+        return null;
+    }
+
     private void Init(uint objId, int space)
     {
         var tmp = new List<uint>();
@@ -29,9 +41,10 @@ public class VehicleSeat(BaseUnit parentVehicle)
     private void AddSeat(Character character, uint seatObjId, int spot)
     {
         _seats[seatObjId][spot] = character.Id;
-        // Static doodad chairs: occupancy only. Transfers keep the passenger parented.
-        if (parentVehicle is Transfer transfer)
-            character.Transform.Parent = transfer.Transform;
+        // Parenting to the carrier is applied by DoodadFuncAttachment after bond setup.
+        // Track transfer passengers for bookkeeping only.
+        if (ResolveCarrier() is Transfer transfer && !transfer.AttachedCharacters.Contains(character))
+            transfer.AttachedCharacters.Add(character);
     }
 
     public void UnLoadPassenger(Character character, uint seatObjId)
@@ -45,7 +58,7 @@ public class VehicleSeat(BaseUnit parentVehicle)
             {
                 spots[i] = 0; // free up space
                 character.Transform.StickyParent = null;
-                if (parentVehicle is Transfer transfer)
+                if (ResolveCarrier() is Transfer transfer)
                     transfer.AttachedCharacters.Remove(character);
             }
         }
@@ -88,11 +101,6 @@ public class VehicleSeat(BaseUnit parentVehicle)
             spot = -1;
         }
 
-        if (spot != -1 && parentVehicle is Transfer transfer)
-            if (!transfer.AttachedCharacters.Contains(character))
-                transfer.AttachedCharacters.Add(character);
-
         return spot;
     }
 }
-

--- a/AAEmu.Game/Models/Game/DoodadObj/VehicleSeat.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/VehicleSeat.cs
@@ -28,18 +28,22 @@ public class VehicleSeat(BaseUnit parentVehicle)
 
     private void AddSeat(Character character, uint seatObjId, int spot)
     {
-        _seats[seatObjId][spot] = character.Id; // occupied place
-        character.Transform.Parent = null;
-        character.Transform.StickyParent = parentVehicle.Transform;
+        _seats[seatObjId][spot] = character.Id;
+        // Static doodad chairs: occupancy only. Transfers keep the passenger parented.
+        if (parentVehicle is Transfer transfer)
+            character.Transform.Parent = transfer.Transform;
     }
 
     public void UnLoadPassenger(Character character, uint seatObjId)
     {
-        for (var i = 0; i < _seats[seatObjId].Count; i++)
+        if (!_seats.TryGetValue(seatObjId, out var spots))
+            return;
+
+        for (var i = 0; i < spots.Count; i++)
         {
-            if (_seats[seatObjId][i] == character.Id)
+            if (spots[i] == character.Id)
             {
-                _seats[seatObjId][i] = 0; // free up space
+                spots[i] = 0; // free up space
                 character.Transform.StickyParent = null;
                 if (parentVehicle is Transfer transfer)
                     transfer.AttachedCharacters.Remove(character);

--- a/AAEmu.Game/Models/Game/Skills/Buffs/BuffRemoveOn.cs
+++ b/AAEmu.Game/Models/Game/Skills/Buffs/BuffRemoveOn.cs
@@ -11,6 +11,7 @@ public enum BuffRemoveOn
     Interaction,
     Unmount,
     Mount,
+    Unbond,
     StartSkill,
     AttackSpellDot,
     AttackEtcDot,

--- a/AAEmu.Game/Models/Game/Units/Buffs.cs
+++ b/AAEmu.Game/Models/Game/Units/Buffs.cs
@@ -737,6 +737,8 @@ public class Buffs : IBuffs
                 }
                 else if (template.RemoveOnUnmount && on == BuffRemoveOn.Unmount)
                     effect.Exit();
+                else if (template.RemoveOnUnbond && on == BuffRemoveOn.Unbond)
+                    effect.Exit();
                 else if (template.RemoveOnUseSkill && on == BuffRemoveOn.UseSkill)
                     effect.Exit();
             }

--- a/AAEmu.Game/WorldIntegration.cs
+++ b/AAEmu.Game/WorldIntegration.cs
@@ -345,7 +345,8 @@ public static class WorldIntegration
 
     /// <summary>
     /// WZUnitBondToDoodad / Unbond. When <paramref name="bond"/> is true, <paramref name="bonding"/>
-    /// must be non-null (full SerializeBonding + root bc). Unbond ignores bonding.
+    /// must be non-null (full bonding payload + unit-space root bc, or 0 for free seats).
+    /// Unbond ignores bonding.
     /// </summary>
     public static Action<uint, BondDoodad, bool> RelayBondDoodadToZone { get; set; }
 

--- a/AAEmu.UnitTests/WorldServer/ZonePacketWireTests.cs
+++ b/AAEmu.UnitTests/WorldServer/ZonePacketWireTests.cs
@@ -9,6 +9,7 @@ using AAEmu.Game.Models.Game.Housing;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Taxations;
 using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.StaticValues;
 using AAEmu.World.Core.Packets.Wz;
 using AAEmu.World.Core.Packets.Zw;
 using AAEmu.World.Core.Relay;
@@ -45,12 +46,17 @@ public class ZonePacketWireTests
     }
 
     [Test]
-    public async Task UnitBond_WritesBondDataAndTrailingParent()
+    public async Task UnitBond_WritesBondDataAndTrailingUnitRoot()
     {
-        var doodad = new Doodad { ObjId = 0x010203 };
+        // Free-world doodad ObjIds live above unit space; body carries the seat, root must not.
+        var doodad = new Doodad { ObjId = 105992 };
         var bond = new BondDoodad(
             doodad, AttachPointKind.Driver, BondKind.BondChairSingle, space: 7, spot: 11);
-        var frame = new PacketStream(new WZUnitBondToDoodadPacket(0x040506, bond, doodad.ObjId).Encode());
+
+        var freeRoot = BondDoodad.ResolveZoneRootUnitId(doodad);
+        await Assert.That(freeRoot).IsEqualTo(0u);
+
+        var frame = new PacketStream(new WZUnitBondToDoodadPacket(0x040506, bond, freeRoot).Encode());
 
         await Assert.That(frame.ReadUInt16()).IsEqualTo((ushort)24); // opcode + 22-byte body
         await Assert.That(frame.ReadUInt16()).IsEqualTo(WzOpcodes.UnitBondToDoodad);
@@ -60,8 +66,40 @@ public class ZonePacketWireTests
         await Assert.That(frame.ReadInt32()).IsEqualTo(7);
         await Assert.That(frame.ReadInt32()).IsEqualTo(11);
         await Assert.That(frame.ReadUInt32()).IsEqualTo((uint)BondKind.BondChairSingle);
-        await Assert.That(frame.ReadBc()).IsEqualTo(doodad.ObjId);
+        await Assert.That(frame.ReadBc()).IsEqualTo(0u);
         await Assert.That(frame.Pos).IsEqualTo(frame.Count);
+
+        var houseUnitId = 1500u;
+        doodad.ParentObjId = houseUnitId;
+        await Assert.That(BondDoodad.ResolveZoneRootUnitId(doodad)).IsEqualTo(houseUnitId);
+
+        doodad.ParentObjId = 105999u;
+        await Assert.That(BondDoodad.ResolveZoneRootUnitId(doodad)).IsEqualTo(0u);
+        await Assert.That(BondDoodad.ResolveZoneRootUnitId(null)).IsEqualTo(0u);
+    }
+
+    [Test]
+    public async Task SeatLeaveIntent_RequiresLocomotionFlagsNotResidueVel()
+    {
+        await Assert.That(
+            BondDoodad.IsIntentionalSeatLeave(MoveTypeFlags.None, (ushort)MoveTypeActorFlags.None))
+            .IsFalse();
+
+        await Assert.That(
+            BondDoodad.IsIntentionalSeatLeave(MoveTypeFlags.Stopping, (ushort)MoveTypeActorFlags.None))
+            .IsFalse();
+
+        await Assert.That(
+            BondDoodad.IsIntentionalSeatLeave(MoveTypeFlags.Moving, (ushort)MoveTypeActorFlags.None))
+            .IsTrue();
+
+        await Assert.That(
+            BondDoodad.IsIntentionalSeatLeave(MoveTypeFlags.Jumping, (ushort)MoveTypeActorFlags.None))
+            .IsTrue();
+
+        await Assert.That(
+            BondDoodad.IsIntentionalSeatLeave(MoveTypeFlags.None, (ushort)MoveTypeActorFlags.Jumping))
+            .IsTrue();
     }
 
     [Test]

--- a/AAEmu.WorldServer/AAEmu.World/Core/Packets/Wz/WZUnitSyncPackets.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Packets/Wz/WZUnitSyncPackets.cs
@@ -87,7 +87,8 @@ public class WZUnitDetachedPacket(uint unitId, byte reason = 0) : ZonePacket(WzO
 }
 
 /// <summary>
-/// bc unit + UnitState_SerializeBonding + bc root (ProcessPassenger).
+/// bc unit + bonding (seat doodad) + bc root.
+/// Root is a zone unit ObjId or 0 — never the seat doodad id.
 /// </summary>
 public class WZUnitBondToDoodadPacket(uint unitId, BondDoodad bonding, uint rootObjId)
     : ZonePacket(WzOpcodes.UnitBondToDoodad)

--- a/AAEmu.WorldServer/AAEmu.World/Program.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Program.cs
@@ -4,8 +4,10 @@ using AAEmu.Commons.IO;
 using AAEmu.Commons.Network;
 using AAEmu.Game;
 using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.Id;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.World.Core.Network;
 using AAEmu.World.Core.Packets.Wz;
@@ -846,10 +848,21 @@ public static class Program
                 return;
             if (bond && bonding != null)
             {
+                // Passenger fields require zone unit ids; doodad ObjIds are invalid as the bonding unit.
+                if (!ObjectIdManager.IsZoneUnitId(unitId))
+                {
+                    Logger.Warn("Not relaying WZUnitBondToDoodad: unit={0} is not a zone unit id", unitId);
+                    return;
+                }
+
                 var doodad = bonding.GetOwner();
-                var rootObjId = doodad != null && doodad.ParentObjId != 0
-                    ? doodad.ParentObjId
-                    : bonding.ObjId;
+                if (doodad == null || bonding.ObjId == 0)
+                {
+                    Logger.Warn("Not relaying WZUnitBondToDoodad: unit={0} has no seat doodad", unitId);
+                    return;
+                }
+
+                var rootObjId = BondDoodad.ResolveZoneRootUnitId(doodad);
                 zone.SendPacket(new WZUnitBondToDoodadPacket(unitId, bonding, rootObjId));
                 Logger.Info("WZUnitBondToDoodad → zone unit={0} doodad={1} root={2} point={3} kind={4}",
                     unitId, bonding.ObjId, rootObjId, (byte)bonding.AttachPoint, (uint)bonding.Kind);


### PR DESCRIPTION
## Summary
- Use zone unit ids (or `0`) for `WZUnitBondToDoodad` root so free chairs no longer take doodad ObjIds as passenger roots.
- Leave seats only on intentional `Moving`/`Jumping` (or `CSUnbond`), not residual settle velocity under zone authority.
- Do not parent free chair seats under the doodad: CSMove world coords stay world-space so interest/AOI does not clear nearby NPCs.
- Shared `BondDoodad.TryRelease` / `ResolveZoneRootUnitId` / leave helper; wire `remove_on_unbond` on release.

## Test plan
- [ ] Sit free-world chairs (skill 15857) — stay seated while idle; walk/jump/CS get-off works
- [ ] Zone does not crash on sit (no free-chair root doodad id)
- [ ] NPCs/enemies remain visible/streamed while seated (no interest dump)
- [ ] `ZonePacketWireTests` bond root + seat leave tests pass