### PR TITLE
fix(indun): off-by-one lets one player past dungeon max capacity

### DIFF
--- a/AAEmu.Game/Core/Managers/IndunManager.cs
+++ b/AAEmu.Game/Core/Managers/IndunManager.cs
@@ -195,7 +195,7 @@ public class IndunManager(ITickManager tickManager, IWorldManager worldManager, 
             if (possibleTargetInstance.PlayersWithAccess.Contains(character.Id))
             {
                 // Return queue if not full yet
-                if (possibleTargetInstance.World.GetCharacterCount() > possibleTargetInstance._indunZone.MaxPlayers)
+                if (IsDungeonFull(possibleTargetInstance.World.GetCharacterCount(), possibleTargetInstance._indunZone.MaxPlayers))
                 {
                     character.SendErrorMessage(ErrorMessageType.InstanceQuota); // Too many users are currently in the dungeon
                     return false;
@@ -337,6 +337,12 @@ public class IndunManager(ITickManager tickManager, IWorldManager worldManager, 
 
         return true;
     }
+
+    /// <summary>
+    /// Returns true when the dungeon already holds its maximum allowed number of players.
+    /// Kept as a single decision point so the manager and <see cref="Dungeon.IsFull"/> stay in sync.
+    /// </summary>
+    private static bool IsDungeonFull(int characterCount, uint maxPlayers) => characterCount >= maxPlayers;
 
     /// <summary>
     /// Creates a new player created dungeon instance

--- a/AAEmu.UnitTests/Game/Core/Managers/IndunManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/IndunManagerTests.cs
@@ -15,4 +15,26 @@ public class IndunManagerTests
 
         mockTick.OnTick.WasCalled(Times.Once);
     }
+
+    [Test]
+    public async Task IsDungeonFull_AtMaxCapacity_ReturnsTrue()
+    {
+        var method = typeof(IndunManager).GetMethod("IsDungeonFull",
+            System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+
+        var result = method!.Invoke(null, [1, 1u]);
+
+        await Assert.That(result).IsEqualTo(true);
+    }
+
+    [Test]
+    public async Task IsDungeonFull_BelowMaxCapacity_ReturnsFalse()
+    {
+        var method = typeof(IndunManager).GetMethod("IsDungeonFull",
+            System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+
+        var result = method!.Invoke(null, [0, 1u]);
+
+        await Assert.That(result).IsEqualTo(false);
+    }
 }


### PR DESCRIPTION
## Problem

`IndunManager` gates entry with `GetCharacterCount() > MaxPlayers`, which admits one player **beyond** the configured maximum. Other paths already use `Dungeon.IsFull` (a `>=` check), so the two disagree at the boundary.

## Fix

Replace the direct comparison with a single `IsDungeonFull` helper using `>=`, aligning `IndunManager` with `Dungeon.IsFull`.

## Notes

- Adds regression tests for the at-capacity and below-capacity cases.
- `AAEmu.Game` and `AAEmu.UnitTests` both build with 0 errors on `client_version/zone-10.0.2_r575`.
- Verified live on a CN 10.0.2.13 (r575) server.