### PR TITLE
feat(world): tower-def playability, ToD isolation, mirror/quest fixes

### DIFF
--- a/AAEmu.Commons/Network/LengthPrefixedFrames.cs
+++ b/AAEmu.Commons/Network/LengthPrefixedFrames.cs
@@ -1,0 +1,80 @@
+namespace AAEmu.Commons.Network;
+
+/// <summary>
+/// Result of slicing one length-prefixed internal/login frame.
+/// </summary>
+public enum LengthPrefixedFrameResult
+{
+    /// <summary>Not enough bytes for a complete frame; stash the stream and wait.</summary>
+    NeedMore,
+    /// <summary>A complete frame is in <c>frame</c>; remainder stays in the source stream (or null).</summary>
+    GotFrame,
+    /// <summary>
+    /// A complete 2-byte length prefix was present but payload length was below the minimum
+    /// (typically 2 for opcode). The prefix was dropped; remainder stays in the source stream.
+    /// </summary>
+    DroppedInvalidLength
+}
+
+/// <summary>
+/// Shared [u16 payloadLen][payload] framing. PacketStream short-reads return 0 instead of throwing,
+/// so callers must not treat a failed length read as payloadLen=0 (that dispatches opcode 0 forever).
+/// </summary>
+public static class LengthPrefixedFrames
+{
+    public const int LengthPrefixBytes = sizeof(ushort);
+    /// <summary>Minimum payload so the frame can carry a u16 opcode.</summary>
+    public const int MinOpcodePayloadBytes = sizeof(ushort);
+
+    /// <summary>
+    /// Take one frame from <paramref name="stream"/>. On <see cref="LengthPrefixedFrameResult.NeedMore"/>
+    /// the same instance should be stored as LastPacket (Pos is reset to 0).
+    /// </summary>
+    public static LengthPrefixedFrameResult TryTake(
+        ref PacketStream? stream,
+        int minPayloadBytes,
+        out PacketStream? frame)
+    {
+        frame = null;
+        if (stream == null || stream.Count == 0)
+            return LengthPrefixedFrameResult.NeedMore;
+
+        stream.Pos = 0;
+        if (stream.Count < LengthPrefixBytes)
+            return LengthPrefixedFrameResult.NeedMore;
+
+        var payloadLen = stream.ReadUInt16();
+        if (payloadLen < minPayloadBytes)
+        {
+            SliceConsumed(ref stream, LengthPrefixBytes);
+            return LengthPrefixedFrameResult.DroppedInvalidLength;
+        }
+
+        var total = payloadLen + LengthPrefixBytes;
+        if (total > stream.Count)
+        {
+            stream.Pos = 0;
+            return LengthPrefixedFrameResult.NeedMore;
+        }
+
+        frame = new PacketStream();
+        frame.Replace(stream, 0, total);
+        SliceConsumed(ref stream, total);
+        return LengthPrefixedFrameResult.GotFrame;
+    }
+
+    private static void SliceConsumed(ref PacketStream? stream, int consumed)
+    {
+        if (stream == null)
+            return;
+        if (stream.Count > consumed)
+        {
+            var rest = new PacketStream();
+            rest.Replace(stream, consumed, stream.Count - consumed);
+            stream = rest;
+            return;
+        }
+
+        stream = null;
+    }
+}

--- a/AAEmu.Commons/Network/PacketStream.cs
+++ b/AAEmu.Commons/Network/PacketStream.cs
@@ -471,7 +471,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 1 > Count)
         {
-            Logger.Debug("Attempted to read beyond the end of the stream.");
+            Logger.Error("Attempted to read beyond the end of the stream.");
             return 0; // Возвращаем значение по умолчанию
         }
         return this[Pos++];
@@ -485,7 +485,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 1 > Count)
         {
-            Logger.Debug("Attempted to read beyond the end of the stream.");
+            Logger.Error("Attempted to read beyond the end of the stream.");
             return 0; // Возвращаем значение по умолчанию
         }
         return (sbyte)this[Pos++];
@@ -500,7 +500,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + count > Count)
         {
-            Logger.Debug("Attempted to read beyond the end of the stream.");
+            Logger.Error("Attempted to read beyond the end of the stream.");
             return []; // Возвращаем пустой массив
         }
 
@@ -520,7 +520,7 @@ public class PacketStream : ICloneable, IComparable
 
         if (Pos + count > Count)
         {
-            Logger.Debug("Attempted to read beyond the end of the stream.");
+            Logger.Error("Attempted to read beyond the end of the stream.");
             return []; // Возвращаем пустой массив
         }
 
@@ -538,7 +538,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 2 > Count)
         {
-            Logger.Debug("Attempted to read beyond the end of the stream.");
+            Logger.Error("Attempted to read beyond the end of the stream.");
             return '\0'; // Возвращаем значение по умолчанию
         }
 
@@ -557,7 +557,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 2 * count > Count)
         {
-            Logger.Debug("Attempted to read beyond the end of the stream.");
+            Logger.Error("Attempted to read beyond the end of the stream.");
             return []; // Возвращаем пустой массив
         }
 
@@ -576,7 +576,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 2 > Count)
         {
-            Logger.Debug("Attempted to read beyond the end of the stream.");
+            Logger.Error("Attempted to read beyond the end of the stream.");
             return 0; // Возвращаем значение по умолчанию
         }
 
@@ -594,7 +594,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 4 > Count)
         {
-            Logger.Debug("Attempted to read beyond the end of the stream.");
+            Logger.Error("Attempted to read beyond the end of the stream.");
             return 0; // Возвращаем значение по умолчанию
         }
 
@@ -612,7 +612,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 8 > Count)
         {
-            Logger.Debug("Attempted to read beyond the end of the stream.");
+            Logger.Error("Attempted to read beyond the end of the stream.");
             return 0; // Возвращаем значение по умолчанию
         }
 
@@ -630,7 +630,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 2 > Count)
         {
-            Logger.Debug("Attempted to read beyond the end of the stream.");
+            Logger.Error("Attempted to read beyond the end of the stream.");
             return 0; // Возвращаем значение по умолчанию
         }
 
@@ -648,7 +648,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 4 > Count)
         {
-            Logger.Debug("Attempted to read beyond the end of the stream.");
+            Logger.Error("Attempted to read beyond the end of the stream.");
             return 0; // Возвращаем значение по умолчанию
         }
 
@@ -666,7 +666,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 3 > Count)
         {
-            Logger.Debug("Attempted to read beyond the end of the stream.");
+            Logger.Error("Attempted to read beyond the end of the stream.");
             return 0; // Возвращаем значение по умолчанию
         }
 
@@ -683,7 +683,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 8 > Count)
         {
-            Logger.Debug("Attempted to read beyond the end of the stream.");
+            Logger.Error("Attempted to read beyond the end of the stream.");
             return 0; // Возвращаем значение по умолчанию
         }
 
@@ -701,7 +701,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 4 > Count)
         {
-            Logger.Debug("Attempted to read beyond the end of the stream.");
+            Logger.Error("Attempted to read beyond the end of the stream.");
             return 0; // Возвращаем значение по умолчанию
         }
 
@@ -719,7 +719,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 8 > Count)
         {
-            Logger.Debug("Attempted to read beyond the end of the stream.");
+            Logger.Error("Attempted to read beyond the end of the stream.");
             return 0; // Возвращаем значение по умолчанию
         }
 
@@ -742,7 +742,7 @@ public class PacketStream : ICloneable, IComparable
         var i = ReadInt16();
         if (Pos + i > Count)
         {
-            Logger.Debug("Attempted to read beyond the end of the stream.");
+            Logger.Error("Attempted to read beyond the end of the stream.");
             return new PacketStream(); // Возвращаем пустой PacketStream
         }
         var newStream = new PacketStream(Buffer, Pos, i);
@@ -760,7 +760,7 @@ public class PacketStream : ICloneable, IComparable
         var i = ReadInt16();
         if (Pos + i > Count)
         {
-            Logger.Debug("Attempted to read beyond the end of the stream.");
+            Logger.Error("Attempted to read beyond the end of the stream.");
             return this; // Возвращаем текущий PacketStream
         }
         stream.Replace(Buffer, Pos, i);

--- a/AAEmu.Commons/Network/PacketStream.cs
+++ b/AAEmu.Commons/Network/PacketStream.cs
@@ -471,7 +471,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 1 > Count)
         {
-            Logger.Error("Attempted to read beyond the end of the stream.");
+            Logger.Debug("Attempted to read beyond the end of the stream.");
             return 0; // Возвращаем значение по умолчанию
         }
         return this[Pos++];
@@ -485,7 +485,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 1 > Count)
         {
-            Logger.Error("Attempted to read beyond the end of the stream.");
+            Logger.Debug("Attempted to read beyond the end of the stream.");
             return 0; // Возвращаем значение по умолчанию
         }
         return (sbyte)this[Pos++];
@@ -500,7 +500,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + count > Count)
         {
-            Logger.Error("Attempted to read beyond the end of the stream.");
+            Logger.Debug("Attempted to read beyond the end of the stream.");
             return []; // Возвращаем пустой массив
         }
 
@@ -520,7 +520,7 @@ public class PacketStream : ICloneable, IComparable
 
         if (Pos + count > Count)
         {
-            Logger.Error("Attempted to read beyond the end of the stream.");
+            Logger.Debug("Attempted to read beyond the end of the stream.");
             return []; // Возвращаем пустой массив
         }
 
@@ -538,7 +538,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 2 > Count)
         {
-            Logger.Error("Attempted to read beyond the end of the stream.");
+            Logger.Debug("Attempted to read beyond the end of the stream.");
             return '\0'; // Возвращаем значение по умолчанию
         }
 
@@ -557,7 +557,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 2 * count > Count)
         {
-            Logger.Error("Attempted to read beyond the end of the stream.");
+            Logger.Debug("Attempted to read beyond the end of the stream.");
             return []; // Возвращаем пустой массив
         }
 
@@ -576,7 +576,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 2 > Count)
         {
-            Logger.Error("Attempted to read beyond the end of the stream.");
+            Logger.Debug("Attempted to read beyond the end of the stream.");
             return 0; // Возвращаем значение по умолчанию
         }
 
@@ -594,7 +594,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 4 > Count)
         {
-            Logger.Error("Attempted to read beyond the end of the stream.");
+            Logger.Debug("Attempted to read beyond the end of the stream.");
             return 0; // Возвращаем значение по умолчанию
         }
 
@@ -612,7 +612,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 8 > Count)
         {
-            Logger.Error("Attempted to read beyond the end of the stream.");
+            Logger.Debug("Attempted to read beyond the end of the stream.");
             return 0; // Возвращаем значение по умолчанию
         }
 
@@ -630,7 +630,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 2 > Count)
         {
-            Logger.Error("Attempted to read beyond the end of the stream.");
+            Logger.Debug("Attempted to read beyond the end of the stream.");
             return 0; // Возвращаем значение по умолчанию
         }
 
@@ -648,7 +648,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 4 > Count)
         {
-            Logger.Error("Attempted to read beyond the end of the stream.");
+            Logger.Debug("Attempted to read beyond the end of the stream.");
             return 0; // Возвращаем значение по умолчанию
         }
 
@@ -666,7 +666,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 3 > Count)
         {
-            Logger.Error("Attempted to read beyond the end of the stream.");
+            Logger.Debug("Attempted to read beyond the end of the stream.");
             return 0; // Возвращаем значение по умолчанию
         }
 
@@ -683,7 +683,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 8 > Count)
         {
-            Logger.Error("Attempted to read beyond the end of the stream.");
+            Logger.Debug("Attempted to read beyond the end of the stream.");
             return 0; // Возвращаем значение по умолчанию
         }
 
@@ -701,7 +701,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 4 > Count)
         {
-            Logger.Error("Attempted to read beyond the end of the stream.");
+            Logger.Debug("Attempted to read beyond the end of the stream.");
             return 0; // Возвращаем значение по умолчанию
         }
 
@@ -719,7 +719,7 @@ public class PacketStream : ICloneable, IComparable
     {
         if (Pos + 8 > Count)
         {
-            Logger.Error("Attempted to read beyond the end of the stream.");
+            Logger.Debug("Attempted to read beyond the end of the stream.");
             return 0; // Возвращаем значение по умолчанию
         }
 
@@ -742,7 +742,7 @@ public class PacketStream : ICloneable, IComparable
         var i = ReadInt16();
         if (Pos + i > Count)
         {
-            Logger.Error("Attempted to read beyond the end of the stream.");
+            Logger.Debug("Attempted to read beyond the end of the stream.");
             return new PacketStream(); // Возвращаем пустой PacketStream
         }
         var newStream = new PacketStream(Buffer, Pos, i);
@@ -760,7 +760,7 @@ public class PacketStream : ICloneable, IComparable
         var i = ReadInt16();
         if (Pos + i > Count)
         {
-            Logger.Error("Attempted to read beyond the end of the stream.");
+            Logger.Debug("Attempted to read beyond the end of the stream.");
             return this; // Возвращаем текущий PacketStream
         }
         stream.Replace(Buffer, Pos, i);

--- a/AAEmu.Game/AAEmu.Game.csproj
+++ b/AAEmu.Game/AAEmu.Game.csproj
@@ -52,6 +52,9 @@
     <None Update="Configurations\Features.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Configurations\TowerDefs.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Configurations\InitialConfig.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/AAEmu.Game/Configurations/TowerDefs.json
+++ b/AAEmu.Game/Configurations/TowerDefs.json
@@ -1,0 +1,15 @@
+{
+  "TowerDefs": {
+    "GameTimeAutoArm": [
+      { "Id": 13, "Family": "Grimghast", "Variant": "Base" },
+      { "Id": 15, "Family": "Grimghast", "Variant": "Base" },
+      { "Id": 28, "Family": "Oblivion", "Variant": "Base" },
+      { "Id": 29, "Family": "Clockwork", "Variant": "Base" },
+      { "Id": 31, "Family": "Oblivion", "Variant": "Base" },
+      { "Id": 32, "Family": "Clockwork", "Variant": "Base" },
+      { "Id": 171, "Family": "Crimson", "Variant": "Expand" },
+      { "Id": 172, "Family": "Crimson", "Variant": "Expand" },
+      { "Id": 173, "Family": "Crimson", "Variant": "Expand" }
+    ]
+  }
+}

--- a/AAEmu.Game/Configurations/TowerDefs.json
+++ b/AAEmu.Game/Configurations/TowerDefs.json
@@ -1,15 +1,5 @@
 {
   "TowerDefs": {
-    "GameTimeAutoArm": [
-      { "Id": 13, "Family": "Grimghast", "Variant": "Base" },
-      { "Id": 15, "Family": "Grimghast", "Variant": "Base" },
-      { "Id": 28, "Family": "Oblivion", "Variant": "Base" },
-      { "Id": 29, "Family": "Clockwork", "Variant": "Base" },
-      { "Id": 31, "Family": "Oblivion", "Variant": "Base" },
-      { "Id": 32, "Family": "Clockwork", "Variant": "Base" },
-      { "Id": 171, "Family": "Crimson", "Variant": "Expand" },
-      { "Id": 172, "Family": "Crimson", "Variant": "Expand" },
-      { "Id": 173, "Family": "Crimson", "Variant": "Expand" }
-    ]
+    "GameTimeAutoArmIds": [13, 15, 28, 29, 31, 32, 171, 172, 173]
   }
 }

--- a/AAEmu.Game/Core/Managers/ITimeManager.cs
+++ b/AAEmu.Game/Core/Managers/ITimeManager.cs
@@ -4,6 +4,8 @@ public interface ITimeManager
 {
     float GetTime { get; }
     float Get();
+    void Start();
     void Set(float hours);
+    /// <summary>Deprecated no-op; instance ZW ToD must not drive the shared day.</summary>
     void OnZoneReport(float hours);
 }

--- a/AAEmu.Game/Core/Managers/QuestManager.cs
+++ b/AAEmu.Game/Core/Managers/QuestManager.cs
@@ -257,10 +257,15 @@ public partial class QuestManager(ITaskManager taskManager, IZoneManager zoneMan
         Logger.Info($"Loaded {_questTemplates.Count} quests");
         _loaded = true;
 
-        // Start daily reset task
-        var dailyCron = "0 0 0 */1 * *"; // Crontab
-        // TODO: Make sure it obeys server time settings
-        taskManager.CronSchedule(new QuestDailyResetTask(), dailyCron);
+        // Calendar quest resets use TaskManager's DateTime.UtcNow (GMT). Host local TZ is ignored.
+        // Daily 00:00 UTC; weekly Monday 00:00 UTC (NCrontab: Sunday=0 → Monday=1). Same boundaries as
+        // merchant daily/weekly purchase limits.
+        taskManager.CronSchedule(new QuestDailyResetTask(), "0 0 0 */1 * *");
+        taskManager.CronSchedule(new QuestWeeklyResetTask(), "0 0 0 * * 1");
+        Logger.Info(
+            "Quest calendar resets armed (UTC): daily at 00:00; weekly Mon 00:00; today={0:yyyy-MM-dd} weekStart={1:yyyy-MM-dd}",
+            Models.ServerCalendar.TodayUtc,
+            Models.ServerCalendar.WeekStartMondayUtc);
     }
 
     /// <summary>

--- a/AAEmu.Game/Core/Managers/SkillManager.cs
+++ b/AAEmu.Game/Core/Managers/SkillManager.cs
@@ -1695,7 +1695,9 @@ public class SkillManager(IAnimationManager animationManager, IPlotManager plotM
                             LifeTime = reader.GetFloat("life_time", 0f),
                             DespawnOnCreatorDeath = reader.GetBoolean("despawn_on_creator_death", true),
                             UseSummonerAggroTarget = reader.GetBoolean("use_summoner_aggro_target", true),
-                            MateStateId = (MateState)reader.GetUInt32("mate_state_id", 0)
+                            MateStateId = (MateState)reader.GetUInt32("mate_state_id", 0),
+                            // Crimson 963/969: ray-cast land under the high portal XY.
+                            EnableRayCast = reader.GetBoolean("enable_ray_cast", true)
                         };
                         _effects["SpawnEffect"][template.Id] = template;
                     }

--- a/AAEmu.Game/Core/Managers/TimeManager.cs
+++ b/AAEmu.Game/Core/Managers/TimeManager.cs
@@ -2,45 +2,212 @@ using AAEmu.Commons.Utils;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Packets.G2C;
 
+using NLog;
+
 namespace AAEmu.Game.Core.Managers;
 
 /// <summary>
-/// World's read-only view of the day cycle. Zone advances the clock and reports it through
-/// ZWTimeOfDay; World uses that same value for time-gated game rules.
+/// Shared in-game day cycle (hours 0–24) for clients, Game-Time schedules, and open-world zone seeds.
 /// </summary>
+/// <remarks>
+/// Seamless main_world dedicades do not ZW-report ToD (retail type-3 / server-type 3). World owns
+/// the shared day math and WZ-seeds only <c>main_world</c> zones. Instance maps (type 2) run a
+/// local clock: join seed noon, then ZW 0x1D/0x1E for clients currently in that zone — never
+/// rebasing this manager. Wall UTC (dailies / Server Time events) is a separate clock.
+/// </remarks>
 public class TimeManager : Singleton<TimeManager>, ITimeManager
 {
-    private const float SecondsPerDay = 86400f;
-    private float _time = 43200f;
-    private float _lastTime = 12f;
-    private float _lastRealTime = GetLocalTimeInHours();
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-    /// <summary>Current game time in hours.</summary>
-    public float GetTime => _time / 3600f;
+    /// <summary>
+    /// Default game-hours per real second (~4 real hours per 24 game hours).
+    /// </summary>
+    public const float DefaultGameHourSpeed = 0.0016666f;
+
+    /// <summary>
+    /// Retail-typical instance start hour (dungeons begin near noon then progress).
+    /// Fixed-noon places (e.g. Mirage) snap themselves via dedicate speed=0 afterward.
+    /// </summary>
+    public const float InstanceDefaultStartHour = 12.0f;
+
+    /// <summary>
+    /// Seamless open world uses the shared day; every other world template has its own ToD.
+    /// Matches dedicate server-type 3 = <c>main_world</c> only.
+    /// </summary>
+    public static bool ZoneUsesSharedGameDay(uint zoneId)
+    {
+        var world = WorldManager.Instance?.GetWorldTemplateByZoneKey(zoneId);
+        if (world == null)
+            return true;
+        return string.Equals(world.Name, "main_world", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// GM snaps and other large jumps skip world-effect cascades (doodad ToD phases overran
+    /// stack when /time set jumped many hours at once).
+    /// </summary>
+    private const float MaxWorldEffectJumpHours = 0.25f;
+
+    private const float SecondsPerDay = 86400f;
+    private const double ClientBroadcastSeconds = 10.0;
+    private const double ZoneResyncSeconds = 300.0;
+
+    private readonly object _lock = new();
+    private bool _started;
+    private float _time; // game-day seconds [0, 86400)
+    private float _lastTimeHours = float.NaN;
+    private float _lastRealTimeHours;
+    private DateTime _lastTickUtc = DateTime.UtcNow;
+    private DateTime _lastClientBroadcastUtc = DateTime.MinValue;
+    private DateTime _lastZonePushUtc = DateTime.MinValue;
+
+    /// <summary>Current game time in hours [0,24).</summary>
+    public float GetTime
+    {
+        get { lock (_lock) return _time / 3600f; }
+    }
 
     public float Get()
     {
-        return _time;
+        lock (_lock)
+            return _time;
     }
 
-    /// <summary>Requests every loaded Zone to move its authoritative clock.</summary>
+    /// <summary>
+    /// Arms the shared day clock from wall epoch and starts 1 Hz integration.
+    /// Safe to call once after TickManager is running.
+    /// </summary>
+    public void Start()
+    {
+        lock (_lock)
+        {
+            if (_started)
+                return;
+            _started = true;
+
+            var hours = NormalizeHour(
+                (float)((DateTime.UtcNow - DateTime.UnixEpoch).TotalSeconds * DefaultGameHourSpeed % 24.0));
+            _time = hours * 3600f;
+            _lastTimeHours = hours;
+            _lastRealTimeHours = GetUtcWallHours();
+            _lastTickUtc = DateTime.UtcNow;
+            _lastZonePushUtc = DateTime.UtcNow;
+        }
+
+        TickManager.Instance.OnTick.Subscribe(Tick, TimeSpan.FromSeconds(1), true);
+        Logger.Info(
+            "Game day clock started — hour={0:F2} speed={1} (~{2:F1} real-h per 24 game-h)",
+            GetTime,
+            DefaultGameHourSpeed,
+            24f / DefaultGameHourSpeed / 3600f);
+    }
+
+    /// <summary>Snaps the shared clock (GM /force) and pushes every loaded Zone + clients.</summary>
     public void Set(float hours)
     {
-        WorldIntegration.RelayTimeOfDayToZones?.Invoke(NormalizeHour(hours));
+        float oldHours;
+        float newHours;
+        float oldReal;
+        float newReal;
+        lock (_lock)
+        {
+            oldHours = float.IsNaN(_lastTimeHours) ? NormalizeHour(hours) : _lastTimeHours;
+            oldReal = _lastRealTimeHours;
+            newHours = NormalizeHour(hours);
+            _time = newHours * 3600f;
+            if (_time >= SecondsPerDay)
+                _time -= SecondsPerDay;
+            newReal = GetUtcWallHours();
+            _lastTimeHours = newHours;
+            _lastRealTimeHours = newReal;
+            _lastTickUtc = DateTime.UtcNow;
+            _lastClientBroadcastUtc = DateTime.UtcNow;
+            _lastZonePushUtc = DateTime.UtcNow;
+        }
+
+        WorldIntegration.RelayTimeOfDayToZones?.Invoke(newHours);
+        BroadcastClients(newHours);
+        // Large snaps skip doodad phase walks (crash); Game-Time tower cross still arms.
+        OnTimeOfDayChange(newHours, oldHours, newReal, oldReal, allowWorldEffects: true);
+        Logger.Info("Game day set {0:F2}h → {1:F2}h (zones+clients pushed)", oldHours, newHours);
     }
 
-    /// <summary>Consumes the hour reported by an authoritative Zone.</summary>
+    /// <summary>
+    /// No-op. Instance / type-2 ZW ToD must not rebase the shared open-world day.
+    /// Kept on the interface so older hooks compile; clients get SC from zone-scoped relay only.
+    /// </summary>
     public void OnZoneReport(float hours)
     {
-        var time = NormalizeHour(hours);
-        var realTime = GetLocalTimeInHours();
-        _time = time * 3600f;
-        if (_time >= SecondsPerDay)
-            _time -= SecondsPerDay;
+        // Intentionally empty — see remarks on class.
+    }
 
-        OnTimeOfDayChange(time, _lastTime, realTime, _lastRealTime);
-        _lastTime = time;
-        _lastRealTime = realTime;
+    private void Tick(TimeSpan _)
+    {
+        float oldHours;
+        float newHours;
+        float oldReal;
+        float newReal;
+        var pushZones = false;
+        var pushClients = false;
+
+        lock (_lock)
+        {
+            if (!_started)
+                return;
+
+            var now = DateTime.UtcNow;
+            var dt = (float)(now - _lastTickUtc).TotalSeconds;
+            _lastTickUtc = now;
+            if (dt <= 0f)
+                return;
+            if (dt > 30f)
+                dt = 1f;
+
+            oldHours = float.IsNaN(_lastTimeHours) ? _time / 3600f : _lastTimeHours;
+            oldReal = _lastRealTimeHours;
+
+            var nextHours = NormalizeHour(oldHours + dt * DefaultGameHourSpeed);
+            _time = nextHours * 3600f;
+            if (_time >= SecondsPerDay)
+                _time -= SecondsPerDay;
+
+            newHours = nextHours;
+            newReal = GetUtcWallHours();
+            _lastTimeHours = newHours;
+            _lastRealTimeHours = newReal;
+
+            if ((now - _lastClientBroadcastUtc).TotalSeconds >= ClientBroadcastSeconds)
+            {
+                _lastClientBroadcastUtc = now;
+                pushClients = true;
+            }
+
+            if ((now - _lastZonePushUtc).TotalSeconds >= ZoneResyncSeconds)
+            {
+                _lastZonePushUtc = now;
+                pushZones = true;
+            }
+        }
+
+        OnTimeOfDayChange(newHours, oldHours, newReal, oldReal, allowWorldEffects: true);
+
+        if (pushClients)
+            BroadcastClients(newHours);
+
+        if (pushZones)
+            WorldIntegration.RelayTimeOfDayToZones?.Invoke(newHours);
+    }
+
+    private static void BroadcastClients(float hour)
+    {
+        // Open-world day only — players inside instances keep their map-local SC from ZW ToD.
+        WorldIntegration.ForEachReadyConnection((connection, character) =>
+        {
+            if (character?.Transform == null || !ZoneUsesSharedGameDay(character.Transform.ZoneId))
+                return;
+            connection.SendPacket(new SCDetailedTimeOfDayPacket(
+                hour, DefaultGameHourSpeed, 0f, 24f));
+        });
     }
 
     private static float NormalizeHour(float hours)
@@ -49,9 +216,18 @@ public class TimeManager : Singleton<TimeManager>, ITimeManager
         return time < 0f ? time + 24f : time;
     }
 
-    private static float GetLocalTimeInHours()
+    /// <summary>Forward distance on the 24h circle from old → new.</summary>
+    private static float ForwardHourDelta(float oldHours, float newHours)
     {
-        return (float)DateTime.Now.TimeOfDay.TotalHours;
+        var d = NormalizeHour(newHours) - NormalizeHour(oldHours);
+        if (d < 0f)
+            d += 24f;
+        return d;
+    }
+
+    private static float GetUtcWallHours()
+    {
+        return (float)DateTime.UtcNow.TimeOfDay.TotalHours;
     }
 
     private static bool CrossedTime(float oldTime, float newTime, float triggerTime)
@@ -59,18 +235,60 @@ public class TimeManager : Singleton<TimeManager>, ITimeManager
         if (oldTime <= newTime)
             return oldTime < triggerTime && triggerTime <= newTime;
 
-        // The selected clock wrapped through midnight.
         return oldTime < triggerTime || triggerTime <= newTime;
     }
 
-    /// <summary>Applies World-owned rules whose gates depend on Zone game time or server wall time.</summary>
-    private static void OnTimeOfDayChange(float newTime, float oldTime, float newRealTime, float oldRealTime)
+    private static void OnTimeOfDayChange(
+        float newTime,
+        float oldTime,
+        float newRealTime,
+        float oldRealTime,
+        bool allowWorldEffects)
     {
-        if ((int)Math.Floor(newTime * 600f) == (int)Math.Floor(oldTime * 600f)
-            && (int)Math.Floor(newRealTime * 600f) == (int)Math.Floor(oldRealTime * 600f))
+        var gameBucketChanged = (int)Math.Floor(newTime * 600f) != (int)Math.Floor(oldTime * 600f);
+        var wallBucketChanged = (int)Math.Floor(newRealTime * 600f) != (int)Math.Floor(oldRealTime * 600f);
+        if (!gameBucketChanged && !wallBucketChanged)
             return;
 
-        foreach (var world in WorldManager.Instance.GetWorlds())
+        var jump = ForwardHourDelta(oldTime, newTime);
+        var largeJump = jump > MaxWorldEffectJumpHours;
+
+        if (!allowWorldEffects)
+            return;
+
+        // Large GM snaps: do NOT cascade every tower between old and new (Grimghast+noon
+        // Crimson+Oblivion at once from wrap math). Still arm events whose ToD sits in a short
+        // trail behind the *landing* hour — so `/time set 0 5` from afternoon starts Grimghast
+        // without faking a 12 h continuous advance. Doodad ToD phases stay skipped on large jumps.
+        if (largeJump)
+        {
+            if (gameBucketChanged)
+            {
+                var windowOld = NormalizeHour(newTime - MaxWorldEffectJumpHours + 0.001f);
+                Logger.Warn(
+                    "ToD jump {0:F2}→{1:F2} (forward Δ={2:F2}h) — skip doodad cascade; " +
+                    "Game-Time arms only for landing window {3:F2}→{1:F2}",
+                    oldTime, newTime, jump, windowOld);
+                WorldIntegration.OnGameTimeAdvanced?.Invoke(windowOld, newTime);
+            }
+            else
+            {
+                Logger.Warn(
+                    "ToD jump {0:F2}→{1:F2} (forward Δ={2:F2}h) — skip Game-Time tower arms and doodad cascade",
+                    oldTime, newTime, jump);
+            }
+
+            return;
+        }
+
+        if (gameBucketChanged)
+            WorldIntegration.OnGameTimeAdvanced?.Invoke(oldTime, newTime);
+
+        var worlds = WorldManager.Instance?.GetWorlds();
+        if (worlds == null)
+            return;
+
+        foreach (var world in worlds)
         {
             foreach (var npc in world.GetAllNpcs())
             {
@@ -91,7 +309,6 @@ public class TimeManager : Singleton<TimeManager>, ITimeManager
                 if (doodad.CurrentToDTriggers.Count <= 0)
                     continue;
 
-                // A phase change replaces this collection, so iterate over a snapshot.
                 foreach (var trigger in doodad.CurrentToDTriggers.ToArray())
                 {
                     if (trigger.NextPhase <= 0)
@@ -102,9 +319,16 @@ public class TimeManager : Singleton<TimeManager>, ITimeManager
                     if (!CrossedTime(triggerOldTime, triggerNewTime, trigger.TodAsHours))
                         continue;
 
-                    // DoChangePhase executes target phase functions and relays the phase to Zone
-                    // before broadcasting the final client state.
-                    doodad.DoChangePhase(null, trigger.NextPhase);
+                    try
+                    {
+                        doodad.DoChangePhase(null, trigger.NextPhase);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error(ex, "ToD phase change failed doodad={0} → phase {1}",
+                            doodad.ObjId, trigger.NextPhase);
+                    }
+
                     break;
                 }
             }

--- a/AAEmu.Game/Core/Managers/TimeManager.cs
+++ b/AAEmu.Game/Core/Managers/TimeManager.cs
@@ -1,6 +1,7 @@
 using AAEmu.Commons.Utils;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.World;
 
 using NLog;
 
@@ -10,10 +11,10 @@ namespace AAEmu.Game.Core.Managers;
 /// Shared in-game day cycle (hours 0–24) for clients, Game-Time schedules, and open-world zone seeds.
 /// </summary>
 /// <remarks>
-/// Seamless main_world dedicades do not ZW-report ToD (retail type-3 / server-type 3). World owns
-/// the shared day math and WZ-seeds only <c>main_world</c> zones. Instance maps (type 2) run a
-/// local clock: join seed noon, then ZW 0x1D/0x1E for clients currently in that zone — never
-/// rebasing this manager. Wall UTC (dailies / Server Time events) is a separate clock.
+/// Seamless open-world dedicades do not report ToD. World owns the shared day math and seeds only
+/// zones that belong to the default world template. Other world templates keep a local clock
+/// (join seed noon, then zone reports for clients in that instance) and must not rebase this manager.
+/// Wall UTC (dailies / Server Time events) is a separate clock.
 /// </remarks>
 public class TimeManager : Singleton<TimeManager>, ITimeManager
 {
@@ -25,28 +26,42 @@ public class TimeManager : Singleton<TimeManager>, ITimeManager
     public const float DefaultGameHourSpeed = 0.0016666f;
 
     /// <summary>
-    /// Retail-typical instance start hour (dungeons begin near noon then progress).
-    /// Fixed-noon places (e.g. Mirage) snap themselves via dedicate speed=0 afterward.
+    /// Typical instance start hour (dungeons begin near noon then progress).
+    /// Fixed-noon places snap themselves via dedicate speed=0 afterward.
     /// </summary>
     public const float InstanceDefaultStartHour = 12.0f;
 
     /// <summary>
-    /// Seamless open world uses the shared day; every other world template has its own ToD.
-    /// Matches dedicate server-type 3 = <c>main_world</c> only.
+    /// Max forward game-hours allowed in one tick before world-effect cascades and Game-Time
+    /// tower arms are skipped. Shared by <c>TowerDefScheduler</c>.
+    /// </summary>
+    public const float MaxWorldEffectJumpHours = 0.25f;
+
+    /// <summary>
+    /// Shared game-day is owned by the default (open-world) world template.
+    /// Unknown or not-yet-loaded zones fail closed (instance-local clock).
     /// </summary>
     public static bool ZoneUsesSharedGameDay(uint zoneId)
     {
         var world = WorldManager.Instance?.GetWorldTemplateByZoneKey(zoneId);
-        if (world == null)
-            return true;
-        return string.Equals(world.Name, "main_world", StringComparison.OrdinalIgnoreCase);
+        return UsesSharedGameDay(world, WorldManager.DefaultWorldTemplateId);
     }
 
     /// <summary>
-    /// GM snaps and other large jumps skip world-effect cascades (doodad ToD phases overran
-    /// stack when /time set jumped many hours at once).
+    /// True only for the default world template. Instance worlds and a missing lookup fail closed.
     /// </summary>
-    private const float MaxWorldEffectJumpHours = 0.25f;
+    public static bool UsesSharedGameDay(WorldTemplate world, uint defaultWorldTemplateId)
+    {
+        if (world == null)
+            return false;
+        if (world.XmlWorld is { IsInstance: > 0 })
+            return false;
+        return world.Id == defaultWorldTemplateId;
+    }
+
+    /// <summary>True when the forward 24h-circle delta exceeds <see cref="MaxWorldEffectJumpHours"/>.</summary>
+    public static bool IsLargeGameHourJump(float oldHours, float newHours) =>
+        ForwardHourDelta(oldHours, newHours) > MaxWorldEffectJumpHours;
 
     private const float SecondsPerDay = 86400f;
     private const double ClientBroadcastSeconds = 10.0;
@@ -251,15 +266,13 @@ public class TimeManager : Singleton<TimeManager>, ITimeManager
             return;
 
         var jump = ForwardHourDelta(oldTime, newTime);
-        var largeJump = jump > MaxWorldEffectJumpHours;
+        var largeJump = IsLargeGameHourJump(oldTime, newTime);
 
         if (!allowWorldEffects)
             return;
 
-        // Large GM snaps: do NOT cascade every tower between old and new (Grimghast+noon
-        // Crimson+Oblivion at once from wrap math). Still arm events whose ToD sits in a short
-        // trail behind the *landing* hour — so `/time set 0 5` from afternoon starts Grimghast
-        // without faking a 12 h continuous advance. Doodad ToD phases stay skipped on large jumps.
+        // Large snaps skip doodad ToD cascades. Game-Time arms use a short landing window so a
+        // GM hour set does not fire every crossing between the old and new hour.
         if (largeJump)
         {
             if (gameBucketChanged)

--- a/AAEmu.Game/Core/Managers/TodayAssignmentManager.cs
+++ b/AAEmu.Game/Core/Managers/TodayAssignmentManager.cs
@@ -3,6 +3,8 @@ using AAEmu.Commons.Utils;
 using AAEmu.Commons.Utils.DB;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.GameData;
+using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.Models;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Items;
@@ -46,8 +48,8 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
     private readonly Dictionary<uint, HashSet<uint>> _lifetimeUnlocks = [];
 
     /// <summary>
-    /// Characters loaded for a specific local calendar day. If the day changes while online,
-    /// EnsureLoaded reloads so assignment/reroll state does not carry across midnight.
+    /// Characters loaded for a specific <b>UTC</b> calendar day. If the day changes while online,
+    /// EnsureLoaded reloads so assignment/reroll state does not carry past 00:00 UTC.
     /// </summary>
     private readonly Dictionary<uint, DateTime> _loadedDay = [];
 
@@ -60,7 +62,8 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
         public TodayAssignmentStatus Status { get; set; }
     }
 
-    private static DateTime TodayKey => DateTime.Today;
+    /// <summary>day_key / in-memory calendar day — always World UTC date (GMT).</summary>
+    private static DateTime TodayKey => ServerCalendar.TodayUtc;
 
     private static bool IsPaidStep(TodayQuestStepTemplate step)
         => step != null && step.ItemId != 0 && step.ItemNum > 0;
@@ -72,6 +75,29 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
 
         var used = _resetsUsed.GetValueOrDefault(character.Id, 0u);
         character.SendPacket(new SCTodayAssignmentResetCountPacket(used, PersonalResetCountType));
+    }
+
+    /// <summary>
+    /// 00:00 UTC day edge (same cron as <c>QuestDailyResetTask</c>). Forces online players through
+    /// day rollover even if they do not touch the daily-schedule UI.
+    /// Restart-safe: next fire is absolute UTC; no local host midnight.
+    /// </summary>
+    public void OnServerDailyReset()
+    {
+        var today = TodayKey;
+        Logger.Info("TodayAssignment server daily reset (UTC day {0:yyyy-MM-dd})", today);
+
+        foreach (var character in WorldManager.Instance.GetAllCharacters())
+        {
+            // Force EnsureLoaded's rollover path when memory still holds yesterday.
+            if (_loadedDay.TryGetValue(character.Id, out var loaded) && loaded == today)
+            {
+                // Already reloaded for this UTC day (e.g. packet right after midnight).
+                continue;
+            }
+
+            EnsureLoaded(character);
+        }
     }
 
     /// <summary>

--- a/AAEmu.Game/Core/Managers/World/SphereQuestManager.cs
+++ b/AAEmu.Game/Core/Managers/World/SphereQuestManager.cs
@@ -2,6 +2,7 @@
 using System.Numerics;
 using AAEmu.Game.GameData;
 using AAEmu.Game.IO;
+using AAEmu.Game.Models;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Quests;
 using AAEmu.Game.Models.Game.Quests.Acts;
@@ -443,7 +444,7 @@ public class SphereQuestManager(WorldInstance parent) : ISphereQuestManager
         var worldLevelDesignDir = Path.Combine("game", "worlds", worldTemplate.Name, "level_design", "zone");
         var pathFiles = ClientFileManager.GetFilesInDirectory(worldLevelDesignDir, "quest_area_sphere.g", true);
 
-        // ClientData/pak may omit loose zone trees; also scan ZoneGameDataRoot / Server game.
+        // ClientData/pak may omit loose zone trees; also scan the configured ZoneGameDataRoot.
         foreach (var extra in EnumerateLooseQuestAreaSphereFiles(worldTemplate.Name))
         {
             if (!pathFiles.Contains(extra, StringComparer.OrdinalIgnoreCase))
@@ -586,8 +587,14 @@ public class SphereQuestManager(WorldInstance parent) : ISphereQuestManager
         }
 
         Offer(Environment.GetEnvironmentVariable("AAEMU_ZONE_GAME_DATA_ROOT"));
-        // World always uses Server/game (same tree dedic.bat loads). Never client\game.
-        Offer(@"G:\AAchina\Server\game");
+        Offer(AppConfiguration.Instance.ZoneGameDataRoot);
+        if (seen.Count == 0)
+        {
+            Logger.Error(
+                "ZoneGameDataRoot is not configured. Set World Config.ZoneGameDataRoot or AAEMU_ZONE_GAME_DATA_ROOT " +
+                "so quest_area_sphere.g can load from the extracted game data tree.");
+        }
+
         return seen;
     }
 

--- a/AAEmu.Game/Core/Managers/World/WorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/WorldManager.cs
@@ -347,6 +347,8 @@ public class WorldManager(
     {
         tickManager.OnTick.Subscribe(ActiveRegionTick, TimeSpan.FromSeconds(1));
         tickManager.OnTick.Subscribe(AutoWaterProbeTick, TimeSpan.FromSeconds(10));
+        // Shared game-day clock (seamless zones do not ZW-report ToD).
+        TimeManager.Instance.Start();
     }
 
     private static readonly Lock AutoWaterProbeLock = new();

--- a/AAEmu.Game/Core/Managers/World/ZoneCoordBoundary.cs
+++ b/AAEmu.Game/Core/Managers/World/ZoneCoordBoundary.cs
@@ -7,23 +7,27 @@ using NLog;
 namespace AAEmu.Game.Core.Managers.World;
 
 /// <summary>
-/// Converts unit positions at the World/Zone boundary when zone-local placement is enabled.
-/// The conversion is opt-in because world-space placement remains the default.
+/// Optional World-side unit-space remapping at the zone TCP boundary.
+/// Spawner geometry packets (Activate circle, ZWSpawnNpc parse) always use zone-local convert;
+/// this flag only affects WZ unit Create/move bodies — leave it off unless reproducing a local-space
+/// unit wire layout.
 /// </summary>
 public static class ZoneCoordBoundary
 {
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
     /// <summary>
-    /// When true: WZ placement + WZUnitMovement are zone-local; ZWUnitMovements convert local→world
-    /// for SC. Default <c>false</c> (world-on-wire). Set <c>AAEMU_WZ_UNIT_POS_LOCAL=1</c> to experiment.
+    /// When true, World rewrites WZ unit placement + moves into zone-local and ZW moves into world.
+    /// Default <c>false</c>: World sends/receives world coords on WZNpcState/WZUnitState/movements.
+    /// Force-local can double-subtract zone origin and place units off-mesh. Opt-in:
+    /// <c>AAEMU_WZ_UNIT_POS_LOCAL=1</c>. Kill with <c>WORLD=1</c> / <c>LOCAL=0</c>. Never flip mid-session.
     /// </summary>
     public static bool UseLocalOnZoneWire { get; } = ResolveUseLocalOnZoneWire();
 
     static ZoneCoordBoundary()
     {
         Logger.Info(
-            "ZoneCoordBoundary: UseLocalOnZoneWire={0} (opt-in LOCAL=1; kill WORLD=1 / LOCAL=0)",
+            "ZoneCoordBoundary: UseLocalOnZoneWire={0} (default world-on-wire; LOCAL=1 only for regression repro)",
             UseLocalOnZoneWire);
     }
 
@@ -33,7 +37,7 @@ public static class ZoneCoordBoundary
             return false;
         if (IsEnv("AAEMU_WZ_UNIT_POS_LOCAL", "0"))
             return false;
-        // Keep the conversion opt-in; world-space placement is the default.
+        // Opt-in only — default is world coordinates on unit wire.
         return IsEnv("AAEMU_WZ_UNIT_POS_LOCAL", "1");
     }
 

--- a/AAEmu.Game/Core/Network/Game/GameProtocolHandler.cs
+++ b/AAEmu.Game/Core/Network/Game/GameProtocolHandler.cs
@@ -2,7 +2,6 @@ using System.Collections.Concurrent;
 using System.Text;
 
 using AAEmu.Commons.Cryptography;
-using AAEmu.Commons.Exceptions;
 using AAEmu.Commons.Network;
 using AAEmu.Commons.Network.Core;
 using AAEmu.Game.Core.Managers.World;
@@ -129,38 +128,26 @@ public class GameProtocolHandler : BaseProtocolHandler
                 connection.LastPacket = null;
             }
             stream.Insert(stream.Count, buf, offset, bytes);
-            while (stream is { Count: > 0 })
+            PacketStream? pending = stream;
+            while (pending is { Count: > 0 })
             {
-                ushort len;
-                try
+                PacketStream stream2;
+                int packetLen;
+                switch (LengthPrefixedFrames.TryTake(ref pending, LengthPrefixedFrames.MinOpcodePayloadBytes, out var frame))
                 {
-                    len = stream.ReadUInt16();
-                }
-                catch (MarshalException)
-                {
-                    //Logger.Warn("Error on reading type {0}", type);
-                    stream.Rollback();
-                    connection.LastPacket = stream;
-                    stream = null;
-                    continue;
-                }
-                var packetLen = len + stream.Pos;
-                if (packetLen <= stream.Count)
-                {
-                    stream.Rollback();
-                    var stream2 = new PacketStream();
-                    stream2.Replace(stream, 0, packetLen);
-                    if (stream.Count > packetLen)
+                    case LengthPrefixedFrameResult.NeedMore:
+                        connection.LastPacket = pending;
+                        return;
+                    case LengthPrefixedFrameResult.DroppedInvalidLength:
+                        Logger.Warn("Dropped invalid CS frame from {0}", connection.Ip);
+                        continue;
+                    case LengthPrefixedFrameResult.GotFrame:
                     {
-                        var stream3 = new PacketStream();
-                        stream3.Replace(stream, packetLen, stream.Count - packetLen);
-                        stream = stream3;
-                    }
-                    else
-                        stream = null;
-                    stream2.ReadUInt16(); //len
-                    stream2.ReadByte(); //unk
-                    var level = stream2.ReadByte();
+                        stream2 = frame!;
+                        packetLen = stream2.Count;
+                        stream2.ReadUInt16(); //len
+                        stream2.ReadByte(); //unk
+                        var level = stream2.ReadByte();
 
                     //byte crc = 0;
                     //byte counter = 0;
@@ -231,12 +218,9 @@ public class GameProtocolHandler : BaseProtocolHandler
                             Logger.Warn("C2S dispatch of 0x{0:X3} ({1}) threw: {2}", type, classType.Name, ex.Message);
                         }
                     }
-                }
-                else
-                {
-                    stream.Rollback();
-                    connection.LastPacket = stream;
-                    stream = null;
+
+                        break;
+                    }
                 }
             }
         }

--- a/AAEmu.Game/Core/Network/Login/LoginNetwork.cs
+++ b/AAEmu.Game/Core/Network/Login/LoginNetwork.cs
@@ -4,15 +4,18 @@ using AAEmu.Commons.Utils;
 using AAEmu.Game.Core.Network.Connections;
 using AAEmu.Game.Core.Packets.L2G;
 using AAEmu.Game.Models;
+using NLog;
 
 namespace AAEmu.Game.Core.Network.Login;
 
 public class LoginNetwork : Singleton<LoginNetwork>
 {
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
     private Client _client;
     private readonly LoginProtocolHandler _handler;
     private LoginConnection _connection;
     private volatile bool _running;
+    private int _reconnectEpoch;
 
     /// <summary>
     /// True between <see cref="Start"/> and <see cref="Stop"/>. A disconnect while running triggers a
@@ -34,17 +37,122 @@ public class LoginNetwork : Singleton<LoginNetwork>
 
     public void Start()
     {
-        var config = AppConfiguration.Instance.LoginNetwork;
-        _client = new Client(Dns.GetHostAddresses(config.Host).First(), config.Port, _handler);
-        _running = true;
-        _client.ConnectAsync();
+        BeginConnect(expectedEpoch: null);
     }
 
     public void Stop()
     {
         _running = false;
-        if (_client?.IsConnected ?? false)
-            _client.DisconnectAsync();
+        Interlocked.Increment(ref _reconnectEpoch);
+        var client = _client;
+        _client = null;
+        SafeDisconnect(client);
+    }
+
+    /// <summary>
+    /// Reconnect after a short delay. Cancelled if <see cref="Stop"/> runs during the wait
+    /// (shutdown) or if another reconnect is already scheduled.
+    /// </summary>
+    public void RequestReconnect()
+    {
+        if (!_running)
+            return;
+
+        Stop();
+        var epoch = Volatile.Read(ref _reconnectEpoch);
+        _ = ReconnectAfterAsync(epoch);
+    }
+
+    private async Task ReconnectAfterAsync(int epoch)
+    {
+        while (Volatile.Read(ref _reconnectEpoch) == epoch)
+        {
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+                if (Volatile.Read(ref _reconnectEpoch) != epoch)
+                    return;
+                BeginConnect(epoch);
+                if (Volatile.Read(ref _reconnectEpoch) != epoch)
+                {
+                    _running = false;
+                    var client = _client;
+                    _client = null;
+                    SafeDisconnect(client);
+                    return;
+                }
+
+                return;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Login reconnect after disconnect failed");
+                _running = false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// DNS + connect. When <paramref name="expectedEpoch"/> is set, abort if <see cref="Stop"/> ran
+    /// during the wait (including while DNS is in flight or the socket is still connecting).
+    /// </summary>
+    private void BeginConnect(int? expectedEpoch)
+    {
+        if (EpochMismatch(expectedEpoch))
+            return;
+
+        var config = AppConfiguration.Instance.LoginNetwork;
+        var address = Dns.GetHostAddresses(config.Host).First();
+        if (EpochMismatch(expectedEpoch))
+            return;
+
+        var client = new Client(address, config.Port, _handler);
+        if (EpochMismatch(expectedEpoch))
+        {
+            SafeDisconnect(client);
+            return;
+        }
+
+        var previous = _client;
+        _client = client;
+        _running = true;
+        SafeDisconnect(previous);
+
+        if (EpochMismatch(expectedEpoch))
+        {
+            AbandonConnect(client);
+            return;
+        }
+
+        client.ConnectAsync();
+
+        if (EpochMismatch(expectedEpoch))
+            AbandonConnect(client);
+    }
+
+    private void AbandonConnect(Client client)
+    {
+        _running = false;
+        if (ReferenceEquals(_client, client))
+            _client = null;
+        SafeDisconnect(client);
+    }
+
+    private bool EpochMismatch(int? expectedEpoch) =>
+        expectedEpoch is int epoch && Volatile.Read(ref _reconnectEpoch) != epoch;
+
+    private static void SafeDisconnect(Client client)
+    {
+        if (client == null)
+            return;
+        try
+        {
+            client.DisconnectAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn(ex, "Login client disconnect failed");
+        }
     }
 
     public void SetConnection(LoginConnection con)

--- a/AAEmu.Game/Core/Network/Login/LoginNetwork.cs
+++ b/AAEmu.Game/Core/Network/Login/LoginNetwork.cs
@@ -14,16 +14,17 @@ public class LoginNetwork : Singleton<LoginNetwork>
     private Client _client;
     private readonly LoginProtocolHandler _handler;
     private LoginConnection _connection;
-    private volatile bool _running;
+    /// <summary>True after <see cref="Start"/> until intentional <see cref="Stop"/> (process shutdown).</summary>
+    private volatile bool _wantLink;
     private int _reconnectEpoch;
 
     /// <summary>
-    /// True between <see cref="Start"/> and <see cref="Stop"/>. A disconnect while running triggers a
-    /// reconnect; a disconnect after an intentional <see cref="Stop"/> (server shutdown) must not, since
-    /// the DI <see cref="System.IServiceProvider"/> backing <see cref="AppConfiguration.Instance"/> is
-    /// already disposed by the time the async disconnect callback fires.
+    /// True while the game server intends to stay linked to Login. Disconnect while wanted triggers
+    /// reconnect; disconnect after intentional <see cref="Stop"/> must not, since the DI
+    /// <see cref="System.IServiceProvider"/> backing <see cref="AppConfiguration.Instance"/> may
+    /// already be disposed when the async disconnect callback fires.
     /// </summary>
-    public bool IsRunning => _running;
+    public bool IsRunning => _wantLink;
 
     private LoginNetwork()
     {
@@ -37,77 +38,92 @@ public class LoginNetwork : Singleton<LoginNetwork>
 
     public void Start()
     {
+        _wantLink = true;
         BeginConnect(expectedEpoch: null);
     }
 
     public void Stop()
     {
-        _running = false;
+        _wantLink = false;
         Interlocked.Increment(ref _reconnectEpoch);
         var client = _client;
         _client = null;
+        _connection = null;
         SafeDisconnect(client);
     }
 
     /// <summary>
-    /// Reconnect after a short delay. Cancelled if <see cref="Stop"/> runs during the wait
-    /// (shutdown) or if another reconnect is already scheduled.
+    /// Tear down the current socket and reconnect after a short delay. Cancelled if <see cref="Stop"/>
+    /// runs (shutdown) or another reconnect is already scheduled.
     /// </summary>
     public void RequestReconnect()
     {
-        if (!_running)
+        if (!_wantLink)
             return;
 
-        Stop();
+        Interlocked.Increment(ref _reconnectEpoch);
         var epoch = Volatile.Read(ref _reconnectEpoch);
+        var client = _client;
+        _client = null;
+        _connection = null;
+        SafeDisconnect(client);
         _ = ReconnectAfterAsync(epoch);
     }
 
     private async Task ReconnectAfterAsync(int epoch)
     {
-        while (Volatile.Read(ref _reconnectEpoch) == epoch)
+        while (_wantLink && Volatile.Read(ref _reconnectEpoch) == epoch)
         {
             try
             {
                 await Task.Delay(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
-                if (Volatile.Read(ref _reconnectEpoch) != epoch)
+                if (!_wantLink || Volatile.Read(ref _reconnectEpoch) != epoch)
                     return;
+
                 BeginConnect(epoch);
-                if (Volatile.Read(ref _reconnectEpoch) != epoch)
+                if (!_wantLink || Volatile.Read(ref _reconnectEpoch) != epoch)
                 {
-                    _running = false;
-                    var client = _client;
-                    _client = null;
-                    SafeDisconnect(client);
+                    TearDownSocket();
                     return;
                 }
 
-                return;
+                // ConnectAsync is fire-and-forget; wait for OnConnect or time out and retry.
+                for (var i = 0; i < 20; i++)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(250)).ConfigureAwait(false);
+                    if (!_wantLink || Volatile.Read(ref _reconnectEpoch) != epoch)
+                        return;
+                    if (_connection != null && (_client?.IsConnected ?? false))
+                        return;
+                }
+
+                Logger.Warn("Login reconnect timed out waiting for link; retrying");
+                TearDownSocket();
             }
             catch (Exception ex)
             {
                 Logger.Error(ex, "Login reconnect after disconnect failed");
-                _running = false;
+                TearDownSocket();
             }
         }
     }
 
     /// <summary>
-    /// DNS + connect. When <paramref name="expectedEpoch"/> is set, abort if <see cref="Stop"/> ran
-    /// during the wait (including while DNS is in flight or the socket is still connecting).
+    /// DNS + connect. When <paramref name="expectedEpoch"/> is set, abort if <see cref="Stop"/> or a
+    /// newer reconnect ran during the wait (including while DNS is in flight).
     /// </summary>
     private void BeginConnect(int? expectedEpoch)
     {
-        if (EpochMismatch(expectedEpoch))
+        if (ShouldAbort(expectedEpoch))
             return;
 
         var config = AppConfiguration.Instance.LoginNetwork;
         var address = Dns.GetHostAddresses(config.Host).First();
-        if (EpochMismatch(expectedEpoch))
+        if (ShouldAbort(expectedEpoch))
             return;
 
         var client = new Client(address, config.Port, _handler);
-        if (EpochMismatch(expectedEpoch))
+        if (ShouldAbort(expectedEpoch))
         {
             SafeDisconnect(client);
             return;
@@ -115,10 +131,9 @@ public class LoginNetwork : Singleton<LoginNetwork>
 
         var previous = _client;
         _client = client;
-        _running = true;
         SafeDisconnect(previous);
 
-        if (EpochMismatch(expectedEpoch))
+        if (ShouldAbort(expectedEpoch))
         {
             AbandonConnect(client);
             return;
@@ -126,20 +141,27 @@ public class LoginNetwork : Singleton<LoginNetwork>
 
         client.ConnectAsync();
 
-        if (EpochMismatch(expectedEpoch))
+        if (ShouldAbort(expectedEpoch))
             AbandonConnect(client);
     }
 
     private void AbandonConnect(Client client)
     {
-        _running = false;
         if (ReferenceEquals(_client, client))
             _client = null;
         SafeDisconnect(client);
     }
 
-    private bool EpochMismatch(int? expectedEpoch) =>
-        expectedEpoch is int epoch && Volatile.Read(ref _reconnectEpoch) != epoch;
+    private void TearDownSocket()
+    {
+        var client = _client;
+        _client = null;
+        _connection = null;
+        SafeDisconnect(client);
+    }
+
+    private bool ShouldAbort(int? expectedEpoch) =>
+        !_wantLink || (expectedEpoch is int epoch && Volatile.Read(ref _reconnectEpoch) != epoch);
 
     private static void SafeDisconnect(Client client)
     {

--- a/AAEmu.Game/Core/Network/Login/LoginProtocolHandler.cs
+++ b/AAEmu.Game/Core/Network/Login/LoginProtocolHandler.cs
@@ -20,11 +20,13 @@ public class LoginProtocolHandler : BaseProtocolHandler
 
     public override void OnConnect(ISession session)
     {
-        _lastPacket = null;
+        // Do not clear _lastPacket here: a rare race can deliver a complete frame before
+        // SetConnection publishes; deferral must survive until the body can be decoded.
         Logger.Info("Connect to {0} established, session id: {1}", session.Ip.ToString(), session.SessionId.ToString(CultureInfo.InvariantCulture));
         var con = new LoginConnection(session);
-        con.OnConnect();
+        session.AddAttribute("LoginConnection", con);
         LoginNetwork.Instance.SetConnection(con);
+        con.OnConnect();
 
         _loadTask = new LoadTask();
         TaskManager.Instance.Schedule(_loadTask, null, TimeSpan.FromMinutes(1));
@@ -34,6 +36,7 @@ public class LoginProtocolHandler : BaseProtocolHandler
     {
         _lastPacket = null;
         Logger.Info("Connection to LoginServer has been lost");
+        session.ClearAttribute("LoginConnection");
         LoginNetwork.Instance.SetConnection(null);
         session.Close();
         if (_loadTask != null)
@@ -42,9 +45,7 @@ public class LoginProtocolHandler : BaseProtocolHandler
             _loadTask = null;
         }
 
-        // A disconnect during an intentional shutdown (Stop already cleared IsRunning) must not reconnect:
-        // the async disconnect callback runs after the DI IServiceProvider behind AppConfiguration.Instance
-        // is disposed, so Start() would throw ObjectDisposedException.
+        // Intentional Stop clears IsRunning; do not reconnect after DI teardown.
         if (!LoginNetwork.Instance.IsRunning)
             return;
 
@@ -53,7 +54,6 @@ public class LoginProtocolHandler : BaseProtocolHandler
 
     public override void OnReceive(ISession session, byte[] buf, int offset, int bytes)
     {
-        var connection = LoginNetwork.Instance.GetConnection();
         PacketStream? stream = new PacketStream();
         if (_lastPacket != null)
         {
@@ -73,8 +73,13 @@ public class LoginProtocolHandler : BaseProtocolHandler
                     Logger.Warn("Dropped invalid login-internal frame from {0}", session.Ip);
                     continue;
                 case LengthPrefixedFrameResult.GotFrame:
+                    var connection = ResolveConnection(session);
                     if (connection == null)
-                        continue;
+                    {
+                        // Keep framing progress; defer body until OnConnect publishes the connection.
+                        _lastPacket = PrependFrame(frame!, stream);
+                        return;
+                    }
                     frame!.ReadUInt16();
                     var type = frame.ReadUInt16();
                     _packets.TryGetValue(type, out var classType);
@@ -92,6 +97,22 @@ public class LoginProtocolHandler : BaseProtocolHandler
                     break;
             }
         }
+    }
+
+    private static LoginConnection ResolveConnection(ISession session)
+    {
+        if (session.GetAttribute("LoginConnection") is LoginConnection fromSession)
+            return fromSession;
+        return LoginNetwork.Instance.GetConnection();
+    }
+
+    private static PacketStream PrependFrame(PacketStream frame, PacketStream? remainder)
+    {
+        var combined = new PacketStream();
+        combined.Insert(0, frame);
+        if (remainder is { Count: > 0 })
+            combined.Insert(combined.Count, remainder);
+        return combined;
     }
 
     public void RegisterPacket(uint type, Type classType)

--- a/AAEmu.Game/Core/Network/Login/LoginProtocolHandler.cs
+++ b/AAEmu.Game/Core/Network/Login/LoginProtocolHandler.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using System.Globalization;
 using System.Text;
-using AAEmu.Commons.Exceptions;
 using AAEmu.Commons.Network;
 using AAEmu.Commons.Network.Core;
 using AAEmu.Game.Core.Managers;
@@ -21,6 +20,7 @@ public class LoginProtocolHandler : BaseProtocolHandler
 
     public override void OnConnect(ISession session)
     {
+        _lastPacket = null;
         Logger.Info("Connect to {0} established, session id: {1}", session.Ip.ToString(), session.SessionId.ToString(CultureInfo.InvariantCulture));
         var con = new LoginConnection(session);
         con.OnConnect();
@@ -32,6 +32,7 @@ public class LoginProtocolHandler : BaseProtocolHandler
 
     public override void OnDisconnect(ISession session)
     {
+        _lastPacket = null;
         Logger.Info("Connection to LoginServer has been lost");
         LoginNetwork.Instance.SetConnection(null);
         session.Close();
@@ -47,69 +48,48 @@ public class LoginProtocolHandler : BaseProtocolHandler
         if (!LoginNetwork.Instance.IsRunning)
             return;
 
-        // TODO Hard Restart
-        LoginNetwork.Instance.Stop();
-        LoginNetwork.Instance.Start();
+        LoginNetwork.Instance.RequestReconnect();
     }
 
     public override void OnReceive(ISession session, byte[] buf, int offset, int bytes)
     {
-        var stream = new PacketStream();
         var connection = LoginNetwork.Instance.GetConnection();
+        PacketStream? stream = new PacketStream();
         if (_lastPacket != null)
         {
             stream.Insert(0, _lastPacket);
             _lastPacket = null;
         }
+
         stream.Insert(stream.Count, buf, offset, bytes);
-        while (stream != null && stream.Count > 0)
+        while (stream is { Count: > 0 })
         {
-            ushort len;
-            try
+            switch (LengthPrefixedFrames.TryTake(ref stream, LengthPrefixedFrames.MinOpcodePayloadBytes, out var frame))
             {
-                len = stream.ReadUInt16();
-            }
-            catch (MarshalException)
-            {
-                //Logger.Warn("Error on reading type {0}", type);
-                stream.Rollback();
-                connection.LastPacket = stream;
-                stream = null;
-                continue;
-            }
-            var packetLen = len + stream.Pos;
-            if (packetLen <= stream.Count)
-            {
-                stream.Rollback();
-                var stream2 = new PacketStream();
-                stream2.Replace(stream, 0, packetLen);
-                if (stream.Count > packetLen)
-                {
-                    var stream3 = new PacketStream();
-                    stream3.Replace(stream, packetLen, stream.Count - packetLen);
-                    stream = stream3;
-                }
-                else
-                    stream = null;
-                stream2.ReadUInt16(); //len
-                var type = stream2.ReadUInt16();
-                _packets.TryGetValue(type, out var classType);
-                if (classType == null)
-                {
-                    HandleUnknownPacket(connection, type, stream2);
-                }
-                else
-                {
-                    var packet = (LoginPacket)Activator.CreateInstance(classType);
-                    packet.Connection = connection;
-                    packet.Decode(stream2);
-                }
-            }
-            else
-            {
-                stream.Rollback();
-                connection.LastPacket = stream;
-                stream = null;
+                case LengthPrefixedFrameResult.NeedMore:
+                    _lastPacket = stream;
+                    return;
+                case LengthPrefixedFrameResult.DroppedInvalidLength:
+                    Logger.Warn("Dropped invalid login-internal frame from {0}", session.Ip);
+                    continue;
+                case LengthPrefixedFrameResult.GotFrame:
+                    if (connection == null)
+                        continue;
+                    frame!.ReadUInt16();
+                    var type = frame.ReadUInt16();
+                    _packets.TryGetValue(type, out var classType);
+                    if (classType == null)
+                    {
+                        HandleUnknownPacket(connection, type, frame);
+                    }
+                    else
+                    {
+                        var packet = (LoginPacket)Activator.CreateInstance(classType);
+                        packet.Connection = connection;
+                        packet.Decode(frame);
+                    }
+
+                    break;
             }
         }
     }

--- a/AAEmu.Game/Core/Network/Stream/StreamProtocolHandler.cs
+++ b/AAEmu.Game/Core/Network/Stream/StreamProtocolHandler.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Concurrent;
 using System.Text;
-using AAEmu.Commons.Exceptions;
 using AAEmu.Commons.Network;
 using AAEmu.Commons.Network.Core;
 using AAEmu.Game.Core.Network.Connections;
@@ -78,56 +77,33 @@ public class StreamProtocolHandler : BaseProtocolHandler
             }
 
             stream.Insert(stream.Count, buf, offset, bytes);
-            while (stream != null && stream.Count > 0)
+            PacketStream? pending = stream;
+            while (pending is { Count: > 0 })
             {
-                ushort len;
-                try
+                switch (LengthPrefixedFrames.TryTake(ref pending, LengthPrefixedFrames.MinOpcodePayloadBytes, out var frame))
                 {
-                    len = stream.ReadUInt16();
-                }
-                catch (MarshalException)
-                {
-                    //Logger.Warn("Error on reading type {0}", type);
-                    stream.Rollback();
-                    connection.LastPacket = stream;
-                    stream = null;
-                    continue;
-                }
+                    case LengthPrefixedFrameResult.NeedMore:
+                        connection.LastPacket = pending;
+                        return;
+                    case LengthPrefixedFrameResult.DroppedInvalidLength:
+                        Logger.Warn("Dropped invalid stream frame from {0}", connection.Ip);
+                        continue;
+                    case LengthPrefixedFrameResult.GotFrame:
+                        frame!.ReadUInt16();
+                        var type = frame.ReadUInt16();
+                        _packets.TryGetValue(type, out var classType);
+                        if (classType == null)
+                        {
+                            HandleUnknownPacket(connection, type, frame);
+                        }
+                        else
+                        {
+                            var packet = (StreamPacket)Activator.CreateInstance(classType);
+                            packet.Connection = connection;
+                            packet.Decode(frame);
+                        }
 
-                var packetLen = len + stream.Pos;
-                if (packetLen <= stream.Count)
-                {
-                    stream.Rollback();
-                    var stream2 = new PacketStream();
-                    stream2.Replace(stream, 0, packetLen);
-                    if (stream.Count > packetLen)
-                    {
-                        var stream3 = new PacketStream();
-                        stream3.Replace(stream, packetLen, stream.Count - packetLen);
-                        stream = stream3;
-                    }
-                    else
-                        stream = null;
-
-                    stream2.ReadUInt16(); //len
-                    var type = stream2.ReadUInt16();
-                    _packets.TryGetValue(type, out var classType);
-                    if (classType == null)
-                    {
-                        HandleUnknownPacket(connection, type, stream2);
-                    }
-                    else
-                    {
-                        var packet = (StreamPacket)Activator.CreateInstance(classType);
-                        packet.Connection = connection;
-                        packet.Decode(stream2);
-                    }
-                }
-                else
-                {
-                    stream.Rollback();
-                    connection.LastPacket = stream;
-                    stream = null;
+                        break;
                 }
             }
         }

--- a/AAEmu.Game/Core/Packets/C2G/CSNotifyInGameCompletedPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSNotifyInGameCompletedPacket.cs
@@ -14,6 +14,8 @@ public class CSNotifyInGameCompletedPacket() : GamePacket(CSOffsets.CSNotifyInGa
         Connection.ActiveChar?.ArmMirrorNpcStream(graceMs: ParseMirrorGraceMs());
         Logger.Info(
             $"NotifyInGameCompleted SubZoneId {Connection.ActiveChar?.SubZoneId}, {Connection.ActiveChar?.Name} ({Connection.ActiveChar?.Id}) mirrorStream armed");
+        if (Connection.ActiveChar != null)
+            WorldIntegration.SyncTowerDefsToCharacter?.Invoke(Connection.ActiveChar);
     }
 
     private static int ParseMirrorGraceMs()

--- a/AAEmu.Game/Core/Packets/C2G/CSSpawnCharacterPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSSpawnCharacterPacket.cs
@@ -36,7 +36,8 @@ public class CSSpawnCharacterPacket() : GamePacket(CSOffsets.CSSpawnCharacterPac
             Connection.SendPacket(new SCUnitFactionChangedPacket(
                 me.ObjId, me.Name ?? "", FactionsEnum.Invalid, me.Faction.Id, false));
 
-        Connection.SendPacket(new SCDetailedTimeOfDayPacket(TimeManager.Instance.GetTime));
+        Connection.SendPacket(new SCDetailedTimeOfDayPacket(
+            TimeManager.Instance.GetTime, TimeManager.DefaultGameHourSpeed, 0f, 24f));
 
         // Deliberately no labor packet here. SCCharacterLaborPowerChanged is a delta - the handler does
         // `add [mgr+0xE58], amount` and `add [mgr+0xE68], localAmount`, never a store - and the client

--- a/AAEmu.Game/Core/Packets/G2C/SCOffsets.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCOffsets.cs
@@ -329,6 +329,7 @@ public static class SCOffsets
     public const ushort CSQuestAcceptConditionalPacket = 0x14a;
     public const ushort SCQuestContextCompletedPacket = 0x190; // 10.0.2.13
     public const ushort SCQuestContextResetPacket = 0x191; // 10.0.2.13
+    public const ushort SCQuestContextResetBulkPacket = 0x192; // 10.0.2.13
     public const ushort SCDoodadCompleteQuestPacket = 0x193; // 10.0.2.13
     public const ushort SCQuestRewardedByMailPacket = 0x194; // 10.0.2.13
     public const ushort SCQuestMailSentPacket = 0x196; // 10.0.2.13
@@ -361,6 +362,8 @@ public static class SCOffsets
     public const ushort SCTowerDefStartPacket = 0x1B3; // 10.0.2.13
     public const ushort SCTowerDefEndPacket = 0x1B4; // 10.0.2.13
     public const ushort SCTowerDefWaveStartPacket = 0x1B5; // 10.0.2.13
+    /// <summary>World-map tower marks; rebuilds client active list (Crimson red skull / icon_key).</summary>
+    public const ushort SCTowerDefActiveInfoListPacket = 0x344; // 10.0.2.13
     public const ushort SCCrimeChangedPacket = 0x1B6; // 10.0.2.13
     public const ushort SCCriminalArrestedPacket = 0x1B7; // 10.0.2.13
     public const ushort SCAskImprisonOrTrialPacket = 0x1B8; // 10.0.2.13

--- a/AAEmu.Game/Core/Packets/G2C/SCQuestContextResetBulkPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCQuestContextResetBulkPacket.cs
@@ -1,0 +1,21 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Network.Game;
+
+namespace AAEmu.Game.Core.Packets.G2C;
+
+/// <summary>
+/// SC 0x192 — batch of quest context ids to clear from the client completed list.
+/// Body: u8 count, then count × u32 context id.
+/// </summary>
+public class SCQuestContextResetBulkPacket(IReadOnlyList<uint> questIds)
+    : GamePacket(SCOffsets.SCQuestContextResetBulkPacket, 1)
+{
+    public override PacketStream Write(PacketStream stream)
+    {
+        var count = Math.Min(questIds.Count, 255);
+        stream.Write((byte)count);
+        for (var i = 0; i < count; i++)
+            stream.Write(questIds[i]);
+        return stream;
+    }
+}

--- a/AAEmu.Game/Core/Packets/G2C/SCTowerDefActiveInfoListPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCTowerDefActiveInfoListPacket.cs
@@ -1,0 +1,22 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.Game.TowerDefs;
+
+namespace AAEmu.Game.Core.Packets.G2C;
+
+/// <summary>
+/// Live tower-def set for world-map marks (icon_key from tower_defs, e.g. Crimson "sign" skull).
+/// Client replaces its full active list when this arrives.
+/// </summary>
+public sealed class SCTowerDefActiveInfoListPacket(IReadOnlyList<TowerDefActiveInfo> entries)
+    : GamePacket(SCOffsets.SCTowerDefActiveInfoListPacket, 1)
+{
+    public override PacketStream Write(PacketStream stream)
+    {
+        var list = entries ?? Array.Empty<TowerDefActiveInfo>();
+        stream.Write(list.Count);
+        foreach (var entry in list)
+            entry.Write(stream);
+        return stream;
+    }
+}

--- a/AAEmu.Game/Core/Packets/G2C/SCTowerDefActiveInfoListPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCTowerDefActiveInfoListPacket.cs
@@ -14,6 +14,7 @@ public sealed class SCTowerDefActiveInfoListPacket(IReadOnlyList<TowerDefActiveI
     public override PacketStream Write(PacketStream stream)
     {
         var list = entries ?? Array.Empty<TowerDefActiveInfo>();
+        // Client "Size" field is a 32-bit count (unlike SCTowerDefListPacket's u8).
         stream.Write(list.Count);
         foreach (var entry in list)
             entry.Write(stream);

--- a/AAEmu.Game/Core/Packets/G2C/SCTowerDefListPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCTowerDefListPacket.cs
@@ -4,13 +4,16 @@ using AAEmu.Game.Models.Game.TowerDefs;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCTowerDefListPacket(List<TowerDefInfo> towerDefInfos) : GamePacket(SCOffsets.SCTowerDefListPacket, 1)
+public class SCTowerDefListPacket(IReadOnlyList<TowerDefInfo> towerDefInfos) : GamePacket(SCOffsets.SCTowerDefListPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(towerDefInfos.Count);
-        foreach (var towerDefInfo in towerDefInfos)
-            towerDefInfo.Write(stream);
+        var list = towerDefInfos ?? Array.Empty<TowerDefInfo>();
+        // Client count field is u8 (max 100 entries).
+        var count = list.Count > 100 ? 100 : list.Count;
+        stream.Write((byte)count);
+        for (var i = 0; i < count; i++)
+            list[i].Write(stream);
         return stream;
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCUnitsRemovedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCUnitsRemovedPacket.cs
@@ -18,10 +18,12 @@ public class SCUnitsRemovedPacket(uint[] ids) : GamePacket(SCOffsets.SCUnitsRemo
 
     public override string Verbose()
     {
-        //if (_ids?.Length > 1)
-            return $" - Removed {ids.Length} objects";
-        //if (_ids?.Length == 1)
-        //    return " - " + WorldManager.Instance.GetGameObject(_ids[0])?.DebugName();
-        //return base.Verbose();
+        if (ids == null || ids.Length == 0)
+            return " - Removed 0 objects";
+        if (ids.Length == 1)
+            return $" - Removed bc={ids[0]}";
+        if (ids.Length <= 8)
+            return $" - Removed {ids.Length}: [{string.Join(',', ids)}]";
+        return $" - Removed {ids.Length} objects (first={ids[0]} last={ids[^1]})";
     }
 }

--- a/AAEmu.Game/GameData/TowerDefGameData.cs
+++ b/AAEmu.Game/GameData/TowerDefGameData.cs
@@ -12,10 +12,33 @@ public class TowerDefGameData : Singleton<TowerDefGameData>, IGameDataLoader
     private Dictionary<uint, TowerDef> _towerDefs;
     private Dictionary<uint, TowerDefProg> _towerDefProgs;
 
+    /// <summary>
+    /// Portal + wave <c>NpcSpawner</c> ids from every tower_def / prog spawn target.
+    /// They carry optional ToD windows for ambient population, but TowerDef OnEvent forces them
+    /// live; the schedule gate must not NpcSpawnFailed those announcements while a wave is on.
+    /// </summary>
+    private HashSet<uint> _eventSpawnerTemplateIds = [];
+
+    /// <summary>
+    /// Portal / stage-spawner <c>Npc</c> members (and group members of those spawners). Soft-stream
+    /// priority so rifts stay painted across region hops. Kill-quota infantry are NOT in this set —
+    /// marking them priority made wave packs thrash <c>AAEMU_MIRROR_NPC_MAX</c> and flood SCUnitState.
+    /// </summary>
+    private HashSet<uint> _priorityNpcTemplateIds = [];
+
+    /// <summary>Spawner template id → direct <c>Npc</c> members (portal seed unit ids).</summary>
+    private Dictionary<uint, HashSet<uint>> _spawnerMemberNpcs = [];
+
+    /// <summary>NpcGroup id → member npc template ids (kill quotas + wave groups).</summary>
+    private Dictionary<uint, HashSet<uint>> _npcGroupMembers = [];
+
     public void Load(SqliteConnection connection)
     {
         _towerDefs = [];
         _towerDefProgs = [];
+        _eventSpawnerTemplateIds = [];
+        _priorityNpcTemplateIds = [];
+        _spawnerMemberNpcs = [];
 
         using (var command = connection.CreateCommand())
         {
@@ -76,7 +99,7 @@ public class TowerDefGameData : Singleton<TowerDefGameData>, IGameDataLoader
                 {
                     var towerDefId = reader.GetUInt32("tower_def_id");
                     if (!_towerDefs.TryGetValue(towerDefId, out var towerDef))
-                        return;
+                        continue;
 
                     var template = new TowerDefProg
                     {
@@ -94,6 +117,10 @@ public class TowerDefGameData : Singleton<TowerDefGameData>, IGameDataLoader
             }
         }
 
+        // Wave indices match dedicate step order: stable by prog id ascending.
+        foreach (var towerDef in _towerDefs.Values)
+            towerDef.Progs.Sort((a, b) => a.Id.CompareTo(b.Id));
+
         using (var command = connection.CreateCommand())
         {
             command.CommandText = "SELECT * FROM tower_def_prog_spawn_targets";
@@ -104,7 +131,7 @@ public class TowerDefGameData : Singleton<TowerDefGameData>, IGameDataLoader
                 {
                     var towerDefProgId = reader.GetUInt32("tower_def_prog_id");
                     if (!_towerDefProgs.TryGetValue(towerDefProgId, out var towerDefProg))
-                        return;
+                        continue;
 
                     var template = new TowerDefProgSpawnTarget
                     {
@@ -130,7 +157,7 @@ public class TowerDefGameData : Singleton<TowerDefGameData>, IGameDataLoader
                 {
                     var towerDefProgId = reader.GetUInt32("tower_def_prog_id");
                     if (!_towerDefProgs.TryGetValue(towerDefProgId, out var towerDefProg))
-                        return;
+                        continue;
 
                     var template = new TowerDefProgKillTarget
                     {
@@ -145,6 +172,127 @@ public class TowerDefGameData : Singleton<TowerDefGameData>, IGameDataLoader
                 }
             }
         }
+
+        RebuildEventIndexes(connection);
+    }
+
+    private void RebuildEventIndexes(SqliteConnection connection)
+    {
+        var spawners = new HashSet<uint>();
+        // Direct Npc spawn targets only (rare) — not kill quotas.
+        var priorityNpcs = new HashSet<uint>();
+
+        foreach (var towerDef in _towerDefs.Values)
+        {
+            if (towerDef.TargetNpcSpawnId != 0)
+                spawners.Add(towerDef.TargetNpcSpawnId);
+
+            if (towerDef.Progs == null)
+                continue;
+
+            foreach (var prog in towerDef.Progs)
+            {
+                if (prog.SpawnTargets == null)
+                    continue;
+                foreach (var spawn in prog.SpawnTargets)
+                {
+                    if (spawn.SpawnTargetId == 0)
+                        continue;
+                    if (string.Equals(spawn.SpawnTargetType, "NpcSpawner", StringComparison.Ordinal))
+                        spawners.Add(spawn.SpawnTargetId);
+                    else if (string.Equals(spawn.SpawnTargetType, "Npc", StringComparison.Ordinal))
+                        priorityNpcs.Add(spawn.SpawnTargetId);
+                }
+            }
+        }
+
+        _eventSpawnerTemplateIds = spawners;
+
+        // Spawner membership → portal/stage seeds (and group packs used as wave spawners, e.g. Grimghast).
+        // Kill-quota templates alone are never added here.
+        var groupIds = new HashSet<uint>();
+        var spawnerMembers = new Dictionary<uint, HashSet<uint>>();
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = "SELECT npc_spawner_id, member_id, member_type FROM npc_spawner_npcs";
+            command.Prepare();
+            using var reader = new SQLiteWrapperReader(command.ExecuteReader());
+            while (reader.Read())
+            {
+                var spawnerId = reader.GetUInt32("npc_spawner_id");
+                if (!spawners.Contains(spawnerId))
+                    continue;
+
+                var memberId = reader.GetUInt32("member_id");
+                var memberType = reader.GetString("member_type", "");
+                if (string.Equals(memberType, "Npc", StringComparison.OrdinalIgnoreCase))
+                {
+                    priorityNpcs.Add(memberId);
+                    if (!spawnerMembers.TryGetValue(spawnerId, out var set))
+                    {
+                        set = [];
+                        spawnerMembers[spawnerId] = set;
+                    }
+
+                    set.Add(memberId);
+                }
+                else if (string.Equals(memberType, "NpcGroup", StringComparison.OrdinalIgnoreCase))
+                    groupIds.Add(memberId);
+            }
+        }
+
+        _spawnerMemberNpcs = spawnerMembers;
+
+        var groupMembers = new Dictionary<uint, HashSet<uint>>();
+        if (groupIds.Count > 0)
+        {
+            using var command = connection.CreateCommand();
+            command.CommandText = "SELECT npc_group_id, npc_id FROM npc_group_members";
+            command.Prepare();
+            using var reader = new SQLiteWrapperReader(command.ExecuteReader());
+            while (reader.Read())
+            {
+                var groupId = reader.GetUInt32("npc_group_id");
+                if (!groupIds.Contains(groupId))
+                    continue;
+                var npcId = reader.GetUInt32("npc_id");
+                if (npcId == 0)
+                    continue;
+                priorityNpcs.Add(npcId);
+                if (!groupMembers.TryGetValue(groupId, out var set))
+                {
+                    set = [];
+                    groupMembers[groupId] = set;
+                }
+
+                set.Add(npcId);
+            }
+        }
+
+        // Also load full npc_group_members for kill-quota cleanup (not limited to wave spawner groups).
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = "SELECT npc_group_id, npc_id FROM npc_group_members";
+            command.Prepare();
+            using var reader = new SQLiteWrapperReader(command.ExecuteReader());
+            while (reader.Read())
+            {
+                var groupId = reader.GetUInt32("npc_group_id");
+                var npcId = reader.GetUInt32("npc_id");
+                if (npcId == 0)
+                    continue;
+                if (!groupMembers.TryGetValue(groupId, out var set))
+                {
+                    set = [];
+                    groupMembers[groupId] = set;
+                }
+
+                set.Add(npcId);
+            }
+        }
+
+        _npcGroupMembers = groupMembers;
+        _priorityNpcTemplateIds = priorityNpcs;
     }
 
     public void PostLoad()
@@ -156,15 +304,137 @@ public class TowerDefGameData : Singleton<TowerDefGameData>, IGameDataLoader
     public IReadOnlyCollection<TowerDef> GetAllTowerDefs() => _towerDefs.Values;
 
     /// <summary>
+    /// True when this spawner template is a TowerDef portal or progressive wave arm — schedule
+    /// day-night gating must not suppress ZW that dedic announced because of TowerDef Start/Wave.
+    /// </summary>
+    public bool IsTowerDefEventSpawner(uint spawnerTemplateId) =>
+        spawnerTemplateId != 0 && _eventSpawnerTemplateIds.Contains(spawnerTemplateId);
+
+    /// <summary>
+    /// True for tower portal/stage (and wave-spawner group) members that must keep priority stream
+    /// paint. Kill-quota infantry are excluded on purpose.
+    /// </summary>
+    public bool IsTowerDefEventNpc(uint npcTemplateId) =>
+        npcTemplateId != 0 && _priorityNpcTemplateIds.Contains(npcTemplateId);
+
+    /// <summary>
+    /// Direct <c>Npc</c> members of a tower portal/wave spawner template (e.g. 9846 → 8828).
+    /// </summary>
+    public IReadOnlyCollection<uint> GetSpawnerMemberNpcIds(uint spawnerTemplateId)
+    {
+        if (spawnerTemplateId == 0 ||
+            !_spawnerMemberNpcs.TryGetValue(spawnerTemplateId, out var set))
+            return Array.Empty<uint>();
+        return set;
+    }
+
+    /// <summary>True when this NPC template is a seed unit for the given tower portal spawner.</summary>
+    public bool IsPortalSeedNpc(uint towerTargetSpawnerId, uint npcTemplateId)
+    {
+        if (towerTargetSpawnerId == 0 || npcTemplateId == 0)
+            return false;
+        return _spawnerMemberNpcs.TryGetValue(towerTargetSpawnerId, out var set) && set.Contains(npcTemplateId);
+    }
+
+    /// <summary>
+    /// All Npc templates that belong to an event for cleanup on End: portal/stage seeds, wave
+    /// spawner members, and kill-quota targets (incl. Crimson army 8826/8834 from plot).
+    /// </summary>
+    public IReadOnlyCollection<uint> GetCleanupNpcTemplates(uint towerDefId)
+    {
+        var towerDef = GetTowerDef(towerDefId);
+        if (towerDef == null)
+            return Array.Empty<uint>();
+
+        var set = new HashSet<uint>();
+        void AddSpawnerMembers(uint spawnerId)
+        {
+            if (spawnerId == 0)
+                return;
+            if (_spawnerMemberNpcs.TryGetValue(spawnerId, out var members))
+            {
+                foreach (var id in members)
+                    set.Add(id);
+            }
+        }
+
+        void AddGroupMembers(uint groupId)
+        {
+            if (groupId == 0)
+                return;
+            if (_npcGroupMembers.TryGetValue(groupId, out var members))
+            {
+                foreach (var id in members)
+                    set.Add(id);
+            }
+        }
+
+        AddSpawnerMembers(towerDef.TargetNpcSpawnId);
+        if (towerDef.KillNpcId != 0)
+            set.Add(towerDef.KillNpcId);
+
+        if (towerDef.Progs != null)
+        {
+            foreach (var prog in towerDef.Progs)
+            {
+                if (prog.SpawnTargets != null)
+                {
+                    foreach (var spawn in prog.SpawnTargets)
+                    {
+                        if (spawn.SpawnTargetId == 0)
+                            continue;
+                        if (string.Equals(spawn.SpawnTargetType, "NpcSpawner", StringComparison.Ordinal))
+                            AddSpawnerMembers(spawn.SpawnTargetId);
+                        else if (string.Equals(spawn.SpawnTargetType, "Npc", StringComparison.Ordinal))
+                            set.Add(spawn.SpawnTargetId);
+                        else if (string.Equals(spawn.SpawnTargetType, "NpcGroup", StringComparison.Ordinal))
+                            AddGroupMembers(spawn.SpawnTargetId);
+                    }
+                }
+
+                if (prog.KillTargets == null)
+                    continue;
+                foreach (var kill in prog.KillTargets)
+                {
+                    if (kill.KillTargetId == 0)
+                        continue;
+                    if (string.Equals(kill.KillTargetType, "Npc", StringComparison.Ordinal))
+                        set.Add(kill.KillTargetId);
+                    else if (string.Equals(kill.KillTargetType, "NpcGroup", StringComparison.Ordinal))
+                        AddGroupMembers(kill.KillTargetId);
+                }
+            }
+        }
+
+        return set;
+    }
+
+    public int EventSpawnerCount => _eventSpawnerTemplateIds.Count;
+    public int EventNpcCount => _priorityNpcTemplateIds.Count;
+
+    /// <summary>
     /// The events that carry a wall-clock start slot on at least one weekday — the timed world
     /// events (world bosses, ghost ship, dragon invasions) as opposed to the rows driven purely by
-    /// kill counts or quest triggers.
+    /// kill counts or quest triggers. Evaluated on World UTC.
     /// </summary>
     public IEnumerable<TowerDef> GetScheduledTowerDefs()
     {
         foreach (var towerDef in _towerDefs.Values)
         {
             if (towerDef.IsScheduled)
+                yield return towerDef;
+        }
+    }
+
+    /// <summary>
+    /// Event Center "Game Time" rifts (Crimson / Grimghast / Oblivion / Clockwork): <c>tod</c>-driven,
+    /// no wall-clock hours. Fired when the zone-simulated hour crosses each row's <c>tod</c>.
+    /// </summary>
+    public IEnumerable<TowerDef> GetGameTimeScheduledTowerDefs()
+    {
+        foreach (var towerDef in _towerDefs.Values)
+        {
+            if (towerDef.IsGameTimeScheduled)
                 yield return towerDef;
         }
     }

--- a/AAEmu.Game/GameData/TowerDefGameData.cs
+++ b/AAEmu.Game/GameData/TowerDefGameData.cs
@@ -293,6 +293,76 @@ public class TowerDefGameData : Singleton<TowerDefGameData>, IGameDataLoader
 
         _npcGroupMembers = groupMembers;
         _priorityNpcTemplateIds = priorityNpcs;
+        ApplyScheduleMetadata();
+    }
+
+    /// <summary>
+    /// Assign Family / Variant / ScheduleMode from StartTimes + <c>Configurations/TowerDefs.json</c>.
+    /// Unknown GameTimeAutoArm ids are logged; classification never uses display names.
+    /// </summary>
+    private void ApplyScheduleMetadata()
+    {
+        foreach (var towerDef in _towerDefs.Values)
+        {
+            towerDef.Family = TowerDefEventFamily.Unspecified;
+            towerDef.Variant = TowerDefEventVariant.Unspecified;
+            towerDef.ScheduleMode = towerDef.IsScheduled
+                ? TowerDefScheduleMode.WallClock
+                : TowerDefScheduleMode.Manual;
+        }
+
+        var entries = Models.AppConfiguration.Instance.TowerDefs?.GameTimeAutoArm;
+        if (entries == null || entries.Count == 0)
+        {
+            NLog.LogManager.GetCurrentClassLogger().Error(
+                "TowerDefs.GameTimeAutoArm is empty — Event Center Game Time auto-arm will not run. " +
+                "Add entries under Configurations/TowerDefs.json");
+            return;
+        }
+
+        var log = NLog.LogManager.GetCurrentClassLogger();
+        foreach (var entry in entries)
+        {
+            if (entry.Id == 0)
+                continue;
+            if (!_towerDefs.TryGetValue(entry.Id, out var towerDef))
+            {
+                log.Error(
+                    "TowerDefs.GameTimeAutoArm references unknown tower_defs.id={0}",
+                    entry.Id);
+                continue;
+            }
+
+            if (!Enum.TryParse<TowerDefEventFamily>(entry.Family, ignoreCase: true, out var family) ||
+                family == TowerDefEventFamily.Unspecified)
+            {
+                log.Error(
+                    "TowerDefs.GameTimeAutoArm id={0} has invalid Family '{1}'",
+                    entry.Id, entry.Family);
+                continue;
+            }
+
+            if (!Enum.TryParse<TowerDefEventVariant>(entry.Variant, ignoreCase: true, out var variant) ||
+                variant == TowerDefEventVariant.Unspecified)
+            {
+                log.Error(
+                    "TowerDefs.GameTimeAutoArm id={0} has invalid Variant '{1}'",
+                    entry.Id, entry.Variant);
+                continue;
+            }
+
+            if (towerDef.IsScheduled)
+            {
+                log.Warn(
+                    "TowerDefs.GameTimeAutoArm id={0} also has weekday StartTimes — keeping WallClock",
+                    entry.Id);
+                continue;
+            }
+
+            towerDef.Family = family;
+            towerDef.Variant = variant;
+            towerDef.ScheduleMode = TowerDefScheduleMode.GameTime;
+        }
     }
 
     public void PostLoad()

--- a/AAEmu.Game/GameData/TowerDefGameData.cs
+++ b/AAEmu.Game/GameData/TowerDefGameData.cs
@@ -32,8 +32,12 @@ public class TowerDefGameData : Singleton<TowerDefGameData>, IGameDataLoader
     /// <summary>NpcGroup id → member npc template ids (kill quotas + wave groups).</summary>
     private Dictionary<uint, HashSet<uint>> _npcGroupMembers = [];
 
+    /// <summary>True after <see cref="Load"/> finishes. Lookups fail closed until then.</summary>
+    public bool IsLoaded { get; private set; }
+
     public void Load(SqliteConnection connection)
     {
+        IsLoaded = false;
         _towerDefs = [];
         _towerDefProgs = [];
         _eventSpawnerTemplateIds = [];
@@ -294,74 +298,44 @@ public class TowerDefGameData : Singleton<TowerDefGameData>, IGameDataLoader
         _npcGroupMembers = groupMembers;
         _priorityNpcTemplateIds = priorityNpcs;
         ApplyScheduleMetadata();
+        IsLoaded = true;
     }
 
     /// <summary>
-    /// Assign Family / Variant / ScheduleMode from StartTimes + <c>Configurations/TowerDefs.json</c>.
-    /// Unknown GameTimeAutoArm ids are logged; classification never uses display names.
+    /// Assign ScheduleMode from weekday StartTimes plus <c>TowerDefs.GameTimeAutoArmIds</c>.
+    /// Unknown or stale overlay ids are logged; classification never uses display names.
     /// </summary>
     private void ApplyScheduleMetadata()
     {
-        foreach (var towerDef in _towerDefs.Values)
-        {
-            towerDef.Family = TowerDefEventFamily.Unspecified;
-            towerDef.Variant = TowerDefEventVariant.Unspecified;
-            towerDef.ScheduleMode = towerDef.IsScheduled
-                ? TowerDefScheduleMode.WallClock
-                : TowerDefScheduleMode.Manual;
-        }
-
-        var entries = Models.AppConfiguration.Instance.TowerDefs?.GameTimeAutoArm;
-        if (entries == null || entries.Count == 0)
-        {
-            NLog.LogManager.GetCurrentClassLogger().Error(
-                "TowerDefs.GameTimeAutoArm is empty — Event Center Game Time auto-arm will not run. " +
-                "Add entries under Configurations/TowerDefs.json");
-            return;
-        }
-
+        var ids = Models.AppConfiguration.Instance.TowerDefs?.GameTimeAutoArmIds ?? [];
+        var result = TowerDefScheduleMetadata.Apply(_towerDefs.Values, ids);
         var log = NLog.LogManager.GetCurrentClassLogger();
-        foreach (var entry in entries)
+
+        if (ids.Count == 0)
         {
-            if (entry.Id == 0)
-                continue;
-            if (!_towerDefs.TryGetValue(entry.Id, out var towerDef))
-            {
-                log.Error(
-                    "TowerDefs.GameTimeAutoArm references unknown tower_defs.id={0}",
-                    entry.Id);
-                continue;
-            }
+            log.Error(
+                "TowerDefs.GameTimeAutoArmIds is empty — Event Center Game Time auto-arm will not run. " +
+                "Add tower_defs.id values under Configurations/TowerDefs.json");
+        }
 
-            if (!Enum.TryParse<TowerDefEventFamily>(entry.Family, ignoreCase: true, out var family) ||
-                family == TowerDefEventFamily.Unspecified)
-            {
-                log.Error(
-                    "TowerDefs.GameTimeAutoArm id={0} has invalid Family '{1}'",
-                    entry.Id, entry.Family);
-                continue;
-            }
+        foreach (var id in result.UnknownIds)
+            log.Error("TowerDefs.GameTimeAutoArmIds references unknown tower_defs.id={0}", id);
 
-            if (!Enum.TryParse<TowerDefEventVariant>(entry.Variant, ignoreCase: true, out var variant) ||
-                variant == TowerDefEventVariant.Unspecified)
-            {
-                log.Error(
-                    "TowerDefs.GameTimeAutoArm id={0} has invalid Variant '{1}'",
-                    entry.Id, entry.Variant);
-                continue;
-            }
+        foreach (var id in result.WallClockConflicts)
+            log.Warn("TowerDefs.GameTimeAutoArmIds id={0} also has weekday StartTimes — keeping WallClock", id);
 
-            if (towerDef.IsScheduled)
-            {
-                log.Warn(
-                    "TowerDefs.GameTimeAutoArm id={0} also has weekday StartTimes — keeping WallClock",
-                    entry.Id);
-                continue;
-            }
+        foreach (var id in result.UnlistedToDCandidates)
+        {
+            log.Warn(
+                "tower_defs.id={0} has tod_day_interval and a seed spawner but is not in GameTimeAutoArmIds — staying Manual",
+                id);
+        }
 
-            towerDef.Family = family;
-            towerDef.Variant = variant;
-            towerDef.ScheduleMode = TowerDefScheduleMode.GameTime;
+        foreach (var id in result.IneligibleIds)
+        {
+            log.Error(
+                "TowerDefs.GameTimeAutoArmIds id={0} is missing tod_day_interval or target_npc_spawner_id — staying Manual",
+                id);
         }
     }
 
@@ -378,14 +352,14 @@ public class TowerDefGameData : Singleton<TowerDefGameData>, IGameDataLoader
     /// day-night gating must not suppress ZW that dedic announced because of TowerDef Start/Wave.
     /// </summary>
     public bool IsTowerDefEventSpawner(uint spawnerTemplateId) =>
-        spawnerTemplateId != 0 && _eventSpawnerTemplateIds.Contains(spawnerTemplateId);
+        IsLoaded && spawnerTemplateId != 0 && _eventSpawnerTemplateIds.Contains(spawnerTemplateId);
 
     /// <summary>
     /// True for tower portal/stage (and wave-spawner group) members that must keep priority stream
-    /// paint. Kill-quota infantry are excluded on purpose.
+    /// paint. Kill-quota infantry are excluded on purpose. Returns false until <see cref="Load"/> completes.
     /// </summary>
     public bool IsTowerDefEventNpc(uint npcTemplateId) =>
-        npcTemplateId != 0 && _priorityNpcTemplateIds.Contains(npcTemplateId);
+        IsLoaded && npcTemplateId != 0 && _priorityNpcTemplateIds.Contains(npcTemplateId);
 
     /// <summary>
     /// Direct <c>Npc</c> members of a tower portal/wave spawner template (e.g. 9846 → 8828).

--- a/AAEmu.Game/Models/AppConfiguration.cs
+++ b/AAEmu.Game/Models/AppConfiguration.cs
@@ -61,6 +61,7 @@ public partial class AppConfiguration
     public SpecialtyConfig Specialty { get; set; } = new();
     public UccConfig Ucc { get; set; } = new();
     public FeaturesConfig Features { get; set; } = new();
+    public TowerDefsConfig TowerDefs { get; set; } = new();
     public InitialConfig InitialConfig { get; set; } = new();
     public LevelRestrictionConfig LevelRestrictions { get; set; } = new();
     public ScriptsConfig Scripts { get; set; } = new();

--- a/AAEmu.Game/Models/AppConfiguration.cs
+++ b/AAEmu.Game/Models/AppConfiguration.cs
@@ -58,6 +58,11 @@ public partial class AppConfiguration
     public CurrencyValuesConfig Credits { get; set; }
     public CurrencyValuesConfig Loyalty { get; set; }
     public ClientDataConfig ClientData { get; set; } = new();
+    /// <summary>
+    /// Extracted game data root (worlds/…/zone_server). Same meaning as World <c>ZoneGameDataRoot</c>.
+    /// Prefer World Config.Local.json; World copies it into <c>AAEMU_ZONE_GAME_DATA_ROOT</c> at boot.
+    /// </summary>
+    public string ZoneGameDataRoot { get; set; } = "";
     public SpecialtyConfig Specialty { get; set; } = new();
     public UccConfig Ucc { get; set; } = new();
     public FeaturesConfig Features { get; set; } = new();

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -100,7 +100,13 @@ public partial class Character : Unit, ICharacter
             MirrorNpcStatesSentCount >= Npc.MirrorNpcMaxPerCharacter)
             return false;
         var d2 = DistanceSq(Transform.World.Position, npc.Transform.World.Position);
-        return d2 <= Npc.MirrorNpcAoiRadiusSq;
+        // Same Transform.ZoneId: event rifts must still paint / show on map so dedic fly-in
+        // movements can be relayed; ambient mirrors keep the short commercial soft AOI.
+        if (npc.IsMirrorStreamPriority &&
+            npc.Transform?.ZoneId != 0 &&
+            Transform?.ZoneId == npc.Transform.ZoneId)
+            return true;
+        return d2 <= npc.MirrorStreamAoiRadiusSq;
     }
 
     /// <summary>Queue a zone mirror for later AOI enter / post-load flush.</summary>
@@ -137,6 +143,7 @@ public partial class Character : Unit, ICharacter
         best = null;
         bestD2 = float.MaxValue;
         bestId = 0;
+        var bestPriority = false;
         var origin = Transform.World.Position;
 
         foreach (var kv in _pendingMirrorSpawns)
@@ -156,14 +163,25 @@ public partial class Character : Unit, ICharacter
 
             var d2 = DistanceSq(origin, npc.Transform.World.Position);
             // Outside soft AOI: skip for send (still pending for when player walks closer).
-            if (d2 > Npc.MirrorNpcAoiRadiusSq)
+            // Priority event mirrors use the larger stream radius / same-zone rule.
+            var aoi = npc.IsMirrorStreamPriority
+                ? (npc.Transform?.ZoneId != 0 && Transform?.ZoneId == npc.Transform.ZoneId
+                    ? float.MaxValue
+                    : npc.MirrorStreamAoiRadiusSq)
+                : Npc.MirrorNpcAoiRadiusSq;
+            if (d2 > aoi)
                 continue;
 
-            if (d2 < bestD2)
+            // Event rifts always beat ambient pending at equal-or-farther distance.
+            var pri = npc.IsMirrorStreamPriority;
+            if (best == null ||
+                (pri && !bestPriority) ||
+                (pri == bestPriority && d2 < bestD2))
             {
                 bestD2 = d2;
                 best = npc;
                 bestId = kv.Key;
+                bestPriority = pri;
             }
         }
 
@@ -214,6 +232,11 @@ public partial class Character : Unit, ICharacter
                 (remove ??= []).Add(objId);
                 continue;
             }
+
+            // Tower/event hellgates stay painted for the whole arm even if soft AOI thrash or a
+            // ZW move briefly poisons World position (seen: Grimghast 12911 flash + SCUnitsRemoved).
+            if (npc.IsMirrorStreamPriority)
+                continue;
 
             if (DistanceSq(origin, npc.Transform.World.Position) > aoiSq)
                 (remove ??= []).Add(objId);
@@ -267,6 +290,10 @@ public partial class Character : Unit, ICharacter
                 continue;
             }
 
+            // Never soft-evict tower/event seeds for ambient backlog.
+            if (npc.IsMirrorStreamPriority)
+                continue;
+
             var d2 = DistanceSq(origin, npc.Transform.World.Position);
             if (d2 > farthestD2)
             {
@@ -282,6 +309,85 @@ public partial class Character : Unit, ICharacter
         // Require meaningful improvement (~15m closer) to avoid thrash.
         const float minImproveSq = 15f * 15f;
         if (farthestD2 - nearerD2 < minImproveSq)
+            return false;
+
+        ReleaseMirrorNpcSlot(farthestId);
+        if (farthestNpc != null && IsStillInRegionInterest(farthestNpc))
+            EnqueuePendingMirrorSpawn(farthestNpc);
+        SendPacket(new SCUnitsRemovedPacket([farthestId]));
+        return true;
+    }
+
+    /// <summary>
+    /// Event/tower mirrors must land on the wire even when ambient already filled MAX.
+    /// Drops the farthest streamed ambient (non-priority preferred) while the priority NPC
+    /// is inside soft AOI and stream-ready.
+    /// </summary>
+    public bool TryEvictFarthestStreamedForPriority(Npc priorityNpc)
+    {
+        if (priorityNpc == null || !priorityNpc.IsMirrorStreamPriority)
+            return false;
+        if (!MirrorNpcStreamReady)
+            return false;
+        if (MirrorNpcStreamNotBeforeTick != 0 &&
+            Environment.TickCount64 < MirrorNpcStreamNotBeforeTick)
+            return false;
+        if (MirrorNpcStatesSentIds.ContainsKey(priorityNpc.ObjId))
+            return true;
+        if (Npc.MirrorNpcMaxPerCharacter <= 0 ||
+            MirrorNpcStatesSentCount < Npc.MirrorNpcMaxPerCharacter)
+            return true;
+
+        var origin = Transform.World.Position;
+        var pD2 = DistanceSq(origin, priorityNpc.Transform.World.Position);
+        var sameZone = priorityNpc.Transform?.ZoneId != 0 &&
+                       Transform?.ZoneId == priorityNpc.Transform.ZoneId;
+        if (!sameZone && pD2 > priorityNpc.MirrorStreamAoiRadiusSq)
+            return false;
+
+        uint farthestId = 0;
+        var farthestD2 = -1f;
+        Npc farthestNpc = null;
+        // Prefer evicting ambient first so a second rift doesn't jettison the first.
+        uint farthestAmbientId = 0;
+        var farthestAmbientD2 = -1f;
+        Npc farthestAmbientNpc = null;
+
+        foreach (var objId in MirrorNpcStatesSentIds.Keys)
+        {
+            var npc = ParentWorld?.GetNpc(objId);
+            if (npc == null)
+            {
+                ReleaseMirrorNpcSlot(objId);
+                continue;
+            }
+
+            var d2 = DistanceSq(origin, npc.Transform.World.Position);
+            if (d2 > farthestD2)
+            {
+                farthestD2 = d2;
+                farthestId = objId;
+                farthestNpc = npc;
+            }
+
+            if (!npc.IsMirrorStreamPriority && d2 > farthestAmbientD2)
+            {
+                farthestAmbientD2 = d2;
+                farthestAmbientId = objId;
+                farthestAmbientNpc = npc;
+            }
+        }
+
+        // Ambient only. Evicting priority-for-priority (wave packs at MAX) loops:
+        // remove→requeue→paint thrash (~thousands SCUnitState/s) and can hard-kill the client
+        // ("too many unit movements"). If every streamed slot is already event priority, refuse.
+        if (farthestAmbientId == 0)
+            return false;
+
+        farthestId = farthestAmbientId;
+        farthestNpc = farthestAmbientNpc;
+
+        if (farthestId == 0 || farthestId == priorityNpc.ObjId)
             return false;
 
         ReleaseMirrorNpcSlot(farthestId);

--- a/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
@@ -667,22 +667,14 @@ public class CharacterQuests(Character owner)
     /// <summary>Applies any missed daily/weekly completion clears at login (no SC spam — client reloads list).</summary>
     public void CheckCalendarResetsAtLogin()
     {
-        var leaveUtc = Owner.LeaveTime.Kind == DateTimeKind.Utc
-            ? Owner.LeaveTime
-            : Owner.LeaveTime.ToUniversalTime();
+        var leaveUtc = ServerCalendar.AsUtc(Owner.LeaveTime);
 
         if (leaveUtc.Date < ServerCalendar.TodayUtc)
             ResetDailyQuests(false);
 
-        var leaveWeek = WeekStartMondayUtc(leaveUtc.Date);
+        var leaveWeek = ServerCalendar.WeekStartMondayContaining(leaveUtc);
         if (leaveWeek < ServerCalendar.WeekStartMondayUtc)
             ResetWeeklyQuests(false);
-    }
-
-    private static DateTime WeekStartMondayUtc(DateTime utcDate)
-    {
-        var offset = ((int)utcDate.DayOfWeek - (int)DayOfWeek.Monday + 7) % 7;
-        return utcDate.Date.AddDays(-offset);
     }
 
     /// <summary>

--- a/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
@@ -677,9 +677,7 @@ public class CharacterQuests(Character owner)
             ResetWeeklyQuests(false);
     }
 
-    /// <summary>
-    /// Clears completed daily-detail quests (Crimson, Grimghast, daily hunt/group/livelihood, today contracts, …).
-    /// </summary>
+    /// <summary>Clears completed daily-detail quests.</summary>
     public void ResetDailyQuests(bool sendPacketsIfChanged)
     {
         ResetQuests(QuestCalendarResetSet.Daily, sendPacketsIfChanged);

--- a/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
@@ -7,6 +7,7 @@ using AAEmu.Game.Core.Managers.UnitManagers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.GameData;
+using AAEmu.Game.Models;
 using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Quests;
 using AAEmu.Game.Models.Game.Quests.Acts;
@@ -479,40 +480,54 @@ public class CharacterQuests(Character owner)
     }
 
     /// <summary>
-    /// Resets all quests of a given types (used by ResetDailyQuests)
+    /// Clears completed_quests bits for every finished quest whose detail is in
+    /// <paramref name="questDetail"/>. Active (in-progress) quests are left alone so mid-run
+    /// work is not cancelled by the calendar edge.
     /// </summary>
-    /// <param name="questDetail"></param>
-    /// <param name="sendIfChanged"></param>
     private void ResetQuests(QuestDetail[] questDetail, bool sendIfChanged = true)
     {
+        if (questDetail == null || questDetail.Length == 0)
+            return;
+
+        var match = new HashSet<QuestDetail>(questDetail);
+        var cleared = new List<uint>();
+
         foreach (var (completeBlockId, completeBlock) in CompletedQuests)
         {
             for (var blockIndex = 0; blockIndex < 64; blockIndex++)
             {
-                var questId = (uint)(completeBlockId * 64) + (uint)blockIndex;
-                var q = QuestManager.Instance.GetTemplate(questId);
-                // Skip unused Ids
-                if (q == null)
-                    continue;
-                // Skip if quest still active
-                if (HasQuest(questId))
+                if (!completeBlock.Body[blockIndex])
                     continue;
 
-                foreach (var qd in questDetail)
-                {
-                    if (q.DetailId == qd && completeBlock.Body[blockIndex])
-                    {
-                        completeBlock.Body.Set(blockIndex, false);
-                        Logger.Info($"QuestReset by {Owner.Name}, reset {questId}");
-                        if (sendIfChanged)
-                        {
-                            var body = new byte[8];
-                            completeBlock.Body.CopyTo(body, 0);
-                            Owner.SendPacket(new SCQuestContextResetPacket(questId));
-                        }
-                    }
-                }
+                var questId = (uint)(completeBlockId * 64) + (uint)blockIndex;
+                var q = QuestManager.Instance.GetTemplate(questId);
+                if (q == null)
+                    continue;
+                // Still active — do not touch.
+                if (HasQuest(questId))
+                    continue;
+                if (!match.Contains(q.DetailId))
+                    continue;
+
+                completeBlock.Body.Set(blockIndex, false);
+                cleared.Add(questId);
+                Logger.Info("QuestReset by {0}, reset {1} detail={2}", Owner.Name, questId, q.DetailId);
             }
+        }
+
+        if (!sendIfChanged || cleared.Count == 0)
+            return;
+
+        // Prefer bulk 0x192 (≤255 per packet); remainder as singles if ever needed.
+        var offset = 0;
+        while (offset < cleared.Count)
+        {
+            var take = Math.Min(255, cleared.Count - offset);
+            if (take == 1)
+                Owner.SendPacket(new SCQuestContextResetPacket(cleared[offset]));
+            else
+                Owner.SendPacket(new SCQuestContextResetBulkPacket(cleared.GetRange(offset, take)));
+            offset += take;
         }
     }
 
@@ -641,30 +656,47 @@ public class CharacterQuests(Character owner)
     }
 
     /// <summary>
-    /// Checks if the player needs to reset daily quests based on last leave time (for use during login only) 
+    /// Offline catch-up for calendar quests using leave_time as last-known wall-clock presence.
+    /// Daily: 00:00 UTC; weekly: Monday 00:00 UTC. Matches online cron tasks even after World restarts.
     /// </summary>
     public void CheckDailyResetAtLogin()
     {
-        // TODO: Put Server timezone offset in configuration file, currently using local machine midnight
-        // var utcDelta = DateTime.Now - DateTime.UtcNow;
-        // var isOld = (DateTime.Today + utcDelta - Owner.LeaveTime.Date) >= TimeSpan.FromDays(1);
-        var isOld = DateTime.UtcNow.Date - Owner.LeaveTime.Date >= TimeSpan.FromDays(1);
-        if (isOld)
+        CheckCalendarResetsAtLogin();
+    }
+
+    /// <summary>Applies any missed daily/weekly completion clears at login (no SC spam — client reloads list).</summary>
+    public void CheckCalendarResetsAtLogin()
+    {
+        var leaveUtc = Owner.LeaveTime.Kind == DateTimeKind.Utc
+            ? Owner.LeaveTime
+            : Owner.LeaveTime.ToUniversalTime();
+
+        if (leaveUtc.Date < ServerCalendar.TodayUtc)
             ResetDailyQuests(false);
+
+        var leaveWeek = WeekStartMondayUtc(leaveUtc.Date);
+        if (leaveWeek < ServerCalendar.WeekStartMondayUtc)
+            ResetWeeklyQuests(false);
+    }
+
+    private static DateTime WeekStartMondayUtc(DateTime utcDate)
+    {
+        var offset = ((int)utcDate.DayOfWeek - (int)DayOfWeek.Monday + 7) % 7;
+        return utcDate.Date.AddDays(-offset);
     }
 
     /// <summary>
-    /// Resets all daily quests
+    /// Clears completed daily-detail quests (Crimson, Grimghast, daily hunt/group/livelihood, today contracts, …).
     /// </summary>
-    /// <param name="sendPacketsIfChanged"></param>
     public void ResetDailyQuests(bool sendPacketsIfChanged)
     {
-        ResetQuests(
-            [
-                QuestDetail.Daily, QuestDetail.DailyGroup, QuestDetail.DailyHunt,
-                QuestDetail.DailyLivelihood
-            ], sendPacketsIfChanged
-        );
+        ResetQuests(QuestCalendarResetSet.Daily, sendPacketsIfChanged);
+    }
+
+    /// <summary>Clears completed weekly-detail quests (detail_id = weekly).</summary>
+    public void ResetWeeklyQuests(bool sendPacketsIfChanged)
+    {
+        ResetQuests(QuestCalendarResetSet.Weekly, sendPacketsIfChanged);
     }
 
     public void TryCompleteQuestAsLetItDone(uint questId, int selectedReward)

--- a/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
@@ -341,6 +341,30 @@ public class Doodad : BaseUnit
     private bool _deleted;
 
     /// <summary>
+    /// Re-entrancy cap for <see cref="DoPhaseFuncs"/>. Phase graphs must settle; without this,
+    /// ToD chains can recurse until StackOverflow (boot / big ToD snaps).
+    /// </summary>
+    private const int MaxPhaseDepth = 32;
+    private int _phaseDepth;
+
+    /// <summary>
+    /// When true, <see cref="Funcs.DoodadFuncTod"/> will not set <see cref="OverridePhase"/>.
+    /// Used after a retail-style settle so applying the chosen phase does not re-walk ToD jumps.
+    /// Runtime ToD still advances via <see cref="TimeManager"/> edge crosses.
+    /// </summary>
+    public bool SuppressTodPhaseOverride { get; set; }
+
+    /// <summary>
+    /// Logic-family currently signalled by a <c>DoodadFuncLogicFamilyProvider</c> on this doodad (0 = none).
+    /// </summary>
+    public uint ActiveLogicFamilyId { get; set; }
+
+    /// <summary>
+    /// Logic-family this doodad is listening for via <c>DoodadFuncLogicFamilySubscriber</c> (0 = none).
+    /// </summary>
+    public uint ListeningLogicFamilyId { get; set; }
+
+    /// <summary>
     /// Seat data for this Doodad
     /// </summary>
     public VehicleSeat Seat { get; set; }
@@ -688,6 +712,30 @@ public class Doodad : BaseUnit
     {
         if (nextPhase <= 0) { return true; }
 
+        // Hard stop self-referential / empty-func phase cycles (ToD chains, prison gates, etc.).
+        // Without this, InitDoodad at boot can recurse until StackOverflow and kill World.
+        if (_phaseDepth >= MaxPhaseDepth)
+        {
+            Logger.Warn(
+                "DoPhaseFuncs: depth limit TemplateId={0} ObjId={1} phase={2} depth={3}",
+                TemplateId, ObjId, nextPhase, _phaseDepth);
+            ListGroupId.Clear();
+            return true;
+        }
+
+        _phaseDepth++;
+        try
+        {
+            return DoPhaseFuncsBody(caster, ref nextPhase);
+        }
+        finally
+        {
+            _phaseDepth--;
+        }
+    }
+
+    private bool DoPhaseFuncsBody(BaseUnit caster, ref int nextPhase)
+    {
         // Changing the phase.
         FuncGroupId = (uint)nextPhase;
         if (WorldIntegration.ZoneAuthority)
@@ -699,25 +747,18 @@ public class Doodad : BaseUnit
         }
         else
         {
-            var funcs = DoodadManager.Instance.GetFuncsForGroup(FuncGroupId);
-            if (funcs.Count > 0)
+            // Cycle detected: always abort. (Previously empty funcs fell through and infinite-looped.)
+            if (caster is Character)
             {
-                // например, если это ID=2231, Target, то надо прервать рекурсию
-                if (caster is Character)
-                {
-                    Logger.Debug($"DoPhase: Finished execution with recurse: TemplateId {TemplateId}, Using phase {FuncGroupId}");
-                }
-                else
-                {
-                    Logger.Trace($"DoPhase: Finished execution with recurse: TemplateId {TemplateId}, Using phase {FuncGroupId}");
-                }
-
-                ListGroupId.Clear();
-                return true;
+                Logger.Debug($"DoPhase: Finished execution with recurse: TemplateId {TemplateId}, Using phase {FuncGroupId}");
+            }
+            else
+            {
+                Logger.Trace($"DoPhase: Finished execution with recurse: TemplateId {TemplateId}, Using phase {FuncGroupId}");
             }
 
-            // например, если это ID=898, Prison Gate, то не надо прервать рекурсию
             ListGroupId.Clear();
+            return true;
         }
 
         if (FuncTask != null)
@@ -913,9 +954,78 @@ public class Doodad : BaseUnit
 
         GrowthTime = PlantTime.AddMilliseconds(growTime);
 
-        // Actually do the phase change
         var unit = ParentWorld.GetUnit(OwnerObjId);
-        DoChangePhase(unit, (int)FuncGroupId);
+        var startPhase = FuncGroupId != 0 ? FuncGroupId : GetFuncGroupId();
+        if (startPhase == 0)
+            return;
+
+        // Retail-shaped settle: walk ToD windows iteratively (visited-set, no call stack blow-up),
+        // then apply that phase once with ToD overrides suppressed so lamp A↔B graphs cannot thrash.
+        var settled = SettlePhaseForCurrentClock(startPhase);
+        SuppressTodPhaseOverride = true;
+        try
+        {
+            DoChangePhase(unit, (int)settled);
+        }
+        finally
+        {
+            SuppressTodPhaseOverride = false;
+            ListGroupId.Clear();
+            _phaseDepth = 0;
+        }
+    }
+
+    /// <summary>
+    /// Pick the phase that should be live at the current game/wall clock by following only
+    /// active ToD descriptors. Cycles terminate by returning the last phase before a revisit —
+    /// never via nested recursion.
+    /// </summary>
+    public uint SettlePhaseForCurrentClock(uint startPhase)
+    {
+        if (startPhase == 0)
+            return 0;
+
+        var phase = startPhase;
+        // Cap length of any single graph; shipped templates stay well under this.
+        const int MaxHops = 64;
+        var visited = new HashSet<uint>();
+
+        for (var hop = 0; hop < MaxHops; hop++)
+        {
+            if (!visited.Add(phase))
+                break; // cycle — keep the pre-cycle phase we already stored
+
+            var forceTop = Template?.ForceTodTopPriority ?? false;
+            var next = 0;
+
+            foreach (var phaseFunc in DoodadManager.Instance.GetPhaseFunc(phase))
+            {
+                if (phaseFunc == null || phaseFunc.FuncType != nameof(DoodadFuncTod))
+                    continue;
+
+                if (DoodadManager.Instance.GetPhaseFuncTemplate(phaseFunc.FuncId, phaseFunc.FuncType)
+                    is not DoodadFuncTod tod)
+                    continue;
+
+                var hours = tod.GetClockHours();
+                if (!tod.ShouldJumpAt(hours, forceTop))
+                    continue;
+
+                if (tod.NextPhase > 0 && tod.NextPhase != (int)phase)
+                {
+                    next = tod.NextPhase;
+                    // First matching ToD on the phase drives the hop (same order as Use()).
+                    break;
+                }
+            }
+
+            if (next <= 0)
+                break;
+
+            phase = (uint)next;
+        }
+
+        return phase;
     }
 
     /// <summary>

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncBuff.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncBuff.cs
@@ -16,23 +16,32 @@ public class DoodadFuncBuff : DoodadFuncTemplate
 
     public override void Use(BaseUnit caster, Doodad owner, uint skillId, int nextPhase = 0)
     {
-        Logger.Trace("DoodadFuncBuff");
-        if (Radius <= 0f)
+        Logger.Trace("DoodadFuncBuff BuffId={0} Radius={1} Count={2} skillId={3} nextPhase={4}",
+            BuffId, Radius, Count, skillId, nextPhase);
+
+        if (BuffId != 0 && caster != null)
         {
-            // Caster only
-            caster.Buffs.AddBuff(BuffId, caster);
-        }
-        else
-        {
-            var relationship = (RelationState)RelationshipId;
-            var targets = WorldManager
-                .GetAround<BaseUnit>(caster, Radius, true)
-                .Where(target => target != null && caster.GetRelationStateTo(target) == relationship)
-                .Take(Count);
-            foreach (var target in targets)
+            if (Radius <= 0f)
             {
-                target.Buffs.AddBuff(BuffId, caster);
+                // Caster only — typical for deliver-pack feedback (e.g. "backpack success").
+                caster.Buffs.AddBuff(BuffId, caster);
+            }
+            else
+            {
+                var relationship = (RelationState)RelationshipId;
+                var targets = WorldManager
+                    .GetAround<BaseUnit>(caster, Radius, true)
+                    .Where(target => target != null && caster.GetRelationStateTo(target) == relationship)
+                    .Take(Count > 0 ? Count : int.MaxValue);
+                foreach (var target in targets)
+                {
+                    target.Buffs.AddBuff(BuffId, caster);
+                }
             }
         }
+
+        // Construction deposits (Grimghast mana trebuchet etc.) use DoodadFuncBuff as the success
+        // interaction that advances NextPhase after skill 20802 consumes the pack.
+        owner.ToNextPhase = true;
     }
 }

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncLogicFamilyProvider.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncLogicFamilyProvider.cs
@@ -3,13 +3,22 @@ using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Models.Game.DoodadObj.Funcs;
 
+/// <summary>
+/// Phase-func signal: this doodad currently provides logic-family <see cref="FamilyId"/>.
+/// Subscribers with the same family id can poll <see cref="Doodad.ActiveLogicFamilyId"/>
+/// on nearby providers. Grimghast treb→harpoon unlock is driven by Pulse, not this family
+/// (provider families 40006/40008 vs harpoon subscriber 40007 do not match in data).
+/// </summary>
 public class DoodadFuncLogicFamilyProvider : DoodadPhaseFuncTemplate
 {
     public uint FamilyId { get; set; }
 
     public override bool Use(BaseUnit caster, Doodad owner)
     {
-        Logger.Trace($"DoodadFuncLogicFamilyProvider: FamilyId {FamilyId}");
+        if (owner != null)
+            owner.ActiveLogicFamilyId = FamilyId;
+
+        Logger.Trace("DoodadFuncLogicFamilyProvider: FamilyId {0} ownerTpl={1}", FamilyId, owner?.TemplateId);
         return false;
     }
 }

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncLogicFamilySubscriber.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncLogicFamilySubscriber.cs
@@ -3,13 +3,21 @@ using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Models.Game.DoodadObj.Funcs;
 
+/// <summary>
+/// Phase-func: doodad is listening for logic-family <see cref="FamilyId"/>.
+/// Does not gate the phase by itself (no next_phase column in data); paired content uses
+/// Pulse / PulseTrigger to advance (e.g. charged harpoons).
+/// </summary>
 public class DoodadFuncLogicFamilySubscriber : DoodadPhaseFuncTemplate
 {
     public uint FamilyId { get; set; }
 
     public override bool Use(BaseUnit caster, Doodad owner)
     {
-        Logger.Trace("DoodadFuncLogicFamilySubscriber");
+        if (owner != null)
+            owner.ListeningLogicFamilyId = FamilyId;
+
+        Logger.Trace("DoodadFuncLogicFamilySubscriber: FamilyId {0} ownerTpl={1}", FamilyId, owner?.TemplateId);
         return false;
     }
 }

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncPulse.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncPulse.cs
@@ -9,45 +9,72 @@ public class DoodadFuncPulse : DoodadPhaseFuncTemplate
 {
     public bool Flag { get; set; }
 
+    /// <summary>
+    /// Neighbourhood radius used when the spawner has no <c>RelatedIds</c>.
+    /// Grimghast harpoons sit ~10–30 m from their mana trebuchet; 60 m covers both lines without
+    /// whole-map side effects.
+    /// </summary>
+    private const float DefaultPulseRadius = 60f;
+
     public override bool Use(BaseUnit caster, Doodad owner)
     {
-        Logger.Trace($"DoodadFuncPulse: Flag {Flag}");
+        Logger.Trace("DoodadFuncPulse: Flag {0} ownerTpl={1} obj={2}", Flag, owner?.TemplateId, owner?.ObjId);
 
-        if (caster is not null)
+        if (owner == null)
+            return false;
+
+        // Intermediate build steps pulse with Flag=false — no neighbour transit.
+        if (!Flag)
+            return false;
+
+        var relatedIds = owner.Spawner?.RelatedIds;
+        var hasRelatedFilter = relatedIds is { Count: > 0 };
+        IEnumerable<Doodad> candidates;
+        if (hasRelatedFilter)
         {
-            var aroundDoodads = WorldManager.GetAround<Doodad>(caster);
-            var doodads = new List<Doodad>();
-            if (owner?.Spawner != null)
-            {
-                if (owner.Spawner.RelatedIds != null)
-                {
-                    foreach (var relatedId in owner.Spawner.RelatedIds)
-                    {
-                        if (aroundDoodads != null)
-                        {
-                            doodads.AddRange(aroundDoodads.Where(doodad => doodad.TemplateId == relatedId));
-                        }
-                    }
-                }
-
-                foreach (var doodad in doodads)
-                {
-                    var funcGroup = DoodadManager.Instance.GetPhaseFunc(doodad.FuncGroupId);
-                    foreach (var func in funcGroup)
-                    {
-                        switch (func.FuncType)
-                        {
-                            case "DoodadFuncPulseTrigger" when Flag:
-                                {
-                                    func.PulseTriggered = false; // Allow one-time execution
-                                    doodad.DoChangePhase(caster, (int)doodad.FuncGroupId);
-                                    break;
-                                }
-                        }
-                    }
-                }
-            }
+            var around = WorldManager.GetAround<Doodad>(owner);
+            var related = relatedIds.ToHashSet();
+            candidates = around.Where(d => related.Contains(d.TemplateId));
         }
+        else
+        {
+            // Most main_world siege furniture (Grimghast treb → harpoons) never got RelatedIds authored
+            // into doodad_spawns.json. Pulse by template proximity instead.
+            candidates = WorldManager.GetAround<Doodad>(owner, DefaultPulseRadius);
+        }
+
+        var triggered = 0;
+        foreach (var doodad in candidates)
+        {
+            if (doodad == null || doodad.ObjId == owner.ObjId)
+                continue;
+
+            var phaseFuncs = DoodadManager.Instance.GetPhaseFunc(doodad.FuncGroupId);
+            var hasPulseTrigger = false;
+            foreach (var func in phaseFuncs)
+            {
+                if (func.FuncType != "DoodadFuncPulseTrigger")
+                    continue;
+                hasPulseTrigger = true;
+                // Allow the one-shot PulseTrigger on this shared phase-func row for this firing.
+                func.PulseTriggered = false;
+            }
+
+            if (!hasPulseTrigger)
+                continue;
+
+            // Re-enter current phase so the DoodadFuncPulseTrigger can set OverridePhase → charged.
+            doodad.DoChangePhase(caster, (int)doodad.FuncGroupId);
+            triggered++;
+        }
+
+        if (triggered > 0)
+        {
+            Logger.Info(
+                "DoodadFuncPulse ownerTpl={0} obj={1} flag={2} relatedFilter={3} charged={4}",
+                owner.TemplateId, owner.ObjId, Flag, hasRelatedFilter, triggered);
+        }
+
         return false;
     }
 }

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncPulseTrigger.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncPulseTrigger.cs
@@ -11,30 +11,30 @@ public class DoodadFuncPulseTrigger : DoodadPhaseFuncTemplate
 
     public override bool Use(BaseUnit caster, Doodad owner)
     {
-        if (caster is not Character)
-        {
-            return true;
-        }
-
-        // Grab the calling PhaseFunc
+        // Grab the calling PhaseFunc (shared phase-func row; Pulse resets PulseTriggered before re-entry).
         var thisPhaseFunc = owner.CurrentPhaseFuncs.FirstOrDefault(x => x.FuncId == Id);
         if (thisPhaseFunc == null)
         {
             Logger.Warn($"DoodadFuncPulseTrigger Flag={Flag}, NextPhase={NextPhase} was not triggered from a DoodadFuncPulseTrigger");
-            return false; // Fail check as there seems to be a mismatch
+            return false;
         }
 
-        Logger.Debug($"DoodadFuncPulseTrigger Flag={Flag}, NextPhase={NextPhase}, PulseTriggered={thisPhaseFunc.PulseTriggered}");
+        // Flag=false triggers are discharge/reset markers; they do not advance.
+        // Flag=true advances only after an external DoodadFuncPulse cleared PulseTriggered.
+        // Non-character casters (boot settle, pure ToD) must not auto-charge: return false so
+        // remaining phase funcs (ToD, etc.) still run. Player-driven pulses pass Character.
+        if (!Flag || thisPhaseFunc.PulseTriggered)
+            return false;
 
-        if (Flag && !thisPhaseFunc.PulseTriggered)
-        {
-            thisPhaseFunc.PulseTriggered = true; // Prevent loops
-            owner.OverridePhase = NextPhase;
+        if (caster is not Character)
+            return false;
 
-            return true;
-        }
+        Logger.Debug(
+            "DoodadFuncPulseTrigger Flag={0}, NextPhase={1}, ownerTpl={2}",
+            Flag, NextPhase, owner.TemplateId);
 
-        return false;
-
+        thisPhaseFunc.PulseTriggered = true; // Prevent loops until next Pulse clears it
+        owner.OverridePhase = NextPhase;
+        return true;
     }
 }

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncTod.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncTod.cs
@@ -24,27 +24,47 @@ public class DoodadFuncTod : DoodadPhaseFuncTemplate
 
     public override bool Use(BaseUnit caster, Doodad owner)
     {
+        // Init already settled this graph against current clock; do not re-fire ToD jumps.
+        // Runtime ToD edges are edge-crossing driven by TimeManager (and scheduled tasks).
+        if (owner.SuppressTodPhaseOverride)
+            return false;
+
         if (NextPhase <= 0)
             return false;
 
-        var currentTime = IsRealtime
-            ? (float)DateTime.Now.TimeOfDay.TotalHours
-            : TimeManager.Instance.GetTime;
-
-        // Ranged descriptors are entry conditions. Point triggers normally wait for the next
-        // crossing; templates marked force_tod_top_priority (for example lamps) resolve their
-        // current phase immediately when initialized.
-        var shouldChange = TodEnd >= 0
-            ? IsWithinWindow(currentTime)
-            : owner.Template.ForceTodTopPriority && currentTime >= TodAsHours;
-        if (!shouldChange)
+        if (!ShouldJumpAt(GetClockHours(), owner.Template.ForceTodTopPriority))
             return false;
 
         Logger.Trace(
             "DoodadFuncTod: currentTime {0}, Tod {1}, TodEnd {2}, IsRealtime {3}, OverridePhase {4}",
-            currentTime, Tod, TodEnd, IsRealtime, NextPhase);
+            GetClockHours(), Tod, TodEnd, IsRealtime, NextPhase);
         owner.OverridePhase = NextPhase;
         return true;
+    }
+
+    /// <summary>
+    /// Pure evaluation for settle/init — whether this descriptor would leave its phase at
+    /// <paramref name="hours"/> without side effects.
+    /// </summary>
+    public bool ShouldJumpAt(float hours, bool forceTodTopPriority)
+    {
+        if (NextPhase <= 0)
+            return false;
+
+        // Ranged descriptors are entry conditions for the next phase while the window is open.
+        if (TodEnd >= 0)
+            return IsWithinWindow(hours);
+
+        // Point triggers normally wait for the next schedule-crossing on TimeManager.
+        // force_tod_top_priority (lamps etc.) re-reads "period of day" on init only — settle walk.
+        return forceTodTopPriority && NormalizeHours(hours) >= TodAsHours;
+    }
+
+    public float GetClockHours()
+    {
+        return IsRealtime
+            ? (float)DateTime.Now.TimeOfDay.TotalHours
+            : TimeManager.Instance.GetTime;
     }
 
     public bool IsWithinWindow(float hours)

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncTod.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncTod.cs
@@ -62,8 +62,9 @@ public class DoodadFuncTod : DoodadPhaseFuncTemplate
 
     public float GetClockHours()
     {
+        // Must match TimeManager wall-clock (UTC). Local Now disagrees near day boundaries.
         return IsRealtime
-            ? (float)DateTime.Now.TimeOfDay.TotalHours
+            ? (float)DateTime.UtcNow.TimeOfDay.TotalHours
             : TimeManager.Instance.GetTime;
     }
 

--- a/AAEmu.Game/Models/Game/NPChar/Npc.cs
+++ b/AAEmu.Game/Models/Game/NPChar/Npc.cs
@@ -1,10 +1,13 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 
 using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.Id;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.GameData;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Formulas;
 using AAEmu.Game.Models.Game.Items;
@@ -13,6 +16,7 @@ using AAEmu.Game.Models.Game.Models;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Skills.Effects;
 using AAEmu.Game.Models.Game.Skills.SkillControllers;
+using AAEmu.Game.Models.Game.Skills.Static;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.Units.Movements;
 using AAEmu.Game.Models.Game.Units.Static;
@@ -1064,7 +1068,8 @@ public partial class Npc : Unit
     /// flood (~150 at once) Quit'd — AOI+MAX prevent that, not artificial 1/s drip.
     /// AAEMU_DISABLE_MIRROR_NPC=1 | AAEMU_MIRROR_NPC_MAX=N (default 50; 0=unlimited) |
     /// AAEMU_MIRROR_NPC_BURST=N (0=flush all/tick) | AAEMU_MIRROR_NPC_INTERVAL_MS (0=off) |
-    /// AAEMU_MIRROR_NPC_AOI=metres | AAEMU_MIRROR_NPC_GRACE_MS.
+    /// AAEMU_MIRROR_NPC_AOI=metres | AAEMU_MIRROR_NPC_GRACE_MS |
+    /// AAEMU_MIRROR_PRIORITY_TPL=8828,8830 (tower/event rifts steal MAX slots).
     /// </summary>
     public static readonly bool DisableMirrorNpcStreaming =
         System.Environment.GetEnvironmentVariable("AAEMU_DISABLE_MIRROR_NPC") == "1";
@@ -1074,6 +1079,46 @@ public partial class Npc : Unit
 
     /// <summary>Squared soft interest radius for mirror SC (commercial AOI, not sticky region set).</summary>
     public static readonly float MirrorNpcAoiRadiusSq = ParseMirrorNpcAoiRadiusSq();
+
+    /// <summary>
+    /// Event/tower rifts fly and land far from the player’s ambient 100 m stream radius — they still
+    /// need SCUnitState so ZW→SC movement (fly-in) is visible on the map. Default 1.5 km; override
+    /// <c>AAEMU_MIRROR_PRIORITY_AOI</c> (metres).
+    /// </summary>
+    public static readonly float MirrorStreamPriorityAoiRadiusSq = ParseMirrorStreamPriorityAoiRadiusSq();
+
+    /// <summary>
+    /// Event NPCs (any tower_def portal / wave / kill-target template) that must paint even when
+    /// ambient mirrors filled MAX first. Base seed list + env <c>AAEMU_MIRROR_PRIORITY_TPL</c>
+    /// still work; full coverage comes from <see cref="TowerDefGameData.IsTowerDefEventNpc"/>.
+    /// </summary>
+    private static readonly HashSet<uint> MirrorStreamPriorityTemplates = BuildMirrorStreamPriorityTemplates();
+
+    public bool IsMirrorStreamPriority =>
+        IsZoneMirror &&
+        (MirrorStreamPriorityTemplates.Contains(TemplateId) ||
+         TowerDefGameData.Instance.IsTowerDefEventNpc(TemplateId));
+
+    private static HashSet<uint> BuildMirrorStreamPriorityTemplates()
+    {
+        // Hardcoded seeds so priority works before / if GameData index is empty.
+        var set = new HashSet<uint>
+        {
+            8828, 8830, 12911, 12720, 12859, 12728, 12729, 12718, 12901, 12719, 12902
+        };
+        var extra = System.Environment.GetEnvironmentVariable("AAEMU_MIRROR_PRIORITY_TPL");
+        if (!string.IsNullOrWhiteSpace(extra))
+        {
+            foreach (var part in extra.Split(',',
+                         StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (uint.TryParse(part, out var id) && id != 0)
+                    set.Add(id);
+            }
+        }
+
+        return set;
+    }
 
     private static int ParseMirrorNpcMax()
     {
@@ -1101,6 +1146,20 @@ public partial class Npc : Unit
         return metres * metres;
     }
 
+    private static float ParseMirrorStreamPriorityAoiRadiusSq()
+    {
+        var raw = System.Environment.GetEnvironmentVariable("AAEMU_MIRROR_PRIORITY_AOI");
+        var metres = 1500f;
+        if (float.TryParse(raw, System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var n) && n >= 50f)
+            metres = n;
+        return metres * metres;
+    }
+
+    /// <summary>AOI for this mirror’s soft stream (priority event NPCs use a larger radius).</summary>
+    public float MirrorStreamAoiRadiusSq =>
+        IsMirrorStreamPriority ? MirrorStreamPriorityAoiRadiusSq : MirrorNpcAoiRadiusSq;
+
     public override void AddVisibleObject(Character character)
     {
         if (DisableMirrorNpcStreaming && IsZoneMirror && WorldIntegration.ZoneAuthority)
@@ -1111,6 +1170,10 @@ public partial class Npc : Unit
 
         if (IsZoneMirror && WorldIntegration.ZoneAuthority)
         {
+            // Priority event NPCs steal a MAX slot if packed AOI only has ambient mirrors.
+            if (IsMirrorStreamPriority && !character.CanStreamMirrorNow(this))
+                character.TryEvictFarthestStreamedForPriority(this);
+
             // Queue only while loading / outside AOI / at MAX (drain + cull recycle slots).
             if (character.CanStreamMirrorNow(this))
                 SendUnitStateTo(character);
@@ -1135,7 +1198,11 @@ public partial class Npc : Unit
 
             if (MirrorNpcMaxPerCharacter > 0 &&
                 character.MirrorNpcStatesSentCount >= MirrorNpcMaxPerCharacter)
-                return;
+            {
+                if (!IsMirrorStreamPriority ||
+                    !character.TryEvictFarthestStreamedForPriority(this))
+                    return;
+            }
 
             if (!character.MirrorNpcStatesSentIds.TryAdd(ObjId, 0))
                 return;
@@ -1156,10 +1223,61 @@ public partial class Npc : Unit
             System.Environment.GetEnvironmentVariable("AAEMU_DISABLE_NPC_FACTION") != "1")
             character.SendPacket(new SCUnitFactionChangedPacket(
                 ObjId, Name ?? "", FactionsEnum.Invalid, Faction.Id, false));
+
+        // SC UnitState writes empty buff lists for NPCs. OnSpawn FX (hellgate storm, etc.) only
+        // arrives via SCBuffCreated. Re-paint when this client got UnitState after World already
+        // applied buffs (late AOI / post-cull re-stream) — Broadcast at Apply time never reached them.
+        if (IsZoneMirror && WorldIntegration.ZoneAuthority)
+            SendActiveBuffsTo(character);
+
+        // Debug only — Info thrash was multi-MB/s during wave packs when something re-painted.
+        if (IsMirrorStreamPriority)
+            Logger.Debug(
+                "Mirror priority SCUnitState → {0} bc={1} tpl={2} zone={3}",
+                character.Name, ObjId, TemplateId, Transform?.ZoneId ?? 0);
+    }
+
+    /// <summary>
+    /// Unicast non-passive buffs currently on this unit (client icons / fx_group). Safe to call on
+    /// every UnitState stream; client replaces by index.
+    /// </summary>
+    public void SendActiveBuffsTo(Character character)
+    {
+        if (character == null || Buffs == null)
+            return;
+
+        var good = new List<Buff>();
+        var bad = new List<Buff>();
+        var hidden = new List<Buff>();
+        Buffs.GetAllBuffs(good, bad, hidden, includeAllPassives: false);
+
+        var sent = 0;
+        foreach (var buff in good.Concat(bad).Concat(hidden))
+        {
+            if (buff == null || buff.Passive || buff.Template == null)
+                continue;
+            character.SendPacket(new SCBuffCreatedPacket(buff));
+            sent++;
+        }
+
+        if (sent > 0 && IsMirrorStreamPriority)
+            Logger.Info(
+                "Mirror priority SCBuffCreated re-sync → {0} bc={1} tpl={2} count={3}",
+                character.Name, ObjId, TemplateId, sent);
     }
 
     public override void RemoveVisibleObject(Character character)
     {
+        // Soft interest leave must not despawn tower / event rifts. True despawn goes through
+        // Hide/Delete (IsVisible=false) after ZWRemove, which is the only path that should SC-remove them.
+        if (IsZoneMirror && WorldIntegration.ZoneAuthority && IsMirrorStreamPriority && IsVisible)
+        {
+            Logger.Debug(
+                "Skip soft SCUnitsRemoved for priority mirror bc={0} tpl={1} char={2}",
+                ObjId, TemplateId, character?.Name);
+            return;
+        }
+
         if (IsZoneMirror && WorldIntegration.ZoneAuthority)
             character.ReleaseMirrorNpcSlot(ObjId);
 
@@ -1461,6 +1579,217 @@ public partial class Npc : Unit
                 Value = bonusTemplate.Value // TODO using LinearLevelBonus
             };
             AddBonus(0, bonus);
+        }
+    }
+
+    /// <summary>
+    /// Apply BuffEffects from np_skills with OnSpawn onto this unit for client visuals.
+    /// Hellgate storm FX (`fx_group_id`) attaches via SCBuffCreated — SC UnitState for Npcs writes
+    /// empty buff lists. Call only after the unit is region-visible (has viewers).
+    /// </summary>
+    /// <param name="zoneAuthored">When true, do not reflect the buff create back to Zone.</param>
+    public void ApplyOnSpawnSkillBuffs(bool zoneAuthored = true)
+    {
+        var skills = NpcGameData.Instance.GetNpSkills(TemplateId, SkillUseConditionKind.OnSpawn);
+        if (skills == null || skills.Count == 0)
+            return;
+
+        var applied = 0;
+        foreach (var npcSkill in skills)
+        {
+            var skillTemplate = SkillManager.Instance.GetSkillTemplate(npcSkill.SkillId);
+            if (skillTemplate?.Effects == null || skillTemplate.Effects.Count == 0)
+                continue;
+
+            foreach (var skillEffect in skillTemplate.Effects)
+            {
+                if (skillEffect?.Template is not BuffEffect buffEffect || buffEffect.Buff == null)
+                    continue;
+                if (Buffs.CheckBuff(buffEffect.Buff.Id))
+                    continue;
+
+                Buffs.AddBuff(new Buff(
+                    this,
+                    this,
+                    new SkillCasterUnit(ObjId),
+                    buffEffect.Buff,
+                    null,
+                    DateTime.UtcNow)
+                {
+                    ZoneAuthored = zoneAuthored
+                });
+                applied++;
+            }
+        }
+
+        if (applied > 0)
+            Logger.Info(
+                "OnSpawn skill FX buffs applied bc={0} tpl={1} count={2} zoneAuthored={3}",
+                ObjId, TemplateId, applied, zoneAuthored);
+    }
+
+    /// <summary>
+    /// SC-only paint for OnSpawn skills that carry <c>fire_anim</c> and no plot.
+    /// Ghost-army units (e.g. skill 21363 / fire_anim 374) have no BuffEffects, so
+    /// <see cref="ApplyOnSpawnSkillBuffs"/> alone leaves them popping in.
+    /// Never calls <c>Skill.Use</c> — that duals dedic OnSpawn under ZoneAuthority (plots/WZ
+    /// once crashed zone 257 after skill 15311→15340). Kill: <c>AAEMU_DISABLE_ONSPAWN_FIRE_ANIM=1</c>.
+    /// </summary>
+    public void CastOnSpawnAnimationSkills()
+    {
+        if (string.Equals(
+                Environment.GetEnvironmentVariable("AAEMU_DISABLE_ONSPAWN_FIRE_ANIM"),
+                "1",
+                StringComparison.Ordinal))
+            return;
+
+        var skills = NpcGameData.Instance.GetNpSkills(TemplateId, SkillUseConditionKind.OnSpawn);
+        if (skills == null || skills.Count == 0)
+            return;
+
+        var fired = 0;
+        foreach (var npcSkill in skills)
+        {
+            var st = SkillManager.Instance.GetSkillTemplate(npcSkill.SkillId);
+            if (st == null)
+                continue;
+            // Plots stay on dedic; World must not re-run plot graphs under ZoneAuthority.
+            if (st.Plot != null || st.PlotOnly)
+                continue;
+
+            var animId = st.FireAnim?.Id ?? 0;
+            if (animId == 0)
+                continue;
+
+            var skill = new Skill(st) { TlId = SkillTlIdManager.GetNextId(this) };
+            try
+            {
+                var caster = new SkillCasterUnit(ObjId);
+                var target = new SkillCastUnitTarget(ObjId);
+                var skillObject = new SkillObject();
+                // Instant cast (casting_time=0): Fired + fireAnim is enough; no Zone WZ bridge.
+                BroadcastPacket(
+                    new SCSkillFiredPacket(st.Id, skill.TlId, caster, target, skill, skillObject)
+                    {
+                        FireAnimId = animId,
+                        EffectDelayMs = st.EffectDelay
+                    },
+                    true);
+                BroadcastPacket(new SCSkillEndedPacket(skill.TlId), true);
+                fired++;
+            }
+            finally
+            {
+                if (skill.TlId != 0)
+                {
+                    SkillTlIdManager.ReleaseId(skill.TlId);
+                    skill.TlId = 0;
+                }
+            }
+        }
+
+        if (fired > 0)
+        {
+            Logger.Info(
+                "OnSpawn fire_anim SC-only bc={0} tpl={1} count={2}",
+                ObjId, TemplateId, fired);
+        }
+    }
+
+    /// <summary>
+    /// ZoneAuthority: dedic rarely starts plot_only OnSpawn for tower stage units (e.g. skill
+    /// 15298 on tpl 8830 → plot summons 8826/8834). World runs those plots so army packs appear.
+    /// Suppresses WZ skill relay so dedic does not dual-fire. Kill: <c>AAEMU_DISABLE_ONSPAWN_PLOTS=1</c>.
+    /// Gated to priority/event mirrors — not ambient plot_only on_spawn (318 rows).
+    /// </summary>
+    public void CastOnSpawnPlotSkills()
+    {
+        if (!WorldIntegration.ZoneAuthority)
+            return;
+        if (string.Equals(
+                Environment.GetEnvironmentVariable("AAEMU_DISABLE_ONSPAWN_PLOTS"),
+                "1",
+                StringComparison.Ordinal))
+            return;
+        if (!IsZoneMirror || !IsMirrorStreamPriority)
+            return;
+
+        var skills = NpcGameData.Instance.GetNpSkills(TemplateId, SkillUseConditionKind.OnSpawn);
+        if (skills == null || skills.Count == 0)
+            return;
+
+        var started = 0;
+        foreach (var npcSkill in skills)
+        {
+            var skill = SkillManager.Instance.GetNpSkillTemplate(npcSkill);
+            if (skill?.Template == null)
+                continue;
+            // Only true plot graphs. plot_only with no plot is a no-op for army work.
+            if (skill.Template.Plot == null || !skill.Template.PlotOnly)
+                continue;
+
+            if (Cooldowns.CheckCooldown(skill.Id))
+                continue;
+            if (skill.Template.CooldownTime == 0)
+                Cooldowns.AddCooldown(skill.Id, uint.MaxValue);
+
+            // skill_use_param1: delay seconds before OnSpawn graph (Crimson stage uses 1.0).
+            var delaySec = npcSkill.SkillUseParam1;
+            skill.SuppressZoneSkillRelay = true;
+            var caster = SkillCaster.GetByType(SkillCasterType.Unit);
+            caster.ObjId = ObjId;
+            var target = SkillCastTarget.GetByType(SkillCastTargetType.Unit);
+            target.ObjId = ObjId;
+
+            void Fire()
+            {
+                if (Hp <= 0 || !IsVisible)
+                    return;
+                try
+                {
+                    var result = skill.Use(this, caster, target, null, true, out _);
+                    Logger.Info(
+                        "OnSpawn plot_only Use bc={0} tpl={1} skill={2} plot={3} result={4}",
+                        ObjId, TemplateId, skill.Id, skill.Template.Plot?.Id ?? 0, result);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warn(
+                        ex,
+                        "OnSpawn plot_only failed bc={0} tpl={1} skill={2}",
+                        ObjId, TemplateId, skill.Id);
+                }
+            }
+
+            if (delaySec > 0.01f)
+            {
+                var delay = TimeSpan.FromSeconds(delaySec);
+                _ = System.Threading.Tasks.Task.Run(async () =>
+                {
+                    try
+                    {
+                        await System.Threading.Tasks.Task.Delay(delay).ConfigureAwait(false);
+                        Fire();
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Warn(ex, "OnSpawn plot_only delay fire bc={0} skill={1}", ObjId, skill.Id);
+                    }
+                });
+            }
+            else
+            {
+                Fire();
+            }
+
+            started++;
+        }
+
+        if (started > 0)
+        {
+            Logger.Info(
+                "OnSpawn plot_only scheduled bc={0} tpl={1} count={2}",
+                ObjId, TemplateId, started);
         }
     }
 

--- a/AAEmu.Game/Models/Game/NPChar/Npc.cs
+++ b/AAEmu.Game/Models/Game/NPChar/Npc.cs
@@ -1065,11 +1065,9 @@ public partial class Npc : Unit
     }
 
     /// <summary>
-    /// flood (~150 at once) Quit'd — AOI+MAX prevent that, not artificial 1/s drip.
     /// AAEMU_DISABLE_MIRROR_NPC=1 | AAEMU_MIRROR_NPC_MAX=N (default 50; 0=unlimited) |
     /// AAEMU_MIRROR_NPC_BURST=N (0=flush all/tick) | AAEMU_MIRROR_NPC_INTERVAL_MS (0=off) |
-    /// AAEMU_MIRROR_NPC_AOI=metres | AAEMU_MIRROR_NPC_GRACE_MS |
-    /// AAEMU_MIRROR_PRIORITY_TPL=8828,8830 (tower/event rifts steal MAX slots).
+    /// AAEMU_MIRROR_NPC_AOI=metres | AAEMU_MIRROR_NPC_GRACE_MS
     /// </summary>
     public static readonly bool DisableMirrorNpcStreaming =
         System.Environment.GetEnvironmentVariable("AAEMU_DISABLE_MIRROR_NPC") == "1";
@@ -1088,37 +1086,11 @@ public partial class Npc : Unit
     public static readonly float MirrorStreamPriorityAoiRadiusSq = ParseMirrorStreamPriorityAoiRadiusSq();
 
     /// <summary>
-    /// Event NPCs (any tower_def portal / wave / kill-target template) that must paint even when
-    /// ambient mirrors filled MAX first. Base seed list + env <c>AAEMU_MIRROR_PRIORITY_TPL</c>
-    /// still work; full coverage comes from <see cref="TowerDefGameData.IsTowerDefEventNpc"/>.
+    /// Event NPCs from loaded tower-def relationships that must paint even when ambient mirrors
+    /// filled MAX first. Returns false until <see cref="TowerDefGameData"/> has loaded.
     /// </summary>
-    private static readonly HashSet<uint> MirrorStreamPriorityTemplates = BuildMirrorStreamPriorityTemplates();
-
     public bool IsMirrorStreamPriority =>
-        IsZoneMirror &&
-        (MirrorStreamPriorityTemplates.Contains(TemplateId) ||
-         TowerDefGameData.Instance.IsTowerDefEventNpc(TemplateId));
-
-    private static HashSet<uint> BuildMirrorStreamPriorityTemplates()
-    {
-        // Hardcoded seeds so priority works before / if GameData index is empty.
-        var set = new HashSet<uint>
-        {
-            8828, 8830, 12911, 12720, 12859, 12728, 12729, 12718, 12901, 12719, 12902
-        };
-        var extra = System.Environment.GetEnvironmentVariable("AAEMU_MIRROR_PRIORITY_TPL");
-        if (!string.IsNullOrWhiteSpace(extra))
-        {
-            foreach (var part in extra.Split(',',
-                         StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-            {
-                if (uint.TryParse(part, out var id) && id != 0)
-                    set.Add(id);
-            }
-        }
-
-        return set;
-    }
+        IsZoneMirror && TowerDefGameData.Instance.IsTowerDefEventNpc(TemplateId);
 
     private static int ParseMirrorNpcMax()
     {

--- a/AAEmu.Game/Models/Game/Quests/QuestCalendarResetSet.cs
+++ b/AAEmu.Game/Models/Game/Quests/QuestCalendarResetSet.cs
@@ -1,0 +1,30 @@
+using AAEmu.Game.Models.Game.Quests.Static;
+
+namespace AAEmu.Game.Models.Game.Quests;
+
+/// <summary>
+/// Calendar roll types for completed_quests bits (World UTC boundaries).
+/// Daily / weekly membership matches the client quest-detail classifier used by IsDailyQuest /
+/// IsWeeklyQuest (detail_id on the quest context).
+/// </summary>
+public static class QuestCalendarResetSet
+{
+    /// <summary>
+    /// Cleared each day at 00:00 UTC: daily, daily_hunt, daily_livelihood, daily_group, today.
+    /// (Not livelihood=8 or group=9; those are different product types.)
+    /// </summary>
+    public static readonly QuestDetail[] Daily =
+    [
+        QuestDetail.Daily,
+        QuestDetail.DailyHunt,
+        QuestDetail.DailyLivelihood,
+        QuestDetail.DailyGroup,
+        QuestDetail.Today
+    ];
+
+    /// <summary>Cleared at Monday 00:00 UTC: weekly only.</summary>
+    public static readonly QuestDetail[] Weekly =
+    [
+        QuestDetail.Weekly
+    ];
+}

--- a/AAEmu.Game/Models/Game/Quests/Static/QuestDetail.cs
+++ b/AAEmu.Game/Models/Game/Quests/Static/QuestDetail.cs
@@ -1,5 +1,8 @@
 ﻿namespace AAEmu.Game.Models.Game.Quests.Static;
 
+/// <summary>
+/// quest_contexts.detail_id (client name map: normal/main/saga/tutorial/hidden, then daily* family).
+/// </summary>
 public enum QuestDetail : uint
 {
     Normal = 1,
@@ -8,11 +11,19 @@ public enum QuestDetail : uint
     Tutorial = 4,
     Hidden = 5,
     Task = 6,
+    /// <summary>Standard dailies (Crimson/Halcyona, Grimghast, kill/clean loops, …).</summary>
     Daily = 7,
+    /// <summary>Livelihood story/work; not calendar-daily in client IsDailyQuest.</summary>
     Livelihood = 8,
+    /// <summary>Weekday-named commissions (Monday…Sunday); not weekly-bit 15.</summary>
     Group = 9,
     DailyHunt = 10,
     DailyLivelihood = 11,
     DailyGroup = 12,
-    Today = 13
+    /// <summary>Path of Destiny / today_quest catalog contracts.</summary>
+    Today = 13,
+    Hero = 14,
+    /// <summary>Weekly quests; cleared Monday 00:00 UTC with the weekly calendar rollover.</summary>
+    Weekly = 15,
+    Expedition = 16
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpawnEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpawnEffect.cs
@@ -1,5 +1,6 @@
 ﻿using AAEmu.Game.Core.Packets;
 using AAEmu.Game.Core.Managers.UnitManagers;
+using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.GameData;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.NPChar;
@@ -24,6 +25,8 @@ public class SpawnEffect : EffectTemplate
     public bool DespawnOnCreatorDeath { get; set; }
     public bool UseSummonerAggroTarget { get; set; }
     public MateState MateStateId { get; set; }
+    /// <summary>When true, non-flying summons snap to terrain under the XY (drop-from-rift).</summary>
+    public bool EnableRayCast { get; set; } = true;
 
     public override bool OnActionTime => false;
 
@@ -75,7 +78,12 @@ public class SpawnEffect : EffectTemplate
 
                     spawner.Position.X = xx;
                     spawner.Position.Y = yy;
-                    spawner.Position.Z = positionRelativeToUnit.Transform.World.Position.Z;
+                    spawner.Position.Z = ResolveSpawnZ(
+                        positionRelativeToUnit,
+                        xx,
+                        yy,
+                        positionRelativeToUnit.Transform.World.Position.Z,
+                        canFly: false);
 
                     spawner.Position.Yaw = orientationRelativeToUnit.Transform.World.Rotation.Z + OriAngle.DegToRad();
 
@@ -113,12 +121,14 @@ public class SpawnEffect : EffectTemplate
 
     private void SpawnNpcInZone(BaseUnit caster, BaseUnit target, CastAction castAction)
     {
-        // SubType is an npc_spawners row. Resolve its member through loaded game content rather
-        // than treating the spawner id as an NPC template id.
-        var member = NpcGameData.Instance.GetNpcSpawnerNpc(SubType);
-        if (member == null)
+        // Crimson / tower stage plots store an Npc template id in SubType (e.g. 8834 궁수,
+        // 8826 보병). Those ids are not always npc_spawners rows; when both exist (8826), the
+        // spawner row is a different mob. Prefer a real Npc template, then fall back to spawner
+        // member lookup (legacy World-local SpawnEffect path).
+        var templateId = ResolveZoneSpawnNpcTemplateId();
+        if (templateId == 0)
         {
-            Logger.Info($"SpawnEffect: SubType={SubType} not found in npc_spawner_npcs.");
+            Logger.Info($"SpawnEffect: SubType={SubType} is neither an Npc template nor npc_spawners member.");
             return;
         }
 
@@ -141,10 +151,10 @@ public class SpawnEffect : EffectTemplate
         }
 
         var world = caster?.ParentWorld;
-        var npc = world == null ? null : NpcManager.Instance.Create(world, 0, member.MemberId);
+        var npc = world == null ? null : NpcManager.Instance.Create(world, 0, templateId);
         if (npc == null)
         {
-            Logger.Warn($"SpawnEffect: NPC template {member.MemberId} for spawner {SubType} could not be created.");
+            Logger.Warn($"SpawnEffect: NPC template {templateId} (SubType={SubType}) could not be created.");
             return;
         }
 
@@ -154,15 +164,17 @@ public class SpawnEffect : EffectTemplate
             positionRelativeToUnit.Transform.World.Position.Y,
             PosAngle);
         var yaw = orientationRelativeToUnit.Transform.World.Rotation.Z + OriAngle.DegToRad();
-
-        npc.Transform = positionRelativeToUnit.Transform.CloneDetached(npc);
-        npc.Transform.Local.SetPosition(
+        // Portal/rift casters sit high for the client ball drop. SpawnEffect rows for ground
+        // army (enable_ray_cast) must land on terrain — otherwise units freeze at air Z.
+        var z = ResolveSpawnZ(
+            positionRelativeToUnit,
             x,
             y,
             positionRelativeToUnit.Transform.World.Position.Z,
-            0f,
-            0f,
-            yaw);
+            npc.CanFly);
+
+        npc.Transform = positionRelativeToUnit.Transform.CloneDetached(npc);
+        npc.Transform.Local.SetPosition(x, y, z, 0f, 0f, yaw);
         npc.OwnerId = caster switch
         {
             Character character => character.Id,
@@ -187,5 +199,58 @@ public class SpawnEffect : EffectTemplate
 
         if (UseSummonerAggroTarget && (target ?? caster) is Unit aggroTarget)
             WorldIntegration.PublishAggro(npc, aggroTarget, 1, castAction);
+    }
+
+    /// <summary>
+    /// Floor Z for ground army (Crimson balls land then emerge). Aerial Z kept for fliers.
+    /// </summary>
+    private float ResolveSpawnZ(BaseUnit anchor, float x, float y, float rawZ, bool canFly)
+    {
+        if (canFly)
+            return rawZ;
+
+        // Retail enable_ray_cast: snap non-flyers unless disabled for this effect row.
+        // Default true when the column was not loaded (older caches).
+        if (!EnableRayCast && rawZ > 0f)
+        {
+            // Still drop when the position unit is a flying portal / synthetic anchor above terrain.
+            var anchorNpc = anchor as Npc;
+            if (anchorNpc is not { CanFly: true } && anchor?.ObjId != uint.MaxValue)
+                return rawZ;
+        }
+
+        var zoneId = anchor?.Transform?.ZoneId ?? 0;
+        if (zoneId == 0)
+            return rawZ;
+
+        var ground = WorldManager.Instance.GetReferenceHeight(null, x, y, rawZ, zoneId);
+        if (ground <= 0f)
+            ground = WorldManager.Instance.GetHeight(zoneId, x, y, rawZ);
+
+        if (ground <= 0f)
+            return rawZ;
+
+        // Only correct obvious air spawns (rift is typically +40–60 m).
+        if (rawZ > ground + 3f)
+        {
+            Logger.Debug(
+                "SpawnEffect terrain snap SubType={0} rawZ={1:F1} → ground={2:F1} @({3:F1},{4:F1})",
+                SubType, rawZ, ground, x, y);
+            return ground;
+        }
+
+        return rawZ;
+    }
+
+    /// <summary>
+    /// Npc template for ZoneAuthority SpawnEffect: template id first, then spawner-member id.
+    /// </summary>
+    private uint ResolveZoneSpawnNpcTemplateId()
+    {
+        if (SubType != 0 && NpcManager.Instance.GetTemplate(SubType) != null)
+            return SubType;
+
+        var member = NpcGameData.Instance.GetNpcSpawnerNpc(SubType);
+        return member?.MemberId ?? 0;
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotTargetInfo.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotTargetInfo.cs
@@ -1,5 +1,6 @@
 ﻿using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game.Faction;
+using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Skills.Plots.Type;
 using AAEmu.Game.Models.Game.Skills.Plots.UpdateTargetMethods;
 using AAEmu.Game.Models.Game.Skills.Utils;
@@ -162,8 +163,8 @@ public class PlotTargetInfo
         {
             posUnit.Transform.Local.AddDistanceToFront(args.Distance / 1000f - 0.01f);
         }
-        // TODO: Make this use geo data, need to check if we can grab parent world from here
-        posUnit.Transform.Local.SetHeight(Math.Max(PreviousTarget.Transform.World.Position.Z + args.HeightOffset / 1000f, WorldManager.Instance.GetHeight(posUnit.Transform)));
+        posUnit.Transform.Local.SetHeight(ResolvePlotLandHeight(
+            PreviousTarget, posUnit, args.HeightOffset));
 
         if (args.MaxTargets == 0)
         {
@@ -251,8 +252,10 @@ public class PlotTargetInfo
         posUnit.Transform.InstanceId = PreviousTarget.Transform.InstanceId;
         posUnit.Transform.Local.SetZRotation(((float)Random.Shared.Next(-180, 180)).DegToRad());
         posUnit.Transform.Local.AddDistanceToFront(args.Distance / 1000f);
-        // TODO: Make this use geo data, need to check if we can grab parent world from here
-        posUnit.Transform.Local.SetHeight(Math.Max(PreviousTarget.Transform.World.Position.Z + args.HeightOffset / 1000f, WorldManager.Instance.GetHeight(posUnit.Transform)));
+        // Crimson plot 143: RandomArea after flying portals used Math.Max(portalZ+offset, ground)
+        // which kept markers at rifts (balls never "landed"); army SpawnEffect copied that Z.
+        posUnit.Transform.Local.SetHeight(ResolvePlotLandHeight(
+            PreviousTarget, posUnit, args.HeightOffset));
 
         if (args.MaxTargets == 0)
         {
@@ -315,6 +318,37 @@ public class PlotTargetInfo
     private static readonly bool AreaDebug = Environment.GetEnvironmentVariable("AAEMU_PLOT_AREA_DEBUG") == "1";
 
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
+
+    /// <summary>
+    /// Land plot area/random markers for ground summons. Legacy used Math.Max(anchorZ+offset, ground),
+    /// which keeps flying portal anchors in the air so Crimson SpawnEffects appear as sky mobs.
+    /// Large HeightOffset values (e.g. 500000 → 500m) are treated as ray-drop range, not lift.
+    /// </summary>
+    private static float ResolvePlotLandHeight(BaseUnit previous, BaseUnit posUnit, int heightOffsetRaw)
+    {
+        var offsetM = heightOffsetRaw / 1000f;
+        var anchorZ = previous?.Transform?.World.Position.Z ?? 0f;
+        var raised = anchorZ + offsetM;
+        var ground = WorldManager.Instance.GetHeight(posUnit.Transform);
+        if (ground <= 0f)
+            return raised;
+
+        // Typical retail RandomArea after portal: |offset| 300–500 m is "search down from sky"
+        // rather than place 500 m above the anchor.
+        if (Math.Abs(offsetM) >= 100f)
+            return ground;
+
+        // Flying portal / synthetic previous keep Math.Max only for shallow lifts; otherwise land.
+        var previousIsAerial = previous is Npc { CanFly: true }
+                               || (previous != null
+                                   && previous.ObjId != uint.MaxValue
+                                   && ground > 0f
+                                   && anchorZ > ground + 8f);
+        if (previousIsAerial && raised > ground + 2f)
+            return ground;
+
+        return Math.Max(raised, ground);
+    }
 
     /// <summary>
     /// One line describing where a plot area search looked and what each filter step removed. This is the

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -55,6 +55,12 @@ public class Skill
     public Action Callback { get; set; }
 
     /// <summary>
+    /// When true, skip WZSkillStarted/Fired/Ended relay. Used for World-authored OnSpawn plots
+    /// under ZoneAuthority so the zone process does not dual-run the same skill graph.
+    /// </summary>
+    public bool SuppressZoneSkillRelay { get; set; }
+
+    /// <summary>
     /// Multiplier that can be added as an additional modifier to casting times
     /// </summary>
     public float CastTimeMultiplier { get; set; } = 1f;
@@ -1755,7 +1761,7 @@ AlwaysHit:
     /// </summary>
     private void RelayZoneSkillStartedIfNeeded(SkillCaster casterCaster, SkillCastTarget targetCaster, SkillObject skillObject)
     {
-        if (_zoneSkillStartedRelayed || TlId == 0)
+        if (_zoneSkillStartedRelayed || TlId == 0 || SuppressZoneSkillRelay)
             return;
         if (!WorldIntegration.ZoneAuthority)
             return;

--- a/AAEmu.Game/Models/Game/TowerDefs/TowerDef.cs
+++ b/AAEmu.Game/Models/Game/TowerDefs/TowerDef.cs
@@ -25,18 +25,16 @@ public class TowerDef
     public TowerDefEventVariant Variant { get; set; } = TowerDefEventVariant.Unspecified;
 
     /// <summary>
-    /// How World auto-arms this row. Set from weekday StartTimes and/or
-    /// <c>Configurations/TowerDefs.json</c> GameTimeAutoArm entries.
+    /// How World auto-arms this row. WallClock comes from weekday StartTimes; GameTime comes from
+    /// explicit <c>TowerDefs.GameTimeAutoArmIds</c> membership.
     /// </summary>
     public TowerDefScheduleMode ScheduleMode { get; set; } = TowerDefScheduleMode.Manual;
 
     /// <summary>
     /// Wall-clock start time per day of the week, index 0 = Sunday, or null on days the event does
     /// not run. The <c>tower_defs</c> row carries seven independent <c>start_hourN</c> /
-    /// <c>start_minuteN</c> pairs and the data uses them as one slot per weekday rather than seven
-    /// starts in a single day — rows that vary them make this plain: 붉은 용의 출현 통합 인던 runs
-    /// 21:30 on some days and 21:40 on others, 풍랑의 전조 runs 23:00 on two days and 22:00 on the
-    /// rest, and 크라켄의 출현 populates exactly one slot.
+    /// <c>start_minuteN</c> pairs used as one slot per weekday. A 00:00 pair means the event does
+    /// not run that day.
     /// </summary>
     public TimeSpan?[] StartTimes { get; } = new TimeSpan?[7];
 
@@ -134,6 +132,15 @@ public class TowerDef
         var start = now.Date.AddDays(dayOffset).Add(slot);
         return now >= start && now < start + Duration;
     }
+
+    /// <summary>
+    /// True when this event shares a portal spawner with <paramref name="other"/>.
+    /// Portal exclusion uses this loaded relationship, not family labels.
+    /// </summary>
+    public bool SharesPortalSpawnerWith(TowerDef other) =>
+        other != null &&
+        TargetNpcSpawnId != 0 &&
+        TargetNpcSpawnId == other.TargetNpcSpawnId;
 
     public List<TowerDefProg> Progs;
 }

--- a/AAEmu.Game/Models/Game/TowerDefs/TowerDef.cs
+++ b/AAEmu.Game/Models/Game/TowerDefs/TowerDef.cs
@@ -2,6 +2,24 @@ namespace AAEmu.Game.Models.Game.TowerDefs;
 
 public class TowerDef
 {
+    /// <summary>
+    /// Event Center "Game Time" rifts are identified by spawner-backed <c>tower_defs</c> rows whose
+    /// names match these substrings (Korean client data / classic localization).
+    /// </summary>
+    private static readonly string[] GameTimeRiftNameMarkers =
+    [
+        "징조의 틈",   // Crimson Rift
+        "전장의 안개",  // Grimghast
+        "망각의 균열",  // Oblivion Rift
+        "기계의 소란"   // Clockwork Rebellion
+    ];
+
+    /// <summary>Expand/hard-mode suffix in rift names (paired base + expand rows share a portal).</summary>
+    private const string ExpandNameMarker = "확장";
+
+    /// <summary>Guide/tutorial variant of Grimghast (separate spawner; not the night main event).</summary>
+    private const string GrimghastGuideNameMarker = "안내";
+
     public uint Id { get; set; }
     public string Name { get; set; }
     public string StartMsg { get; set; }
@@ -31,7 +49,7 @@ public class TowerDef
     /// <summary>Start time for a day, or null when this event does not run that day.</summary>
     public TimeSpan? StartTimeFor(DayOfWeek day) => StartTimes[(int)day];
 
-    /// <summary>True when any weekday carries a start time.</summary>
+    /// <summary>True when any weekday carries a wall-clock start time (UTC on World).</summary>
     public bool IsScheduled
     {
         get
@@ -39,6 +57,61 @@ public class TowerDef
             foreach (var slot in StartTimes)
             {
                 if (slot.HasValue)
+                    return true;
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Event-Center "Game Time" strip: no wall-clock hours, has a day interval, armed spawner,
+    /// and a name marker for rift-family content. Driven by zone-simulated hour, not UTC.
+    /// </summary>
+    /// <remarks>
+    /// Shipped rows pair base + expand on the same portal. Event Center Game Time strip:
+    /// Grimghast @0 (base), Crimson @12 Cinderstone/Ynystere + @18 Auroria (expand only),
+    /// Oblivion/Clockwork @2/@14. Base Crimson still has <c>tod=0</c> in data — arming every
+    /// marker twin-spawns Crimson with Grimghast at night. Expand Grimghast / guide rows stay
+    /// GM-startable, not auto Game-Time.
+    /// </remarks>
+    public bool IsGameTimeScheduled
+    {
+        get
+        {
+            if (IsScheduled)
+                return false;
+            if (TimeOfDayDayInterval == 0)
+                return false;
+            if (TargetNpcSpawnId == 0)
+                return false;
+            if (string.IsNullOrEmpty(Name))
+                return false;
+            if (Name.Contains("[테스트]", StringComparison.Ordinal) ||
+                Name.Contains("[TEST]", StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            var isExpand = Name.Contains(ExpandNameMarker, StringComparison.Ordinal);
+            var isCrimson = Name.Contains(GameTimeRiftNameMarkers[0], StringComparison.Ordinal);
+            var isGrimghast = Name.Contains(GameTimeRiftNameMarkers[1], StringComparison.Ordinal);
+
+            // Crimson: only expand rows (tod 12 Cinderstone/Ynystere, 18 Auroria).
+            if (isCrimson)
+                return isExpand;
+
+            // Grimghast main: base only. Skip expand (shares portal) and "안내" guides.
+            if (isGrimghast)
+            {
+                if (isExpand)
+                    return false;
+                if (Name.Contains(GrimghastGuideNameMarker, StringComparison.Ordinal))
+                    return false;
+                return true;
+            }
+
+            foreach (var marker in GameTimeRiftNameMarkers)
+            {
+                if (Name.Contains(marker, StringComparison.Ordinal))
                     return true;
             }
 
@@ -56,13 +129,42 @@ public class TowerDef
         : TimeSpan.FromHours(1);
 
     /// <summary>
-    /// True when <paramref name="now"/> falls inside this event's window. A window that runs past
-    /// midnight stays owned by the day it started on, so yesterday's slot is checked as well.
+    /// True when <paramref name="now"/> falls inside this event's wall-clock window. A window that
+    /// runs past midnight stays owned by the day it started on, so yesterday's slot is checked as well.
     /// </summary>
     public bool IsWithinWindow(DateTime now)
     {
         return InSlot(now, now.DayOfWeek, 0) ||
                InSlot(now, now.AddDays(-1).DayOfWeek, -1);
+    }
+
+    /// <summary>
+    /// True when simulated game hour advances across this row's <c>tod</c> (handles day wrap).
+    /// </summary>
+    public bool CrossedGameStartHour(float oldHour, float newHour)
+    {
+        var trigger = TimeOfDay;
+        if (trigger < 0f)
+            trigger = 0f;
+        if (trigger >= 24f)
+            trigger = 0f;
+
+        oldHour = NormalizeHour(oldHour);
+        newHour = NormalizeHour(newHour);
+        if (Math.Abs(oldHour - newHour) < 1e-6f)
+            return false;
+
+        if (oldHour <= newHour)
+            return oldHour < trigger && trigger <= newHour;
+
+        // Wrapped past 24 → 0.
+        return oldHour < trigger || trigger <= newHour;
+    }
+
+    private static float NormalizeHour(float hours)
+    {
+        var h = hours % 24f;
+        return h < 0f ? h + 24f : h;
     }
 
     private bool InSlot(DateTime now, DayOfWeek day, int dayOffset)

--- a/AAEmu.Game/Models/Game/TowerDefs/TowerDef.cs
+++ b/AAEmu.Game/Models/Game/TowerDefs/TowerDef.cs
@@ -2,24 +2,6 @@ namespace AAEmu.Game.Models.Game.TowerDefs;
 
 public class TowerDef
 {
-    /// <summary>
-    /// Event Center "Game Time" rifts are identified by spawner-backed <c>tower_defs</c> rows whose
-    /// names match these substrings (Korean client data / classic localization).
-    /// </summary>
-    private static readonly string[] GameTimeRiftNameMarkers =
-    [
-        "징조의 틈",   // Crimson Rift
-        "전장의 안개",  // Grimghast
-        "망각의 균열",  // Oblivion Rift
-        "기계의 소란"   // Clockwork Rebellion
-    ];
-
-    /// <summary>Expand/hard-mode suffix in rift names (paired base + expand rows share a portal).</summary>
-    private const string ExpandNameMarker = "확장";
-
-    /// <summary>Guide/tutorial variant of Grimghast (separate spawner; not the night main event).</summary>
-    private const string GrimghastGuideNameMarker = "안내";
-
     public uint Id { get; set; }
     public string Name { get; set; }
     public string StartMsg { get; set; }
@@ -35,6 +17,18 @@ public class TowerDef
     public uint MilestoneId { get; set; }
     public bool BroadcastToWholeWorld { get; set; }
     public uint StartDayOfWeekBit { get; set; }
+
+    /// <summary>Event family from typed schedule config (not display name).</summary>
+    public TowerDefEventFamily Family { get; set; } = TowerDefEventFamily.Unspecified;
+
+    /// <summary>Base / expand / guide from typed schedule config.</summary>
+    public TowerDefEventVariant Variant { get; set; } = TowerDefEventVariant.Unspecified;
+
+    /// <summary>
+    /// How World auto-arms this row. Set from weekday StartTimes and/or
+    /// <c>Configurations/TowerDefs.json</c> GameTimeAutoArm entries.
+    /// </summary>
+    public TowerDefScheduleMode ScheduleMode { get; set; } = TowerDefScheduleMode.Manual;
 
     /// <summary>
     /// Wall-clock start time per day of the week, index 0 = Sunday, or null on days the event does
@@ -65,57 +59,22 @@ public class TowerDef
     }
 
     /// <summary>
-    /// Event-Center "Game Time" strip: no wall-clock hours, has a day interval, armed spawner,
-    /// and a name marker for rift-family content. Driven by zone-simulated hour, not UTC.
+    /// Event-Center Game Time strip: ToD-driven auto-arm from typed schedule config.
+    /// Requires day interval + seed spawner; never uses display-name substrings.
     /// </summary>
-    /// <remarks>
-    /// Shipped rows pair base + expand on the same portal. Event Center Game Time strip:
-    /// Grimghast @0 (base), Crimson @12 Cinderstone/Ynystere + @18 Auroria (expand only),
-    /// Oblivion/Clockwork @2/@14. Base Crimson still has <c>tod=0</c> in data — arming every
-    /// marker twin-spawns Crimson with Grimghast at night. Expand Grimghast / guide rows stay
-    /// GM-startable, not auto Game-Time.
-    /// </remarks>
     public bool IsGameTimeScheduled
     {
         get
         {
+            if (ScheduleMode != TowerDefScheduleMode.GameTime)
+                return false;
             if (IsScheduled)
                 return false;
             if (TimeOfDayDayInterval == 0)
                 return false;
             if (TargetNpcSpawnId == 0)
                 return false;
-            if (string.IsNullOrEmpty(Name))
-                return false;
-            if (Name.Contains("[테스트]", StringComparison.Ordinal) ||
-                Name.Contains("[TEST]", StringComparison.OrdinalIgnoreCase))
-                return false;
-
-            var isExpand = Name.Contains(ExpandNameMarker, StringComparison.Ordinal);
-            var isCrimson = Name.Contains(GameTimeRiftNameMarkers[0], StringComparison.Ordinal);
-            var isGrimghast = Name.Contains(GameTimeRiftNameMarkers[1], StringComparison.Ordinal);
-
-            // Crimson: only expand rows (tod 12 Cinderstone/Ynystere, 18 Auroria).
-            if (isCrimson)
-                return isExpand;
-
-            // Grimghast main: base only. Skip expand (shares portal) and "안내" guides.
-            if (isGrimghast)
-            {
-                if (isExpand)
-                    return false;
-                if (Name.Contains(GrimghastGuideNameMarker, StringComparison.Ordinal))
-                    return false;
-                return true;
-            }
-
-            foreach (var marker in GameTimeRiftNameMarkers)
-            {
-                if (Name.Contains(marker, StringComparison.Ordinal))
-                    return true;
-            }
-
-            return false;
+            return true;
         }
     }
 

--- a/AAEmu.Game/Models/Game/TowerDefs/TowerDefActiveInfo.cs
+++ b/AAEmu.Game/Models/Game/TowerDefs/TowerDefActiveInfo.cs
@@ -1,0 +1,23 @@
+using AAEmu.Commons.Network;
+
+namespace AAEmu.Game.Models.Game.TowerDefs;
+
+/// <summary>
+/// One live tower event for <see cref="G2C.SCTowerDefActiveInfoListPacket"/> (world-map marks).
+/// </summary>
+public sealed class TowerDefActiveInfo : PacketMarshaler
+{
+    public uint ZoneId { get; set; }
+    public uint CurrentStep { get; set; }
+    public uint TowerDefId { get; set; }
+    public ushort ZoneGroupId { get; set; }
+
+    public override PacketStream Write(PacketStream stream)
+    {
+        stream.Write(ZoneId);
+        stream.Write(CurrentStep);
+        stream.Write(TowerDefId);
+        stream.Write(ZoneGroupId);
+        return stream;
+    }
+}

--- a/AAEmu.Game/Models/Game/TowerDefs/TowerDefScheduleEnums.cs
+++ b/AAEmu.Game/Models/Game/TowerDefs/TowerDefScheduleEnums.cs
@@ -1,0 +1,35 @@
+namespace AAEmu.Game.Models.Game.TowerDefs;
+
+/// <summary>Stable event family for tower_defs rows (not derived from display names).</summary>
+public enum TowerDefEventFamily : byte
+{
+    Unspecified = 0,
+    Crimson = 1,
+    Grimghast = 2,
+    Oblivion = 3,
+    Clockwork = 4,
+    Other = 255
+}
+
+/// <summary>Base / expand / guide relationship for a tower_def row.</summary>
+public enum TowerDefEventVariant : byte
+{
+    Unspecified = 0,
+    Base = 1,
+    Expand = 2,
+    Guide = 3
+}
+
+/// <summary>
+/// How World auto-arms this event. Wall-clock slots use <see cref="TowerDef.StartTimes"/>;
+/// GameTime uses simulated hour / <see cref="TowerDef.TimeOfDay"/>.
+/// </summary>
+public enum TowerDefScheduleMode : byte
+{
+    /// <summary>GM / API start only (or incomplete config).</summary>
+    Manual = 0,
+    /// <summary>UTC weekday StartTimes windows.</summary>
+    WallClock = 1,
+    /// <summary>Simulated game-hour ToD crossing (Event Center "Game Time" strip).</summary>
+    GameTime = 2
+}

--- a/AAEmu.Game/Models/Game/TowerDefs/TowerDefScheduleMetadata.cs
+++ b/AAEmu.Game/Models/Game/TowerDefs/TowerDefScheduleMetadata.cs
@@ -1,0 +1,96 @@
+namespace AAEmu.Game.Models.Game.TowerDefs;
+
+/// <summary>
+/// Applies Event Center Game-Time membership onto loaded <c>tower_defs</c> rows.
+/// </summary>
+/// <remarks>
+/// <c>tower_defs</c> has no schedule-mode column. Weekday <see cref="TowerDef.StartTimes"/> uniquely
+/// identify WallClock events. Game-Time vs Manual cannot be derived from <c>tod</c> /
+/// <c>tod_day_interval</c> / <c>target_npc_spawner_id</c> alone — those columns are populated on
+/// both auto-armed Event Center rows and GM-only rows that share a portal spawner.
+/// <see cref="AAEmu.Game.Models.Game.TowerDefsConfig.GameTimeAutoArmIds"/> is therefore the explicit membership overlay.
+/// Omitted ToD-capable rows stay Manual and are reported so the overlay cannot go stale silently.
+/// Family/variant labels are not required: portal exclusion uses
+/// <see cref="TowerDef.TargetNpcSpawnId"/>.
+/// </remarks>
+public static class TowerDefScheduleMetadata
+{
+    public readonly record struct ApplyResult(
+        int AppliedGameTime,
+        IReadOnlyList<uint> UnknownIds,
+        IReadOnlyList<uint> WallClockConflicts,
+        IReadOnlyList<uint> UnlistedToDCandidates,
+        IReadOnlyList<uint> IneligibleIds);
+
+    /// <summary>
+    /// True when the row has the Game-Time columns but no weekday slots — a completeness candidate.
+    /// </summary>
+    public static bool IsToDCapable(TowerDef towerDef) =>
+        towerDef != null &&
+        !towerDef.IsScheduled &&
+        towerDef.TimeOfDayDayInterval > 0 &&
+        towerDef.TargetNpcSpawnId != 0;
+
+    public static ApplyResult Apply(IEnumerable<TowerDef> towerDefs, IReadOnlyList<uint> gameTimeAutoArmIds)
+    {
+        var byId = new Dictionary<uint, TowerDef>();
+        foreach (var towerDef in towerDefs)
+        {
+            if (towerDef == null || towerDef.Id == 0)
+                continue;
+            byId[towerDef.Id] = towerDef;
+            towerDef.ScheduleMode = towerDef.IsScheduled
+                ? TowerDefScheduleMode.WallClock
+                : TowerDefScheduleMode.Manual;
+        }
+
+        var unknown = new List<uint>();
+        var wallConflicts = new List<uint>();
+        var ineligible = new List<uint>();
+        var applied = 0;
+        var listed = new HashSet<uint>();
+        var ids = gameTimeAutoArmIds ?? Array.Empty<uint>();
+
+        foreach (var id in ids)
+        {
+            if (id == 0 || !listed.Add(id))
+                continue;
+            if (!byId.TryGetValue(id, out var towerDef))
+            {
+                unknown.Add(id);
+                continue;
+            }
+
+            if (towerDef.IsScheduled)
+            {
+                wallConflicts.Add(id);
+                continue;
+            }
+
+            if (towerDef.TimeOfDayDayInterval == 0 || towerDef.TargetNpcSpawnId == 0)
+            {
+                ineligible.Add(id);
+                continue;
+            }
+
+            towerDef.ScheduleMode = TowerDefScheduleMode.GameTime;
+            applied++;
+        }
+
+        var unlisted = new List<uint>();
+        foreach (var towerDef in byId.Values)
+        {
+            if (listed.Contains(towerDef.Id))
+                continue;
+            if (!IsToDCapable(towerDef))
+                continue;
+            unlisted.Add(towerDef.Id);
+        }
+
+        unlisted.Sort();
+        unknown.Sort();
+        wallConflicts.Sort();
+        ineligible.Sort();
+        return new ApplyResult(applied, unknown, wallConflicts, unlisted, ineligible);
+    }
+}

--- a/AAEmu.Game/Models/Game/TowerDefsConfig.cs
+++ b/AAEmu.Game/Models/Game/TowerDefsConfig.cs
@@ -1,0 +1,22 @@
+namespace AAEmu.Game.Models.Game;
+
+/// <summary>
+/// Authoritative schedule classification for <c>tower_defs</c> rows.
+/// Configure in <c>AAEmu.Game/Configurations/TowerDefs.json</c> under <c>TowerDefs</c>.
+/// Display names are localization only and must not drive server behavior.
+/// </summary>
+public class TowerDefsConfig
+{
+    /// <summary>
+    /// Rows that auto-arm on simulated game-hour crossings. Missing ids stay Manual unless
+    /// they carry weekday StartTimes (those become WallClock from data alone).
+    /// </summary>
+    public List<TowerDefScheduleEntryConfig> GameTimeAutoArm { get; set; } = [];
+}
+
+public class TowerDefScheduleEntryConfig
+{
+    public uint Id { get; set; }
+    public string Family { get; set; } = "Unspecified";
+    public string Variant { get; set; } = "Unspecified";
+}

--- a/AAEmu.Game/Models/Game/TowerDefsConfig.cs
+++ b/AAEmu.Game/Models/Game/TowerDefsConfig.cs
@@ -1,22 +1,27 @@
 namespace AAEmu.Game.Models.Game;
 
 /// <summary>
-/// Authoritative schedule classification for <c>tower_defs</c> rows.
-/// Configure in <c>AAEmu.Game/Configurations/TowerDefs.json</c> under <c>TowerDefs</c>.
-/// Display names are localization only and must not drive server behavior.
+/// Server-owned Event Center Game-Time membership overlay for <c>tower_defs</c>.
+/// Bind from <c>AAEmu.Game/Configurations/TowerDefs.json</c> under <c>TowerDefs</c>.
 /// </summary>
+/// <remarks>
+/// Contract:
+/// <list type="bullet">
+/// <item>WallClock is derived from weekday StartTimes on the loaded row.</item>
+/// <item>GameTime is explicit membership in <see cref="GameTimeAutoArmIds"/> (ids must exist in
+/// <c>tower_defs</c>, have <c>tod_day_interval</c> and <c>target_npc_spawner_id</c>, and must not
+/// also carry weekday slots).</item>
+/// <item>Every other row is Manual. ToD-capable rows omitted from the list stay Manual and are
+/// logged at load so a stale overlay is visible.</item>
+/// <item>Display names never classify events. Portal exclusion uses
+/// <c>target_npc_spawner_id</c>, not family labels.</item>
+/// </list>
+/// </remarks>
 public class TowerDefsConfig
 {
     /// <summary>
-    /// Rows that auto-arm on simulated game-hour crossings. Missing ids stay Manual unless
-    /// they carry weekday StartTimes (those become WallClock from data alone).
+    /// <c>tower_defs.id</c> values that auto-arm when simulated game hour crosses the row's
+    /// <c>tod</c>. Empty means no Game-Time auto-arm.
     /// </summary>
-    public List<TowerDefScheduleEntryConfig> GameTimeAutoArm { get; set; } = [];
-}
-
-public class TowerDefScheduleEntryConfig
-{
-    public uint Id { get; set; }
-    public string Family { get; set; } = "Unspecified";
-    public string Variant { get; set; } = "Unspecified";
+    public List<uint> GameTimeAutoArmIds { get; set; } = [];
 }

--- a/AAEmu.Game/Models/Game/World/Region.cs
+++ b/AAEmu.Game/Models/Game/World/Region.cs
@@ -194,23 +194,39 @@ public class Region(WorldInstance worldInstance, int x, int y, uint zoneKey)
         // Special handling for characters (players)
         if (obj is Character character1)
         {
-            // Existing logic for sending SCUnitsRemovedPacket, SCDoodadsRemovedPacket, etc. remains unchanged.
-            var unitIds = GetListId<Unit>([], character1.ObjId).ToArray();
+            // Leaving a region batches SCUnitsRemoved for every unit in that cell. Soft AOI cull
+            // already skips priority event mirrors; this path did not — so walking one cell away
+            // stripped hellgate UnitState (+ OnSpawn FX buffs) even while still same zone.
             var units = GetList(new List<Unit>(), character1.ObjId);
+            var unitIds = new List<uint>(units.Count);
             foreach (var t in units)
             {
-                // Region leave batches SCUnitsRemoved and does not call Npc.RemoveVisibleObject —
-                // still free mirror MAX slots / pending so walking recycles interest capacity.
+                if (t is Npc
+                    {
+                        IsZoneMirror: true,
+                        IsMirrorStreamPriority: true,
+                        IsVisible: true
+                    } priorityMirror
+                    && priorityMirror.Transform?.ZoneId != 0
+                    && character1.Transform?.ZoneId == priorityMirror.Transform.ZoneId)
+                {
+                    // Keep stream slot + client unit for tower_def / event rifts across region hops.
+                    continue;
+                }
+
+                // Ambient mirrors: free MAX slots so walking recycles interest capacity.
                 if (t is Npc { IsZoneMirror: true } mirror)
                     character1.ReleaseMirrorNpcSlot(mirror.ObjId);
+                unitIds.Add(t.ObjId);
             }
-            for (var offset = 0; offset < unitIds.Length; offset += SCUnitsRemovedPacket.MaxCountPerPacket)
+
+            for (var offset = 0; offset < unitIds.Count; offset += SCUnitsRemovedPacket.MaxCountPerPacket)
             {
-                var length = unitIds.Length - offset;
+                var length = unitIds.Count - offset;
                 var temp = new uint[length > SCUnitsRemovedPacket.MaxCountPerPacket
                     ? SCUnitsRemovedPacket.MaxCountPerPacket
                     : length];
-                Array.Copy(unitIds, offset, temp, 0, temp.Length);
+                unitIds.CopyTo(offset, temp, 0, temp.Length);
                 character1.SendPacket(new SCUnitsRemovedPacket(temp));
             }
 
@@ -281,6 +297,9 @@ public class Region(WorldInstance worldInstance, int x, int y, uint zoneKey)
             // Send the removal packet ONLY to the filtered list of players
             foreach (var character in charactersToRemoveFrom)
             {
+                // Priority event mirrors stay painted on soft region hops (ZW move poison / id reuse).
+                if (obj is Npc { IsMirrorStreamPriority: true, IsVisible: true })
+                    continue;
                 obj.RemoveVisibleObject(character);
             }
         }

--- a/AAEmu.Game/Models/ServerCalendar.cs
+++ b/AAEmu.Game/Models/ServerCalendar.cs
@@ -25,6 +25,26 @@ public static class ServerCalendar
         }
     }
 
-    /// <summary>True when <paramref name="utc"/> is at or after the first moment of the current UTC day.</summary>
-    public static bool IsBeforeToday(DateTime utcMoment) => utcMoment.ToUniversalTime().Date < TodayUtc;
+    /// <summary>
+    /// Normalize a persisted timestamp to UTC without treating <see cref="DateTimeKind.Unspecified"/>
+    /// as local (MySQL readers often materialize UTC columns as Unspecified).
+    /// </summary>
+    public static DateTime AsUtc(DateTime value) =>
+        value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+        };
+
+    /// <summary>True when <paramref name="moment"/> is strictly before the current UTC calendar day.</summary>
+    public static bool IsBeforeToday(DateTime moment) => AsUtc(moment).Date < TodayUtc;
+
+    /// <summary>Monday 00:00 UTC of the week containing <paramref name="moment"/>.</summary>
+    public static DateTime WeekStartMondayContaining(DateTime moment)
+    {
+        var day = AsUtc(moment).Date;
+        var offset = ((int)day.DayOfWeek - (int)DayOfWeek.Monday + 7) % 7;
+        return day.AddDays(-offset);
+    }
 }

--- a/AAEmu.Game/Models/ServerCalendar.cs
+++ b/AAEmu.Game/Models/ServerCalendar.cs
@@ -1,0 +1,30 @@
+namespace AAEmu.Game.Models;
+
+/// <summary>
+/// Single wall-clock source for day/week boundaries on World.
+/// Always UTC (GMT). Restarts do not invent a local midnight — next fire is absolute UTC.
+/// </summary>
+public static class ServerCalendar
+{
+    public static DateTime UtcNow => DateTime.UtcNow;
+
+    /// <summary>Calendar day used for daily quests, Path of Destiny day_key, merchant daily limits.</summary>
+    public static DateTime TodayUtc => UtcNow.Date;
+
+    /// <summary>
+    /// Start of the Monday–Sunday week containing <see cref="TodayUtc"/> (Monday 00:00:00 UTC).
+    /// Matches merchant weekly limits and cron <c>0 0 0 * * 1</c>.
+    /// </summary>
+    public static DateTime WeekStartMondayUtc
+    {
+        get
+        {
+            var day = TodayUtc;
+            var offset = ((int)day.DayOfWeek - (int)DayOfWeek.Monday + 7) % 7;
+            return day.AddDays(-offset);
+        }
+    }
+
+    /// <summary>True when <paramref name="utc"/> is at or after the first moment of the current UTC day.</summary>
+    public static bool IsBeforeToday(DateTime utcMoment) => utcMoment.ToUniversalTime().Date < TodayUtc;
+}

--- a/AAEmu.Game/Models/Tasks/Network/MirrorSpawnStreamTask.cs
+++ b/AAEmu.Game/Models/Tasks/Network/MirrorSpawnStreamTask.cs
@@ -47,12 +47,17 @@ public class MirrorSpawnStreamTask : Task
                 // Leave-view first (beyond soft AOI) — frees MAX slots before we try to send.
                 character.CullStreamedMirrorsBeyondAoi();
 
-                // At cap with nearer pending: replace farthest (interest swap).
+                // At cap: nearer pending first, then event/tower priority rifts (steal ambient slot).
                 if (Npc.MirrorNpcMaxPerCharacter > 0 &&
                     character.MirrorNpcStatesSentCount >= Npc.MirrorNpcMaxPerCharacter &&
                     character.HasPendingMirrorSpawns)
                 {
-                    character.TryEvictFarthestStreamedForNearerPending();
+                    if (!character.TryEvictFarthestStreamedForNearerPending() &&
+                        character.TryPeekNearestPendingMirror(out var pendingPri, out _, out _) &&
+                        pendingPri is { IsMirrorStreamPriority: true })
+                    {
+                        character.TryEvictFarthestStreamedForPriority(pendingPri);
+                    }
                 }
 
                 if (!character.HasPendingMirrorSpawns)
@@ -75,7 +80,13 @@ public class MirrorSpawnStreamTask : Task
                 {
                     if (Npc.MirrorNpcMaxPerCharacter > 0 &&
                         character.MirrorNpcStatesSentCount >= Npc.MirrorNpcMaxPerCharacter)
-                        break;
+                    {
+                        // One more priority peel per burst wave if still capped.
+                        if (!character.TryPeekNearestPendingMirror(out var p2, out _, out _) ||
+                            p2 is not { IsMirrorStreamPriority: true } ||
+                            !character.TryEvictFarthestStreamedForPriority(p2))
+                            break;
+                    }
 
                     var npc = character.TryTakeNearestPendingMirror();
                     if (npc == null)

--- a/AAEmu.Game/Models/Tasks/Quests/QuestDailyResetTask.cs
+++ b/AAEmu.Game/Models/Tasks/Quests/QuestDailyResetTask.cs
@@ -1,27 +1,32 @@
 ﻿using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.Models;
+using NLog;
 
 namespace AAEmu.Game.Models.Tasks.Quests;
 
 /// <summary>
-/// Task that triggers daily, used for resetting daily quests, and updating daily login when the player is online
+/// Fires at 00:00:00 UTC every day (cron <c>0 0 0 */1 * *</c> on TaskManager's UTC clock).
+/// Resets all daily-detail completed quests (not just Path of Destiny), today-assignment state,
+/// and daily-login account rewards for online characters. Offline catch-up is leave_time based.
 /// </summary>
 public class QuestDailyResetTask : Task
 {
-    /// <summary>
-    /// Task used to do the quest resets for daily quests
-    /// </summary>
-    public QuestDailyResetTask()
-    {
-
-    }
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
     public override void Execute()
     {
+        Logger.Info(
+            "Server daily reset (UTC {0:yyyy-MM-dd HH:mm:ss}Z) — daily/hunt/group/livelihood/today completed_quests",
+            ServerCalendar.UtcNow);
+
         foreach (var character in WorldManager.Instance.GetAllCharacters())
         {
             character.Quests.ResetDailyQuests(true);
             TimedRewardsManager.Instance.DoDailyAccountLogin(character.AccountId);
         }
+
+        // Today (detail 13) completion bits above; also reseed Path of Destiny UI/DB day_key state.
+        TodayAssignmentManager.Instance.OnServerDailyReset();
     }
 }

--- a/AAEmu.Game/Models/Tasks/Quests/QuestWeeklyResetTask.cs
+++ b/AAEmu.Game/Models/Tasks/Quests/QuestWeeklyResetTask.cs
@@ -1,0 +1,27 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.Models;
+using NLog;
+
+namespace AAEmu.Game.Models.Tasks.Quests;
+
+/// <summary>
+/// Monday 00:00:00 UTC (cron <c>0 0 0 * * 1</c>, NCrontab Sunday=0).
+/// Clears completed_quests bits for weekly detail quests for all online characters.
+/// Offline players catch up via leave_time week-boundary on login.
+/// </summary>
+public class QuestWeeklyResetTask : Task
+{
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+    public override void Execute()
+    {
+        Logger.Info(
+            "Server weekly reset (UTC {0:yyyy-MM-dd HH:mm:ss}Z, week start {1:yyyy-MM-dd})",
+            ServerCalendar.UtcNow,
+            ServerCalendar.WeekStartMondayUtc);
+
+        foreach (var character in WorldManager.Instance.GetAllCharacters())
+            character.Quests.ResetWeeklyQuests(true);
+    }
+}

--- a/AAEmu.Game/Utils/Scripts/SubCommands/Time/TimeSetSubCommand.cs
+++ b/AAEmu.Game/Utils/Scripts/SubCommands/Time/TimeSetSubCommand.cs
@@ -27,15 +27,12 @@ public class TimeSetSubCommand : SubCommandBase
         var oldSnap = oldTime;
         TimeManager.Instance.Set(newTime);
 
-        var forward = newTime - oldSnap;
-        if (forward < 0f)
-            forward += 24f;
-        if (forward > 0.25f)
+        if (TimeManager.IsLargeGameHourJump(oldSnap, newTime))
         {
             SendMessage(messageOutput,
                 $"Changed game time {oldSnap:F2} -> {newTime:F2} ({hour}h{minute}m). " +
-                "Large jump: only Event-Center rifts near the landing hour auto-arm " +
-                "(e.g. set 0 1 for Grimghast). Prefer /towerdef start <id> for a force arm.");
+                "Large jump: only Event-Center rifts near the landing hour auto-arm. " +
+                "Prefer /towerdef start <id> for a force arm.");
         }
         else
             SendMessage(messageOutput, $"Changed game time {oldSnap:F2} -> {newTime:F2} ({hour}h{minute}m)");

--- a/AAEmu.Game/Utils/Scripts/SubCommands/Time/TimeSetSubCommand.cs
+++ b/AAEmu.Game/Utils/Scripts/SubCommands/Time/TimeSetSubCommand.cs
@@ -24,8 +24,20 @@ public class TimeSetSubCommand : SubCommandBase
         if (parameters.TryGetValue("minute", out var minuteValue))
             minute = minuteValue;
         var newTime = hour * 1f + minute / 60f;
+        var oldSnap = oldTime;
         TimeManager.Instance.Set(newTime);
 
-        SendMessage(messageOutput, $"Changed game time {oldTime:F2} -> {newTime:F2} ({hour}h{minute}m)");
+        var forward = newTime - oldSnap;
+        if (forward < 0f)
+            forward += 24f;
+        if (forward > 0.25f)
+        {
+            SendMessage(messageOutput,
+                $"Changed game time {oldSnap:F2} -> {newTime:F2} ({hour}h{minute}m). " +
+                "Large jump: only Event-Center rifts near the landing hour auto-arm " +
+                "(e.g. set 0 1 for Grimghast). Prefer /towerdef start <id> for a force arm.");
+        }
+        else
+            SendMessage(messageOutput, $"Changed game time {oldSnap:F2} -> {newTime:F2} ({hour}h{minute}m)");
     }
 }

--- a/AAEmu.Game/WorldIntegration.cs
+++ b/AAEmu.Game/WorldIntegration.cs
@@ -8,6 +8,7 @@ using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Network.Connections;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.GameData;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.Gimmicks;
@@ -147,7 +148,7 @@ public static class WorldIntegration
     /// <summary>
     /// Relay WZUnitDamaged (0x030) after World authors SCUnitDamaged.
     /// Args: skillId, tl, caster, target, damage, absorbed, casterBc, targetBc.
-    /// HARD-BLOCKED until full UnitDamaged body RE — use <see cref="RelayUnitPointsToZone"/> instead.
+    /// Not wired: UnitDamaged WZ body is incomplete — use <see cref="RelayUnitPointsToZone"/> instead.
     /// </summary>
     public static Action<uint, ushort, SkillCaster, SkillCastTarget, int, int, uint, uint> RelayUnitDamagedToZone { get; set; }
 
@@ -245,6 +246,11 @@ public static class WorldIntegration
     /// Zone day-cycle report. Args: zoneId, time, speed, start, end, isDetailed.
     /// </summary>
     public static Action<uint, float, float, float, float, bool> OnZoneTimeOfDay { get; set; }
+
+    /// <summary>
+    /// Game-hour advanced (oldHour, newHour in [0,24)). World arms Game-Time tower_defs rifts here.
+    /// </summary>
+    public static Action<float, float> OnGameTimeAdvanced { get; set; }
 
     /// <summary>WZRemoveDoodad.</summary>
     public static Action<uint> RelayRemoveDoodadToZone { get; set; }
@@ -476,6 +482,23 @@ public static class WorldIntegration
     public static Func<IEnumerable<string>> DescribeTowerDefs { get; set; }
 
     /// <summary>
+    /// Push current tower map marks (ActiveInfoList + positioned List) to a late-joining player.
+    /// Set by World from <c>TowerDefScheduler.SyncToCharacter</c>.
+    /// </summary>
+    public static Action<Character> SyncTowerDefsToCharacter { get; set; }
+
+    /// <summary>
+    /// Portal seed NPC mirror ready — refresh map pins. Arg: NPC template id.
+    /// </summary>
+    public static Action<uint> OnTowerDefEventNpcMirrored { get; set; }
+
+    /// <summary>
+    /// After WZTowerDefEnd: despawn World-owned army + portal/stage mirrors for this tower.
+    /// Args: towerDefId, host zone ids (empty = any zone).
+    /// </summary>
+    public static Action<uint, IReadOnlyList<uint>> CleanupTowerDefEventUnits { get; set; }
+
+    /// <summary>
     /// Broadcast a finished SC body (opcode + body only) to in-world clients only.
     /// Must NOT target lobby/select/loading connections — ActiveChar is set on SelectCharacter,
     /// and premature SCUnitMovements (zone flood) hard-closes the client before enter finishes.
@@ -695,8 +718,14 @@ public static class WorldIntegration
             lifeTime,
             despawnOnCreatorDeath,
             useSummonerAggroTarget);
-        return body is { Length: > 0 }
-               && RelayNpcSpawnToZone?.Invoke(new WorldNpcSpawnRequest(zoneId, npc.ObjId, body)) == true;
+        if (body is not { Length: > 0 }
+            || RelayNpcSpawnToZone?.Invoke(new WorldNpcSpawnRequest(zoneId, npc.ObjId, body)) != true)
+            return false;
+
+        // Same OnSpawn plot_only path as ZW mirrors (tower stage 8830 → army). Safe: zone skill
+        // relay suppressed inside CastOnSpawnPlotSkills.
+        npc.CastOnSpawnPlotSkills();
+        return true;
     }
 
     public static void PublishNpcDespawn(BaseUnit npc)
@@ -760,6 +789,69 @@ public static class WorldIntegration
         {
             Logger.Error(ex, "Pending NPC handoff failed obj={0}", objId);
         }
+    }
+
+    /// <summary>
+    /// Retire event NPCs (seed/stage + World-authored army) on End. Prefer zone notify so dedic
+    /// retires units; then delete World mirrors.
+    /// </summary>
+    public static int DespawnTowerDefEventUnits(uint towerDefId, IReadOnlyList<uint> hostZoneIds)
+    {
+        if (!ZoneAuthority || towerDefId == 0)
+            return 0;
+
+        var templates = TowerDefGameData.Instance.GetCleanupNpcTemplates(towerDefId);
+        if (templates.Count == 0)
+            return 0;
+
+        var filterZones = hostZoneIds is { Count: > 0 }
+            ? new HashSet<uint>(hostZoneIds)
+            : null;
+
+        var victims = new List<Npc>();
+        foreach (var world in WorldManager.Instance.GetWorlds() ?? [])
+        {
+            foreach (var npc in world.GetAllNpcs())
+            {
+                if (npc is not { IsZoneMirror: true })
+                    continue;
+                if (!templates.Contains(npc.TemplateId))
+                    continue;
+                if (filterZones != null)
+                {
+                    var z = npc.Transform?.ZoneId ?? 0;
+                    if (z == 0 || !filterZones.Contains(z))
+                        continue;
+                }
+
+                victims.Add(npc);
+            }
+        }
+
+        foreach (var npc in victims)
+        {
+            try
+            {
+                // Drop World plot/cast so late SpawnEffect nodes stop filling the field after End.
+                npc.InterruptSkills();
+                DeleteNpcMirror(npc, notifyZone: true);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn(ex, "DespawnTowerDefEventUnits failed bc={0} tpl={1}", npc.ObjId, npc.TemplateId);
+            }
+        }
+
+        if (victims.Count > 0)
+        {
+            Logger.Info(
+                "DespawnTowerDefEventUnits tower={0} count={1} zones=[{2}]",
+                towerDefId,
+                victims.Count,
+                filterZones == null ? "*" : string.Join(',', filterZones.OrderBy(z => z)));
+        }
+
+        return victims.Count;
     }
 
     /// <summary>
@@ -1063,14 +1155,38 @@ public static class WorldIntegration
             npc.Transform.Local.SetPosition(worldPos.X, worldPos.Y, worldPos.Z, 0f, 0f, zRot);
             NpcHeightDiagnostics.RecordSpawn(
                 bcId, templateId, zoneId, x, y, z, worldPos.X, worldPos.Y, worldPos.Z);
+            // Hellgate portals (8828/12911): mesh is invisible.chr — client VFX is fx_group from
+            // OnSpawn buffs via SCBuffCreated (0x0EB). SC UnitState for Npcs deliberately writes
+            // 0/0/0 buff counts, so the storm cannot ride UnitState. Apply buffs *after* Spawn so
+            // region viewers receive SCBuffCreated; pre-Spawn Apply OnSpawn left FX silent.
             npc.Spawn();
+            // Paint before FX so SCBuffCreated lands after the unit exists for late AOI/MAX cases.
+            if (npc.IsMirrorStreamPriority)
+                PaintPriorityMirrorToNearby(npc);
+            npc.ApplyOnSpawnSkillBuffs(zoneAuthored: true);
+            // AddBuff → BroadcastPacket only hits region neighbors. Priority paint can stream the
+            // same-zone UnitState from km away, so OnSpawn 2293 never reaches those clients unless
+            // we unicast SCBuffCreated to everyone who already got UnitState.
+            ResyncMirrorBuffsToStreamed(npc);
 
-            if ((bcId - 0x00F00000) <= 5 || (bcId - 0x00F00000) % 100 == 0 || bcId <= 5 || bcId % 100 == 0)
+            // Ghost-army OnSpawn is fire_anim-only (no buffs) — SC SkillFired, never Skill.Use/WZ.
+            // After UnitState: client must already know the bc for fire_anim attach.
+            npc.CastOnSpawnAnimationSkills();
+            // Tower stage portals: plot_only OnSpawn (15298 → army SpawnEffect). Dedic is silent;
+            // World graph with zone skill relay suppressed (see CastOnSpawnPlotSkills).
+            npc.CastOnSpawnPlotSkills();
+
+            if ((bcId - 0x00F00000) <= 5 || (bcId - 0x00F00000) % 100 == 0 || bcId <= 5 || bcId % 100 == 0
+                || npc.IsMirrorStreamPriority)
             {
                 Logger.Info(
-                    "Mirrored zone NPC bc={0} tpl={1} zone={2} local=({3:F1},{4:F1},{5:F1}) world=({6:F1},{7:F1},{8:F1})",
-                    bcId, templateId, zoneId, x, y, z, worldPos.X, worldPos.Y, worldPos.Z);
+                    "Mirrored zone NPC bc={0} tpl={1} zone={2} local=({3:F1},{4:F1},{5:F1}) world=({6:F1},{7:F1},{8:F1}) pri={9}",
+                    bcId, templateId, zoneId, x, y, z, worldPos.X, worldPos.Y, worldPos.Z,
+                    npc.IsMirrorStreamPriority);
             }
+
+            if (TowerDefGameData.Instance.IsTowerDefEventNpc(templateId))
+                OnTowerDefEventNpcMirrored?.Invoke(templateId);
 
             return true;
         }
@@ -1079,6 +1195,88 @@ public static class WorldIntegration
             Logger.Warn(ex, "MirrorZoneNpcSpawn failed bc={0} tpl={1}", bcId, templateId);
             return false;
         }
+    }
+
+    /// <summary>
+    /// After a late tower/event emit, push SC paint to every stream-ready client that can see this
+    /// mirror. Without this, MAX slots filled at load leave the rift pending forever.
+    /// </summary>
+    private static void PaintPriorityMirrorToNearby(Npc npc)
+    {
+        if (npc == null || !npc.IsMirrorStreamPriority)
+            return;
+
+        var painted = 0;
+        foreach (var character in WorldManager.Instance.GetAllCharacters())
+        {
+            if (character == null || character.ParentWorld != npc.ParentWorld)
+                continue;
+            if (!character.MirrorNpcStreamReady)
+            {
+                character.EnqueuePendingMirrorSpawn(npc);
+                continue;
+            }
+
+            // TryEvict first when at MAX so CanStreamMirrorNow can succeed for same-zone events.
+            if (!character.CanStreamMirrorNow(npc))
+                character.TryEvictFarthestStreamedForPriority(npc);
+
+            if (character.CanStreamMirrorNow(npc))
+            {
+                // Do not ReleaseMirrorNpcSlot when already painted — release+resend races with
+                // soft-remove and produced SCUnitsRemoved for the same bc same tick.
+                if (!character.MirrorNpcStatesSentIds.ContainsKey(npc.ObjId))
+                    npc.SendUnitStateTo(character);
+                painted++;
+            }
+            else
+                character.EnqueuePendingMirrorSpawn(npc);
+        }
+
+        if (painted > 0)
+            Logger.Info(
+                "Mirror priority paint bc={0} tpl={1} clients={2}",
+                npc.ObjId, npc.TemplateId, painted);
+        else
+            Logger.Info(
+                "Mirror priority paint pending bc={0} tpl={1} zone={2} (no stream-ready client in AOI/MAX)",
+                npc.ObjId, npc.TemplateId, npc.Transform?.ZoneId ?? 0);
+    }
+
+    /// <summary>
+    /// Unicast active buffs to every client that already received SCUnitState for this zone mirror.
+    /// Complements <see cref="GameObject.BroadcastPacket"/> (region-only) for same-zone priority
+    /// and re-stream paths where OnSpawn FX would otherwise miss.
+    /// </summary>
+    private static void ResyncMirrorBuffsToStreamed(Npc npc)
+    {
+        if (npc == null || !npc.IsZoneMirror)
+            return;
+
+        var n = 0;
+        foreach (var character in WorldManager.Instance.GetAllCharacters())
+        {
+            if (character == null || character.ParentWorld != npc.ParentWorld)
+                continue;
+            if (!character.MirrorNpcStatesSentIds.ContainsKey(npc.ObjId))
+                continue;
+            npc.SendActiveBuffsTo(character);
+            n++;
+        }
+
+        if (n > 0 && npc.IsMirrorStreamPriority)
+            Logger.Info(
+                "Mirror buff re-sync after OnSpawn bc={0} tpl={1} clients={2}",
+                npc.ObjId, npc.TemplateId, n);
+    }
+
+    /// <summary>
+    /// After Zone has acknowledged Create (WZNpcState). Most OnSpawn paint happens at mirror
+    /// create (buffs / fire_anim / plot_only for tower stage). Left for post-Create zone-safe hooks.
+    /// </summary>
+    public static void AfterZoneMirrorNpcState(uint bcId)
+    {
+        _ = bcId;
     }
 
     /// <summary>Flush NPCs that arrived before MainWorld existed. Call after CreateStaticInstances.</summary>

--- a/AAEmu.Game/WorldIntegration.cs
+++ b/AAEmu.Game/WorldIntegration.cs
@@ -1070,10 +1070,8 @@ public static class WorldIntegration
     }
 
     /// <summary>
-    /// WorldInstance that owns a zone. Mirrors and doodad pushes must target it rather than
-    /// MainWorld: zone 260 (arche_mall_world) mirrored into main_world, so its NPCs landed
-    /// nowhere near the player's own instance and region interest streamed no SCUnitState —
-    /// Mirage Isle looked completely empty.
+    /// WorldInstance that owns a zone. Mirrors and doodad pushes must target that instance,
+    /// not always MainWorld.
     /// </summary>
     public static Models.Game.World.WorldInstance ResolveWorldForZone(uint zoneId)
     {

--- a/AAEmu.Login/Core/Network/Internal/InternalProtocolHandler.cs
+++ b/AAEmu.Login/Core/Network/Internal/InternalProtocolHandler.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using System.Globalization;
 using System.Text;
-using AAEmu.Commons.Exceptions;
 using AAEmu.Commons.Network;
 using AAEmu.Login.Core.Controllers;
 using AAEmu.Login.Core.Network.Connections;
@@ -46,7 +45,7 @@ public class InternalProtocolHandler(
             return;
         }
 
-        var stream = new PacketStream();
+        PacketStream? stream = new PacketStream();
         if (connection.LastPacket != null)
         {
             stream.Insert(0, connection.LastPacket);
@@ -56,58 +55,34 @@ public class InternalProtocolHandler(
         stream.Insert(stream.Count, buf, offset, bytes);
         while (stream is { Count: > 0 })
         {
-            ushort len;
-            try
+            switch (LengthPrefixedFrames.TryTake(ref stream, LengthPrefixedFrames.MinOpcodePayloadBytes, out var frame))
             {
-                len = stream.ReadUInt16();
-            }
-            catch (MarshalException)
-            {
-                //Logger.Warn("Error on reading type {0}", type);
-                stream.Rollback();
-                connection.LastPacket = stream;
-                stream = null;
-                continue;
-            }
-
-            var packetLen = len + stream.Pos;
-            if (packetLen <= stream.Count)
-            {
-                stream.Rollback();
-                var stream2 = new PacketStream();
-                stream2.Replace(stream, 0, packetLen);
-                if (stream.Count > packetLen)
-                {
-                    var stream3 = new PacketStream();
-                    stream3.Replace(stream, packetLen, stream.Count - packetLen);
-                    stream = stream3;
-                }
-                else
-                    stream = null;
-
-                stream2.ReadUInt16();
-                var type = stream2.ReadUInt16();
-                if (!_packets.TryGetValue(type, out var packetDescriptor))
-                {
-                    HandleUnknownPacket(session, type, stream2);
-                }
-                else
-                {
-                    try
+                case LengthPrefixedFrameResult.NeedMore:
+                    connection.LastPacket = stream;
+                    return;
+                case LengthPrefixedFrameResult.DroppedInvalidLength:
+                    logger.LogWarning("Dropped invalid internal frame from {IP}", session.Ip);
+                    continue;
+                case LengthPrefixedFrameResult.GotFrame:
+                    frame!.ReadUInt16();
+                    var type = frame.ReadUInt16();
+                    if (!_packets.TryGetValue(type, out var packetDescriptor))
                     {
-                        packetDescriptor.Dispatch(stream2, connection);
+                        HandleUnknownPacket(session, type, frame);
                     }
-                    catch (Exception ex)
+                    else
                     {
-                        logger.LogError(ex, "Error on packet dispatch {Type}", type);
+                        try
+                        {
+                            packetDescriptor.Dispatch(frame, connection);
+                        }
+                        catch (Exception ex)
+                        {
+                            logger.LogError(ex, "Error on packet dispatch {Type}", type);
+                        }
                     }
-                }
-            }
-            else
-            {
-                stream.Rollback();
-                connection.LastPacket = stream;
-                stream = null;
+
+                    break;
             }
         }
     }

--- a/AAEmu.Login/Core/Packets/G2L/GLRegisterGameServerPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLRegisterGameServerPacket.cs
@@ -26,11 +26,25 @@ public class GLRegisterGameServerPacket() : InternalPacket(TypeId), IInternalPac
     /// </summary>
     public List<GameServerId>? Mirrors { get; private set; }
 
+    /// <summary>Upper bound on mirror GS ids in one register body. Count must match remaining bytes exactly.</summary>
+    public const int MaxMirrorCount = 32;
+
     public override void Read(PacketStream stream)
     {
         SecretKey = stream.ReadString();
         GsId = new GameServerId(stream.ReadByte());
+        if (stream.LeftBytes < sizeof(int))
+            throw new InvalidDataException("GLRegisterGameServerPacket: truncated mirror count");
+
         var additionalesCount = stream.ReadInt32();
+        if (additionalesCount < 0
+            || additionalesCount > MaxMirrorCount
+            || additionalesCount != stream.LeftBytes)
+        {
+            throw new InvalidDataException(
+                $"GLRegisterGameServerPacket: mirror count {additionalesCount} does not match remaining {stream.LeftBytes} bytes");
+        }
+
         var mirrors = new List<GameServerId>(additionalesCount);
         for (var i = 0; i < additionalesCount; i++)
             mirrors.Add(new GameServerId(stream.ReadByte()));

--- a/AAEmu.Login/NLog.config
+++ b/AAEmu.Login/NLog.config
@@ -17,12 +17,16 @@
               xsi:type="File" 
               fileName="${basedir}/Logs/Error.log" 
               archiveFileName="${basedir}/Logs/Error.{#}.log"
-              archiveNumbering="Date" archiveDateFormat="yyyy-MM-dd" archiveEvery="Day" maxArchiveFiles="9"
+              archiveNumbering="Sequence"
+              archiveAboveSize="10485760"
+              maxArchiveFiles="3"
               layout="${date:format=HH\:mm\:ss} [${level:uppercase=true}] ${logger:shortName=true} - ${message} ${exception:format=tostring}" 
-              keepFileOpen="false" encoding="utf-8" concurrentWrites="false" deleteOldFileOnStartup="true" />
+              keepFileOpen="true" encoding="utf-8" concurrentWrites="false" deleteOldFileOnStartup="true" />
     </targets>
 
     <rules>
+      <!-- PacketStream short-read spam was filling G: (multi-GB Error.log). Drop to console only. -->
+      <logger name="AAEmu.Commons.Network.PacketStream" maxlevel="Fatal" writeTo="console" final="true" />
       <logger name="Quartz*" minlevel="Trace" maxlevel="Info" final="true" /> 
       <logger name="*" minlevel="Debug" writeTo="console" />
       <logger name="*" minlevel="Error" writeTo="errors" />

--- a/AAEmu.Login/NLog.config
+++ b/AAEmu.Login/NLog.config
@@ -17,16 +17,12 @@
               xsi:type="File" 
               fileName="${basedir}/Logs/Error.log" 
               archiveFileName="${basedir}/Logs/Error.{#}.log"
-              archiveNumbering="Sequence"
-              archiveAboveSize="10485760"
-              maxArchiveFiles="3"
+              archiveNumbering="Date" archiveDateFormat="yyyy-MM-dd" archiveEvery="Day" maxArchiveFiles="9"
               layout="${date:format=HH\:mm\:ss} [${level:uppercase=true}] ${logger:shortName=true} - ${message} ${exception:format=tostring}" 
-              keepFileOpen="true" encoding="utf-8" concurrentWrites="false" deleteOldFileOnStartup="true" />
+              keepFileOpen="false" encoding="utf-8" concurrentWrites="false" deleteOldFileOnStartup="true" />
     </targets>
 
     <rules>
-      <!-- PacketStream short-read spam was filling G: (multi-GB Error.log). Drop to console only. -->
-      <logger name="AAEmu.Commons.Network.PacketStream" maxlevel="Fatal" writeTo="console" final="true" />
       <logger name="Quartz*" minlevel="Trace" maxlevel="Info" final="true" /> 
       <logger name="*" minlevel="Debug" writeTo="console" />
       <logger name="*" minlevel="Error" writeTo="errors" />

--- a/AAEmu.UnitTests/Commons/Network/LengthPrefixedFramesTests.cs
+++ b/AAEmu.UnitTests/Commons/Network/LengthPrefixedFramesTests.cs
@@ -1,0 +1,81 @@
+using AAEmu.Commons.Network;
+
+namespace AAEmu.UnitTests.Commons.Network;
+
+public class LengthPrefixedFramesTests
+{
+    [Test]
+    public async Task OneByteLeftover_WaitsWithoutConsuming()
+    {
+        PacketStream? stream = new PacketStream();
+        stream.Insert(0, [0x01]);
+
+        var result = LengthPrefixedFrames.TryTake(ref stream, 2, out var frame);
+
+        await Assert.That(result).IsEqualTo(LengthPrefixedFrameResult.NeedMore);
+        await Assert.That(frame).IsNull();
+        await Assert.That(stream).IsNotNull();
+        await Assert.That(stream!.Count).IsEqualTo(1);
+        await Assert.That(stream.Pos).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ZeroPayloadLength_IsDroppedNotDispatched()
+    {
+        PacketStream? stream = new PacketStream();
+        stream.Insert(0, [0x00, 0x00]);
+
+        var result = LengthPrefixedFrames.TryTake(ref stream, 2, out var frame);
+
+        await Assert.That(result).IsEqualTo(LengthPrefixedFrameResult.DroppedInvalidLength);
+        await Assert.That(frame).IsNull();
+        await Assert.That(stream).IsNull();
+    }
+
+    [Test]
+    public async Task ValidFrame_SlicesPayloadAndLeavesRemainder()
+    {
+        PacketStream? stream = new PacketStream();
+        // payloadLen=4 (type u16 + 2 body bytes), then leftover 0x99
+        stream.Insert(0, [0x04, 0x00, 0x2A, 0x00, 0x01, 0x02, 0x99]);
+
+        var result = LengthPrefixedFrames.TryTake(ref stream, 2, out var frame);
+
+        await Assert.That(result).IsEqualTo(LengthPrefixedFrameResult.GotFrame);
+        await Assert.That(frame).IsNotNull();
+        await Assert.That(frame!.Count).IsEqualTo(6);
+        await Assert.That(stream).IsNotNull();
+        await Assert.That(stream!.Count).IsEqualTo(1);
+        await Assert.That(stream.Buffer[0]).IsEqualTo((byte)0x99);
+    }
+
+    [Test]
+    public async Task PartialPayload_WaitsWithPosReset()
+    {
+        PacketStream? stream = new PacketStream();
+        // payloadLen=8 but only 2 payload bytes present
+        stream.Insert(0, [0x08, 0x00, 0x2A, 0x00]);
+
+        var result = LengthPrefixedFrames.TryTake(ref stream, 2, out var frame);
+
+        await Assert.That(result).IsEqualTo(LengthPrefixedFrameResult.NeedMore);
+        await Assert.That(frame).IsNull();
+        await Assert.That(stream!.Count).IsEqualTo(4);
+        await Assert.That(stream.Pos).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task RepeatedOneByteTake_DoesNotSpin()
+    {
+        PacketStream? stream = new PacketStream();
+        stream.Insert(0, [0x01]);
+
+        for (var i = 0; i < 1000; i++)
+        {
+            var result = LengthPrefixedFrames.TryTake(ref stream, 2, out _);
+            await Assert.That(result).IsEqualTo(LengthPrefixedFrameResult.NeedMore);
+        }
+
+        await Assert.That(stream!.Count).IsEqualTo(1);
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/TimeManagerClockTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/TimeManagerClockTests.cs
@@ -1,0 +1,75 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.Game.World;
+using AAEmu.Game.Models.Game.World.Xml;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class TimeManagerClockTests
+{
+    private const uint DefaultWorldId = 0;
+
+    [Test]
+    public async Task UsesSharedGameDay_DefaultOpenWorld_True()
+    {
+        var world = new WorldTemplate
+        {
+            Id = DefaultWorldId,
+            XmlWorld = new XmlWorld { IsInstance = 0 }
+        };
+
+        await Assert.That(TimeManager.UsesSharedGameDay(world, DefaultWorldId)).IsTrue();
+    }
+
+    [Test]
+    public async Task UsesSharedGameDay_InstanceWorld_FalseEvenIfIdsMatch()
+    {
+        var world = new WorldTemplate
+        {
+            Id = DefaultWorldId,
+            XmlWorld = new XmlWorld { IsInstance = 1 }
+        };
+
+        await Assert.That(TimeManager.UsesSharedGameDay(world, DefaultWorldId)).IsFalse();
+    }
+
+    [Test]
+    public async Task UsesSharedGameDay_OtherWorldTemplate_False()
+    {
+        var world = new WorldTemplate
+        {
+            Id = 7,
+            XmlWorld = new XmlWorld { IsInstance = 0 }
+        };
+
+        await Assert.That(TimeManager.UsesSharedGameDay(world, DefaultWorldId)).IsFalse();
+    }
+
+    [Test]
+    public async Task UsesSharedGameDay_UnknownWorld_FailsClosed()
+    {
+        await Assert.That(TimeManager.UsesSharedGameDay(null, DefaultWorldId)).IsFalse();
+    }
+
+    [Test]
+    public async Task IsLargeGameHourJump_ExactThreshold_IsNotLarge()
+    {
+        var from = 1.0f;
+        var to = from + TimeManager.MaxWorldEffectJumpHours;
+        await Assert.That(TimeManager.IsLargeGameHourJump(from, to)).IsFalse();
+    }
+
+    [Test]
+    public async Task IsLargeGameHourJump_JustAboveThreshold_IsLarge()
+    {
+        var from = 1.0f;
+        var to = from + TimeManager.MaxWorldEffectJumpHours + 0.01f;
+        await Assert.That(TimeManager.IsLargeGameHourJump(from, to)).IsTrue();
+    }
+
+    [Test]
+    public async Task IsLargeGameHourJump_WrapAroundMidnight_UsesForwardDelta()
+    {
+        await Assert.That(TimeManager.IsLargeGameHourJump(23.9f, 0.05f)).IsFalse();
+        await Assert.That(TimeManager.IsLargeGameHourJump(22.5f, 11.75f)).IsTrue();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/DoodadObj/Funcs/DoodadFuncTodTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/DoodadObj/Funcs/DoodadFuncTodTests.cs
@@ -1,0 +1,25 @@
+using AAEmu.Game.Models.Game.DoodadObj.Funcs;
+
+namespace AAEmu.UnitTests.Game.Models.Game.DoodadObj.Funcs;
+
+public class DoodadFuncTodTests
+{
+    [Test]
+    public async Task GetClockHours_Realtime_UsesUtcWallClock()
+    {
+        var tod = new DoodadFuncTod { IsRealtime = true };
+        var before = (float)DateTime.UtcNow.TimeOfDay.TotalHours;
+        var hours = tod.GetClockHours();
+        var after = (float)DateTime.UtcNow.TimeOfDay.TotalHours;
+
+        // Allow day wrap near midnight.
+        if (after + 0.001f < before)
+        {
+            await Assert.That(hours is >= 0f and < 24f).IsTrue();
+            return;
+        }
+
+        await Assert.That(hours).IsGreaterThanOrEqualTo(before - 0.001f);
+        await Assert.That(hours).IsLessThanOrEqualTo(after + 0.001f);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Quests/QuestCalendarResetTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Quests/QuestCalendarResetTests.cs
@@ -1,0 +1,39 @@
+using AAEmu.Game.Models;
+using AAEmu.Game.Models.Game.Quests;
+using AAEmu.Game.Models.Game.Quests.Static;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Quests;
+
+public class QuestCalendarResetTests
+{
+    [Test]
+    public async Task DailySet_Matches_ClientIsDailyDetail()
+    {
+        // Client classifier: detail in {7,10,11,12,13}
+        await Assert.That(QuestCalendarResetSet.Daily).Contains(QuestDetail.Daily);
+        await Assert.That(QuestCalendarResetSet.Daily).Contains(QuestDetail.DailyHunt);
+        await Assert.That(QuestCalendarResetSet.Daily).Contains(QuestDetail.DailyLivelihood);
+        await Assert.That(QuestCalendarResetSet.Daily).Contains(QuestDetail.DailyGroup);
+        await Assert.That(QuestCalendarResetSet.Daily).Contains(QuestDetail.Today);
+        await Assert.That(QuestCalendarResetSet.Daily).DoesNotContain(QuestDetail.Livelihood);
+        await Assert.That(QuestCalendarResetSet.Daily).DoesNotContain(QuestDetail.Group);
+        await Assert.That(QuestCalendarResetSet.Daily).DoesNotContain(QuestDetail.Weekly);
+    }
+
+    [Test]
+    public async Task WeeklySet_IsWeeklyDetailOnly()
+    {
+        await Assert.That(QuestCalendarResetSet.Weekly).IsEquivalentTo(new[] { QuestDetail.Weekly });
+    }
+
+    [Test]
+    public async Task WeekStartMonday_UsesMonday()
+    {
+        // 2026-08-09 is Sunday UTC; week start is preceding Monday 2026-08-03.
+        var sunday = new DateTime(2026, 8, 9, 12, 0, 0, DateTimeKind.Utc);
+        var offset = ((int)sunday.DayOfWeek - (int)DayOfWeek.Monday + 7) % 7;
+        var weekStart = sunday.Date.AddDays(-offset);
+        await Assert.That(weekStart).IsEqualTo(new DateTime(2026, 8, 3));
+        await Assert.That(weekStart.DayOfWeek).IsEqualTo(DayOfWeek.Monday);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/TowerDefs/TowerDefScheduleMetadataTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/TowerDefs/TowerDefScheduleMetadataTests.cs
@@ -1,0 +1,100 @@
+using AAEmu.Game.Models.Game.TowerDefs;
+
+namespace AAEmu.UnitTests.Game.Models.Game.TowerDefs;
+
+public class TowerDefScheduleMetadataTests
+{
+    private static TowerDef ToDRow(uint id, uint spawner, float tod = 0f, uint interval = 1) => new()
+    {
+        Id = id,
+        TimeOfDay = tod,
+        TimeOfDayDayInterval = interval,
+        TargetNpcSpawnId = spawner,
+        ForceEndTime = 3600f
+    };
+
+    private static TowerDef WallClockRow(uint id)
+    {
+        var towerDef = new TowerDef { Id = id, ForceEndTime = 3600f };
+        towerDef.StartTimes[(int)DayOfWeek.Tuesday] = new TimeSpan(21, 30, 0);
+        return towerDef;
+    }
+
+    [Test]
+    public async Task Apply_MarksListedToDRowsGameTime()
+    {
+        var listed = ToDRow(171, 100);
+        var omitted = ToDRow(3, 100);
+        var result = TowerDefScheduleMetadata.Apply([listed, omitted], [171]);
+
+        await Assert.That(listed.ScheduleMode).IsEqualTo(TowerDefScheduleMode.GameTime);
+        await Assert.That(omitted.ScheduleMode).IsEqualTo(TowerDefScheduleMode.Manual);
+        await Assert.That(result.AppliedGameTime).IsEqualTo(1);
+        await Assert.That(result.UnlistedToDCandidates).IsEquivalentTo(new uint[] { 3 });
+    }
+
+    [Test]
+    public async Task Apply_UnknownIds_AreReportedAndDoNotThrow()
+    {
+        var listed = ToDRow(13, 200);
+        var result = TowerDefScheduleMetadata.Apply([listed], [13, 9999]);
+
+        await Assert.That(listed.ScheduleMode).IsEqualTo(TowerDefScheduleMode.GameTime);
+        await Assert.That(result.UnknownIds).IsEquivalentTo(new uint[] { 9999 });
+    }
+
+    [Test]
+    public async Task Apply_WeekdaySlots_StayWallClockEvenIfListed()
+    {
+        var wall = WallClockRow(152);
+        var result = TowerDefScheduleMetadata.Apply([wall], [152]);
+
+        await Assert.That(wall.ScheduleMode).IsEqualTo(TowerDefScheduleMode.WallClock);
+        await Assert.That(result.WallClockConflicts).IsEquivalentTo(new uint[] { 152 });
+        await Assert.That(result.AppliedGameTime).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Apply_EmptyOverlay_LeavesToDRowsManualAndReportsThem()
+    {
+        var row = ToDRow(13, 200);
+        var result = TowerDefScheduleMetadata.Apply([row], []);
+
+        await Assert.That(row.ScheduleMode).IsEqualTo(TowerDefScheduleMode.Manual);
+        await Assert.That(result.AppliedGameTime).IsEqualTo(0);
+        await Assert.That(result.UnlistedToDCandidates).IsEquivalentTo(new uint[] { 13 });
+    }
+
+    [Test]
+    public async Task Apply_DoesNotUseDisplayNames()
+    {
+        var row = ToDRow(171, 100);
+        row.Name = "renamed-without-markers";
+        TowerDefScheduleMetadata.Apply([row], [171]);
+        await Assert.That(row.IsGameTimeScheduled).IsTrue();
+        await Assert.That(row.Name).IsEqualTo("renamed-without-markers");
+    }
+
+    [Test]
+    public async Task SharesPortalSpawnerWith_UsesLoadedSpawnerId()
+    {
+        var baseRow = ToDRow(3, 9846);
+        var expand = ToDRow(171, 9846);
+        var other = ToDRow(13, 14335);
+
+        await Assert.That(baseRow.SharesPortalSpawnerWith(expand)).IsTrue();
+        await Assert.That(expand.SharesPortalSpawnerWith(other)).IsFalse();
+        await Assert.That(baseRow.SharesPortalSpawnerWith(null)).IsFalse();
+    }
+
+    [Test]
+    public async Task Apply_ListedRowMissingGameTimeColumns_IsReportedIneligible()
+    {
+        var row = new TowerDef { Id = 50, ForceEndTime = 3600f };
+        var result = TowerDefScheduleMetadata.Apply([row], [50]);
+
+        await Assert.That(row.ScheduleMode).IsEqualTo(TowerDefScheduleMode.Manual);
+        await Assert.That(result.IneligibleIds).IsEquivalentTo(new uint[] { 50 });
+        await Assert.That(result.AppliedGameTime).IsEqualTo(0);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/TowerDefs/TowerDefScheduleTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/TowerDefs/TowerDefScheduleTests.cs
@@ -11,7 +11,13 @@ public class TowerDefScheduleTests
     /// <summary>Kraken: one populated slot (Tuesday 21:30), a one-hour window.</summary>
     private static TowerDef Kraken()
     {
-        var towerDef = new TowerDef { Id = 152, Name = "크라켄의 출현", ForceEndTime = 3600f };
+        var towerDef = new TowerDef
+        {
+            Id = 152,
+            Name = "크라켄의 출현",
+            ForceEndTime = 3600f,
+            ScheduleMode = TowerDefScheduleMode.WallClock
+        };
         towerDef.StartTimes[(int)DayOfWeek.Tuesday] = new TimeSpan(21, 30, 0);
         return towerDef;
     }
@@ -90,7 +96,10 @@ public class TowerDefScheduleTests
         TimeOfDay = tod,
         TimeOfDayDayInterval = 1,
         TargetNpcSpawnId = 9846,
-        ForceEndTime = 3600f
+        ForceEndTime = 3600f,
+        Family = TowerDefEventFamily.Crimson,
+        Variant = TowerDefEventVariant.Expand,
+        ScheduleMode = TowerDefScheduleMode.GameTime
     };
 
     private static TowerDef CrimsonBase(float tod = 0f) => new()
@@ -100,7 +109,10 @@ public class TowerDefScheduleTests
         TimeOfDay = tod,
         TimeOfDayDayInterval = 1,
         TargetNpcSpawnId = 9846,
-        ForceEndTime = 3600f
+        ForceEndTime = 3600f,
+        Family = TowerDefEventFamily.Crimson,
+        Variant = TowerDefEventVariant.Base,
+        ScheduleMode = TowerDefScheduleMode.Manual
     };
 
     private static TowerDef GrimghastBase(float tod = 0f) => new()
@@ -110,7 +122,10 @@ public class TowerDefScheduleTests
         TimeOfDay = tod,
         TimeOfDayDayInterval = 1,
         TargetNpcSpawnId = 14335,
-        ForceEndTime = 3600f
+        ForceEndTime = 3600f,
+        Family = TowerDefEventFamily.Grimghast,
+        Variant = TowerDefEventVariant.Base,
+        ScheduleMode = TowerDefScheduleMode.GameTime
     };
 
     private static TowerDef GrimghastExpand(float tod = 0.1f) => new()
@@ -120,11 +135,14 @@ public class TowerDefScheduleTests
         TimeOfDay = tod,
         TimeOfDayDayInterval = 1,
         TargetNpcSpawnId = 14335,
-        ForceEndTime = 3600f
+        ForceEndTime = 3600f,
+        Family = TowerDefEventFamily.Grimghast,
+        Variant = TowerDefEventVariant.Expand,
+        ScheduleMode = TowerDefScheduleMode.Manual
     };
 
     [Test]
-    public async Task IsGameTimeScheduled_RequiresTodIntervalSpawnerAndRiftName()
+    public async Task IsGameTimeScheduled_RequiresTypedModeIntervalAndSpawner()
     {
         await Assert.That(CrimsonExpand().IsGameTimeScheduled).IsTrue();
 
@@ -136,10 +154,15 @@ public class TowerDefScheduleTests
         var noSpawner = CrimsonExpand();
         noSpawner.TargetNpcSpawnId = 0;
         await Assert.That(noSpawner.IsGameTimeScheduled).IsFalse();
+
+        // Same name as Crimson expand, but Manual mode — must not auto-arm from display text.
+        var manual = CrimsonExpand();
+        manual.ScheduleMode = TowerDefScheduleMode.Manual;
+        await Assert.That(manual.IsGameTimeScheduled).IsFalse();
     }
 
     [Test]
-    public async Task IsGameTimeScheduled_CinderstoneYnystere_NightGrimghast_DayCrimsonExpand()
+    public async Task IsGameTimeScheduled_UsesSemanticFieldsNotDisplayNames()
     {
         // Midnight: Grimghast base only — not base Crimson (legacy tod=0) or Grimghast expand.
         await Assert.That(GrimghastBase().IsGameTimeScheduled).IsTrue();
@@ -151,20 +174,20 @@ public class TowerDefScheduleTests
 
         var ynystereGrim = GrimghastBase();
         ynystereGrim.Id = 15;
-        ynystereGrim.Name = "전장의 안개(이니스테르)";
+        ynystereGrim.Name = "renamed-without-korean-markers";
         ynystereGrim.TargetNpcSpawnId = 14441;
         await Assert.That(ynystereGrim.IsGameTimeScheduled).IsTrue();
 
         var ynystereCrim = CrimsonExpand();
         ynystereCrim.Id = 172;
-        ynystereCrim.Name = "징조의 틈 확장 (이니스테르)";
+        ynystereCrim.Name = "also-renamed";
         ynystereCrim.TargetNpcSpawnId = 8939;
         await Assert.That(ynystereCrim.IsGameTimeScheduled).IsTrue();
 
         // Event Center: Crimson Rift (Auroria) triangle at game hour 18.
         var auroriaCrim = CrimsonExpand(18f);
         auroriaCrim.Id = 173;
-        auroriaCrim.Name = "징조의 틈 확장 (원대륙)";
+        auroriaCrim.Name = "auroria-renamed";
         auroriaCrim.TargetNpcSpawnId = 9998;
         await Assert.That(auroriaCrim.IsGameTimeScheduled).IsTrue();
         await Assert.That(auroriaCrim.CrossedGameStartHour(17.9f, 18.1f)).IsTrue();

--- a/AAEmu.UnitTests/Game/Models/Game/TowerDefs/TowerDefScheduleTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/TowerDefs/TowerDefScheduleTests.cs
@@ -81,4 +81,119 @@ public class TowerDefScheduleTests
             await Assert.That(towerDef.IsWithinWindow(now)).IsFalse();
         }
     }
+
+    /// <summary>Crimson expand (scheduled noon Event Center row).</summary>
+    private static TowerDef CrimsonExpand(float tod = 12f) => new()
+    {
+        Id = 171,
+        Name = "징조의 틈 확장 (십자별 평원)",
+        TimeOfDay = tod,
+        TimeOfDayDayInterval = 1,
+        TargetNpcSpawnId = 9846,
+        ForceEndTime = 3600f
+    };
+
+    private static TowerDef CrimsonBase(float tod = 0f) => new()
+    {
+        Id = 3,
+        Name = "징조의 틈(십자별 평원)",
+        TimeOfDay = tod,
+        TimeOfDayDayInterval = 1,
+        TargetNpcSpawnId = 9846,
+        ForceEndTime = 3600f
+    };
+
+    private static TowerDef GrimghastBase(float tod = 0f) => new()
+    {
+        Id = 13,
+        Name = "전장의 안개(십자별 평원)",
+        TimeOfDay = tod,
+        TimeOfDayDayInterval = 1,
+        TargetNpcSpawnId = 14335,
+        ForceEndTime = 3600f
+    };
+
+    private static TowerDef GrimghastExpand(float tod = 0.1f) => new()
+    {
+        Id = 174,
+        Name = "전장의 안개 확장 (십자별 평원)",
+        TimeOfDay = tod,
+        TimeOfDayDayInterval = 1,
+        TargetNpcSpawnId = 14335,
+        ForceEndTime = 3600f
+    };
+
+    [Test]
+    public async Task IsGameTimeScheduled_RequiresTodIntervalSpawnerAndRiftName()
+    {
+        await Assert.That(CrimsonExpand().IsGameTimeScheduled).IsTrue();
+
+        // Wall slot → not a Game Time event (Event Center lower strip is Server Time UTC).
+        var wall = CrimsonExpand();
+        wall.StartTimes[(int)DayOfWeek.Monday] = new TimeSpan(21, 0, 0);
+        await Assert.That(wall.IsGameTimeScheduled).IsFalse();
+
+        var noSpawner = CrimsonExpand();
+        noSpawner.TargetNpcSpawnId = 0;
+        await Assert.That(noSpawner.IsGameTimeScheduled).IsFalse();
+    }
+
+    [Test]
+    public async Task IsGameTimeScheduled_CinderstoneYnystere_NightGrimghast_DayCrimsonExpand()
+    {
+        // Midnight: Grimghast base only — not base Crimson (legacy tod=0) or Grimghast expand.
+        await Assert.That(GrimghastBase().IsGameTimeScheduled).IsTrue();
+        await Assert.That(CrimsonBase().IsGameTimeScheduled).IsFalse();
+        await Assert.That(GrimghastExpand().IsGameTimeScheduled).IsFalse();
+
+        // Noon: Crimson expand only.
+        await Assert.That(CrimsonExpand().IsGameTimeScheduled).IsTrue();
+
+        var ynystereGrim = GrimghastBase();
+        ynystereGrim.Id = 15;
+        ynystereGrim.Name = "전장의 안개(이니스테르)";
+        ynystereGrim.TargetNpcSpawnId = 14441;
+        await Assert.That(ynystereGrim.IsGameTimeScheduled).IsTrue();
+
+        var ynystereCrim = CrimsonExpand();
+        ynystereCrim.Id = 172;
+        ynystereCrim.Name = "징조의 틈 확장 (이니스테르)";
+        ynystereCrim.TargetNpcSpawnId = 8939;
+        await Assert.That(ynystereCrim.IsGameTimeScheduled).IsTrue();
+
+        // Event Center: Crimson Rift (Auroria) triangle at game hour 18.
+        var auroriaCrim = CrimsonExpand(18f);
+        auroriaCrim.Id = 173;
+        auroriaCrim.Name = "징조의 틈 확장 (원대륙)";
+        auroriaCrim.TargetNpcSpawnId = 9998;
+        await Assert.That(auroriaCrim.IsGameTimeScheduled).IsTrue();
+        await Assert.That(auroriaCrim.CrossedGameStartHour(17.9f, 18.1f)).IsTrue();
+    }
+
+    [Test]
+    [Arguments(11.9f, 12.0f, true)]
+    [Arguments(12.0f, 12.1f, false)]
+    [Arguments(23.9f, 0.1f, true)] // wrap across midnight onto tod=0
+    [Arguments(0.0f, 0.5f, false)] // already past 0 for tod=0? old=0 new=0.5, trigger 0: old < 0 is false
+    public async Task CrossedGameStartHour_FiresOncePerCrossing(float oldH, float newH, bool expected)
+    {
+        var tod = Math.Abs(oldH - 23.9f) < 0.01f ? 0f : 12f;
+        var towerDef = tod < 1f ? GrimghastBase(tod) : CrimsonExpand(tod);
+        await Assert.That(towerDef.CrossedGameStartHour(oldH, newH)).IsEqualTo(expected);
+    }
+
+    /// <summary>
+    /// Documents the failure mode of large /time set before the ≤0.25h arm gate: an evening→morning
+    /// snap is a wrap, so <c>CrossedGameStartHour</c> reports tod=0 Grimghast as "crossed" even though
+    /// the GM never intended to pass midnight. Scheduler/TimeManager must refuse those jumps.
+    /// </summary>
+    [Test]
+    public async Task LargeEveningToMorningSnap_CrossesMidnightGrimghastInMath()
+    {
+        var grimghast = GrimghastBase();
+        // 22.5 → 11.75 is ~13.25h forward via midnight, or ~10.75h backward.
+        await Assert.That(grimghast.CrossedGameStartHour(22.5f, 11.75f)).IsTrue();
+        // Crimson noon is not yet "crossed" on that wrap (stop at 11.75).
+        await Assert.That(CrimsonExpand(12f).CrossedGameStartHour(22.5f, 11.75f)).IsFalse();
+    }
 }

--- a/AAEmu.UnitTests/Game/Models/ServerCalendarTests.cs
+++ b/AAEmu.UnitTests/Game/Models/ServerCalendarTests.cs
@@ -1,0 +1,44 @@
+using AAEmu.Game.Models;
+
+namespace AAEmu.UnitTests.Game.Models;
+
+public class ServerCalendarTests
+{
+    [Test]
+    public async Task AsUtc_PreservesUtcKind()
+    {
+        var utc = new DateTime(2026, 8, 11, 23, 30, 0, DateTimeKind.Utc);
+        await Assert.That(ServerCalendar.AsUtc(utc)).IsEqualTo(utc);
+        await Assert.That(ServerCalendar.AsUtc(utc).Kind).IsEqualTo(DateTimeKind.Utc);
+    }
+
+    [Test]
+    public async Task AsUtc_Unspecified_IsTreatedAsAlreadyUtc()
+    {
+        // MySQL leave_time often arrives Unspecified even when the stored value is UTC.
+        var unspecified = new DateTime(2026, 8, 11, 23, 30, 0, DateTimeKind.Unspecified);
+        var asUtc = ServerCalendar.AsUtc(unspecified);
+        await Assert.That(asUtc).IsEqualTo(new DateTime(2026, 8, 11, 23, 30, 0, DateTimeKind.Utc));
+        await Assert.That(asUtc.Kind).IsEqualTo(DateTimeKind.Utc);
+        // Must NOT shift by local offset the way ToUniversalTime() would.
+        await Assert.That(asUtc.Hour).IsEqualTo(23);
+    }
+
+    [Test]
+    public async Task WeekStartMondayContaining_UsesUtcDate()
+    {
+        // Sunday 2026-08-09 01:00 Unspecified → still Sunday UTC → week starts Monday 2026-08-03.
+        var sunday = new DateTime(2026, 8, 9, 1, 0, 0, DateTimeKind.Unspecified);
+        await Assert.That(ServerCalendar.WeekStartMondayContaining(sunday))
+            .IsEqualTo(new DateTime(2026, 8, 3));
+    }
+
+    [Test]
+    public async Task AsUtc_Local_ConvertsToUtc()
+    {
+        var local = new DateTime(2026, 8, 11, 12, 0, 0, DateTimeKind.Local);
+        var asUtc = ServerCalendar.AsUtc(local);
+        await Assert.That(asUtc.Kind).IsEqualTo(DateTimeKind.Utc);
+        await Assert.That(asUtc).IsEqualTo(local.ToUniversalTime());
+    }
+}

--- a/AAEmu.UnitTests/Login/Core/Packets/G2L/GLRegisterGameServerPacketTests.cs
+++ b/AAEmu.UnitTests/Login/Core/Packets/G2L/GLRegisterGameServerPacketTests.cs
@@ -1,0 +1,79 @@
+using AAEmu.Commons.Network;
+using AAEmu.Login.Core.Packets.G2L;
+
+namespace AAEmu.UnitTests.Login.Core.Packets.G2L;
+
+public class GLRegisterGameServerPacketTests
+{
+    private static PacketStream Body(string secret, byte gsId, params byte[] mirrors)
+    {
+        var stream = new PacketStream();
+        stream.Write(secret);
+        stream.Write(gsId);
+        stream.Write(mirrors.Length);
+        foreach (var id in mirrors)
+            stream.Write(id);
+        stream.Pos = 0;
+        return stream;
+    }
+
+    [Test]
+    public async Task Read_ValidMirrors_PopulatesFields()
+    {
+        var packet = new GLRegisterGameServerPacket();
+        packet.Read(Body("secret", 1, 2, 3));
+
+        await Assert.That(packet.SecretKey).IsEqualTo("secret");
+        await Assert.That(packet.GsId.Value).IsEqualTo((byte)1);
+        await Assert.That(packet.Mirrors).IsNotNull();
+        await Assert.That(packet.Mirrors!.Count).IsEqualTo(2);
+        await Assert.That(packet.Mirrors[0].Value).IsEqualTo((byte)2);
+        await Assert.That(packet.Mirrors[1].Value).IsEqualTo((byte)3);
+    }
+
+    [Test]
+    public async Task Read_ZeroMirrors_Succeeds()
+    {
+        var packet = new GLRegisterGameServerPacket();
+        packet.Read(Body("secret", 1));
+
+        await Assert.That(packet.Mirrors).IsNotNull();
+        await Assert.That(packet.Mirrors!.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Read_TruncatedCount_Throws()
+    {
+        var stream = new PacketStream();
+        stream.Write("secret");
+        stream.Write((byte)1);
+        stream.Pos = 0;
+
+        await Assert.That(() => new GLRegisterGameServerPacket().Read(stream))
+            .Throws<InvalidDataException>();
+    }
+
+    [Test]
+    public async Task Read_CountDoesNotMatchRemaining_Throws()
+    {
+        var stream = new PacketStream();
+        stream.Write("secret");
+        stream.Write((byte)1);
+        stream.Write(5);
+        stream.Write((byte)2);
+        stream.Pos = 0;
+
+        await Assert.That(() => new GLRegisterGameServerPacket().Read(stream))
+            .Throws<InvalidDataException>();
+    }
+
+    [Test]
+    public async Task Read_CountExceedsMax_Throws()
+    {
+        var extra = new byte[GLRegisterGameServerPacket.MaxMirrorCount + 1];
+        var stream = Body("secret", 1, extra);
+
+        await Assert.That(() => new GLRegisterGameServerPacket().Read(stream))
+            .Throws<InvalidDataException>();
+    }
+}

--- a/AAEmu.UnitTests/World/Core/Relay/ZoneGameDataRootResolverTests.cs
+++ b/AAEmu.UnitTests/World/Core/Relay/ZoneGameDataRootResolverTests.cs
@@ -1,0 +1,115 @@
+using AAEmu.World.Core.Relay;
+
+namespace AAEmu.UnitTests.World.Core.Relay;
+
+public class ZoneGameDataRootResolverTests
+{
+    [Test]
+    public async Task ConfiguredOnly_ReturnsExistingDirectory()
+    {
+        var dir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var root = ZoneGameDataRootResolver.Resolve(null, dir.FullName, Directory.Exists);
+            await Assert.That(root).IsEqualTo(Path.GetFullPath(dir.FullName));
+        }
+        finally
+        {
+            dir.Delete(true);
+        }
+    }
+
+    [Test]
+    public async Task OverrideOnly_ReturnsExistingDirectory()
+    {
+        var dir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var root = ZoneGameDataRootResolver.Resolve(dir.FullName, null, Directory.Exists);
+            await Assert.That(root).IsEqualTo(Path.GetFullPath(dir.FullName));
+        }
+        finally
+        {
+            dir.Delete(true);
+        }
+    }
+
+    [Test]
+    public async Task Override_TakesPrecedenceOverConfig()
+    {
+        var envDir = Directory.CreateTempSubdirectory();
+        var cfgDir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var root = ZoneGameDataRootResolver.Resolve(envDir.FullName, cfgDir.FullName, Directory.Exists);
+            await Assert.That(root).IsEqualTo(Path.GetFullPath(envDir.FullName));
+        }
+        finally
+        {
+            envDir.Delete(true);
+            cfgDir.Delete(true);
+        }
+    }
+
+    [Test]
+    public async Task InvalidOverride_FallsThroughToConfig()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var cfgDir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var root = ZoneGameDataRootResolver.Resolve(missing, cfgDir.FullName, Directory.Exists);
+            await Assert.That(root).IsEqualTo(Path.GetFullPath(cfgDir.FullName));
+        }
+        finally
+        {
+            cfgDir.Delete(true);
+        }
+    }
+
+    [Test]
+    public async Task InvalidConfig_DoesNotBlockValidOverride()
+    {
+        var envDir = Directory.CreateTempSubdirectory();
+        var missing = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        try
+        {
+            var root = ZoneGameDataRootResolver.Resolve(envDir.FullName, missing, Directory.Exists);
+            await Assert.That(root).IsEqualTo(Path.GetFullPath(envDir.FullName));
+        }
+        finally
+        {
+            envDir.Delete(true);
+        }
+    }
+
+    [Test]
+    public async Task BothInvalid_ReturnsNull()
+    {
+        var missingA = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var missingB = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var root = ZoneGameDataRootResolver.Resolve(missingA, missingB, Directory.Exists);
+        await Assert.That(root).IsNull();
+    }
+
+    [Test]
+    public async Task InvalidPath_FallsThroughToConfig()
+    {
+        var cfgDir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var root = ZoneGameDataRootResolver.Resolve("\0invalid", cfgDir.FullName, Directory.Exists);
+            await Assert.That(root).IsEqualTo(Path.GetFullPath(cfgDir.FullName));
+        }
+        finally
+        {
+            cfgDir.Delete(true);
+        }
+    }
+
+    [Test]
+    public async Task BothUnset_ReturnsNull()
+    {
+        await Assert.That(ZoneGameDataRootResolver.Resolve(null, "  ", Directory.Exists)).IsNull();
+    }
+}

--- a/AAEmu.UnitTests/World/Core/Relay/ZoneSpawnerPlacementCatalogTests.cs
+++ b/AAEmu.UnitTests/World/Core/Relay/ZoneSpawnerPlacementCatalogTests.cs
@@ -1,0 +1,79 @@
+using AAEmu.World.Core.Relay;
+
+namespace AAEmu.UnitTests.World.Core.Relay;
+
+public class ZoneSpawnerPlacementCatalogTests
+{
+    [Test]
+    public async Task ParseFile_ReadsValidSpawnerBlocks()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"npc_spawners_{Guid.NewGuid():N}.g");
+        await File.WriteAllTextAsync(path, """
+            spawner
+            {
+            	spawnerId 1001
+            	spawnerType 9846
+            	pos( x 10.5, y 20.25, z 30 )
+            	zRot 1.5
+            }
+            spawner
+            {
+            	spawnerId 1002
+            	spawnerType 9848
+            	pos( x -1, y 2, z 3.5 )
+            }
+            """);
+        try
+        {
+            var list = ZoneSpawnerPlacementCatalog.ParseFile(path);
+            await Assert.That(list.Count).IsEqualTo(2);
+            await Assert.That(list[0].PlacementId).IsEqualTo(1001u);
+            await Assert.That(list[0].SpawnerType).IsEqualTo(9846u);
+            await Assert.That(list[0].X).IsEqualTo(10.5f);
+            await Assert.That(list[1].PlacementId).IsEqualTo(1002u);
+            await Assert.That(list[1].SpawnerType).IsEqualTo(9848u);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task ParseFile_MissingPath_Throws()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), $"missing_{Guid.NewGuid():N}.g");
+        await Assert.That(() => ZoneSpawnerPlacementCatalog.ParseFile(missing))
+            .Throws<FileNotFoundException>();
+    }
+
+    [Test]
+    public async Task ParseFile_SkipsInvalidBlocks()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"npc_spawners_bad_{Guid.NewGuid():N}.g");
+        await File.WriteAllTextAsync(path, """
+            spawner
+            {
+            	spawnerId not-a-number
+            	spawnerType 1
+            	pos( x 1, y 2, z 3 )
+            }
+            spawner
+            {
+            	spawnerId 7
+            	spawnerType 8
+            	pos( x 1, y 2, z 3 )
+            }
+            """);
+        try
+        {
+            var list = ZoneSpawnerPlacementCatalog.ParseFile(path);
+            await Assert.That(list.Count).IsEqualTo(1);
+            await Assert.That(list[0].PlacementId).IsEqualTo(7u);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/AAEmu.WorldServer/AAEmu.World/Core/Network/ClientProtocolHandler.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Network/ClientProtocolHandler.cs
@@ -1,4 +1,3 @@
-using AAEmu.Commons.Exceptions;
 using AAEmu.Commons.Network;
 using AAEmu.Commons.Network.Core;
 using AAEmu.World.Core.Relay;
@@ -14,7 +13,7 @@ namespace AAEmu.World.Core.Network;
 /// </summary>
 public class ClientProtocolHandler : BaseProtocolHandler
 {
-    // Matches AAEmu.Game CSOffsets for 10.0.2.13
+    // Matches AAEmu.Game CSOffsets.
     private const ushort CSSelectCharacter = 0x04C;
     private const ushort CSSpawnCharacter = 0x04E;
     private const ushort CSNotifyInGame = 0x051;
@@ -46,57 +45,42 @@ public class ClientProtocolHandler : BaseProtocolHandler
     public override void OnReceive(ISession session, byte[] buf, int offset, int bytes)
     {
         var stream = new PacketStream();
-        if (_buffers.TryGetValue(session.SessionId, out var pending))
+        if (_buffers.TryGetValue(session.SessionId, out var leftover))
         {
-            stream.Insert(0, pending);
+            stream.Insert(0, leftover);
             _buffers.Remove(session.SessionId);
         }
 
         stream.Insert(stream.Count, buf, offset, bytes);
 
-        while (stream is { Count: > 0 })
+        PacketStream? cursor = stream;
+        while (cursor is { Count: > 0 })
         {
-            ushort len;
-            try
+            switch (LengthPrefixedFrames.TryTake(ref cursor, LengthPrefixedFrames.MinOpcodePayloadBytes, out var frame))
             {
-                len = stream.ReadUInt16();
+                case LengthPrefixedFrameResult.NeedMore:
+                    if (cursor != null)
+                        _buffers[session.SessionId] = cursor;
+                    return;
+                case LengthPrefixedFrameResult.DroppedInvalidLength:
+                    Logger.Warn("Dropped invalid CS frame from {0}", session.Ip);
+                    continue;
+                case LengthPrefixedFrameResult.GotFrame:
+                    frame!.ReadUInt16();
+                    _ = frame.ReadByte();
+                    var level = frame.ReadByte();
+                    if (level == 1)
+                    {
+                        _ = frame.ReadByte();
+                        _ = frame.ReadByte();
+                    }
+
+                    var opcode = frame.ReadUInt16();
+                    var bodyLen = frame.Count - frame.Pos;
+                    var body = bodyLen > 0 ? frame.ReadBytes(bodyLen) : [];
+                    HandleCs(session, opcode, body);
+                    break;
             }
-            catch (MarshalException)
-            {
-                stream.Rollback();
-                _buffers[session.SessionId] = stream;
-                return;
-            }
-
-            var packetLen = len + stream.Pos;
-            if (packetLen > stream.Count)
-            {
-                stream.Rollback();
-                _buffers[session.SessionId] = stream;
-                return;
-            }
-
-            stream.Rollback();
-            var frame = new PacketStream();
-            frame.Replace(stream, 0, packetLen);
-            stream = stream.Count > packetLen
-                ? new PacketStream().Replace(stream.Buffer, packetLen, stream.Count - packetLen)
-                : null;
-
-            frame.ReadUInt16(); // length
-            _ = frame.ReadByte(); // 0xDD
-            var level = frame.ReadByte();
-            if (level == 1)
-            {
-                _ = frame.ReadByte();
-                _ = frame.ReadByte();
-            }
-
-            var opcode = frame.ReadUInt16();
-            var bodyLen = frame.Count - frame.Pos;
-            var body = bodyLen > 0 ? frame.ReadBytes(bodyLen) : [];
-
-            HandleCs(session, opcode, body);
         }
     }
 

--- a/AAEmu.WorldServer/AAEmu.World/Core/Network/GameBridgeProtocolHandler.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Network/GameBridgeProtocolHandler.cs
@@ -1,4 +1,3 @@
-using AAEmu.Commons.Exceptions;
 using AAEmu.Commons.Network;
 using AAEmu.Commons.Network.Core;
 using AAEmu.World.Core.Relay;
@@ -34,49 +33,34 @@ public class GameBridgeProtocolHandler : BaseProtocolHandler
     public override void OnReceive(ISession session, byte[] buf, int offset, int bytes)
     {
         var stream = new PacketStream();
-        if (_buffers.TryGetValue(session.SessionId, out var pending))
+        if (_buffers.TryGetValue(session.SessionId, out var leftover))
         {
-            stream.Insert(0, pending);
+            stream.Insert(0, leftover);
             _buffers.Remove(session.SessionId);
         }
 
         stream.Insert(stream.Count, buf, offset, bytes);
 
-        while (stream is { Count: > 0 })
+        PacketStream? cursor = stream;
+        while (cursor is { Count: > 0 })
         {
-            ushort len;
-            try
+            switch (LengthPrefixedFrames.TryTake(ref cursor, LengthPrefixedFrames.MinOpcodePayloadBytes, out var frame))
             {
-                len = stream.ReadUInt16();
+                case LengthPrefixedFrameResult.NeedMore:
+                    if (cursor != null)
+                        _buffers[session.SessionId] = cursor;
+                    return;
+                case LengthPrefixedFrameResult.DroppedInvalidLength:
+                    Logger.Warn("Dropped invalid game-bridge frame from {0}", session.Ip);
+                    continue;
+                case LengthPrefixedFrameResult.GotFrame:
+                    frame!.ReadUInt16();
+                    var opcode = frame.ReadUInt16();
+                    var bodyLen = frame.Count - frame.Pos;
+                    var body = bodyLen > 0 ? frame.ReadBytes(bodyLen) : [];
+                    Handle(opcode, body);
+                    break;
             }
-            catch (MarshalException)
-            {
-                stream.Rollback();
-                _buffers[session.SessionId] = stream;
-                return;
-            }
-
-            var packetLen = len + stream.Pos;
-            if (packetLen > stream.Count)
-            {
-                stream.Rollback();
-                _buffers[session.SessionId] = stream;
-                return;
-            }
-
-            stream.Rollback();
-            var frame = new PacketStream();
-            frame.Replace(stream, 0, packetLen);
-            stream = stream.Count > packetLen
-                ? new PacketStream().Replace(stream.Buffer, packetLen, stream.Count - packetLen)
-                : null;
-
-            frame.ReadUInt16();
-            var opcode = frame.ReadUInt16();
-            var bodyLen = packetLen - 4;
-            var body = bodyLen > 0 ? frame.ReadBytes(bodyLen) : [];
-
-            Handle(opcode, body);
         }
     }
 

--- a/AAEmu.WorldServer/AAEmu.World/Core/Network/ZoneProtocolHandler.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Network/ZoneProtocolHandler.cs
@@ -1,6 +1,5 @@
 using System;
 
-using AAEmu.Commons.Exceptions;
 using AAEmu.Commons.Network;
 using AAEmu.Commons.Network.Core;
 using AAEmu.Game;
@@ -84,64 +83,31 @@ public class ZoneProtocolHandler : BaseProtocolHandler
 
         stream.Insert(stream.Count, buf, offset, bytes);
 
-        while (stream is { Count: > 0 })
+        PacketStream? pending = stream;
+        while (pending is { Count: > 0 })
         {
-            ushort len;
-            try
+            switch (LengthPrefixedFrames.TryTake(ref pending, LengthPrefixedFrames.MinOpcodePayloadBytes, out var frame))
             {
-                len = stream.ReadUInt16();
+                case LengthPrefixedFrameResult.NeedMore:
+                    connection.LastPacket = pending;
+                    return;
+                case LengthPrefixedFrameResult.DroppedInvalidLength:
+                    var dropped = Interlocked.Increment(ref _emptyFrameDrops);
+                    if (dropped <= 5 || dropped % 10000 == 0)
+                        Logger.Warn(
+                            "ZW empty frame from {0} zoneId={1} dropped={2}",
+                            connection.Ip, connection.ZoneId, dropped);
+                    continue;
+                case LengthPrefixedFrameResult.GotFrame:
+                    frame!.ReadUInt16();
+                    var opcode = frame.ReadUInt16();
+                    var bodyLen = frame.Count - frame.Pos;
+                    var body = new PacketStream();
+                    if (bodyLen > 0)
+                        body.Replace(frame.Buffer, frame.Pos, bodyLen);
+                    HandleZwPacket(connection, opcode, body, bodyLen);
+                    break;
             }
-            catch (MarshalException)
-            {
-                stream.Rollback();
-                connection.LastPacket = stream;
-                return;
-            }
-
-            // Payload length must cover type (u16). Zero (and 1) used to become bodyLen=-4 and
-            // re-entered Join as opcode 0 — multi-GB Warn spam + no useful dispatch.
-            if (len < 2)
-            {
-                // length field already consumed; drop empty frame and keep scanning
-                var dropped = System.Threading.Interlocked.Increment(ref _emptyFrameDrops);
-                if (dropped <= 5 || dropped % 10000 == 0)
-                    Logger.Warn(
-                        "ZW empty frame (len={0}) from {1} zoneId={2} dropped={3}",
-                        len, connection.Ip, connection.ZoneId, dropped);
-                continue;
-            }
-
-            var packetLen = len + stream.Pos;
-            if (packetLen > stream.Count)
-            {
-                stream.Rollback();
-                connection.LastPacket = stream;
-                return;
-            }
-
-            stream.Rollback();
-            var frame = new PacketStream();
-            frame.Replace(stream, 0, packetLen);
-
-            if (stream.Count > packetLen)
-            {
-                var remainder = new PacketStream();
-                remainder.Replace(stream, packetLen, stream.Count - packetLen);
-                stream = remainder;
-            }
-            else
-            {
-                stream = null;
-            }
-
-            frame.ReadUInt16(); // length
-            var opcode = frame.ReadUInt16();
-            var bodyLen = packetLen - 4;
-            var body = new PacketStream();
-            if (bodyLen > 0)
-                body.Replace(frame.Buffer, frame.Pos, bodyLen);
-
-            HandleZwPacket(connection, opcode, body, bodyLen);
         }
     }
 

--- a/AAEmu.WorldServer/AAEmu.World/Core/Network/ZoneProtocolHandler.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Network/ZoneProtocolHandler.cs
@@ -4,6 +4,7 @@ using AAEmu.Commons.Exceptions;
 using AAEmu.Commons.Network;
 using AAEmu.Commons.Network.Core;
 using AAEmu.Game;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.World.Core.Packets.Wz;
 using AAEmu.World.Core.Packets.Zw;
@@ -21,6 +22,7 @@ public class ZoneProtocolHandler : BaseProtocolHandler
     private readonly MovementRelay _movementRelay = new();
     private readonly NpcSpawnRelay _npcSpawnRelay = new();
     private readonly ZoneSimRelay _zoneSimRelay = new();
+    private static long _emptyFrameDrops;
 
     public override void OnConnect(ISession session)
     {
@@ -37,7 +39,10 @@ public class ZoneProtocolHandler : BaseProtocolHandler
         // otherwise sibling zones that later allocate colliding bcIds (pre-fix) or
         // remirror leave ghost units and SC movement thrash.
         if (connection != null)
+        {
             NpcSpawnRelay.RemoveMirrorsForConnection(connection, $"zone TCP disconnect {session.Ip}");
+            TowerDefScheduler.OnZoneDisconnected(connection.ZoneId);
+        }
         ZoneSession.Instance.Remove(session.SessionId);
         NpcSpawnRelay.ResetNpcStateSentForZone(zoneId, $"zone TCP disconnect {session.Ip}");
         Logger.Error(
@@ -93,6 +98,19 @@ public class ZoneProtocolHandler : BaseProtocolHandler
                 return;
             }
 
+            // Payload length must cover type (u16). Zero (and 1) used to become bodyLen=-4 and
+            // re-entered Join as opcode 0 — multi-GB Warn spam + no useful dispatch.
+            if (len < 2)
+            {
+                // length field already consumed; drop empty frame and keep scanning
+                var dropped = System.Threading.Interlocked.Increment(ref _emptyFrameDrops);
+                if (dropped <= 5 || dropped % 10000 == 0)
+                    Logger.Warn(
+                        "ZW empty frame (len={0}) from {1} zoneId={2} dropped={3}",
+                        len, connection.Ip, connection.ZoneId, dropped);
+                continue;
+            }
+
             var packetLen = len + stream.Pos;
             if (packetLen > stream.Count)
             {
@@ -134,8 +152,7 @@ public class ZoneProtocolHandler : BaseProtocolHandler
             case ZwOpcodes.Join:
                 if (connection.State < ZoneConnectionState.Joined)
                     HandleJoin(connection, body);
-                else
-                    Logger.Warn("ZW opcode 0 after join from {0} len={1}", connection.Ip, bodyLen);
+                // Post-join opcode 0 is almost always frame desync (empty/short packs); do not spam.
                 break;
             case ZwOpcodes.UnitMovements:
                 Logger.Info("ZWUnitMovements from zone {0} len={1}", connection.Ip, bodyLen);
@@ -158,6 +175,7 @@ public class ZoneProtocolHandler : BaseProtocolHandler
                 WorldIntegration.NotifyZoneReadyForGimmicks?.Invoke(connection.ZoneId);
                 // schedule-linked spawners stay held back until the period next reopens.
                 GameScheduleRelay.OnZoneLoaded(connection);
+                TowerDefScheduler.OnZoneLoaded(connection);
                 var npcActivate = global::AAEmu.World.WorldRuntime.Config.NpcSpawnerActivate;
                 if (npcActivate.PrewarmOnZoneLoaded)
                     ActivateNpcSpawnersForZone(connection);
@@ -222,17 +240,30 @@ public class ZoneProtocolHandler : BaseProtocolHandler
         // Saved indun spawner state; empty last=1 for seamless worlds, which is every open-world
         var persistent = ZoneNpcSpawnerCatalog.GetPersistentSpawners(connection.ZoneId, connection.InstanceId);
         WZSpawnerListPacket.SendAll(connection, persistent);
-        connection.SendPacket(new WZTimeOfDayPacket(12.0f));
-        if (Environment.GetEnvironmentVariable("AAEMU_WZ_WORLD_GAMETIME") == "1")
-        {
-            var gameTime = (uint)(DateTime.UtcNow.TimeOfDay.TotalSeconds);
-            connection.SendPacket(new WZWorldGameTimePacket(gameTime));
-            connection.SendPacket(new WZDetailedTimeOfDayPacket(12.0f, 1.0f, 0.0f, 24.0f));
-        }
+        // main_world: shared day. Instance maps: noon start + local advance (type-2 ZW report).
+        // WZWorldGameTime is UTC wall seconds-of-day, independent of game hour.
+        var sharedDay = TimeManager.ZoneUsesSharedGameDay(connection.ZoneId);
+        var seedHour = sharedDay
+            ? TimeManager.Instance.GetTime
+            : TimeManager.InstanceDefaultStartHour;
+        connection.SendPacket(new WZTimeOfDayPacket(seedHour));
+        connection.SendPacket(new WZDetailedTimeOfDayPacket(
+            seedHour,
+            TimeManager.DefaultGameHourSpeed,
+            0.0f,
+            24.0f));
+        connection.SendPacket(new WZWorldGameTimePacket((uint)DateTime.UtcNow.TimeOfDay.TotalSeconds));
         connection.State = ZoneConnectionState.Joined;
         Logger.Info(
-            "Sent bring-online gate (JoinResponse + FactionList/Relations + SpawnerList({0}) + ToD) to {1} zoneId={2} realFactions={3}",
-            persistent.Count, connection.Ip, connection.ZoneId, realFactions);
+            "Sent bring-online gate (JoinResponse + FactionList/Relations + SpawnerList({0}) + ToD seed={1:F2}h speed={2} sharedDay={3} UTC-s={4}) to {5} zoneId={6} realFactions={7}",
+            persistent.Count,
+            seedHour,
+            TimeManager.DefaultGameHourSpeed,
+            sharedDay,
+            (uint)DateTime.UtcNow.TimeOfDay.TotalSeconds,
+            connection.Ip,
+            connection.ZoneId,
+            realFactions);
     }
 
     private static void ActivateNpcSpawnersForZone(ZoneConnection connection)

--- a/AAEmu.WorldServer/AAEmu.World/Core/Packets/Wz/WZNpcSpawnerEventPacket.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Packets/Wz/WZNpcSpawnerEventPacket.cs
@@ -8,6 +8,11 @@ namespace AAEmu.World.Core.Packets.Wz;
 /// <summary>
 /// type(i32), despawnOnCreatorDeath(bool), useSummonerAggroTarget(bool), lifeTime(f32).
 /// </summary>
+/// <remarks>
+/// Keep reason type as Default (0) with no reason sub-payload. A non-Default reason or incorrect
+/// case padding size-mismatches the zone deserializer (NpcSpawnerEvent / WZ 0x070) and can
+/// terminate the zone process. Leave tower-only filter layout alone until the wire is known.
+/// </remarks>
 public sealed class WZNpcSpawnerEventPacket(WorldNpcSpawnerEventRequest request)
     : ZonePacket(WzOpcodes.NpcSpawnerEvent)
 {

--- a/AAEmu.WorldServer/AAEmu.World/Core/Relay/MovementRelay.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Relay/MovementRelay.cs
@@ -208,6 +208,42 @@ public class MovementRelay
         if (source != null && unitZone != 0 && source.ZoneId != unitZone)
             return;
 
+        // Dedic owns pathing/flight — World only mirrors. Never clamp mid-path jumps (rift fly-ins
+        // span hundreds of metres). Only repair multi-km snaps that look like raw zone-local on a
+        // world-space mirror (ObjectId recycle / space poisoning), by converting local→world when
+        // that lands much closer to the last known world position.
+        if (unit is Npc { IsZoneMirror: true } && unitZone != 0)
+        {
+            var cur = unit.Transform.World.Position;
+            var raw = new System.Numerics.Vector3(move.X, move.Y, move.Z);
+            var dx = raw.X - cur.X;
+            var dy = raw.Y - cur.Y;
+            var dz = raw.Z - cur.Z;
+            var rawD2 = dx * dx + dy * dy + dz * dz;
+            const float poisonJumpM = 2000f;
+            if (rawD2 > poisonJumpM * poisonJumpM)
+            {
+                var asWorld = ZoneManager.Instance.ConvertToWorldCoordinates(unitZone, raw);
+                var wx = asWorld.X - cur.X;
+                var wy = asWorld.Y - cur.Y;
+                var wz = asWorld.Z - cur.Z;
+                var worldD2 = wx * wx + wy * wy + wz * wz;
+                if (worldD2 < rawD2 * 0.25f)
+                {
+                    if (LogMovePositions)
+                    {
+                        Logger.Warn(
+                            "ZW move local→world bc={0} jump={1:F0}m raw=({2:F1},{3:F1}) → world=({4:F1},{5:F1}) zoneId={6}",
+                            bcId, MathF.Sqrt(rawD2), raw.X, raw.Y, asWorld.X, asWorld.Y, unitZone);
+                    }
+
+                    move.X = asWorld.X;
+                    move.Y = asWorld.Y;
+                    move.Z = asWorld.Z;
+                }
+            }
+        }
+
         unit.Transform.Local.SetPosition(
             move.X, move.Y, move.Z,
             (float)MathUtil.ConvertDirectionToRadian(move.RotationX),

--- a/AAEmu.WorldServer/AAEmu.World/Core/Relay/NpcScheduleGate.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Relay/NpcScheduleGate.cs
@@ -50,7 +50,16 @@ public static class NpcScheduleGate
     /// </summary>
     public static bool IsClosed(uint spawnerTemplateId)
     {
-        return Config.Enabled && _closed.Contains(spawnerTemplateId);
+        if (!Config.Enabled || spawnerTemplateId == 0)
+            return false;
+
+        // TowerDef portal / wave spawners often carry a day-night window (e.g. Grimghast 14133
+        // 0.1–1.0h). Dedic arms them via WZTowerDef*, not ambient geometry + schedule. Applying the
+        // ToD gate answers WZNpcSpawnFailed and tears the whole NpcGroup down mid-wave.
+        if (AAEmu.Game.GameData.TowerDefGameData.Instance.IsTowerDefEventSpawner(spawnerTemplateId))
+            return false;
+
+        return _closed.Contains(spawnerTemplateId);
     }
 
     /// <summary>

--- a/AAEmu.WorldServer/AAEmu.World/Core/Relay/NpcSpawnRelay.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Relay/NpcSpawnRelay.cs
@@ -26,6 +26,24 @@ public class NpcSpawnRelay
     /// </summary>
     private static readonly ConcurrentDictionary<ulong, byte> NpcStateSent = new();
 
+    /// <summary>
+    /// ObjectIds pending delayed free after ZWRemove. Dedicate ProcessFreeUnits is deferred;
+    /// reusing the same bc the next second causes Create collisions (DataMap / unit table) and
+    /// SCUnitsRemoved flashes on tower rifts (bc reused for 8828 while the old body still moves).
+    /// Hold matches mate id release (default 60s). Override: <c>AAEMU_ZONE_OBJID_HOLD_MS</c>.
+    /// </summary>
+    private static readonly ConcurrentDictionary<uint, byte> PendingObjectIdReleases = new();
+
+    private static readonly int ObjectIdHoldMs = ParseObjectIdHoldMs();
+
+    private static int ParseObjectIdHoldMs()
+    {
+        var raw = Environment.GetEnvironmentVariable("AAEMU_ZONE_OBJID_HOLD_MS");
+        if (int.TryParse(raw, out var n) && n >= 0)
+            return n;
+        return 60_000;
+    }
+
     private int _hexDumps;
     private int _mirrorOk;
     private int _mirrorFail;
@@ -36,6 +54,31 @@ public class NpcSpawnRelay
 
     private static readonly bool DisableFlyState =
         Environment.GetEnvironmentVariable("AAEMU_DISABLE_WZ_FLY_STATE") == "1";
+
+    /// <summary>
+    /// Always log these sTypes (retail event seeds: Crimson/Grimghast portals + waves).
+    /// Env <c>AAEMU_ZW_SPAWN_TRACE_TYPES=9846,14335</c> extends the set.
+    /// </summary>
+    private static readonly HashSet<uint> TraceSpawnerTypes = BuildTraceSpawnerTypes();
+
+    /// <summary>sType → emit count (process lifetime). Used to prove OnEvent→ZW for event arms.</summary>
+    private static readonly ConcurrentDictionary<uint, long> SpawnerTypeEmits = new();
+
+    private static HashSet<uint> BuildTraceSpawnerTypes()
+    {
+        var set = new HashSet<uint> { 9846, 9848, 9849, 9865, 9866, 14335, 14133, 14122, 14280, 23862, 23868, 23869 };
+        var extra = Environment.GetEnvironmentVariable("AAEMU_ZW_SPAWN_TRACE_TYPES");
+        if (!string.IsNullOrWhiteSpace(extra))
+        {
+            foreach (var part in extra.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (uint.TryParse(part, out var id) && id != 0)
+                    set.Add(id);
+            }
+        }
+
+        return set;
+    }
 
     private static ulong MarkerKey(uint zoneId, uint bcId) => ((ulong)zoneId << 32) | bcId;
 
@@ -96,7 +139,7 @@ public class NpcSpawnRelay
                 if (WorldIntegration.FindUnitAcrossWorlds(bcId) is Npc { IsZoneMirror: true })
                 {
                     WorldIntegration.OnZoneNpcRemove?.Invoke(bcId);
-                    ObjectIdManager.Instance.ReleaseId(bcId);
+                    ScheduleObjectIdRelease(bcId);
                     removed++;
                 }
                 else
@@ -108,7 +151,7 @@ public class NpcSpawnRelay
             }
 
             WorldIntegration.OnZoneNpcRemove?.Invoke(bcId);
-            ObjectIdManager.Instance.ReleaseId(bcId);
+            ScheduleObjectIdRelease(bcId);
             removed++;
             connection.Units.TryRemove(bcId);
         }
@@ -122,6 +165,19 @@ public class NpcSpawnRelay
     {
         var parsed = ZwSpawnNpcParser.TryParse(raw);
 
+        // Event OnEvent may emit non-78 B bodies; surface those for seed sTypes.
+        ZwSpawnNpcParser.TryPeekIds(raw, out var peekSid, out var peekType);
+        var eventSpawner = peekType != 0 &&
+                           AAEmu.Game.GameData.TowerDefGameData.Instance.IsTowerDefEventSpawner(peekType);
+        var tracePeek = peekType != 0 && (TraceSpawnerTypes.Contains(peekType) || eventSpawner);
+        if (parsed == null && (tracePeek || raw is { Length: > 0 and not ZwSpawnNpcParser.AmbientBodyLength }))
+        {
+            Logger.Warn(
+                "ZWSpawnNpc REJECT zoneId={0} len={1} sid={2} sType={3} hex={4}",
+                connection.ZoneId, raw?.Length ?? 0, peekSid, peekType,
+                raw == null ? "-" : BitConverter.ToString(raw, 0, Math.Min(raw.Length, 64)));
+        }
+
         // Reject before a bcId is spent. Leaving the announcement unacknowledged keeps Zone from
         // running NpcManager::Create, so the NPC exists nowhere.
         if (parsed != null && NpcScheduleGate.IsClosed(parsed.SpawnerType))
@@ -131,41 +187,65 @@ public class NpcSpawnRelay
             connection.SendPacket(new WZNpcSpawnFailedPacket(raw));
             NpcScheduleGate.CountSuppressed(
                 connection.ZoneId, parsed.SpawnerId, parsed.SpawnerType, parsed.TemplateId);
+            if (TraceSpawnerTypes.Contains(parsed.SpawnerType) ||
+                AAEmu.Game.GameData.TowerDefGameData.Instance.IsTowerDefEventSpawner(parsed.SpawnerType))
+            {
+                Logger.Warn(
+                    "ZWSpawnNpc GATECLOSED zoneId={0} sid={1} sType={2} tpl={3} pos=({4:F1},{5:F1},{6:F1})",
+                    connection.ZoneId, parsed.SpawnerId, parsed.SpawnerType, parsed.TemplateId,
+                    parsed.X, parsed.Y, parsed.Z);
+            }
+
             return 0;
         }
 
         var bcId = connection.Units.Register(raw);
         var count = connection.Units.Count;
 
-        if (_hexDumps < 3)
-        {
-            _hexDumps++;
-            Logger.Info("ZWSpawnNpc HEX#{0} len={1} {2}", _hexDumps, raw.Length, BitConverter.ToString(raw));
-            if (parsed != null)
-            {
-                Logger.Info(
-                    "ZWSpawnNpc PARSE#{0} sid={1} sType={2} tpl={3} pos=({4:F1},{5:F1},{6:F1}) zRot={7:F2} scale={8:F2} → bc={9}",
-                    _hexDumps, parsed.SpawnerId, parsed.SpawnerType, parsed.TemplateId,
-                    parsed.X, parsed.Y, parsed.Z, parsed.ZRot, parsed.Scale, bcId);
-            }
-            else
-            {
-                Logger.Warn("ZWSpawnNpc PARSE#{0} failed", _hexDumps);
-            }
-        }
-
         if (parsed != null)
         {
+            var typeTotal = SpawnerTypeEmits.AddOrUpdate(parsed.SpawnerType, 1, (_, n) => n + 1);
+            var isTdEvent =
+                AAEmu.Game.GameData.TowerDefGameData.Instance.IsTowerDefEventSpawner(parsed.SpawnerType);
+            var trace = TraceSpawnerTypes.Contains(parsed.SpawnerType) || isTdEvent;
+            if (trace || typeTotal <= 2 || _hexDumps < 3
+                || raw.Length != ZwSpawnNpcParser.AmbientBodyLength)
+            {
+                if (_hexDumps < 3)
+                    _hexDumps++;
+                Logger.Info(
+                    "ZWSpawnNpc TRACE zoneId={0} #{1} sTypeTotal={2} sid={3} sType={4} tpl={5} " +
+                    "pos=({6:F1},{7:F1},{8:F1}) zRot={9:F2} scale={10:F2} → bc={11} len={12}",
+                    connection.ZoneId, count, typeTotal, parsed.SpawnerId, parsed.SpawnerType,
+                    parsed.TemplateId, parsed.X, parsed.Y, parsed.Z, parsed.ZRot, parsed.Scale,
+                    bcId, raw?.Length ?? 0);
+            }
+
             if (TryMirror(connection.ZoneId, bcId, parsed))
             {
                 if (TrySendNpcState(connection, bcId, parsed))
+                {
                     ZoneNpcSpawnerCatalog.SetState(connection, parsed, active: true);
+                    // Create is on Zone; now run tower_def OnSpawn plot/animation skills for all events.
+                    WorldIntegration.AfterZoneMirrorNpcState(bcId);
+                }
             }
             else
                 _mirrorFail++;
         }
         else
+        {
             _mirrorFail++;
+            if (_hexDumps < 3 || tracePeek)
+            {
+                if (_hexDumps < 3)
+                    _hexDumps++;
+                Logger.Warn(
+                    "ZWSpawnNpc PARSE failed zoneId={0} len={1} sid={2} sType={3} hex={4}",
+                    connection.ZoneId, raw?.Length ?? 0, peekSid, peekType,
+                    raw == null ? "-" : BitConverter.ToString(raw));
+            }
+        }
 
         if (count <= 5 || count % 100 == 0)
         {
@@ -287,6 +367,9 @@ public class NpcSpawnRelay
                 return false;
             }
 
+            // Drop any zombie unit still keyed by this bc (ObjectId recycle / incomplete free).
+            // Empty slot is a no-op; occupied slot must clear before Create or OnSpawn plots never run.
+            connection.SendPacket(new WZUnitRemovedPacket(bcId));
             connection.SendPacket(new WZNpcStatePacket(body));
             _npcStateOk++;
             // Faction is synchronized separately from the initial unit state.
@@ -343,12 +426,29 @@ public class NpcSpawnRelay
 
         try
         {
-            if (WorldIntegration.FindUnitAcrossWorlds(bcId) is not Npc npc || !npc.CanFly)
+            if (WorldIntegration.FindUnitAcrossWorlds(bcId) is not Npc npc)
+            {
+                if (IsEventFlyingTemplate(templateId))
+                    Logger.Warn("WZUnitFlyingState skip bc={0} tpl={1}: mirror not found", bcId, templateId);
                 return;
+            }
+
+            if (!npc.CanFly)
+            {
+                if (IsEventFlyingTemplate(templateId) || npc.IsMirrorStreamPriority)
+                {
+                    Logger.Info(
+                        "WZUnitFlyingState skip bc={0} tpl={1}: CanFly=false (event/priority mirror)",
+                        bcId, templateId);
+                }
+
+                return;
+            }
 
             connection.SendPacket(new WZUnitFlyingStateChangedPacket(bcId, true));
             var sent = Interlocked.Increment(ref _flyStateOk);
-            if (sent <= 5 || sent % 50 == 0)
+            // Always log first few, every 50th, and every known tower seed template.
+            if (sent <= 5 || sent % 50 == 0 || IsEventFlyingTemplate(templateId) || npc.IsMirrorStreamPriority)
             {
                 Logger.Info(
                     "WZUnitFlyingState #{0} → zone {1} zoneId={2} bc={3} tpl={4} flying=true",
@@ -360,6 +460,10 @@ public class NpcSpawnRelay
             Logger.Warn(ex, "WZUnitFlyingState failed bc={0} tpl={1}", bcId, templateId);
         }
     }
+
+    /// <summary>Crimson/Grimghast portal + wave seeds — always log fly success/skip.</summary>
+    private static bool IsEventFlyingTemplate(uint templateId) =>
+        templateId is 8828 or 8830 or 12911 or 4175;
 
     public void OnRemove(ZoneConnection connection, byte[] raw)
     {
@@ -407,6 +511,45 @@ public class NpcSpawnRelay
         NpcStateSent.TryRemove(MarkerKey(connection.ZoneId, bcId), out _);
         WorldIntegration.OnZoneNpcRemove?.Invoke(bcId);
         if (wasZoneAuthoredNpc || hadMirror)
+            ScheduleObjectIdRelease(bcId);
+    }
+
+    /// <summary>
+    /// Return a zone-mirror (or world-authored NPC) bc to the ObjectId pool only after dedicate
+    /// ProcessFreeUnits has had time to clear the slot. Immediate reuse was the Crimson portal
+    /// SCUnitsRemoved path (reused bc=1053 while dedic still owned the id).
+    /// </summary>
+    private static void ScheduleObjectIdRelease(uint bcId)
+    {
+        if (bcId == 0 || !ObjectIdManager.IsZoneUnitId(bcId))
+            return;
+
+        if (ObjectIdHoldMs <= 0)
+        {
             ObjectIdManager.Instance.ReleaseId(bcId);
+            return;
+        }
+
+        if (!PendingObjectIdReleases.TryAdd(bcId, 0))
+            return;
+
+        _ = ReleaseObjectIdAfterHoldAsync(bcId);
+    }
+
+    private static async System.Threading.Tasks.Task ReleaseObjectIdAfterHoldAsync(uint bcId)
+    {
+        try
+        {
+            await System.Threading.Tasks.Task.Delay(ObjectIdHoldMs).ConfigureAwait(false);
+            ObjectIdManager.Instance.ReleaseId(bcId);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn(ex, "Deferred ObjectId release failed bc={0}", bcId);
+        }
+        finally
+        {
+            PendingObjectIdReleases.TryRemove(bcId, out _);
+        }
     }
 }

--- a/AAEmu.WorldServer/AAEmu.World/Core/Relay/NpcSpawnRelay.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Relay/NpcSpawnRelay.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using AAEmu.Game;
 using AAEmu.Game.Core.Managers.Id;
 using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.GameData;
 using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.World.Core.Network;
 using AAEmu.World.Core.Packets.Wz;
@@ -28,9 +29,8 @@ public class NpcSpawnRelay
 
     /// <summary>
     /// ObjectIds pending delayed free after ZWRemove. Dedicate ProcessFreeUnits is deferred;
-    /// reusing the same bc the next second causes Create collisions (DataMap / unit table) and
-    /// SCUnitsRemoved flashes on tower rifts (bc reused for 8828 while the old body still moves).
-    /// Hold matches mate id release (default 60s). Override: <c>AAEMU_ZONE_OBJID_HOLD_MS</c>.
+    /// reusing the same bc immediately causes Create collisions. Hold matches mate id release
+    /// (default 60s). Override: <c>AAEMU_ZONE_OBJID_HOLD_MS</c>.
     /// </summary>
     private static readonly ConcurrentDictionary<uint, byte> PendingObjectIdReleases = new();
 
@@ -55,30 +55,8 @@ public class NpcSpawnRelay
     private static readonly bool DisableFlyState =
         Environment.GetEnvironmentVariable("AAEMU_DISABLE_WZ_FLY_STATE") == "1";
 
-    /// <summary>
-    /// Always log these sTypes (retail event seeds: Crimson/Grimghast portals + waves).
-    /// Env <c>AAEMU_ZW_SPAWN_TRACE_TYPES=9846,14335</c> extends the set.
-    /// </summary>
-    private static readonly HashSet<uint> TraceSpawnerTypes = BuildTraceSpawnerTypes();
-
-    /// <summary>sType → emit count (process lifetime). Used to prove OnEvent→ZW for event arms.</summary>
+    /// <summary>sType → emit count (process lifetime).</summary>
     private static readonly ConcurrentDictionary<uint, long> SpawnerTypeEmits = new();
-
-    private static HashSet<uint> BuildTraceSpawnerTypes()
-    {
-        var set = new HashSet<uint> { 9846, 9848, 9849, 9865, 9866, 14335, 14133, 14122, 14280, 23862, 23868, 23869 };
-        var extra = Environment.GetEnvironmentVariable("AAEMU_ZW_SPAWN_TRACE_TYPES");
-        if (!string.IsNullOrWhiteSpace(extra))
-        {
-            foreach (var part in extra.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-            {
-                if (uint.TryParse(part, out var id) && id != 0)
-                    set.Add(id);
-            }
-        }
-
-        return set;
-    }
 
     private static ulong MarkerKey(uint zoneId, uint bcId) => ((ulong)zoneId << 32) | bcId;
 
@@ -167,10 +145,8 @@ public class NpcSpawnRelay
 
         // Event OnEvent may emit non-78 B bodies; surface those for seed sTypes.
         ZwSpawnNpcParser.TryPeekIds(raw, out var peekSid, out var peekType);
-        var eventSpawner = peekType != 0 &&
-                           AAEmu.Game.GameData.TowerDefGameData.Instance.IsTowerDefEventSpawner(peekType);
-        var tracePeek = peekType != 0 && (TraceSpawnerTypes.Contains(peekType) || eventSpawner);
-        if (parsed == null && (tracePeek || raw is { Length: > 0 and not ZwSpawnNpcParser.AmbientBodyLength }))
+        var eventSpawner = peekType != 0 && TowerDefGameData.Instance.IsTowerDefEventSpawner(peekType);
+        if (parsed == null && (eventSpawner || raw is { Length: > 0 and not ZwSpawnNpcParser.AmbientBodyLength }))
         {
             Logger.Warn(
                 "ZWSpawnNpc REJECT zoneId={0} len={1} sid={2} sType={3} hex={4}",
@@ -187,8 +163,7 @@ public class NpcSpawnRelay
             connection.SendPacket(new WZNpcSpawnFailedPacket(raw));
             NpcScheduleGate.CountSuppressed(
                 connection.ZoneId, parsed.SpawnerId, parsed.SpawnerType, parsed.TemplateId);
-            if (TraceSpawnerTypes.Contains(parsed.SpawnerType) ||
-                AAEmu.Game.GameData.TowerDefGameData.Instance.IsTowerDefEventSpawner(parsed.SpawnerType))
+            if (TowerDefGameData.Instance.IsTowerDefEventSpawner(parsed.SpawnerType))
             {
                 Logger.Warn(
                     "ZWSpawnNpc GATECLOSED zoneId={0} sid={1} sType={2} tpl={3} pos=({4:F1},{5:F1},{6:F1})",
@@ -205,10 +180,8 @@ public class NpcSpawnRelay
         if (parsed != null)
         {
             var typeTotal = SpawnerTypeEmits.AddOrUpdate(parsed.SpawnerType, 1, (_, n) => n + 1);
-            var isTdEvent =
-                AAEmu.Game.GameData.TowerDefGameData.Instance.IsTowerDefEventSpawner(parsed.SpawnerType);
-            var trace = TraceSpawnerTypes.Contains(parsed.SpawnerType) || isTdEvent;
-            if (trace || typeTotal <= 2 || _hexDumps < 3
+            var isTdEvent = TowerDefGameData.Instance.IsTowerDefEventSpawner(parsed.SpawnerType);
+            if (isTdEvent || typeTotal <= 2 || _hexDumps < 3
                 || raw.Length != ZwSpawnNpcParser.AmbientBodyLength)
             {
                 if (_hexDumps < 3)
@@ -236,7 +209,7 @@ public class NpcSpawnRelay
         else
         {
             _mirrorFail++;
-            if (_hexDumps < 3 || tracePeek)
+            if (_hexDumps < 3 || eventSpawner)
             {
                 if (_hexDumps < 3)
                     _hexDumps++;
@@ -415,9 +388,7 @@ public class NpcSpawnRelay
     }
 
     /// <summary>
-    /// Birds and other fliers only hold altitude once Zone knows they fly: the flag reaches
-    /// CryAI as bFlyingCreature / b3DMove, and until then living-entity physics free-falls them
-    /// (observed on Falcony hawks — Z dropped at ~9.8 m/s² and snapped back to spawn on a loop).
+    /// Push flying state to Zone after Create so altitude is simulated server-side.
     /// </summary>
     private void TrySendFlyingState(ZoneConnection connection, uint bcId, uint templateId)
     {
@@ -428,17 +399,17 @@ public class NpcSpawnRelay
         {
             if (WorldIntegration.FindUnitAcrossWorlds(bcId) is not Npc npc)
             {
-                if (IsEventFlyingTemplate(templateId))
+                if (TowerDefGameData.Instance.IsTowerDefEventNpc(templateId))
                     Logger.Warn("WZUnitFlyingState skip bc={0} tpl={1}: mirror not found", bcId, templateId);
                 return;
             }
 
             if (!npc.CanFly)
             {
-                if (IsEventFlyingTemplate(templateId) || npc.IsMirrorStreamPriority)
+                if (npc.IsMirrorStreamPriority)
                 {
                     Logger.Info(
-                        "WZUnitFlyingState skip bc={0} tpl={1}: CanFly=false (event/priority mirror)",
+                        "WZUnitFlyingState skip bc={0} tpl={1}: CanFly=false (priority mirror)",
                         bcId, templateId);
                 }
 
@@ -447,8 +418,7 @@ public class NpcSpawnRelay
 
             connection.SendPacket(new WZUnitFlyingStateChangedPacket(bcId, true));
             var sent = Interlocked.Increment(ref _flyStateOk);
-            // Always log first few, every 50th, and every known tower seed template.
-            if (sent <= 5 || sent % 50 == 0 || IsEventFlyingTemplate(templateId) || npc.IsMirrorStreamPriority)
+            if (sent <= 5 || sent % 50 == 0 || npc.IsMirrorStreamPriority)
             {
                 Logger.Info(
                     "WZUnitFlyingState #{0} → zone {1} zoneId={2} bc={3} tpl={4} flying=true",
@@ -459,11 +429,7 @@ public class NpcSpawnRelay
         {
             Logger.Warn(ex, "WZUnitFlyingState failed bc={0} tpl={1}", bcId, templateId);
         }
-    }
-
-    /// <summary>Crimson/Grimghast portal + wave seeds — always log fly success/skip.</summary>
-    private static bool IsEventFlyingTemplate(uint templateId) =>
-        templateId is 8828 or 8830 or 12911 or 4175;
+        }
 
     public void OnRemove(ZoneConnection connection, byte[] raw)
     {

--- a/AAEmu.WorldServer/AAEmu.World/Core/Relay/TowerDefPortalAuthor.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Relay/TowerDefPortalAuthor.cs
@@ -1,0 +1,26 @@
+namespace AAEmu.World.Core.Relay;
+
+/// <summary>
+/// Intentionally unused stub. Tower-def portals must come from zone OnEvent/ZW, not World mesh authoring.
+/// </summary>
+public static class TowerDefPortalAuthor
+{
+    public static void ArmStart(
+        AAEmu.Game.Models.Game.TowerDefs.TowerDef towerDef,
+        IReadOnlyList<uint> hostZoneIds,
+        IReadOnlyDictionary<uint, uint> spotByZone)
+    {
+    }
+
+    public static void ArmWave(
+        AAEmu.Game.Models.Game.TowerDefs.TowerDef towerDef,
+        int step,
+        IReadOnlyList<uint> hostZoneIds,
+        IReadOnlyDictionary<uint, uint> spotByZone)
+    {
+    }
+
+    public static void ClearRun(uint towerDefId, string reason)
+    {
+    }
+}

--- a/AAEmu.WorldServer/AAEmu.World/Core/Relay/TowerDefScheduler.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Relay/TowerDefScheduler.cs
@@ -1,5 +1,6 @@
 using AAEmu.Game;
 using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.GameData;
 using AAEmu.Game.Models.Game.TowerDefs;
 using AAEmu.World.Core.Network;
@@ -11,22 +12,14 @@ using NLog;
 namespace AAEmu.World.Core.Relay;
 
 /// <summary>
-/// Runs the timed world events in <c>tower_defs</c> — the world-boss layer.
+/// Schedule authority for <c>tower_defs</c> under ZoneAuthority.
 /// </summary>
 /// <remarks>
-/// This is a separate system from <c>game_schedules</c> (see <see cref="GameScheduleRelay"/>), and
-/// the two do not overlap: no Kraken, Leviathan or dragon spawner appears in
-/// <c>game_schedule_spawners</c>. A <c>tower_defs</c> row names a target spawner, a duration, a
-/// broadcast message and seven <c>start_hourN</c>/<c>start_minuteN</c> slots, one per weekday.
-///
-/// 24 live rows carry a slot: 크라켄의 출현 (Kraken, row 152), 레비아탄의 출현 (Leviathan, 77),
-/// 붉은 용의 출현 (Red Dragon, 103), 검은 용의 침공 (Black Dragon, 108/151), 칼리디스의 출현 (144),
-/// 뒤틀린 자 안탈론 raid (150), 델피나드 유령선 (44) and 풍랑의 전조 (22). Almost all sit between
-/// 21:00 and 21:45 local server time.
-///
-/// Nothing read those columns before, so every one of them was dead. World drives the zone with
-/// <c>WZTowerDefStart</c> / <c>WaveStart</c> / <c>End</c> (0x067-0x069); the dedicate owns the
-/// spawner activation and the wave progression from there.
+/// Zone holds spot playability and executes spawner arm/disarm on WZ. World owns the schedule,
+/// progression clock (timed or kill-quota), and client banners (<c>SCTowerDef*</c>).
+/// Only zones that report playable spots for a tower receive Start/Wave/End; SC fires only when
+/// at least one such host exists (prevents twin-continent false announces).
+/// Kill-switch: <c>AAEMU_DISABLE_GAME_TIME_TOWERS=1</c> skips Game-Time arms only.
 /// </remarks>
 public static class TowerDefScheduler
 {
@@ -34,40 +27,62 @@ public static class TowerDefScheduler
     private static readonly object Sync = new();
 
     /// <summary>
-    /// Events currently up. <c>Deadline</c> is the hard stop from <c>force_end_time</c>;
-    /// <c>Manual</c> marks a run started by hand, which the schedule check must not reap — it is
-    /// by definition outside its weekday slot, so without this flag the next tick ends it.
+    /// Live run. Kill quota for the step just opened, if any, must be met before the next step.
     /// </summary>
-    private readonly record struct RunState(DateTime Deadline, bool Manual);
+    private sealed class RunState
+    {
+        public DateTime Deadline;
+        public bool Manual;
+        public bool FromGameTime;
+        /// <summary>Next prog index to open with <c>WZTowerDefWaveStart</c>.</summary>
+        public int NextStep;
+        public DateTime NextWaveAt;
+        public uint AnnounceZoneId;
+        public ushort AnnounceZoneGroupId;
+        /// <summary>Zone keys that accepted Start (playable spots &gt; 0).</summary>
+        public List<uint> HostZoneIds = [];
+        /// <summary>Spot index chosen per host zone id for this run.</summary>
+        public Dictionary<uint, uint> SpotByZone = [];
+        /// <summary>prog index currently waiting on kill targets (-1 = not waiting).</summary>
+        public int KillWaitStep = -1;
+        public Dictionary<uint, int> KillRemaining;
+        /// <summary>Last opened wave index, or -1 before any WaveStart (matches client map curStep).</summary>
+        public int CurrentStep = -1;
+    }
 
     private static readonly Dictionary<uint, RunState> Running = [];
+    /// <summary>Playable spot counts reported by zones: towerDefId → (zoneId → count).</summary>
+    private static readonly Dictionary<uint, Dictionary<uint, uint>> Playability = [];
     private static bool _primed;
 
     public static int RunningCount { get { lock (Sync) return Running.Count; } }
 
     /// <summary>
-    /// The <c>spotIdx</c> field of the WZTowerDef packets is an index into the event's own spot
-    /// list, not a zone key. Passing the zone key made the dedicate reject the packet with
-    /// <c>TowerDef(152,36): Invalid idx(210)</c>; every shipped row defines a single spot, so 0 is
-    /// the only valid value until a multi-spot event turns up.
+    /// Max forward game-hours allowed in one <see cref="OnGameTimeAdvanced"/> callback.
+    /// Must match <c>TimeManager</c> large-jump threshold.
     /// </summary>
-    private const uint PrimarySpotIdx = 0;
+    private const float MaxGameTimeArmJumpHours = 0.25f;
+
+    private static bool GameTimeTowersDisabled =>
+        Environment.GetEnvironmentVariable("AAEMU_DISABLE_GAME_TIME_TOWERS") == "1";
 
     /// <summary>
-    /// Evaluates the weekday slots and drives the start/end edges. Shares the schedule gate's tick
-    /// so all timed content is decided from one clock reading.
+    /// Wall-clock (UTC) windows. Called from the schedule gate tick.
     /// </summary>
     public static void Tick()
     {
         lock (Sync)
         {
-            var now = DateTime.Now;
+            var now = DateTime.UtcNow;
 
             if (!_primed)
             {
                 _primed = true;
-                var scheduled = TowerDefGameData.Instance.GetScheduledTowerDefs().Count();
-                Logger.Info("TowerDefScheduler armed — {0} timed world events carry a weekday slot", scheduled);
+                var wall = TowerDefGameData.Instance.GetScheduledTowerDefs().Count();
+                var game = TowerDefGameData.Instance.GetGameTimeScheduledTowerDefs().Count();
+                Logger.Info(
+                    "TowerDefScheduler armed — {0} UTC wall-slot events, {1} Game-Time (tod) rifts (zone-auth WZ arm)",
+                    wall, game);
             }
 
             foreach (var towerDef in TowerDefGameData.Instance.GetScheduledTowerDefs())
@@ -76,18 +91,16 @@ public static class TowerDefScheduler
                 if (!Running.TryGetValue(towerDef.Id, out var state))
                 {
                     if (shouldRun)
-                        Start(towerDef, now, manual: false, "schedule");
+                        Start(towerDef, now, manual: false, fromGameTime: false, "utc schedule");
                     continue;
                 }
 
-                // A hand-started run sits outside its weekday slot on purpose; only its deadline
-                // or an explicit end may stop it.
-                if (!shouldRun && !state.Manual)
-                    End(towerDef, "window closed");
+                if (!shouldRun && !state.Manual && !state.FromGameTime)
+                    End(towerDef, "utc window closed");
             }
 
-            // force_end_time is a hard stop independent of the window, and the only thing that
-            // retires a manual run on its own.
+            AdvanceTimedWaves(now);
+
             foreach (var (id, state) in Running.ToList())
             {
                 if (now < state.Deadline)
@@ -101,6 +114,154 @@ public static class TowerDefScheduler
         }
     }
 
+    /// <summary>
+    /// Game-hour advanced. Arms Game-Time rifts when the hour crosses <c>tod</c>.
+    /// </summary>
+    public static void OnGameTimeAdvanced(float oldHour, float newHour)
+    {
+        if (GameTimeTowersDisabled)
+            return;
+
+        var jump = ForwardHourDelta(oldHour, newHour);
+        if (jump > MaxGameTimeArmJumpHours)
+        {
+            Logger.Warn(
+                "OnGameTimeAdvanced skipped tower arms for large jump {0:F2}→{1:F2} (Δ={2:F2}h) — use /towerdef start",
+                oldHour, newHour, jump);
+            return;
+        }
+
+        lock (Sync)
+        {
+            var now = DateTime.UtcNow;
+            if (!_primed)
+            {
+                _primed = true;
+                var wall = TowerDefGameData.Instance.GetScheduledTowerDefs().Count();
+                var game = TowerDefGameData.Instance.GetGameTimeScheduledTowerDefs().Count();
+                Logger.Info(
+                    "TowerDefScheduler armed — {0} UTC wall-slot events, {1} Game-Time (tod) rifts (zone-auth WZ arm)",
+                    wall, game);
+            }
+
+            // Bases (tod=0) before expands (tod=0.1) so portal mutex can keep the first owner.
+            foreach (var towerDef in TowerDefGameData.Instance.GetGameTimeScheduledTowerDefs()
+                         .OrderBy(t => t.TimeOfDay)
+                         .ThenBy(t => t.Id))
+            {
+                if (!towerDef.CrossedGameStartHour(oldHour, newHour))
+                    continue;
+                if (Running.ContainsKey(towerDef.Id))
+                    continue;
+
+                Start(
+                    towerDef,
+                    now,
+                    manual: false,
+                    fromGameTime: true,
+                    $"game ToD {oldHour:F2}→{newHour:F2} crossed tod={towerDef.TimeOfDay:F2}");
+            }
+        }
+    }
+
+    private static float ForwardHourDelta(float from, float to)
+    {
+        from %= 24f;
+        to %= 24f;
+        if (from < 0f) from += 24f;
+        if (to < 0f) to += 24f;
+        var d = to - from;
+        if (d < 0f)
+            d += 24f;
+        return d;
+    }
+
+    /// <summary>Drop playability cache rows for a disconnected zone.</summary>
+    public static void OnZoneDisconnected(uint zoneId)
+    {
+        if (zoneId == 0)
+            return;
+        lock (Sync)
+        {
+            foreach (var byZone in Playability.Values)
+                byZone.Remove(zoneId);
+        }
+    }
+
+    /// <summary>
+    /// After a dedicate reaches ZoneLoaded, refresh playability for scheduled tower defs.
+    /// </summary>
+    public static void OnZoneLoaded(ZoneConnection zone)
+    {
+        if (zone.State < ZoneConnectionState.ZoneLoaded)
+            return;
+
+        QueryPlayabilityForZone(zone);
+    }
+
+    /// <summary>
+    /// ZWTowerDefReportPlayability: store playableSpotCount for later host selection.
+    /// </summary>
+    public static void OnPlayabilityReport(uint zoneId, uint towerDefId, ushort zoneGroupType2, uint playableSpots)
+    {
+        lock (Sync)
+        {
+            if (!Playability.TryGetValue(towerDefId, out var byZone))
+            {
+                byZone = [];
+                Playability[towerDefId] = byZone;
+            }
+
+            byZone[zoneId] = playableSpots;
+            Logger.Info(
+                "ZWTowerDefReportPlayability zoneId={0} towerDef={1} type2={2} playableSpots={3}",
+                zoneId, towerDefId, zoneGroupType2, playableSpots);
+        }
+    }
+
+    /// <summary>
+    /// Zone (or World combat) killed an NPC — advance kill-gated tower steps.
+    /// </summary>
+    public static void OnNpcKilled(uint templateId)
+    {
+        if (templateId == 0)
+            return;
+
+        lock (Sync)
+        {
+            var now = DateTime.UtcNow;
+            foreach (var (id, state) in Running.ToList())
+            {
+                if (state.KillWaitStep < 0 || state.KillRemaining == null || state.KillRemaining.Count == 0)
+                    continue;
+                if (!state.KillRemaining.TryGetValue(templateId, out var left) || left <= 0)
+                    continue;
+
+                left--;
+                if (left <= 0)
+                    state.KillRemaining.Remove(templateId);
+                else
+                    state.KillRemaining[templateId] = left;
+
+                if (state.KillRemaining.Count > 0)
+                {
+                    Running[id] = state;
+                    continue;
+                }
+
+                Logger.Info(
+                    "TowerDef {0} step {1} kill quotas met — scheduling next wave",
+                    id, state.KillWaitStep);
+                state.KillWaitStep = -1;
+                state.KillRemaining = null;
+                state.NextWaveAt = now;
+                Running[id] = state;
+            }
+
+            AdvanceTimedWaves(now);
+        }
+    }
+
     /// <summary>Fires an event immediately, ignoring its schedule. Used by the GM trigger.</summary>
     public static bool ForceStart(uint towerDefId)
     {
@@ -109,10 +270,32 @@ public static class TowerDefScheduler
             var towerDef = TowerDefGameData.Instance.GetTowerDef(towerDefId);
             if (towerDef == null)
                 return false;
-            if (Running.ContainsKey(towerDefId))
-                return true;
 
-            Start(towerDef, DateTime.Now, manual: true, "manual trigger");
+            // Restart path: leftover Running / portal liveCount left users with banner-only Start.
+            if (Running.ContainsKey(towerDefId))
+            {
+                Logger.Info("ForceStart tower={0}: ending live run first (manual restart)", towerDefId);
+                End(towerDef, "manual restart");
+            }
+
+            // Manual takeover of a shared portal (e.g. end expand thrash, re-run base).
+            if (towerDef.TargetNpcSpawnId != 0)
+            {
+                foreach (var (otherId, _) in Running.ToList())
+                {
+                    if (otherId == towerDefId)
+                        continue;
+                    var other = TowerDefGameData.Instance.GetTowerDef(otherId);
+                    if (other == null || other.TargetNpcSpawnId != towerDef.TargetNpcSpawnId)
+                        continue;
+                    Logger.Info(
+                        "ForceStart tower={0}: ending conflicting owner tower={1} on portal sType={2}",
+                        towerDefId, otherId, towerDef.TargetNpcSpawnId);
+                    End(other, "manual portal reclaim");
+                }
+            }
+
+            Start(towerDef, DateTime.UtcNow, manual: true, fromGameTime: false, "manual trigger");
             return true;
         }
     }
@@ -123,82 +306,656 @@ public static class TowerDefScheduler
         lock (Sync)
         {
             var towerDef = TowerDefGameData.Instance.GetTowerDef(towerDefId);
-            if (towerDef == null || !Running.ContainsKey(towerDefId))
+            if (towerDef == null)
                 return false;
+
+            // Allow cleanup even if schedule mark is gone (orphan army after thrash).
+            if (!Running.ContainsKey(towerDefId))
+            {
+                var state = new RunState
+                {
+                    AnnounceZoneId = FirstLoadedZoneId(),
+                    AnnounceZoneGroupId = FirstLoadedZoneGroup()
+                };
+                foreach (var (zone, spots, group) in EnumeratePlayableHosts(towerDefId, manualFallbackAll: true))
+                {
+                    state.HostZoneIds.Add(zone.ZoneId);
+                    state.SpotByZone[zone.ZoneId] = 0;
+                    state.AnnounceZoneId = zone.ZoneId;
+                    state.AnnounceZoneGroupId = group;
+                }
+
+                Running[towerDefId] = state;
+            }
 
             End(towerDef, "manual trigger");
             return true;
         }
     }
 
-    /// <summary>Advances a running event to the next wave. Used by the GM trigger.</summary>
+    /// <summary>Advances a running event to an explicit progression step. Used by the GM trigger.</summary>
     public static bool ForceWave(uint towerDefId, uint step)
     {
-        var towerDef = TowerDefGameData.Instance.GetTowerDef(towerDefId);
-        if (towerDef == null)
-            return false;
-
-        foreach (var zone in LoadedZones())
+        lock (Sync)
         {
-            zone.SendPacket(new WZTowerDefWaveStartPacket(
-                (int)towerDef.Id, (short)ZoneGroupOf(zone), PrimarySpotIdx, step));
-        }
+            var towerDef = TowerDefGameData.Instance.GetTowerDef(towerDefId);
+            if (towerDef == null)
+                return false;
 
-        Logger.Info("WZTowerDefWaveStart → towerDef={0} step={1} ({2})", towerDef.Id, step, towerDef.Name);
-        return true;
+            if (!Running.TryGetValue(towerDefId, out var state))
+            {
+                state = new RunState
+                {
+                    AnnounceZoneId = FirstLoadedZoneId(),
+                    AnnounceZoneGroupId = FirstLoadedZoneGroup()
+                };
+                // Host all currently playable zones for an ad-hoc wave.
+                foreach (var (zone, spots, group) in EnumeratePlayableHosts(towerDefId, manualFallbackAll: true))
+                {
+                    state.HostZoneIds.Add(zone.ZoneId);
+                    state.SpotByZone[zone.ZoneId] = PickSpot(spots);
+                    state.AnnounceZoneId = zone.ZoneId;
+                    state.AnnounceZoneGroupId = group;
+                }
+            }
+
+            OpenStep(towerDef, state, (int)step, "manual wave");
+            state.NextStep = (int)step + 1;
+            ArmPostStep(towerDef, state, (int)step, DateTime.UtcNow);
+            if (Running.ContainsKey(towerDefId) || state.HostZoneIds.Count > 0)
+                Running[towerDefId] = state;
+            return true;
+        }
     }
 
-    private static void Start(TowerDef towerDef, DateTime now, bool manual, string reason)
+    private static void Start(TowerDef towerDef, DateTime now, bool manual, bool fromGameTime, string reason)
     {
-        Running[towerDef.Id] = new RunState(now + towerDef.Duration, manual);
-
-        var zones = 0;
+        // Soft refresh: query any loaded zone that has not yet reported for this def.
         foreach (var zone in LoadedZones())
         {
+            if (!HasPlayabilityReport(towerDef.Id, zone.ZoneId))
+                QueryPlayability(zone, towerDef.Id);
+        }
+
+        // Ship data has base+expand pairs on the same portal sType (13/174 → 14335, 3/171 → 9846).
+        // Auto-arm must not thrash two WZTowerDefStart on one placement — expand at tod=0.1
+        // (not noon; noon 171 is Crimson expand) was removing the live portal ~60s later.
+        // Manual ForceStart reclaims via End of the other owner first.
+        if (!manual &&
+            towerDef.TargetNpcSpawnId != 0 &&
+            TryFindRunningPortalOwner(towerDef.TargetNpcSpawnId, out var ownerId) &&
+            ownerId != towerDef.Id)
+        {
+            Logger.Info(
+                "TowerDef {0} skipped Start — portal sType={1} already owned by tower={2} ({3}) — {4}",
+                towerDef.Id, towerDef.TargetNpcSpawnId, ownerId, reason, towerDef.Name);
+            return;
+        }
+
+        var hosts = EnumeratePlayableHosts(towerDef.Id, manualFallbackAll: manual).ToList();
+        if (hosts.Count == 0)
+        {
+            Logger.Warn(
+                "TowerDef {0} skipped Start — no zone with playable spots (spawner={1}) — {2} ({3})",
+                towerDef.Id, towerDef.TargetNpcSpawnId, reason, towerDef.Name);
+            return;
+        }
+
+        var firstWaveDelay = towerDef.FirstWaveAfter > 0f
+            ? TimeSpan.FromSeconds(towerDef.FirstWaveAfter)
+            : TimeSpan.Zero;
+
+        var announceZoneId = hosts[0].Zone.ZoneId;
+        var announceGroup = hosts[0].Group;
+
+        var state = new RunState
+        {
+            Deadline = now + towerDef.Duration,
+            Manual = manual,
+            FromGameTime = fromGameTime,
+            NextStep = 0,
+            NextWaveAt = now + firstWaveDelay,
+            AnnounceZoneId = announceZoneId,
+            AnnounceZoneGroupId = announceGroup,
+            KillWaitStep = -1
+        };
+
+        foreach (var (zone, spots, group) in hosts)
+        {
+            var spotIdx = PickSpot(spots);
+            state.HostZoneIds.Add(zone.ZoneId);
+            state.SpotByZone[zone.ZoneId] = spotIdx;
             zone.SendPacket(new WZTowerDefStartPacket(
-                (int)towerDef.Id, (short)ZoneGroupOf(zone), PrimarySpotIdx));
+                (int)towerDef.Id, (short)group, spotIdx));
+            Logger.Info(
+                "WZTowerDefStart → zoneId={0} group={1} towerDef={2} spot={3}/{4}",
+                zone.ZoneId, group, towerDef.Id, spotIdx, spots);
+        }
+
+        // Prefer the first host as SC eventKey (real host zone + group, not "any loaded").
+        state.AnnounceZoneId = announceZoneId;
+        state.AnnounceZoneGroupId = announceGroup;
+        Running[towerDef.Id] = state;
+
+        Logger.Info(
+            "WZTowerDefStart hosts={0}: towerDef={1} spawner={2} for {3} ({4}) — {5}",
+            hosts.Count, towerDef.Id, towerDef.TargetNpcSpawnId, towerDef.Duration, reason, towerDef.Name);
+
+        BroadcastScStart(towerDef, state);
+
+        // Retail: dedic Start OnEvent → ZW. Optional portal re-OnEvent helps silent re-arms
+        // (maxPop / stuck template after thrash). Never World-mesh author.
+        TowerDefWaveForce.ArmPortalTargets(towerDef, state.HostZoneIds);
+
+        if (firstWaveDelay <= TimeSpan.Zero)
+            AdvanceTimedWaves(now);
+    }
+
+    /// <summary>True if any running tower owns this portal spawner type.</summary>
+    private static bool TryFindRunningPortalOwner(uint portalSpawnerType, out uint towerDefId)
+    {
+        foreach (var id in Running.Keys)
+        {
+            var def = TowerDefGameData.Instance.GetTowerDef(id);
+            if (def == null || def.TargetNpcSpawnId != portalSpawnerType)
+                continue;
+            towerDefId = id;
+            return true;
+        }
+
+        towerDefId = 0;
+        return false;
+    }
+
+    private static void AdvanceTimedWaves(DateTime now)
+    {
+        const int MaxStepsPerTick = 4;
+
+        foreach (var (id, state) in Running.ToList())
+        {
+            if (state.KillWaitStep >= 0)
+                continue; // wait for OnNpcKilled
+
+            var towerDef = TowerDefGameData.Instance.GetTowerDef(id);
+            if (towerDef?.Progs == null || towerDef.Progs.Count == 0)
+                continue;
+
+            var stepsThisTick = 0;
+            while (state.NextStep < towerDef.Progs.Count &&
+                   now >= state.NextWaveAt &&
+                   stepsThisTick < MaxStepsPerTick)
+            {
+                var step = state.NextStep;
+                OpenStep(towerDef, state, step, "schedule");
+                stepsThisTick++;
+                state.NextStep = step + 1;
+                ArmPostStep(towerDef, state, step, now);
+
+                if (state.KillWaitStep >= 0 || now < state.NextWaveAt)
+                    break;
+            }
+
+            Running[id] = state;
+        }
+    }
+
+    /// <summary>
+    /// After opening <paramref name="openedStep"/>, schedule the next open or arm kill tracking.
+    /// </summary>
+    private static void ArmPostStep(TowerDef towerDef, RunState state, int openedStep, DateTime now)
+    {
+        var progs = towerDef.Progs;
+        if (openedStep < 0 || openedStep >= progs.Count)
+        {
+            state.NextWaveAt = DateTime.MaxValue;
+            state.KillWaitStep = -1;
+            state.KillRemaining = null;
+            return;
+        }
+
+        if (state.NextStep >= progs.Count)
+        {
+            state.NextWaveAt = DateTime.MaxValue;
+            state.KillWaitStep = -1;
+            state.KillRemaining = null;
+            return;
+        }
+
+        var prog = progs[openedStep];
+        if (prog.KillTargets is { Count: > 0 })
+        {
+            state.KillWaitStep = openedStep;
+            state.KillRemaining = [];
+            foreach (var kt in prog.KillTargets)
+            {
+                if (kt.KillCount <= 0)
+                    continue;
+                state.KillRemaining[kt.KillTargetId] =
+                    state.KillRemaining.GetValueOrDefault(kt.KillTargetId) + (int)kt.KillCount;
+            }
+
+            if (state.KillRemaining.Count == 0)
+            {
+                state.KillWaitStep = -1;
+                state.KillRemaining = null;
+            }
+            else
+            {
+                state.NextWaveAt = DateTime.MaxValue;
+                Logger.Info(
+                    "TowerDef {0} step {1} waiting for kill quotas ({2} npc types)",
+                    towerDef.Id, openedStep, state.KillRemaining.Count);
+                return;
+            }
+        }
+
+        var hold = prog.CondToNextTime > 0f ? prog.CondToNextTime : 0f;
+        state.KillWaitStep = -1;
+        state.KillRemaining = null;
+        state.NextWaveAt = now + TimeSpan.FromSeconds(hold);
+    }
+
+    private static void OpenStep(TowerDef towerDef, RunState state, int step, string reason)
+    {
+        var zones = 0;
+        foreach (var zoneId in state.HostZoneIds)
+        {
+            var zone = ZoneSession.Instance.GetByZoneId(zoneId);
+            if (zone == null || zone.State < ZoneConnectionState.ZoneLoaded)
+                continue;
+            if (!state.SpotByZone.TryGetValue(zoneId, out var spotIdx))
+                spotIdx = 0;
+            var group = (ushort)ZoneGroupOf(zone);
+            zone.SendPacket(new WZTowerDefWaveStartPacket(
+                (int)towerDef.Id, (short)group, spotIdx, (uint)step));
             zones++;
         }
 
-        Logger.Info(
-            "WZTowerDefStart → {0} zones: towerDef={1} spawner={2} for {3} ({4}) — {5}",
-            zones, towerDef.Id, towerDef.TargetNpcSpawnId, towerDef.Duration, reason, towerDef.Name);
+        if (zones > 0)
+        {
+            state.CurrentStep = step;
+            BroadcastScWave(towerDef, state, (uint)step);
+            BroadcastClientMapState();
+        }
 
-        // The spawner the event names is armed by the dedicate, but placements still need the
-        // activate sphere to actually run — same rule as an opening game_schedule period.
-        foreach (var zone in LoadedZones())
-            ZoneProtocolHandler.ReactivateNpcSpawners(zone, $"towerDef {towerDef.Id} started");
+        // Retail ChangeStep can log success with zero emit; re-fire tower OnEvent on g placements.
+        if (zones > 0)
+            TowerDefWaveForce.ArmProgSpawners(towerDef, step, state.HostZoneIds);
+
+        Logger.Info(
+            "WZTowerDefWaveStart → {0} host zones: towerDef={1} step={2} ({3}) — {4}",
+            zones, towerDef.Id, step, reason, towerDef.Name);
     }
 
     private static void End(TowerDef towerDef, string reason)
     {
+        if (!Running.TryGetValue(towerDef.Id, out var state))
+        {
+            state = new RunState
+            {
+                AnnounceZoneId = FirstLoadedZoneId(),
+                AnnounceZoneGroupId = FirstLoadedZoneGroup()
+            };
+            foreach (var (zone, spots, group) in EnumeratePlayableHosts(towerDef.Id, manualFallbackAll: false))
+            {
+                state.HostZoneIds.Add(zone.ZoneId);
+                state.SpotByZone[zone.ZoneId] = PickSpot(spots);
+                state.AnnounceZoneId = zone.ZoneId;
+                state.AnnounceZoneGroupId = group;
+            }
+        }
+
         Running.Remove(towerDef.Id);
 
         var zones = 0;
-        foreach (var zone in LoadedZones())
+        var zoneList = state.HostZoneIds.Count > 0
+            ? state.HostZoneIds
+            : LoadedZones().Select(z => z.ZoneId).ToList();
+
+        foreach (var zoneId in zoneList)
         {
+            var zone = ZoneSession.Instance.GetByZoneId(zoneId);
+            if (zone == null || zone.State < ZoneConnectionState.ZoneLoaded)
+                continue;
+            if (!state.SpotByZone.TryGetValue(zoneId, out var spotIdx))
+                spotIdx = 0;
             zone.SendPacket(new WZTowerDefEndPacket(
-                (int)towerDef.Id, (short)ZoneGroupOf(zone), PrimarySpotIdx));
+                (int)towerDef.Id, (short)ZoneGroupOf(zone), spotIdx));
             zones++;
         }
+
+        if (state.HostZoneIds.Count > 0 || zones > 0)
+            BroadcastScEnd(towerDef, state);
+
+        // Map / list packets always carry the post-remove snapshot (empty or remaining events).
+        BroadcastClientMapState();
+
+        // WZ End removes dedic-created units eventually; World-authored plot army (8826/8834…) and
+        // lagging stage mirrors need an explicit cleanup or they stick after /towerdef end.
+        // Run off the scheduler lock so WZ/ZW do not re-enter under Sync.
+        var hostZones = state.HostZoneIds.Count > 0
+            ? (IReadOnlyList<uint>)state.HostZoneIds.ToList()
+            : Array.Empty<uint>();
+        var towerId = towerDef.Id;
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                var n = WorldIntegration.DespawnTowerDefEventUnits(towerId, hostZones);
+                if (n > 0)
+                    Logger.Info("TowerDef {0} End cleanup pass-1 despawned={1}", towerId, n);
+                // Late plot tickets keep SpawnEffect after stage Interrupt — second sweep.
+                await Task.Delay(2500).ConfigureAwait(false);
+                var n2 = WorldIntegration.DespawnTowerDefEventUnits(towerId, hostZones);
+                if (n2 > 0)
+                    Logger.Info("TowerDef {0} End cleanup pass-2 despawned={1}", towerId, n2);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn(ex, "TowerDef {0} End cleanup failed", towerId);
+            }
+        });
 
         Logger.Info("WZTowerDefEnd → {0} zones: towerDef={1} ({2}) — {3}",
             zones, towerDef.Id, reason, towerDef.Name);
     }
 
+    private static void BroadcastScStart(TowerDef towerDef, RunState state)
+    {
+        var key = MakeKey(towerDef, state);
+        var seamless = towerDef.BroadcastToWholeWorld;
+        WorldIntegration.BroadcastPacket(new SCTowerDefStartPacket(
+            key, state.AnnounceZoneId, isStartSeamlessWorld: seamless, isBroadCastSeamless: seamless));
+        Logger.Info(
+            "SCTowerDefStart towerDef={0} zoneGroup={1} eventZone={2} seamless={3} hosts={4}",
+            towerDef.Id, key.ZoneGroupId, state.AnnounceZoneId, seamless, state.HostZoneIds.Count);
+        BroadcastClientMapState();
+    }
+
+    private static void BroadcastScEnd(TowerDef towerDef, RunState state)
+    {
+        var key = MakeKey(towerDef, state);
+        var seamless = towerDef.BroadcastToWholeWorld;
+        WorldIntegration.BroadcastPacket(new SCTowerDefEndPacket(
+            key, state.AnnounceZoneId, isStartSeamlessWorld: seamless, isBroadCastSeamless: seamless));
+    }
+
+    private static void BroadcastScWave(TowerDef towerDef, RunState state, uint step)
+    {
+        var key = MakeKey(towerDef, state);
+        // isSyncStep updates the client map mark's curStep for seamless path; ActiveInfo still
+        // covers non-broadcast events (Crimson).
+        WorldIntegration.BroadcastPacket(new SCTowerDefWaveStartPacket(
+            key, state.AnnounceZoneId, step, isSyncStep: true));
+    }
+
     /// <summary>
-    /// Zone group for a connection. <c>tower_def_map_events</c> keys events by ZoneGroup and the
-    /// dedicate echoes this back as the second half of its <c>TowerDef(id,group)</c> identity, so
-    /// it has to be the real group id.
+    /// Push map marks + positioned list for every running tower. Required for zone-local
+    /// events where <c>broadcast_event_to_whole_seamless_world</c> is false — Start alone does
+    /// not place the world-map skull (client only does that when the seamless start bit is set).
     /// </summary>
-    /// <remarks>
-    /// Resolve through the zone, not <c>ZoneManager.GetZoneGroupById</c> — that method is named for
-    /// its return type, but it indexes the group table by <em>group</em> id, so handing it a zone
-    /// key silently yields null and the packet goes out claiming group 0.
-    /// </remarks>
+    private static void BroadcastClientMapState()
+    {
+        List<TowerDefActiveInfo> active;
+        List<TowerDefInfo> list;
+        lock (Sync)
+        {
+            active = BuildActiveInfoList();
+            list = BuildPositionedList();
+        }
+
+        WorldIntegration.BroadcastPacket(new SCTowerDefActiveInfoListPacket(active));
+        WorldIntegration.BroadcastPacket(new SCTowerDefListPacket(list));
+        Logger.Info(
+            "SCTowerDef map sync active={0} list={1}",
+            active.Count, list.Count);
+    }
+
+    /// <summary>Late-join / after load: send the current map snapshot to one player.</summary>
+    public static void SyncToCharacter(AAEmu.Game.Models.Game.Char.Character character)
+    {
+        if (character?.Connection == null)
+            return;
+
+        List<TowerDefActiveInfo> active;
+        List<TowerDefInfo> list;
+        lock (Sync)
+        {
+            active = BuildActiveInfoList();
+            list = BuildPositionedList();
+        }
+
+        try
+        {
+            character.SendPacket(new SCTowerDefActiveInfoListPacket(active));
+            character.SendPacket(new SCTowerDefListPacket(list));
+            Logger.Info(
+                "SCTowerDef sync → {0}: active={1} list={2}",
+                character.Name, active.Count, list.Count);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn(ex, "SCTowerDef sync failed for {0}", character.Name);
+        }
+    }
+
+    /// <summary>
+    /// Portal seed mirrored after Start — refresh positioned list so the map pin follows the unit.
+    /// </summary>
+    public static void OnEventNpcMirrored(uint templateId)
+    {
+        if (templateId == 0)
+            return;
+
+        bool hits;
+        lock (Sync)
+        {
+            if (Running.Count == 0)
+                return;
+
+            hits = false;
+            foreach (var (id, _) in Running)
+            {
+                var def = TowerDefGameData.Instance.GetTowerDef(id);
+                if (def == null)
+                    continue;
+                if (TowerDefGameData.Instance.IsPortalSeedNpc(def.TargetNpcSpawnId, templateId))
+                {
+                    hits = true;
+                    break;
+                }
+            }
+        }
+
+        if (hits)
+            BroadcastClientMapState();
+    }
+
+    private static List<TowerDefActiveInfo> BuildActiveInfoList()
+    {
+        var result = new List<TowerDefActiveInfo>();
+        foreach (var (id, state) in Running)
+        {
+            var def = TowerDefGameData.Instance.GetTowerDef(id);
+            if (def == null)
+                continue;
+
+            var step = state.CurrentStep < 0 ? 0u : (uint)state.CurrentStep;
+            var hostZones = state.HostZoneIds.Count > 0
+                ? state.HostZoneIds
+                : [state.AnnounceZoneId];
+
+            foreach (var zoneId in hostZones)
+            {
+                if (zoneId == 0)
+                    continue;
+                var group = state.AnnounceZoneGroupId;
+                var zone = ZoneSession.Instance.GetByZoneId(zoneId);
+                if (zone != null)
+                    group = (ushort)ZoneGroupOf(zone);
+
+                result.Add(new TowerDefActiveInfo
+                {
+                    ZoneId = zoneId,
+                    CurrentStep = step,
+                    TowerDefId = def.Id,
+                    ZoneGroupId = group
+                });
+            }
+        }
+
+        return result;
+    }
+
+    private static List<TowerDefInfo> BuildPositionedList()
+    {
+        var result = new List<TowerDefInfo>();
+        foreach (var (id, state) in Running)
+        {
+            var def = TowerDefGameData.Instance.GetTowerDef(id);
+            if (def == null)
+                continue;
+
+            var step = state.CurrentStep < 0 ? 0u : (uint)state.CurrentStep;
+            var hostZones = state.HostZoneIds.Count > 0
+                ? state.HostZoneIds
+                : [state.AnnounceZoneId];
+
+            foreach (var zoneId in hostZones)
+            {
+                if (zoneId == 0)
+                    continue;
+
+                var group = state.AnnounceZoneGroupId;
+                var zone = ZoneSession.Instance.GetByZoneId(zoneId);
+                if (zone != null)
+                    group = (ushort)ZoneGroupOf(zone);
+
+                state.SpotByZone.TryGetValue(zoneId, out var spotIdx);
+                TryFindPortal(def, zoneId, out var portalObjId, out var x, out var y, out var z);
+
+                result.Add(new TowerDefInfo
+                {
+                    TowerDefKey = new TowerDefKey { TowerDefId = def.Id, ZoneGroupId = group },
+                    ZoneId = zoneId,
+                    SpotId = spotIdx,
+                    TargetObjId = portalObjId,
+                    Position = new AAEmu.Game.Models.Game.World.Point(x, y, z),
+                    CurrentStep = step
+                });
+            }
+        }
+
+        return result;
+    }
+
+    private static void TryFindPortal(TowerDef def, uint zoneId, out uint objId, out float x, out float y, out float z)
+    {
+        objId = 0;
+        x = y = z = 0f;
+        if (def.TargetNpcSpawnId == 0)
+            return;
+
+        var members = TowerDefGameData.Instance.GetSpawnerMemberNpcIds(def.TargetNpcSpawnId);
+        if (members.Count == 0)
+            return;
+
+        var world = WorldIntegration.ResolveWorldForZone(zoneId);
+        if (world == null)
+            return;
+
+        foreach (var npc in world.GetAllNpcs())
+        {
+            if (npc is not { IsZoneMirror: true } || !members.Contains(npc.TemplateId))
+                continue;
+
+            if (npc.Transform == null)
+                continue;
+            if (npc.Transform.ZoneId != 0 && npc.Transform.ZoneId != zoneId)
+                continue;
+
+            var pos = npc.Transform.World.Position;
+            objId = npc.ObjId;
+            x = pos.X;
+            y = pos.Y;
+            z = pos.Z;
+            return;
+        }
+    }
+
+    private static TowerDefKey MakeKey(TowerDef towerDef, RunState state)
+    {
+        return new TowerDefKey
+        {
+            TowerDefId = towerDef.Id,
+            ZoneGroupId = state.AnnounceZoneGroupId
+        };
+    }
+
+    private static bool HasPlayabilityReport(uint towerDefId, uint zoneId)
+    {
+        return Playability.TryGetValue(towerDefId, out var byZone) && byZone.ContainsKey(zoneId);
+    }
+
+    private static IEnumerable<(ZoneConnection Zone, uint Spots, ushort Group)> EnumeratePlayableHosts(
+        uint towerDefId, bool manualFallbackAll)
+    {
+        var anyReport = Playability.TryGetValue(towerDefId, out var byZone) && byZone.Count > 0;
+
+        foreach (var zone in LoadedZones())
+        {
+            var group = (ushort)ZoneGroupOf(zone);
+            if (byZone != null && byZone.TryGetValue(zone.ZoneId, out var spots))
+            {
+                if (spots > 0)
+                    yield return (zone, spots, group);
+                continue;
+            }
+
+            // Manual GM when no cache yet: try spot 0 on every loaded zone (debug path).
+            if (manualFallbackAll && !anyReport)
+                yield return (zone, 1, group);
+        }
+    }
+
+    private static uint PickSpot(uint playableSpots)
+    {
+        if (playableSpots <= 1)
+            return 0;
+        return (uint)Random.Shared.Next(0, (int)playableSpots);
+    }
+
+    private static void QueryPlayabilityForZone(ZoneConnection zone)
+    {
+        foreach (var towerDef in TowerDefGameData.Instance.GetGameTimeScheduledTowerDefs())
+            QueryPlayability(zone, towerDef.Id);
+        foreach (var towerDef in TowerDefGameData.Instance.GetScheduledTowerDefs())
+            QueryPlayability(zone, towerDef.Id);
+    }
+
+    private static void QueryPlayability(ZoneConnection zone, uint towerDefId)
+    {
+        var group = (short)ZoneGroupOf(zone);
+        zone.SendPacket(new WZTowerDefQueryPlayabilityPacket((int)towerDefId, group));
+    }
+
     private static uint ZoneGroupOf(ZoneConnection zone)
     {
         return ZoneManager.Instance.GetZoneByKey(zone.ZoneId)?.GroupId ?? 0;
+    }
+
+    private static uint FirstLoadedZoneId()
+    {
+        foreach (var zone in LoadedZones())
+            return zone.ZoneId;
+        return 0;
+    }
+
+    private static ushort FirstLoadedZoneGroup()
+    {
+        foreach (var zone in LoadedZones())
+            return (ushort)ZoneGroupOf(zone);
+        return 0;
     }
 
     private static IEnumerable<ZoneConnection> LoadedZones()
@@ -215,8 +972,14 @@ public static class TowerDefScheduler
     {
         var days = new[] { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
         HashSet<uint> running;
+        Dictionary<uint, Dictionary<uint, uint>> playabilitySnapshot;
         lock (Sync)
+        {
             running = [.. Running.Keys];
+            playabilitySnapshot = Playability.ToDictionary(
+                kv => kv.Key,
+                kv => kv.Value.ToDictionary(z => z.Key, z => z.Value));
+        }
 
         var lines = new List<string>();
         foreach (var towerDef in TowerDefGameData.Instance.GetScheduledTowerDefs().OrderBy(t => t.Id))
@@ -230,8 +993,19 @@ public static class TowerDefScheduler
 
             var state = running.Contains(towerDef.Id) ? "RUNNING" : "idle";
             lines.Add(
-                $"{towerDef.Id,4} [{state,7}] spawner={towerDef.TargetNpcSpawnId,6} " +
+                $"{towerDef.Id,4} [{state,7}] UTC  spawner={towerDef.TargetNpcSpawnId,6} " +
                 $"{towerDef.Duration:hh\\:mm} {string.Join(", ", slots)}  {towerDef.Name}");
+        }
+
+        foreach (var towerDef in TowerDefGameData.Instance.GetGameTimeScheduledTowerDefs().OrderBy(t => t.Id))
+        {
+            var state = running.Contains(towerDef.Id) ? "RUNNING" : "idle";
+            var play = playabilitySnapshot.TryGetValue(towerDef.Id, out var byZ)
+                ? string.Join(",", byZ.Select(z => $"{z.Key}:{z.Value}"))
+                : "-";
+            lines.Add(
+                $"{towerDef.Id,4} [{state,7}] GAME tod={towerDef.TimeOfDay:F1} spawner={towerDef.TargetNpcSpawnId,6} " +
+                $"{towerDef.Duration:hh\\:mm} progs={towerDef.Progs?.Count ?? 0} play=[{play}]  {towerDef.Name}");
         }
 
         return lines;

--- a/AAEmu.WorldServer/AAEmu.World/Core/Relay/TowerDefScheduler.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Relay/TowerDefScheduler.cs
@@ -1,4 +1,5 @@
 using AAEmu.Game;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.GameData;
@@ -56,12 +57,6 @@ public static class TowerDefScheduler
     private static bool _primed;
 
     public static int RunningCount { get { lock (Sync) return Running.Count; } }
-
-    /// <summary>
-    /// Max forward game-hours allowed in one <see cref="OnGameTimeAdvanced"/> callback.
-    /// Must match <c>TimeManager</c> large-jump threshold.
-    /// </summary>
-    private const float MaxGameTimeArmJumpHours = 0.25f;
 
     private static bool GameTimeTowersDisabled =>
         Environment.GetEnvironmentVariable("AAEMU_DISABLE_GAME_TIME_TOWERS") == "1";
@@ -122,12 +117,11 @@ public static class TowerDefScheduler
         if (GameTimeTowersDisabled)
             return;
 
-        var jump = ForwardHourDelta(oldHour, newHour);
-        if (jump > MaxGameTimeArmJumpHours)
+        if (TimeManager.IsLargeGameHourJump(oldHour, newHour))
         {
             Logger.Warn(
-                "OnGameTimeAdvanced skipped tower arms for large jump {0:F2}→{1:F2} (Δ={2:F2}h) — use /towerdef start",
-                oldHour, newHour, jump);
+                "OnGameTimeAdvanced skipped tower arms for large jump {0:F2}→{1:F2} — use /towerdef start",
+                oldHour, newHour);
             return;
         }
 
@@ -144,7 +138,7 @@ public static class TowerDefScheduler
                     wall, game);
             }
 
-            // Bases (tod=0) before expands (tod=0.1) so portal mutex can keep the first owner.
+            // Earlier TimeOfDay first so a shared portal keeps the first owner.
             foreach (var towerDef in TowerDefGameData.Instance.GetGameTimeScheduledTowerDefs()
                          .OrderBy(t => t.TimeOfDay)
                          .ThenBy(t => t.Id))
@@ -162,18 +156,6 @@ public static class TowerDefScheduler
                     $"game ToD {oldHour:F2}→{newHour:F2} crossed tod={towerDef.TimeOfDay:F2}");
             }
         }
-    }
-
-    private static float ForwardHourDelta(float from, float to)
-    {
-        from %= 24f;
-        to %= 24f;
-        if (from < 0f) from += 24f;
-        if (to < 0f) to += 24f;
-        var d = to - from;
-        if (d < 0f)
-            d += 24f;
-        return d;
     }
 
     /// <summary>Drop playability cache rows for a disconnected zone.</summary>
@@ -377,10 +359,8 @@ public static class TowerDefScheduler
                 QueryPlayability(zone, towerDef.Id);
         }
 
-        // Ship data has base+expand pairs on the same portal sType (13/174 → 14335, 3/171 → 9846).
-        // Auto-arm must not thrash two WZTowerDefStart on one placement — expand at tod=0.1
-        // (not noon; noon 171 is Crimson expand) was removing the live portal ~60s later.
-        // Manual ForceStart reclaims via End of the other owner first.
+        // Auto-arm must not start a second event on a portal spawner another run already owns.
+        // Identity is target_npc_spawner_id (loaded relationship). Manual ForceStart reclaims first.
         if (!manual &&
             towerDef.TargetNpcSpawnId != 0 &&
             TryFindRunningPortalOwner(towerDef.TargetNpcSpawnId, out var ownerId) &&

--- a/AAEmu.WorldServer/AAEmu.World/Core/Relay/TowerDefWaveForce.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Relay/TowerDefWaveForce.cs
@@ -1,0 +1,499 @@
+using System.Collections.Concurrent;
+using System.Numerics;
+using System.Text.RegularExpressions;
+
+using AAEmu.Game;
+using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.GameData;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.NPChar;
+using AAEmu.Game.Models.Game.TowerDefs;
+using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.StaticValues;
+using AAEmu.World.Core.Network;
+using AAEmu.World.Core.Packets.Wz;
+using AAEmu.World.Core.Zone;
+using AAEmu.World.Models;
+
+using NLog;
+
+namespace AAEmu.World.Core.Relay;
+
+/// <summary>
+/// Optional re-arm of <c>WZNpcSpawnerEvent</c> (TowerDefense / RespawnAllOnce) for tower_def wave
+/// spawn targets. ChangeStep can report success while type-1 emit is silent (validation or
+/// maxPop caps), so stage portals may never send ZW without a second arm.
+/// </summary>
+/// <remarks>
+/// Off by default. Wire body must use reason Default (no extra reason payload); wrong packing
+/// previously size-mismatched the zone deserializer and crashed the process. Enable with
+/// <c>AAEMU_TOWER_WAVE_FORCE=1</c>. Portal re-arm is separate: <c>AAEMU_TOWER_PORTAL_FORCE=1</c>.
+/// When on, only the placement of each wanted sType nearest the live seed portal is fired.
+/// </remarks>
+public static partial class TowerDefWaveForce
+{
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+    private sealed record Placement(uint Id, uint Type, float LocalX, float LocalY, float LocalZ);
+
+    private static readonly ConcurrentDictionary<uint, IReadOnlyList<Placement>> PlacementCache = new();
+
+    private static readonly Regex SpawnerIdRegex = SpawnerIdPattern();
+    private static readonly Regex SpawnerTypeRegex = SpawnerTypePattern();
+    private static readonly Regex PosRegex = PosPattern();
+    private static readonly Regex SplitBlocksRegex = SplitSpawnerBlocks();
+
+    /// <summary>Max distance (m) from seed portal to a step placement of the arm type.</summary>
+    private const float SpotRadiusMetres = 80f;
+
+    private static bool WaveForceEnabled
+    {
+        get
+        {
+            if (Environment.GetEnvironmentVariable("AAEMU_DISABLE_TOWER_WAVE_FORCE") == "1")
+                return false;
+            // Opt-in only — mis-sized WZNpcSpawnerEvent bodies have crashed dedicated zones.
+            return Environment.GetEnvironmentVariable("AAEMU_TOWER_WAVE_FORCE") == "1";
+        }
+    }
+
+    private static bool PortalForceEnabled =>
+        Environment.GetEnvironmentVariable("AAEMU_DISABLE_TOWER_PORTAL_FORCE") != "1"
+        && Environment.GetEnvironmentVariable("AAEMU_TOWER_PORTAL_FORCE") == "1";
+
+    /// <summary>
+    /// After WaveStart when force is enabled: arm nearest g-file placement per prog spawn sType
+    /// next to the live seed portal on each host zone.
+    /// </summary>
+    public static void ArmProgSpawners(TowerDef towerDef, int step, IReadOnlyList<uint> hostZoneIds)
+    {
+        if (!WaveForceEnabled || towerDef?.Progs == null || hostZoneIds == null || hostZoneIds.Count == 0)
+            return;
+        if (step < 0 || step >= towerDef.Progs.Count)
+            return;
+
+        var prog = towerDef.Progs[step];
+        if (prog.SpawnTargets is not { Count: > 0 })
+            return;
+
+        var wantedTypes = new HashSet<uint>();
+        foreach (var target in prog.SpawnTargets)
+        {
+            if (target.SpawnTargetId == 0)
+                continue;
+            if (!string.Equals(target.SpawnTargetType, "NpcSpawner", StringComparison.Ordinal))
+                continue;
+            wantedTypes.Add(target.SpawnTargetId);
+        }
+
+        if (wantedTypes.Count == 0)
+            return;
+
+        ArmNearActivePortal(
+            towerDef,
+            hostZoneIds,
+            wantedTypes,
+            $"wave tower={towerDef.Id} step={step}");
+    }
+
+    /// <summary>
+    /// After WZ Start only when <c>AAEMU_TOWER_PORTAL_FORCE=1</c>.
+    /// </summary>
+    public static void ArmPortalTargets(TowerDef towerDef, IReadOnlyList<uint> hostZoneIds)
+    {
+        if (!PortalForceEnabled || towerDef == null || towerDef.TargetNpcSpawnId == 0)
+            return;
+        if (hostZoneIds == null || hostZoneIds.Count == 0)
+            return;
+
+        ArmSpawnerTypes(
+            hostZoneIds,
+            [towerDef.TargetNpcSpawnId],
+            $"portal tower={towerDef.Id} sType={towerDef.TargetNpcSpawnId}");
+    }
+
+    /// <summary>
+    /// Fire RespawnAllOnce / TowerDefense on every g placement of the given types (all spots).
+    /// Prefer <see cref="ArmNearActivePortal"/> for wave steps.
+    /// </summary>
+    public static void ArmSpawnerTypes(
+        IReadOnlyList<uint> hostZoneIds,
+        IReadOnlyCollection<uint> spawnerTypes,
+        string reason)
+    {
+        if (hostZoneIds == null || hostZoneIds.Count == 0 || spawnerTypes == null || spawnerTypes.Count == 0)
+            return;
+
+        var wanted = spawnerTypes is HashSet<uint> hs ? hs : spawnerTypes.ToHashSet();
+        var total = 0;
+        foreach (var zoneId in hostZoneIds)
+        {
+            var zone = ZoneSession.Instance.GetByZoneId(zoneId);
+            if (zone == null || zone.State < ZoneConnectionState.ZoneLoaded)
+                continue;
+
+            var creator = ResolveCreator(zoneId, towerDef: null);
+            if (creator == null)
+            {
+                Logger.Warn(
+                    "TowerDefOnEventForce skip zoneId={0} ({1}) — no character/NPC creator in zone",
+                    zoneId, reason);
+                continue;
+            }
+
+            var placements = PlacementCache.GetOrAdd(zoneId, LoadPlacements);
+            var fired = 0;
+            foreach (var p in placements)
+            {
+                if (!wanted.Contains(p.Type))
+                    continue;
+
+                if (!SendTowerRespawn(zone, creator, p.Id))
+                    continue;
+                fired++;
+                total++;
+            }
+
+            if (fired > 0)
+            {
+                Logger.Info(
+                    "TowerDefOnEventForce zoneId={0} placements={1} types=[{2}] ({3})",
+                    zoneId, fired, string.Join(',', wanted.OrderBy(x => x)), reason);
+            }
+        }
+
+        if (total == 0)
+            Logger.Warn(
+                "TowerDefOnEventForce armed 0 placements across {0} host zone(s) types=[{1}] ({2})",
+                hostZoneIds.Count, string.Join(',', wanted.OrderBy(x => x)), reason);
+    }
+
+    /// <summary>
+    /// One placement per wanted sType: nearest to a live seed portal of this tower in that zone.
+    /// Infantry (e.g. 9844/9852) often have zero g placements — stage summoner 9848→8830 owns that.
+    /// </summary>
+    private static void ArmNearActivePortal(
+        TowerDef towerDef,
+        IReadOnlyList<uint> hostZoneIds,
+        HashSet<uint> wantedTypes,
+        string reason)
+    {
+        var total = 0;
+        foreach (var zoneId in hostZoneIds)
+        {
+            var zone = ZoneSession.Instance.GetByZoneId(zoneId);
+            if (zone == null || zone.State < ZoneConnectionState.ZoneLoaded)
+                continue;
+
+            var creator = ResolveCreator(zoneId, towerDef);
+            if (creator == null)
+            {
+                Logger.Warn(
+                    "TowerDefOnEventForce skip zoneId={0} ({1}) — no character/NPC creator in zone",
+                    zoneId, reason);
+                continue;
+            }
+
+            var anchors = CollectPortalWorldAnchors(towerDef, zoneId);
+            if (anchors.Count == 0)
+            {
+                Logger.Warn(
+                    "TowerDefOnEventForce zoneId={0} ({1}) — no seed portal anchor (tpl for sType {2})",
+                    zoneId, reason, towerDef.TargetNpcSpawnId);
+                continue;
+            }
+
+            var placements = PlacementCache.GetOrAdd(zoneId, LoadPlacements);
+            var r2 = SpotRadiusMetres * SpotRadiusMetres;
+            var firedIds = new List<uint>();
+
+            foreach (var sType in wantedTypes.OrderBy(x => x))
+            {
+                Placement best = null;
+                var bestD2 = float.MaxValue;
+                foreach (var p in placements)
+                {
+                    if (p.Type != sType)
+                        continue;
+                    var world = ZoneManager.Instance.ConvertToWorldCoordinates(
+                        zoneId, new Vector3(p.LocalX, p.LocalY, p.LocalZ));
+                    foreach (var a in anchors)
+                    {
+                        var d2 = DistanceSq(world, a);
+                        if (d2 > r2 || d2 >= bestD2)
+                            continue;
+                        bestD2 = d2;
+                        best = p;
+                    }
+                }
+
+                if (best == null)
+                {
+                    Logger.Warn(
+                        "TowerDefOnEventForce zoneId={0} no placement sType={1} within {2}m of seed ({3})",
+                        zoneId, sType, SpotRadiusMetres, reason);
+                    continue;
+                }
+
+                if (!SendTowerRespawn(zone, creator, best.Id))
+                    continue;
+                firedIds.Add(best.Id);
+                total++;
+                Logger.Info(
+                    "TowerDefOnEventForce zoneId={0} placement={1} sType={2} d={3:F1}m ({4})",
+                    zoneId, best.Id, sType, MathF.Sqrt(bestD2), reason);
+            }
+        }
+
+        if (total == 0)
+            Logger.Warn(
+                "TowerDefOnEventForce armed 0 near-portal placements types=[{0}] ({1})",
+                string.Join(',', wantedTypes.OrderBy(x => x)), reason);
+    }
+
+    private static List<Vector3> CollectPortalWorldAnchors(TowerDef towerDef, uint zoneId)
+    {
+        var list = new List<Vector3>();
+        var seedNpcs = TowerDefGameData.Instance.GetSpawnerMemberNpcIds(towerDef.TargetNpcSpawnId);
+        if (seedNpcs is { Count: > 0 })
+        {
+            foreach (var world in WorldManager.Instance.GetWorlds() ?? [])
+            {
+                foreach (var npc in world.GetAllNpcs())
+                {
+                    if (npc is not { IsZoneMirror: true } || npc.Transform?.ZoneId != zoneId)
+                        continue;
+                    if (!seedNpcs.Contains(npc.TemplateId))
+                        continue;
+                    list.Add(npc.Transform.World.Position);
+                }
+            }
+        }
+
+        // Cold / not yet mirrored: use g-file portal points for this zone's sType.
+        if (list.Count == 0 && towerDef.TargetNpcSpawnId != 0)
+        {
+            var placements = PlacementCache.GetOrAdd(zoneId, LoadPlacements);
+            foreach (var p in placements)
+            {
+                if (p.Type != towerDef.TargetNpcSpawnId)
+                    continue;
+                list.Add(ZoneManager.Instance.ConvertToWorldCoordinates(
+                    zoneId, new Vector3(p.LocalX, p.LocalY, p.LocalZ)));
+            }
+        }
+
+        return list;
+    }
+
+    public static void InvalidatePlacementCache(uint zoneId = 0)
+    {
+        if (zoneId == 0)
+            PlacementCache.Clear();
+        else
+            PlacementCache.TryRemove(zoneId, out _);
+    }
+
+    private static bool SendTowerRespawn(ZoneConnection zone, BaseUnit creator, uint placementId)
+    {
+        try
+        {
+            var creatorType = creator switch
+            {
+                Character => BaseUnitType.Character,
+                Npc => BaseUnitType.Npc,
+                _ => BaseUnitType.Invalid
+            };
+            if (creatorType == BaseUnitType.Invalid)
+                return false;
+
+            var characterId = creator is Character ch ? ch.Id : 0UL;
+            var ownerId = creator is Npc npc ? npc.OwnerId : 0UL;
+            var flag = creator is Npc n ? n.UnitStateFlag : (byte)0;
+
+            var request = new WorldNpcSpawnerEventRequest(
+                creator.ObjId,
+                creatorType,
+                characterId,
+                0L,
+                creator.TemplateId,
+                ownerId,
+                flag,
+                placementId,
+                NpcSpawnerEvent.RespawnAllOnce,
+                NpcSpawnerEventType.TowerDefense,
+                0f,
+                false,
+                false);
+
+            zone.SendPacket(new WZNpcSpawnerEventPacket(request));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn(ex, "TowerDefWaveForce event failed placement={0}", placementId);
+            return false;
+        }
+    }
+
+    private static BaseUnit ResolveCreator(uint zoneId, TowerDef towerDef)
+    {
+        // Prefer the seed portal itself when it already exists as a mirror.
+        if (towerDef != null)
+        {
+            var seedNpcs = TowerDefGameData.Instance.GetSpawnerMemberNpcIds(towerDef.TargetNpcSpawnId);
+            if (seedNpcs is { Count: > 0 })
+            {
+                foreach (var world in WorldManager.Instance.GetWorlds() ?? [])
+                {
+                    foreach (var npc in world.GetAllNpcs())
+                    {
+                        if (npc is not { IsZoneMirror: true } || npc.Transform?.ZoneId != zoneId)
+                            continue;
+                        if (seedNpcs.Contains(npc.TemplateId))
+                            return npc;
+                    }
+                }
+            }
+        }
+
+        foreach (var character in WorldManager.Instance.GetAllCharacters())
+        {
+            if (character?.Transform == null)
+                continue;
+            if (character.Transform.ZoneId == zoneId)
+                return character;
+        }
+
+        foreach (var world in WorldManager.Instance.GetWorlds() ?? [])
+        {
+            foreach (var npc in world.GetAllNpcs())
+            {
+                if (npc is not { IsZoneMirror: true } || npc.Transform?.ZoneId != zoneId)
+                    continue;
+                return npc;
+            }
+        }
+
+        return null;
+    }
+
+    private static IReadOnlyList<Placement> LoadPlacements(uint zoneId)
+    {
+        var world = WorldManager.Instance.GetWorldTemplateByZoneKey(zoneId);
+        if (world == null)
+            return [];
+
+        var path = ResolveSpawnerFile(zoneId, world.Name);
+        if (path == null)
+        {
+            Logger.Warn("TowerDefWaveForce: no npc_spawners.g for zoneId={0}", zoneId);
+            return [];
+        }
+
+        try
+        {
+            var text = File.ReadAllText(path);
+            var blocks = SplitBlocksRegex.Split(text);
+            var list = new List<Placement>(blocks.Length);
+            foreach (var block in blocks)
+            {
+                if (string.IsNullOrWhiteSpace(block))
+                    continue;
+                var idMatch = SpawnerIdRegex.Match(block);
+                var typeMatch = SpawnerTypeRegex.Match(block);
+                if (!idMatch.Success || !typeMatch.Success)
+                    continue;
+                if (!uint.TryParse(idMatch.Groups[1].Value, out var id))
+                    continue;
+                if (!uint.TryParse(typeMatch.Groups[1].Value, out var type))
+                    continue;
+                var posMatch = PosRegex.Match(block);
+                var x = 0f;
+                var y = 0f;
+                var z = 0f;
+                if (posMatch.Success)
+                {
+                    float.TryParse(posMatch.Groups[1].Value, System.Globalization.NumberStyles.Float,
+                        System.Globalization.CultureInfo.InvariantCulture, out x);
+                    float.TryParse(posMatch.Groups[2].Value, System.Globalization.NumberStyles.Float,
+                        System.Globalization.CultureInfo.InvariantCulture, out y);
+                    float.TryParse(posMatch.Groups[3].Value, System.Globalization.NumberStyles.Float,
+                        System.Globalization.CultureInfo.InvariantCulture, out z);
+                }
+
+                list.Add(new Placement(id, type, x, y, z));
+            }
+
+            Logger.Info(
+                "TowerDefWaveForce catalog zoneId={0} placements={1} from {2}",
+                zoneId, list.Count, path);
+            return list;
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn(ex, "TowerDefWaveForce failed to parse {0}", path);
+            return [];
+        }
+    }
+
+    private static string ResolveSpawnerFile(uint zoneId, string worldName)
+    {
+        foreach (var root in EnumerateGameRoots())
+        {
+            var path = Path.Combine(
+                root,
+                "worlds",
+                worldName,
+                "level_design",
+                "zone",
+                zoneId.ToString(),
+                "zone_server",
+                "npc_spawners.g");
+            if (File.Exists(path))
+                return Path.GetFullPath(path);
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<string> EnumerateGameRoots()
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        void Offer(string candidate)
+        {
+            if (string.IsNullOrWhiteSpace(candidate))
+                return;
+            var full = Path.GetFullPath(candidate.Trim());
+            if (Directory.Exists(full))
+                seen.Add(full);
+        }
+
+        Offer(WorldRuntime.Config.ZoneGameDataRoot);
+        Offer(Environment.GetEnvironmentVariable("AAEMU_ZONE_GAME_DATA_ROOT"));
+        Offer(@"G:\AAchina\Server\game");
+        return seen;
+    }
+
+    private static float DistanceSq(Vector3 a, Vector3 b)
+    {
+        var dx = a.X - b.X;
+        var dy = a.Y - b.Y;
+        var dz = a.Z - b.Z;
+        return dx * dx + dy * dy + dz * dz;
+    }
+
+    [GeneratedRegex(@"spawnerId\s+(\d+)", RegexOptions.CultureInvariant)]
+    private static partial Regex SpawnerIdPattern();
+
+    [GeneratedRegex(@"spawnerType\s+(\d+)", RegexOptions.CultureInvariant)]
+    private static partial Regex SpawnerTypePattern();
+
+    [GeneratedRegex(
+        @"pos\s*\(\s*x\s*([-\d.]+),\s*y\s*([-\d.]+),\s*z\s*([-\d.]+)",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex PosPattern();
+
+    [GeneratedRegex(@"(?m)^spawner\r?\n", RegexOptions.CultureInvariant)]
+    private static partial Regex SplitSpawnerBlocks();
+}

--- a/AAEmu.WorldServer/AAEmu.World/Core/Relay/TowerDefWaveForce.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Relay/TowerDefWaveForce.cs
@@ -1,6 +1,4 @@
-using System.Collections.Concurrent;
 using System.Numerics;
-using System.Text.RegularExpressions;
 
 using AAEmu.Game;
 using AAEmu.Game.Core.Managers.World;
@@ -30,21 +28,28 @@ namespace AAEmu.World.Core.Relay;
 /// <c>AAEMU_TOWER_WAVE_FORCE=1</c>. Portal re-arm is separate: <c>AAEMU_TOWER_PORTAL_FORCE=1</c>.
 /// When on, only the placement of each wanted sType nearest the live seed portal is fired.
 /// </remarks>
-public static partial class TowerDefWaveForce
+public static class TowerDefWaveForce
 {
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-    private sealed record Placement(uint Id, uint Type, float LocalX, float LocalY, float LocalZ);
+    /// <summary>
+    /// Max distance (m) from seed portal to a step placement of the arm type.
+    /// Override with World <c>TowerDef.WaveSpotRadiusMetres</c> or env <c>AAEMU_TOWER_WAVE_SPOT_RADIUS</c>.
+    /// </summary>
+    private static float SpotRadiusMetres
+    {
+        get
+        {
+            var raw = Environment.GetEnvironmentVariable("AAEMU_TOWER_WAVE_SPOT_RADIUS");
+            if (float.TryParse(raw, System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture, out var metres) &&
+                metres > 0f)
+                return metres;
 
-    private static readonly ConcurrentDictionary<uint, IReadOnlyList<Placement>> PlacementCache = new();
-
-    private static readonly Regex SpawnerIdRegex = SpawnerIdPattern();
-    private static readonly Regex SpawnerTypeRegex = SpawnerTypePattern();
-    private static readonly Regex PosRegex = PosPattern();
-    private static readonly Regex SplitBlocksRegex = SplitSpawnerBlocks();
-
-    /// <summary>Max distance (m) from seed portal to a step placement of the arm type.</summary>
-    private const float SpotRadiusMetres = 80f;
+            var configured = WorldRuntime.Config?.TowerDef?.WaveSpotRadiusMetres ?? 0f;
+            return configured > 0f ? configured : 80f;
+        }
+    }
 
     private static bool WaveForceEnabled
     {
@@ -141,14 +146,14 @@ public static partial class TowerDefWaveForce
                 continue;
             }
 
-            var placements = PlacementCache.GetOrAdd(zoneId, LoadPlacements);
+            var placements = ZoneSpawnerPlacementCatalog.GetAll(zoneId);
             var fired = 0;
             foreach (var p in placements)
             {
-                if (!wanted.Contains(p.Type))
+                if (!wanted.Contains(p.SpawnerType))
                     continue;
 
-                if (!SendTowerRespawn(zone, creator, p.Id))
+                if (!SendTowerRespawn(zone, creator, p.PlacementId))
                     continue;
                 fired++;
                 total++;
@@ -203,20 +208,20 @@ public static partial class TowerDefWaveForce
                 continue;
             }
 
-            var placements = PlacementCache.GetOrAdd(zoneId, LoadPlacements);
+            var placements = ZoneSpawnerPlacementCatalog.GetAll(zoneId);
             var r2 = SpotRadiusMetres * SpotRadiusMetres;
             var firedIds = new List<uint>();
 
             foreach (var sType in wantedTypes.OrderBy(x => x))
             {
-                Placement best = null;
+                ZoneSpawnerPlacementCatalog.SpawnerPlacement? best = null;
                 var bestD2 = float.MaxValue;
                 foreach (var p in placements)
                 {
-                    if (p.Type != sType)
+                    if (p.SpawnerType != sType)
                         continue;
                     var world = ZoneManager.Instance.ConvertToWorldCoordinates(
-                        zoneId, new Vector3(p.LocalX, p.LocalY, p.LocalZ));
+                        zoneId, new Vector3(p.X, p.Y, p.Z));
                     foreach (var a in anchors)
                     {
                         var d2 = DistanceSq(world, a);
@@ -235,13 +240,13 @@ public static partial class TowerDefWaveForce
                     continue;
                 }
 
-                if (!SendTowerRespawn(zone, creator, best.Id))
+                if (!SendTowerRespawn(zone, creator, best.Value.PlacementId))
                     continue;
-                firedIds.Add(best.Id);
+                firedIds.Add(best.Value.PlacementId);
                 total++;
                 Logger.Info(
                     "TowerDefOnEventForce zoneId={0} placement={1} sType={2} d={3:F1}m ({4})",
-                    zoneId, best.Id, sType, MathF.Sqrt(bestD2), reason);
+                    zoneId, best.Value.PlacementId, sType, MathF.Sqrt(bestD2), reason);
             }
         }
 
@@ -273,13 +278,10 @@ public static partial class TowerDefWaveForce
         // Cold / not yet mirrored: use g-file portal points for this zone's sType.
         if (list.Count == 0 && towerDef.TargetNpcSpawnId != 0)
         {
-            var placements = PlacementCache.GetOrAdd(zoneId, LoadPlacements);
-            foreach (var p in placements)
+            foreach (var p in ZoneSpawnerPlacementCatalog.GetByType(zoneId, towerDef.TargetNpcSpawnId))
             {
-                if (p.Type != towerDef.TargetNpcSpawnId)
-                    continue;
                 list.Add(ZoneManager.Instance.ConvertToWorldCoordinates(
-                    zoneId, new Vector3(p.LocalX, p.LocalY, p.LocalZ)));
+                    zoneId, new Vector3(p.X, p.Y, p.Z)));
             }
         }
 
@@ -288,10 +290,7 @@ public static partial class TowerDefWaveForce
 
     public static void InvalidatePlacementCache(uint zoneId = 0)
     {
-        if (zoneId == 0)
-            PlacementCache.Clear();
-        else
-            PlacementCache.TryRemove(zoneId, out _);
+        ZoneSpawnerPlacementCatalog.Invalidate(zoneId);
     }
 
     private static bool SendTowerRespawn(ZoneConnection zone, BaseUnit creator, uint placementId)
@@ -378,103 +377,6 @@ public static partial class TowerDefWaveForce
         return null;
     }
 
-    private static IReadOnlyList<Placement> LoadPlacements(uint zoneId)
-    {
-        var world = WorldManager.Instance.GetWorldTemplateByZoneKey(zoneId);
-        if (world == null)
-            return [];
-
-        var path = ResolveSpawnerFile(zoneId, world.Name);
-        if (path == null)
-        {
-            Logger.Warn("TowerDefWaveForce: no npc_spawners.g for zoneId={0}", zoneId);
-            return [];
-        }
-
-        try
-        {
-            var text = File.ReadAllText(path);
-            var blocks = SplitBlocksRegex.Split(text);
-            var list = new List<Placement>(blocks.Length);
-            foreach (var block in blocks)
-            {
-                if (string.IsNullOrWhiteSpace(block))
-                    continue;
-                var idMatch = SpawnerIdRegex.Match(block);
-                var typeMatch = SpawnerTypeRegex.Match(block);
-                if (!idMatch.Success || !typeMatch.Success)
-                    continue;
-                if (!uint.TryParse(idMatch.Groups[1].Value, out var id))
-                    continue;
-                if (!uint.TryParse(typeMatch.Groups[1].Value, out var type))
-                    continue;
-                var posMatch = PosRegex.Match(block);
-                var x = 0f;
-                var y = 0f;
-                var z = 0f;
-                if (posMatch.Success)
-                {
-                    float.TryParse(posMatch.Groups[1].Value, System.Globalization.NumberStyles.Float,
-                        System.Globalization.CultureInfo.InvariantCulture, out x);
-                    float.TryParse(posMatch.Groups[2].Value, System.Globalization.NumberStyles.Float,
-                        System.Globalization.CultureInfo.InvariantCulture, out y);
-                    float.TryParse(posMatch.Groups[3].Value, System.Globalization.NumberStyles.Float,
-                        System.Globalization.CultureInfo.InvariantCulture, out z);
-                }
-
-                list.Add(new Placement(id, type, x, y, z));
-            }
-
-            Logger.Info(
-                "TowerDefWaveForce catalog zoneId={0} placements={1} from {2}",
-                zoneId, list.Count, path);
-            return list;
-        }
-        catch (Exception ex)
-        {
-            Logger.Warn(ex, "TowerDefWaveForce failed to parse {0}", path);
-            return [];
-        }
-    }
-
-    private static string ResolveSpawnerFile(uint zoneId, string worldName)
-    {
-        foreach (var root in EnumerateGameRoots())
-        {
-            var path = Path.Combine(
-                root,
-                "worlds",
-                worldName,
-                "level_design",
-                "zone",
-                zoneId.ToString(),
-                "zone_server",
-                "npc_spawners.g");
-            if (File.Exists(path))
-                return Path.GetFullPath(path);
-        }
-
-        return null;
-    }
-
-    private static IEnumerable<string> EnumerateGameRoots()
-    {
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        void Offer(string candidate)
-        {
-            if (string.IsNullOrWhiteSpace(candidate))
-                return;
-            var full = Path.GetFullPath(candidate.Trim());
-            if (Directory.Exists(full))
-                seen.Add(full);
-        }
-
-        Offer(WorldRuntime.Config.ZoneGameDataRoot);
-        Offer(Environment.GetEnvironmentVariable("AAEMU_ZONE_GAME_DATA_ROOT"));
-        Offer(@"G:\AAchina\Server\game");
-        return seen;
-    }
-
     private static float DistanceSq(Vector3 a, Vector3 b)
     {
         var dx = a.X - b.X;
@@ -482,18 +384,4 @@ public static partial class TowerDefWaveForce
         var dz = a.Z - b.Z;
         return dx * dx + dy * dy + dz * dz;
     }
-
-    [GeneratedRegex(@"spawnerId\s+(\d+)", RegexOptions.CultureInvariant)]
-    private static partial Regex SpawnerIdPattern();
-
-    [GeneratedRegex(@"spawnerType\s+(\d+)", RegexOptions.CultureInvariant)]
-    private static partial Regex SpawnerTypePattern();
-
-    [GeneratedRegex(
-        @"pos\s*\(\s*x\s*([-\d.]+),\s*y\s*([-\d.]+),\s*z\s*([-\d.]+)",
-        RegexOptions.CultureInvariant)]
-    private static partial Regex PosPattern();
-
-    [GeneratedRegex(@"(?m)^spawner\r?\n", RegexOptions.CultureInvariant)]
-    private static partial Regex SplitSpawnerBlocks();
 }

--- a/AAEmu.WorldServer/AAEmu.World/Core/Relay/ZoneGameDataRootResolver.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Relay/ZoneGameDataRootResolver.cs
@@ -1,0 +1,83 @@
+using NLog;
+
+namespace AAEmu.World.Core.Relay;
+
+/// <summary>
+/// Resolves the configured zone game-data root used for <c>npc_spawners.g</c> and related level files.
+/// Never falls back to machine-specific absolute paths — missing config fails loudly.
+/// </summary>
+public static class ZoneGameDataRootResolver
+{
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+    private static bool _missingRootWarned;
+
+    /// <summary>
+    /// Configured root directory, or null when unset / missing on disk.
+    /// Prefer <see cref="WorldRuntime.Config.ZoneGameDataRoot"/>; env
+    /// <c>AAEMU_ZONE_GAME_DATA_ROOT</c> is an explicit override for ops.
+    /// </summary>
+    public static string? TryGetRoot()
+    {
+        var candidates = new[]
+        {
+            WorldRuntime.Config?.ZoneGameDataRoot,
+            Environment.GetEnvironmentVariable("AAEMU_ZONE_GAME_DATA_ROOT")
+        };
+
+        foreach (var candidate in candidates)
+        {
+            if (string.IsNullOrWhiteSpace(candidate))
+                continue;
+
+            var full = Path.GetFullPath(candidate.Trim());
+            if (Directory.Exists(full))
+                return full;
+
+            Logger.Error(
+                "ZoneGameDataRoot configured but directory missing: {0}",
+                full);
+            return null;
+        }
+
+        if (!_missingRootWarned)
+        {
+            _missingRootWarned = true;
+            Logger.Error(
+                "ZoneGameDataRoot is not configured. Set World Config.ZoneGameDataRoot (or AAEMU_ZONE_GAME_DATA_ROOT) " +
+                "to the extracted game data root that contains worlds/.../zone_server/npc_spawners.g");
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Absolute path to <c>npc_spawners.g</c> for a zone, or null when root/file is unavailable.
+    /// </summary>
+    public static string? TryResolveNpcSpawnersFile(uint zoneId, string worldName)
+    {
+        if (zoneId == 0 || string.IsNullOrWhiteSpace(worldName))
+            return null;
+
+        var root = TryGetRoot();
+        if (root is null)
+            return null;
+
+        var path = Path.Combine(
+            root,
+            "worlds",
+            worldName,
+            "level_design",
+            "zone",
+            zoneId.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            "zone_server",
+            "npc_spawners.g");
+
+        if (File.Exists(path))
+            return Path.GetFullPath(path);
+
+        Logger.Warn(
+            "npc_spawners.g missing under ZoneGameDataRoot zoneId={0} world={1} path={2}",
+            zoneId, worldName, path);
+        return null;
+    }
+}

--- a/AAEmu.WorldServer/AAEmu.World/Core/Relay/ZoneGameDataRootResolver.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Relay/ZoneGameDataRootResolver.cs
@@ -8,43 +8,62 @@ namespace AAEmu.World.Core.Relay;
 /// </summary>
 public static class ZoneGameDataRootResolver
 {
+    public const string EnvVarName = "AAEMU_ZONE_GAME_DATA_ROOT";
+
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
     private static bool _missingRootWarned;
 
     /// <summary>
-    /// Configured root directory, or null when unset / missing on disk.
-    /// Prefer <see cref="WorldRuntime.Config.ZoneGameDataRoot"/>; env
-    /// <c>AAEMU_ZONE_GAME_DATA_ROOT</c> is an explicit override for ops.
+    /// Existing directory for zone level files, or null when unset / missing on disk.
+    /// <see cref="EnvVarName"/> is an explicit override and is tried first; then
+    /// <see cref="WorldRuntime.Config.ZoneGameDataRoot"/>. Invalid paths are skipped so the
+    /// remaining candidate can still apply.
     /// </summary>
     public static string? TryGetRoot()
     {
-        var candidates = new[]
-        {
+        var root = Resolve(
+            Environment.GetEnvironmentVariable(EnvVarName),
             WorldRuntime.Config?.ZoneGameDataRoot,
-            Environment.GetEnvironmentVariable("AAEMU_ZONE_GAME_DATA_ROOT")
-        };
+            Directory.Exists);
 
-        foreach (var candidate in candidates)
+        if (root is null && !_missingRootWarned)
+        {
+            _missingRootWarned = true;
+            Logger.Error(
+                "ZoneGameDataRoot is not configured. Set World Config.ZoneGameDataRoot (or {0}) " +
+                "to the extracted game data root that contains worlds/.../zone_server/npc_spawners.g",
+                EnvVarName);
+        }
+
+        return root;
+    }
+
+    /// <summary>
+    /// Resolve a root from an env override then a configured path. Invalid or missing candidates
+    /// are skipped so a later valid candidate can still apply.
+    /// </summary>
+    public static string? Resolve(string? envOverride, string? configuredRoot, Func<string, bool> directoryExists)
+    {
+        foreach (var candidate in new[] { envOverride, configuredRoot })
         {
             if (string.IsNullOrWhiteSpace(candidate))
                 continue;
 
-            var full = Path.GetFullPath(candidate.Trim());
-            if (Directory.Exists(full))
+            string full;
+            try
+            {
+                full = Path.GetFullPath(candidate.Trim());
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "ZoneGameDataRoot candidate is not a valid path: {0}", candidate);
+                continue;
+            }
+
+            if (directoryExists(full))
                 return full;
 
-            Logger.Error(
-                "ZoneGameDataRoot configured but directory missing: {0}",
-                full);
-            return null;
-        }
-
-        if (!_missingRootWarned)
-        {
-            _missingRootWarned = true;
-            Logger.Error(
-                "ZoneGameDataRoot is not configured. Set World Config.ZoneGameDataRoot (or AAEMU_ZONE_GAME_DATA_ROOT) " +
-                "to the extracted game data root that contains worlds/.../zone_server/npc_spawners.g");
+            Logger.Error("ZoneGameDataRoot candidate missing: {0}", full);
         }
 
         return null;

--- a/AAEmu.WorldServer/AAEmu.World/Core/Relay/ZoneNpcSpawnerCatalog.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Relay/ZoneNpcSpawnerCatalog.cs
@@ -267,19 +267,9 @@ public static partial class ZoneNpcSpawnerCatalog
     private static IEnumerable<string> EnumerateGameRoots()
     {
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        void Offer(string? candidate)
-        {
-            if (string.IsNullOrWhiteSpace(candidate))
-                return;
-            var full = Path.GetFullPath(candidate.Trim());
-            if (Directory.Exists(full))
-                seen.Add(full);
-        }
-
-        Offer(WorldRuntime.Config.ZoneGameDataRoot);
-        Offer(Environment.GetEnvironmentVariable("AAEMU_ZONE_GAME_DATA_ROOT"));
-        // World always uses Server/game (same tree dedic.bat loads). Never client\game.
-        Offer(@"G:\AAchina\Server\game");
+        var root = ZoneGameDataRootResolver.TryGetRoot();
+        if (root != null)
+            seen.Add(root);
         return seen;
     }
 

--- a/AAEmu.WorldServer/AAEmu.World/Core/Relay/ZoneSimRelay.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Relay/ZoneSimRelay.cs
@@ -66,7 +66,7 @@ public class ZoneSimRelay
             ZwOpcodes.ReportMoleTrader => HandleMole("ZWReportMoleTrader", bodyLen),
             ZwOpcodes.ReportMoveHack => HandleMole("ZWReportMoveHack", bodyLen),
             ZwOpcodes.ReportDoodadSurfaceHack => HandleMole("ZWReportDoodadSurfaceHack", bodyLen),
-            ZwOpcodes.TowerDefReportPlayability => HandleTowerDef(stream),
+            ZwOpcodes.TowerDefReportPlayability => HandleTowerDef(zoneId, stream),
             ZwOpcodes.ResponseCombatUnits => HandleResponseCombatUnits(stream, bodyLen),
             ZwOpcodes.TimeOfDay => HandleTimeOfDay(zoneId, stream, detailed: false),
             ZwOpcodes.DetailedTimeOfDay => HandleTimeOfDay(zoneId, stream, detailed: true),
@@ -577,14 +577,14 @@ public class ZoneSimRelay
         return true;
     }
 
-    private static bool HandleTowerDef(PacketStream stream)
+    private static bool HandleTowerDef(uint zoneId, PacketStream stream)
     {
         if (stream.Count < 10)
             return false;
         var type = stream.ReadUInt32();
         var type2 = stream.ReadUInt16();
         var playable = stream.ReadUInt32();
-        Logger.Info("ZWTowerDefReportPlayability type={0}/{1} playableSpots={2}", type, type2, playable);
+        TowerDefScheduler.OnPlayabilityReport(zoneId, type, type2, playable);
         return true;
     }
 
@@ -607,10 +607,12 @@ public class ZoneSimRelay
             speed = stream.ReadSingle();
             start = stream.ReadSingle();
             end = stream.ReadSingle();
-            Logger.Info("ZWDetailedTimeOfDay time={0:F2} speed={1:F3} start={2:F2} end={3:F2}", time, speed, start, end);
+            Logger.Info(
+                "ZWDetailedTimeOfDay zoneId={0} time={1:F2} speed={2:F3} start={3:F2} end={4:F2}",
+                zoneId, time, speed, start, end);
         }
         else
-            Logger.Info("ZWTimeOfDay time={0:F2}", time);
+            Logger.Info("ZWTimeOfDay zoneId={0} time={1:F2}", zoneId, time);
         WorldIntegration.OnZoneTimeOfDay?.Invoke(zoneId, time, speed, start, end, detailed);
         return true;
     }

--- a/AAEmu.WorldServer/AAEmu.World/Core/Relay/ZoneSpawnerPlacementCatalog.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Relay/ZoneSpawnerPlacementCatalog.cs
@@ -1,0 +1,171 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using AAEmu.Game.Core.Managers.World;
+using NLog;
+
+namespace AAEmu.World.Core.Relay;
+
+/// <summary>
+/// Zone-local npc_spawners.g placements keyed by <c>spawnerType</c> (npc_spawners template id).
+/// Used when World must place event NPCs that Zone fails to emit via ZWSpawnNpc.
+/// </summary>
+public static partial class ZoneSpawnerPlacementCatalog
+{
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+    private static readonly ConcurrentDictionary<uint, IReadOnlyList<SpawnerPlacement>> ByZone = new();
+
+    public readonly record struct SpawnerPlacement(
+        uint PlacementId,
+        uint SpawnerType,
+        float X,
+        float Y,
+        float Z,
+        float ZRot);
+
+    public static IReadOnlyList<SpawnerPlacement> GetByType(uint zoneId, uint spawnerType)
+    {
+        if (zoneId == 0 || spawnerType == 0)
+            return [];
+
+        var all = ByZone.GetOrAdd(zoneId, LoadZone);
+        if (all.Count == 0)
+            return [];
+
+        List<SpawnerPlacement> match = null;
+        foreach (var p in all)
+        {
+            if (p.SpawnerType != spawnerType)
+                continue;
+            match ??= [];
+            match.Add(p);
+        }
+
+        return match ?? [];
+    }
+
+    public static void Invalidate(uint zoneId = 0)
+    {
+        if (zoneId == 0)
+            ByZone.Clear();
+        else
+            ByZone.TryRemove(zoneId, out _);
+    }
+
+    private static IReadOnlyList<SpawnerPlacement> LoadZone(uint zoneId)
+    {
+        var world = WorldManager.Instance.GetWorldTemplateByZoneKey(zoneId);
+        if (world == null)
+        {
+            Logger.Warn("ZoneSpawnerPlacementCatalog: no world template for zoneId={0}", zoneId);
+            return [];
+        }
+
+        var path = ResolveSpawnerFile(zoneId, world.Name);
+        if (path is null)
+        {
+            Logger.Warn(
+                "ZoneSpawnerPlacementCatalog: no npc_spawners.g zoneId={0} world={1}",
+                zoneId, world.Name);
+            return [];
+        }
+
+        var list = ParsePlacements(path);
+        Logger.Info(
+            "ZoneSpawnerPlacementCatalog zoneId={0} world={1} file={2} placements={3}",
+            zoneId, world.Name, path, list.Count);
+        return list;
+    }
+
+    private static string? ResolveSpawnerFile(uint zoneId, string worldName)
+    {
+        foreach (var root in EnumerateGameRoots())
+        {
+            var path = Path.Combine(
+                root,
+                "worlds",
+                worldName,
+                "level_design",
+                "zone",
+                zoneId.ToString(CultureInfo.InvariantCulture),
+                "zone_server",
+                "npc_spawners.g");
+            if (File.Exists(path))
+                return Path.GetFullPath(path);
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<string> EnumerateGameRoots()
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        void Offer(string? candidate)
+        {
+            if (string.IsNullOrWhiteSpace(candidate))
+                return;
+            var full = Path.GetFullPath(candidate.Trim());
+            if (Directory.Exists(full))
+                seen.Add(full);
+        }
+
+        Offer(WorldRuntime.Config.ZoneGameDataRoot);
+        Offer(Environment.GetEnvironmentVariable("AAEMU_ZONE_GAME_DATA_ROOT"));
+        Offer(@"G:\AAchina\Server\game");
+        return seen;
+    }
+
+    private static List<SpawnerPlacement> ParsePlacements(string path)
+    {
+        var text = File.ReadAllText(path);
+        var blocks = SplitSpawnerBlocks().Split(text);
+        var list = new List<SpawnerPlacement>(Math.Max(64, blocks.Length / 4));
+        foreach (var block in blocks)
+        {
+            if (string.IsNullOrWhiteSpace(block))
+                continue;
+
+            var idMatch = SpawnerIdRegex().Match(block);
+            var typeMatch = SpawnerTypeRegex().Match(block);
+            var posMatch = PosRegex().Match(block);
+            if (!idMatch.Success || !typeMatch.Success || !posMatch.Success)
+                continue;
+            if (!uint.TryParse(idMatch.Groups[1].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id))
+                continue;
+            if (!uint.TryParse(typeMatch.Groups[1].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var type))
+                continue;
+            if (!TryF(posMatch.Groups[1].Value, out var x) ||
+                !TryF(posMatch.Groups[2].Value, out var y) ||
+                !TryF(posMatch.Groups[3].Value, out var z))
+                continue;
+
+            var zRot = 0f;
+            var rotMatch = ZRotRegex().Match(block);
+            if (rotMatch.Success)
+                TryF(rotMatch.Groups[1].Value, out zRot);
+
+            list.Add(new SpawnerPlacement(id, type, x, y, z, zRot));
+        }
+
+        return list;
+    }
+
+    private static bool TryF(string s, out float v) =>
+        float.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out v);
+
+    [GeneratedRegex(@"spawnerId\s+(\d+)", RegexOptions.CultureInvariant)]
+    private static partial Regex SpawnerIdRegex();
+
+    [GeneratedRegex(@"spawnerType\s+(\d+)", RegexOptions.CultureInvariant)]
+    private static partial Regex SpawnerTypeRegex();
+
+    [GeneratedRegex(@"pos\s*\(\s*x\s+([-\d.]+)\s*,\s*y\s+([-\d.]+)\s*,\s*z\s+([-\d.]+)\s*\)",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex PosRegex();
+
+    [GeneratedRegex(@"zRot\s+([-\d.]+)", RegexOptions.CultureInvariant)]
+    private static partial Regex ZRotRegex();
+
+    [GeneratedRegex(@"(?m)^spawner\r?\n", RegexOptions.CultureInvariant)]
+    private static partial Regex SplitSpawnerBlocks();
+}

--- a/AAEmu.WorldServer/AAEmu.World/Core/Relay/ZoneSpawnerPlacementCatalog.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Relay/ZoneSpawnerPlacementCatalog.cs
@@ -28,7 +28,7 @@ public static partial class ZoneSpawnerPlacementCatalog
         if (zoneId == 0 || spawnerType == 0)
             return [];
 
-        var all = ByZone.GetOrAdd(zoneId, LoadZone);
+        var all = GetAll(zoneId);
         if (all.Count == 0)
             return [];
 
@@ -42,6 +42,14 @@ public static partial class ZoneSpawnerPlacementCatalog
         }
 
         return match ?? [];
+    }
+
+    /// <summary>All placements for a zone (empty when ZoneGameDataRoot / file is unavailable).</summary>
+    public static IReadOnlyList<SpawnerPlacement> GetAll(uint zoneId)
+    {
+        if (zoneId == 0)
+            return [];
+        return ByZone.GetOrAdd(zoneId, LoadZone);
     }
 
     public static void Invalidate(uint zoneId = 0)
@@ -61,14 +69,9 @@ public static partial class ZoneSpawnerPlacementCatalog
             return [];
         }
 
-        var path = ResolveSpawnerFile(zoneId, world.Name);
+        var path = ZoneGameDataRootResolver.TryResolveNpcSpawnersFile(zoneId, world.Name);
         if (path is null)
-        {
-            Logger.Warn(
-                "ZoneSpawnerPlacementCatalog: no npc_spawners.g zoneId={0} world={1}",
-                zoneId, world.Name);
             return [];
-        }
 
         var list = ParsePlacements(path);
         Logger.Info(
@@ -77,42 +80,12 @@ public static partial class ZoneSpawnerPlacementCatalog
         return list;
     }
 
-    private static string? ResolveSpawnerFile(uint zoneId, string worldName)
+    /// <summary>Parse placements from an absolute <c>npc_spawners.g</c> path (tests / tooling).</summary>
+    public static IReadOnlyList<SpawnerPlacement> ParseFile(string path)
     {
-        foreach (var root in EnumerateGameRoots())
-        {
-            var path = Path.Combine(
-                root,
-                "worlds",
-                worldName,
-                "level_design",
-                "zone",
-                zoneId.ToString(CultureInfo.InvariantCulture),
-                "zone_server",
-                "npc_spawners.g");
-            if (File.Exists(path))
-                return Path.GetFullPath(path);
-        }
-
-        return null;
-    }
-
-    private static IEnumerable<string> EnumerateGameRoots()
-    {
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        void Offer(string? candidate)
-        {
-            if (string.IsNullOrWhiteSpace(candidate))
-                return;
-            var full = Path.GetFullPath(candidate.Trim());
-            if (Directory.Exists(full))
-                seen.Add(full);
-        }
-
-        Offer(WorldRuntime.Config.ZoneGameDataRoot);
-        Offer(Environment.GetEnvironmentVariable("AAEMU_ZONE_GAME_DATA_ROOT"));
-        Offer(@"G:\AAchina\Server\game");
-        return seen;
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+            throw new FileNotFoundException("npc_spawners.g not found", path);
+        return ParsePlacements(path);
     }
 
     private static List<SpawnerPlacement> ParsePlacements(string path)

--- a/AAEmu.WorldServer/AAEmu.World/Core/Relay/ZwSpawnNpcParser.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Relay/ZwSpawnNpcParser.cs
@@ -1,4 +1,5 @@
 using AAEmu.Commons.Network;
+using AAEmu.Game.GameData;
 
 namespace AAEmu.World.Core.Relay;
 
@@ -28,11 +29,16 @@ public sealed class ZwSpawnNpcParsed
 
 public static class ZwSpawnNpcParser
 {
+    /// <summary>Minimum body for fixed header+pos (sid…scale). Ambient pad is 78 B.</summary>
+    public const int MinBodyLength = 41;
+
+    /// <summary>Retail ambient body size (zeroed optional tail).</summary>
+    public const int AmbientBodyLength = 78;
+
     public static ZwSpawnNpcParsed? TryParse(byte[] raw)
     {
-        // Live ZWSpawnNpc from dedicate is a fixed 78-byte body. Reject other blobs
-        // (e.g. player WZUnitState stored in the same UnitRegistry).
-        if (raw == null || raw.Length != 78)
+        // Ambient is 78 B; event OnEvent may append creator fields. Soft-cap avoids UnitState dumps.
+        if (raw == null || raw.Length < MinBodyLength || raw.Length > 512)
             return null;
 
         try
@@ -57,6 +63,10 @@ public static class ZwSpawnNpcParser
             var z = s.ReadSingle();
             var zRot = s.ReadSingle();
             var scale = s.ReadSingle();
+
+            // Type-2 group path sometimes writes template 0; resolve first Npc member from sType.
+            if (templateId == 0 && sType != 0)
+                templateId = ResolveTemplateFromSpawnerType(sType);
 
             if (templateId == 0)
                 return null;
@@ -83,5 +93,45 @@ public static class ZwSpawnNpcParser
         {
             return null;
         }
+    }
+
+    /// <summary>Peek sid/sType for TRACE when full parse fails.</summary>
+    public static bool TryPeekIds(byte[] raw, out uint spawnerId, out uint spawnerType)
+    {
+        spawnerId = 0;
+        spawnerType = 0;
+        if (raw == null || raw.Length < 8)
+            return false;
+        spawnerId = BitConverter.ToUInt32(raw, 0);
+        spawnerType = BitConverter.ToUInt32(raw, 4);
+        return true;
+    }
+
+    private static uint ResolveTemplateFromSpawnerType(uint spawnerType)
+    {
+        try
+        {
+            var template = NpcGameData.Instance.GetNpcSpawnerTemplate(spawnerType);
+            if (template?.Npcs == null)
+                return 0;
+
+            foreach (var member in template.Npcs)
+            {
+                if (member == null || member.MemberId == 0)
+                    continue;
+                if (string.Equals(member.MemberType, "Npc", StringComparison.OrdinalIgnoreCase))
+                    return member.MemberId;
+            }
+
+            // NpcGroup wire with templateId 0 — leave reject for non-Npc membership.
+            // Member Npc templates may still sit inside group tables only if desc expands them
+            // differently; World will still TRACE reject for pure groups with zero template.
+        }
+        catch
+        {
+            // GameData not ready — reject as before.
+        }
+
+        return 0;
     }
 }

--- a/AAEmu.WorldServer/AAEmu.World/Models/WorldAppConfiguration.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Models/WorldAppConfiguration.cs
@@ -19,6 +19,17 @@ public class WorldAppConfiguration
     public NpcSpawnerActivateConfig NpcSpawnerActivate { get; set; } = new();
     /// <summary>Hold back spawners that are outside their game_schedule or day-night window.</summary>
     public NpcScheduleGateConfig NpcScheduleGate { get; set; } = new();
+    /// <summary>Optional tower-def World helpers (wave re-arm radius, etc.).</summary>
+    public TowerDefWorldConfig TowerDef { get; set; } = new();
+}
+
+public class TowerDefWorldConfig
+{
+    /// <summary>
+    /// When wave force is enabled, max metres from the live seed portal to the chosen
+    /// <c>npc_spawners.g</c> placement for each step spawn type.
+    /// </summary>
+    public float WaveSpotRadiusMetres { get; set; } = 80f;
 }
 
 public class NpcScheduleGateConfig

--- a/AAEmu.WorldServer/AAEmu.World/Program.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Program.cs
@@ -75,14 +75,23 @@ public static class Program
             .OrderBy(zone => zone.ZoneId)
             .ThenBy(zone => zone.SessionId)
             .ToArray();
+        // Shared day → main_world dedicades only (instances own a local noon-start clock).
         WorldIntegration.RelayTimeOfDayToZones = hour =>
         {
             foreach (var zone in PlayerEnterService.AllLoadedZones())
+            {
+                if (!TimeManager.ZoneUsesSharedGameDay(zone.ZoneId))
+                    continue;
                 zone.SendPacket(new WZTimeOfDayPacket(hour));
+                zone.SendPacket(new WZDetailedTimeOfDayPacket(
+                    hour, TimeManager.DefaultGameHourSpeed, 0f, 24f));
+            }
         };
+        // Type-2 ZW ToD: clients in that zone only — never rebases shared TimeManager.
         WorldIntegration.OnZoneTimeOfDay = (zoneId, time, speed, start, end, detailed) =>
         {
-            TimeManager.Instance.OnZoneReport(time);
+            if (TimeManager.ZoneUsesSharedGameDay(zoneId))
+                return;
             WorldIntegration.ForEachReadyConnection((connection, character) =>
             {
                 if (character.Transform.ZoneId != zoneId)
@@ -92,6 +101,8 @@ public static class Program
                     : new SCTimeOfDayPacket(time));
             });
         };
+        // Shared World hour crosses drive Game-Time tower arms (seamless has no ZW ToD).
+        WorldIntegration.OnGameTimeAdvanced = TowerDefScheduler.OnGameTimeAdvanced;
         WorldIntegration.RelayUnitStateToZone = (zoneId, body) =>
         {
             var zone = PlayerEnterService.ForZoneId(zoneId)
@@ -105,7 +116,16 @@ public static class Program
         WorldIntegration.OnPlayerLeave = bcId => enter.LeaveZone(bcId);
         WorldIntegration.OnZoneNpcSpawn = WorldIntegration.MirrorZoneNpcSpawn;
         WorldIntegration.OnZoneNpcRemove = WorldIntegration.MirrorZoneNpcRemove;
-        WorldIntegration.OnZoneNpcKilled = WorldIntegration.MirrorZoneNpcKilled;
+        WorldIntegration.OnZoneNpcKilled = bcId =>
+        {
+            // Capture template before the death path may remove the mirror.
+            uint tpl = 0;
+            if (WorldIntegration.FindUnitAcrossWorlds(bcId) is AAEmu.Game.Models.Game.NPChar.Npc npc)
+                tpl = npc.TemplateId;
+            WorldIntegration.MirrorZoneNpcKilled(bcId);
+            if (tpl != 0)
+                TowerDefScheduler.OnNpcKilled(tpl);
+        };
         WorldIntegration.OnWorldInstanceRemoved = ZoneNpcSpawnerCatalog.RemoveInstance;
         WorldIntegration.TriggerTowerDef = (action, towerDefId, step) => action switch
         {
@@ -121,6 +141,8 @@ public static class Program
             _ => $"unknown action {action}"
         };
         WorldIntegration.DescribeTowerDefs = TowerDefScheduler.Describe;
+        WorldIntegration.SyncTowerDefsToCharacter = TowerDefScheduler.SyncToCharacter;
+        WorldIntegration.OnTowerDefEventNpcMirrored = TowerDefScheduler.OnEventNpcMirrored;
         WorldIntegration.OnMainWorldReady = () =>
         {
             // Arm the schedule gate before remirroring, so the pass that re-accepts already
@@ -1033,6 +1055,7 @@ public static class Program
             WorldIntegration.GetZoneConnectionStatus = null;
             WorldIntegration.RelayTimeOfDayToZones = null;
             WorldIntegration.OnZoneTimeOfDay = null;
+            WorldIntegration.OnGameTimeAdvanced = null;
             WorldIntegration.RelayUnitStateToZone = null;
             WorldIntegration.OnPlayerLeave = null;
             WorldIntegration.RelayMoveToZone = null;

--- a/AAEmu.WorldServer/AAEmu.World/Program.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Program.cs
@@ -53,6 +53,11 @@ public static class Program
         var appConfig = new WorldAppConfiguration();
         configuration.Bind(appConfig);
         WorldRuntime.Config = appConfig;
+        if (!string.IsNullOrWhiteSpace(appConfig.ZoneGameDataRoot) &&
+            string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("AAEMU_ZONE_GAME_DATA_ROOT")))
+        {
+            Environment.SetEnvironmentVariable("AAEMU_ZONE_GAME_DATA_ROOT", appConfig.ZoneGameDataRoot);
+        }
 
         ZoneNetwork.Instance.Start(appConfig.ZoneNetwork);
         if (appConfig.GameBridge.Enabled)


### PR DESCRIPTION
## Summary
- **Tower defense (zone-authority):** stage OnSpawn plot skills for army spawn, ground-land SpawnEffect / plot offsets, end/restart cleanup, active info SC list, opt-in wave re-arm (`AAEMU_TOWER_WAVE_FORCE`), spawn-portal stream priority from loaded tower-def NPC relationships.
- **World glue:** instance ToD no longer rebases the shared open-world clock (unknown zones fail closed; shared day is the default world template id, not a display name). NPC spawn relay / movement / schedule gate hardening; doodad pulse / Tod / logic-family path fixes. Length-prefixed framing waits on short TCP leftovers instead of dispatching opcode 0.
- **Quests calendar:** weekly reset task, bulk quest-context reset packet, calendar helpers. Persisted `DateTimeKind.Unspecified` is treated as UTC (`ServerCalendar.AsUtc`).
- **Config contracts:** `ZoneGameDataRoot` env override is tried first and invalid paths fall through to config. Game-Time auto-arm is explicit `tower_defs.id` membership in `Configurations/TowerDefs.json` (`GameTimeAutoArmIds`); weekday StartTimes remain WallClock from data; omitted ToD-capable rows stay Manual and are logged. Jump threshold lives once on `TimeManager.MaxWorldEffectJumpHours`.

## Test plan
Unit tests: `AAEmu.UnitTests` (1184 passed) covering calendar UTC kinds, schedule predicates, Game-Time overlay completeness/staleness, clock isolation + jump threshold, placement parse failures, and ZoneGameDataRoot precedence.

Live smoke (unchecked until run):
- [ ] Cold boot World + zone 257 dedicate; confirm `registry loadedCount` and ZoneLoaded for 257
- [ ] Natural ToD start for tower_def **171** → seed→hold→step 1 → stage portal → army on ground; no thrash on ambient NPCs
- [ ] `/towerdef end 171` (or API) clears seed/stage and army; force start while RUNNING restarts cleanly
- [ ] Instance dedicade ToD does not jump open-world day
- [ ] Quest daily/weekly calendar reset smoke if Path of Destiny is live
- [ ] Default: wave force **off**; optional `AAEMU_TOWER_WAVE_FORCE=1` only when intentionally re-arming silent step spawns

## Split (follow-up)
This PR is still wider than one reviewable slice. Proposed cut after this round:
1. Quest calendar
2. ToD isolation
3. Tower-def core
4. Placement / wave-force opt-in
5. Mirror / doodad / framing