### PR TITLE
fix(actability): send the whole actability entry on a rank change

### DIFF
--- a/AAEmu.Game/Core/Packets/G2C/SCActabilityPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCActabilityPacket.cs
@@ -4,19 +4,31 @@ using AAEmu.Game.Models.Game.Char;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
+/// <summary>
+/// Sends a batch of the character's actabilities.
+/// </summary>
+/// <remarks>
+/// Schema: <c>bool last</c>, <c>u8 count</c>, then <c>count</c> actability entries written by
+/// <see cref="Actability.Write"/>.
+/// <para>
+/// <c>count</c> is the only length a reader has, so it must match the number of entries written, and a
+/// batch may hold at most <see cref="MaxEntries"/>. Entries are variable width, which is why they are
+/// written through the shared entry writer rather than field by field here - the same entry appears on
+/// its own in <see cref="SCExpertLimitModifiedPacket"/> and the two must not diverge.
+/// </para>
+/// <para><c>last</c> marks the final batch, so a caller sending several must set it on that one alone.</para>
+/// </remarks>
 public class SCActabilityPacket(bool last, Actability[] actabilities) : GamePacket(SCOffsets.SCActabilityPacket, 1)
 {
+    /// <summary>Most entries one batch can carry.</summary>
+    public const int MaxEntries = 100;
+
     public override PacketStream Write(PacketStream stream)
     {
-        // last(bool) | count(u8, max 100) | per entry: pish/pisc(id, point) then step(u8). The old fixed
-        // id(u32)+point(u32)+step layout is ~4 bytes too long per entry and trips the client size check.
         stream.Write(last);
         stream.Write((byte)actabilities.Length);
         foreach (var actability in actabilities)
-        {
-            stream.WritePisc(actability.Id, (uint)actability.Point);
-            stream.Write(actability.Step);
-        }
+            actability.Write(stream);
 
         return stream;
     }

--- a/AAEmu.Game/Core/Packets/G2C/SCExpertLimitModifiedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCExpertLimitModifiedPacket.cs
@@ -1,16 +1,34 @@
 using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.Game.Char;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCExpertLimitModifiedPacket(bool isUpgrade, uint id, byte step)
+/// <summary>
+/// Reports the outcome of one proficiency rank change.
+/// </summary>
+/// <remarks>
+/// Schema: <c>bool isUpgrade</c> followed by one actability entry, written by
+/// <see cref="Actability.Write"/>.
+/// <para>
+/// The entry is the same element the full actability list sends, so the two have to stay identical;
+/// that is why neither packet writes those fields itself. Sending anything shorter - an id alone, or an
+/// id without its point - leaves the body under length and the change is not applied, which shows up as
+/// a rank that appears only after the next login, once the whole list is sent again.
+/// </para>
+/// <para>
+/// The entry is taken from the Actability rather than from loose values, so the point published here is
+/// always the one the server holds. That matters on a downgrade, where the point is clamped to the
+/// target rank's limit as part of the same change.
+/// </para>
+/// </remarks>
+public class SCExpertLimitModifiedPacket(bool isUpgrade, Actability actability)
     : GamePacket(SCOffsets.SCExpertLimitModifiedPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
         stream.Write(isUpgrade);
-        stream.Write(id);
-        stream.Write(step);
+        actability.Write(stream);
         return stream;
     }
 }

--- a/AAEmu.Game/Models/Game/Char/Actability.cs
+++ b/AAEmu.Game/Models/Game/Char/Actability.cs
@@ -1,3 +1,4 @@
+using AAEmu.Commons.Network;
 using AAEmu.Game.Models.Game.Char.Templates;
 
 namespace AAEmu.Game.Models.Game.Char;
@@ -8,6 +9,26 @@ public class Actability(ActabilityTemplate template)
     public ActabilityTemplate Template { get; set; } = template;
     public int Point { get; set; }
     public byte Step { get; set; }
+
+    /// <summary>
+    /// Writes this actability as the entry every packet that carries one uses.
+    /// </summary>
+    /// <remarks>
+    /// Schema: <c>packed(id, point)</c> followed by <c>u8 step</c>. Id and point share one packed block,
+    /// so the entry is not a fixed width and neither field can be written on its own - a reader takes the
+    /// pair together. Point is published unsigned and is clamped at zero rather than wrapping.
+    /// <para>
+    /// This lives here rather than in a packet because more than one packet sends it, as a single entry
+    /// and as a list element, and they have to agree: an entry written a field short is not skipped, it
+    /// mis-frames everything after it in the body.
+    /// </para>
+    /// </remarks>
+    public PacketStream Write(PacketStream stream)
+    {
+        stream.WritePisc(Id, (uint)Math.Max(0, Point));
+        stream.Write(Step);
+        return stream;
+    }
 
     // Values for 1.2, not sure about the XP multiplier, might not have existed back then
     //                                                Rank    0      1      2      3      4      5      6      7

--- a/AAEmu.Game/Models/Game/Char/CharacterActability.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterActability.cs
@@ -117,7 +117,7 @@ public class CharacterActability(Character owner)
             actability.Point = Math.Min(actability.Point, targetTemplate.UpLimit);
         }
 
-        Owner.SendPacket(new SCExpertLimitModifiedPacket(isUpgrade, id, actability.Step));
+        Owner.SendPacket(new SCExpertLimitModifiedPacket(isUpgrade, actability));
         return true;
     }
 

--- a/AAEmu.UnitTests/Game/Models/Game/Char/ActabilityEntryTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Char/ActabilityEntryTests.cs
@@ -1,0 +1,100 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Char.Templates;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Char;
+
+/// <summary>
+/// Pins the actability entry layout and, more importantly, pins the two packets that carry it to the
+/// same bytes. They used to write the fields separately and drifted apart, which left the rank-change
+/// packet a field short.
+/// </summary>
+public class ActabilityEntryTests
+{
+    private static Actability Entry(uint id, int point, byte step) =>
+        new(new ActabilityTemplate { Id = id }) { Point = point, Step = step };
+
+    private static byte[] Written(Actability actability)
+    {
+        var stream = new PacketStream();
+        actability.Write(stream);
+        return stream.GetBytes();
+    }
+
+    [Test]
+    public async Task Entry_IsPackedIdAndPointThenStep()
+    {
+        // pisc packs the two values behind a leading descriptor byte, so the entry is not a fixed width
+        // and the step is whatever byte follows it.
+        var bytes = Written(Entry(18, 20000, 3));
+
+        var stream = new PacketStream();
+        stream.Insert(0, bytes);
+        var values = stream.ReadPisc(2);
+
+        await Assert.That(values[0]).IsEqualTo(18u);
+        await Assert.That(values[1]).IsEqualTo(20000u);
+        await Assert.That(stream.ReadByte()).IsEqualTo((byte)3);
+        await Assert.That(stream.Count - stream.Pos).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Entry_WidthVariesWithValue()
+    {
+        // A packed block is only as wide as its values need, so nothing may assume a fixed entry size.
+        var small = Written(Entry(1, 0, 0));
+        var large = Written(Entry(uint.MaxValue, int.MaxValue, 12));
+
+        await Assert.That(large.Length > small.Length).IsTrue();
+    }
+
+    [Test]
+    public async Task Entry_ClampsNegativePointInsteadOfWrapping()
+    {
+        var bytes = Written(Entry(7, -50, 1));
+
+        var stream = new PacketStream();
+        stream.Insert(0, bytes);
+        var values = stream.ReadPisc(2);
+
+        await Assert.That(values[1]).IsEqualTo(0u);
+    }
+
+    [Test]
+    public async Task BothPackets_WriteTheSameEntryBytes()
+    {
+        // The guard that matters: a layout change must not be able to move one packet and not the other.
+        var actability = Entry(18, 20000, 3);
+        var entry = Written(actability);
+
+        var listBody = new PacketStream();
+        new SCActabilityPacket(true, [actability]).Write(listBody);
+
+        var modifiedBody = new PacketStream();
+        new SCExpertLimitModifiedPacket(true, actability).Write(modifiedBody);
+
+        // list: bool last, u8 count, entry -- modified: bool isUpgrade, entry
+        await Assert.That(listBody.GetBytes()[2..]).IsEquivalentTo(entry);
+        await Assert.That(modifiedBody.GetBytes()[1..]).IsEquivalentTo(entry);
+    }
+
+    [Test]
+    public async Task ListPacket_CountMatchesEntriesWritten()
+    {
+        var entries = new[] { Entry(1, 10, 1), Entry(2, 20, 2), Entry(3, 30, 3) };
+
+        var body = new PacketStream();
+        new SCActabilityPacket(false, entries).Write(body);
+        var bytes = body.GetBytes();
+
+        await Assert.That(bytes[0]).IsEqualTo((byte)0);   // last
+        await Assert.That(bytes[1]).IsEqualTo((byte)3);   // count
+
+        var expected = new List<byte>();
+        foreach (var entry in entries)
+            expected.AddRange(Written(entry));
+
+        await Assert.That(bytes[2..]).IsEquivalentTo(expected.ToArray());
+    }
+}


### PR DESCRIPTION
Hello.

This is a small fix for the proficiency update, please take a look