### PR TITLE
fix(housing): resolve every attach point a house model defines

### DIFF
--- a/AAEmu.Game/Core/Managers/HousingManager.cs
+++ b/AAEmu.Game/Core/Managers/HousingManager.cs
@@ -1,4 +1,4 @@
-using System.Drawing;
+﻿using System.Drawing;
 using System.Numerics;
 
 using AAEmu.Commons.Utils;
@@ -282,6 +282,7 @@ public class HousingManager(
         Logger.Info("Reconciling bound doodads for completed houses...");
         var addedCount = 0;
         var removedCount = 0;
+        var realignedCount = 0;
 
         foreach (var house in _houses.Values)
         {
@@ -299,7 +300,15 @@ public class HousingManager(
 
                 if (matches.Count == 0)
                 {
-                    // Missing from DB — spawn fresh and save (first-run migration or data loss recovery)
+                    // An unresolved binding has no offset to spawn at. Creating one anyway would persist a
+                    // position that was never defined, and every later pass would then treat it as correct.
+                    if (!bindingDoodad.HasResolvedPosition)
+                    {
+                        Logger.Warn($"Reconcile: Not spawning bound doodad templateId={bindingDoodad.DoodadId} attachPoint={bindingDoodad.AttachPointId} for house {house.Id} - attach point unresolved");
+                        continue;
+                    }
+
+                    // Missing from DB - spawn fresh and save (first-run migration or data loss recovery)
                     Logger.Debug($"Reconcile: Spawning missing bound doodad templateId={bindingDoodad.DoodadId} attachPoint={bindingDoodad.AttachPointId} for house {house.Id}");
                     var doodad = doodadManager.Create(house.ParentWorld, 0, bindingDoodad.DoodadId, house, true);
                     if (doodad == null)
@@ -334,10 +343,50 @@ public class HousingManager(
                         removedCount++;
                     }
                 }
+
+                // The kept doodad carries whatever offset it was saved with, and a house built while its
+                // attach point was still unresolved saved the house origin. The template is authoritative
+                // for bound doodads, so pull a drifted one back onto it.
+                if (matches.Count > 0 && RealignBoundDoodad(house, matches[0], bindingDoodad))
+                    realignedCount++;
             }
         }
 
-        Logger.Info($"Bound doodad reconciliation complete: {addedCount} added, {removedCount} duplicates removed.");
+        Logger.Info($"Bound doodad reconciliation complete: {addedCount} added, {removedCount} duplicates removed, {realignedCount} realigned.");
+    }
+
+    /// <summary>
+    /// Moves a bound doodad back onto the offset its house template gives it, and returns whether it moved.
+    /// </summary>
+    /// <remarks>
+    /// Bound doodads are fixtures rather than player-placed furniture, so the template offset is
+    /// authoritative and a saved one that disagrees is stale. This matters because the offset is
+    /// persisted: a house built while its attach point could not be resolved keeps that transform
+    /// indefinitely, leaving the doodad out of interaction range of where it is drawn.
+    /// <para>
+    /// Position and orientation are both compared, by <see cref="BoundDoodadAlignment"/>. A binding
+    /// whose attach point is unresolved is skipped entirely - see
+    /// <see cref="HousingBindingDoodad.HasResolvedPosition"/>.
+    /// </para>
+    /// </remarks>
+    private static bool RealignBoundDoodad(House house, Doodad doodad, HousingBindingDoodad binding)
+    {
+        // Nothing to align to. The saved transform is left exactly as it is rather than being overwritten
+        // with an offset the template does not actually define.
+        if (!binding.HasResolvedPosition || binding.Position is null)
+            return false;
+
+        var target = binding.Position;
+        if (!BoundDoodadAlignment.NeedsRealignment(doodad.Transform.Local.Position,
+                doodad.Transform.Local.Rotation, target))
+            return false;
+
+        Logger.Debug($"Reconcile: Realigning bound doodad templateId={binding.DoodadId} attachPoint={binding.AttachPointId} on house {house.Id}");
+        doodad.Transform.Local.ApplyWorldSpawnPositionWithDeg(target);
+        if (doodad.IsPersistent)
+            doodad.Save();
+
+        return true;
     }
 
     /// <summary>

--- a/AAEmu.Game/GameData/HousingGameData.cs
+++ b/AAEmu.Game/GameData/HousingGameData.cs
@@ -1,4 +1,4 @@
-using AAEmu.Commons.IO;
+﻿using AAEmu.Commons.IO;
 using System.Numerics;
 
 using AAEmu.Commons.Utils;
@@ -164,8 +164,14 @@ public class HousingGameData : Singleton<HousingGameData>, IGameDataLoader
                                 if (templateBindings != null &&
                                     templateBindings.AttachPointId.TryGetValue(bindingDoodad.AttachPointId,
                                         out var pos))
+                                {
                                     bindingDoodad.Position = pos.Clone();
+                                    bindingDoodad.HasResolvedPosition = true;
+                                }
 
+                                // Left unresolved until the model can supply it. The placeholder keeps the
+                                // property non-null; HasResolvedPosition is what says whether it means
+                                // anything, since the origin is a legitimate offset.
                                 bindingDoodad.Position ??= new WorldSpawnPosition();
 
                                 doodads.Add(bindingDoodad);
@@ -273,13 +279,14 @@ public class HousingGameData : Singleton<HousingGameData>, IGameDataLoader
     }
 
     /// <summary>
-    /// Replaces the binding offsets taken from housing_bindings.json with the ones held in the model the house
-    /// actually uses. Runs in PostLoad because the attach point table is built by another loader and the
-    /// loaders' Load() order is reflection order.
+    /// Fills in binding offsets that the json table does not define, from the model the house actually uses.
+    /// Runs in PostLoad because the attach point table is built by another loader and the loaders' Load()
+    /// order is reflection order.
     ///
-    /// The json only ever covered 104 of the 631 templates that have bindings, keyed by template id; everything
-    /// else fell back to (0,0,0) and stacked its doodads on the house origin. Attach point geometry belongs to
-    /// the model, not the template, so templates sharing a model now resolve from the same place.
+    /// Attach point geometry belongs to the model rather than to the template, so templates sharing a model
+    /// resolve from the same place. The json covers a minority of the templates that have bindings; the rest
+    /// depend entirely on this pass, and any binding still unresolved afterwards stays marked as such rather
+    /// than being given a placeholder offset.
     /// </summary>
     private void ResolveBindingPositionsFromClientData()
     {
@@ -296,9 +303,9 @@ public class HousingGameData : Singleton<HousingGameData>, IGameDataLoader
 
             foreach (var bindingDoodad in template.HousingBindingDoodad)
             {
-                // Only fill the gaps. Where housing_bindings.json has an offset it stays — the two sources
-                // disagree on a handful of points and the json is what the server has been running on.
-                if (bindingDoodad.Position != null && bindingDoodad.Position.AsPositionVector() != Vector3.Zero)
+                // Only fill the gaps. Where the json defines an offset it stays: the two sources disagree on
+                // a handful of points and the json is what the server has been running on.
+                if (bindingDoodad.HasResolvedPosition)
                     continue;
 
                 var pos = ModelAttachPointGameData.Instance
@@ -307,6 +314,7 @@ public class HousingGameData : Singleton<HousingGameData>, IGameDataLoader
                 if (pos != null)
                 {
                     bindingDoodad.Position = pos.Clone();
+                    bindingDoodad.HasResolvedPosition = true;
                     resolved++;
                 }
                 else

--- a/AAEmu.Game/GameData/ModelAttachPointGameData.cs
+++ b/AAEmu.Game/GameData/ModelAttachPointGameData.cs
@@ -1,4 +1,4 @@
-using System.Numerics;
+﻿using System.Numerics;
 using System.Xml.Linq;
 
 using AAEmu.Commons.IO;
@@ -18,18 +18,24 @@ using NLog;
 namespace AAEmu.Game.GameData;
 
 /// <summary>
-/// Attach point offsets for every model housing and slaves bind doodads to, resolved from the client's own
-/// data instead of a hand-kept table.
+/// Attach point offsets for every model that housing and slaves bind doodads to, resolved from the shipped
+/// static data rather than from a hand-kept table.
 ///
-/// The chain is entirely in the shipped data:
-///   models.sub_id + sub_type  →  prefab_elements.file_path (PrefabModel) or
-///                                ship_models.normal / vehicle_models.normal (Ship/VehicleModel)
-///                             →  prefab://prefabs/&lt;lib&gt;.xml/&lt;prefab&gt;  →  game/prefabs/&lt;lib&gt;.xml
-///                             →  &lt;Object Type="Brush" Prefab="…cgf"&gt;
-///                             →  that cgf's '$' helper nodes, named by model_attach_point_strings.prefab
+/// The chain is entirely within that data: a model names a prefab, a prefab names the meshes it places and
+/// where it places them, and a mesh carries named helper nodes. An attach point is the helper whose name
+/// the attach point table gives it, expressed as an offset from the model.
 ///
-/// Reading ~900 meshes out of a 68 GB game_pak is not something to repeat every boot, so the resolved table
-/// is cached next to the other client data and rebuilt only when the pak changes.
+/// Invariants:
+///   - every element of a model's selected state contributes, since an attach point may be defined by any
+///     of them and reading a subset leaves points unresolved
+///   - a model that defines no helper for an attach point leaves it unresolved, which is distinct from
+///     resolving it to the origin
+///   - resolution is deterministic: elements are read in a fixed order, and a helper defined twice at
+///     different positions is reported rather than settled by enumeration order
+///
+/// Resolution is expensive, so the result is cached beside the other static data and rebuilt only when its
+/// inputs change: the configured static-data sources, or this resolver's format version, so that a change
+/// to what the resolver reads discards a cache that would otherwise still look current.
 /// </summary>
 [GameData]
 public class ModelAttachPointGameData : Singleton<ModelAttachPointGameData>, IGameDataLoader
@@ -38,10 +44,31 @@ public class ModelAttachPointGameData : Singleton<ModelAttachPointGameData>, IGa
 
     private const string CacheFileName = "model_attach_points.cache.json";
 
+    /// <summary>
+    /// Part of the cache identity. Bump it whenever resolution changes what it reads or how it merges,
+    /// so that caches produced under the previous rules are discarded rather than reused.
+    /// </summary>
+    private const int CacheFormatVersion = 2;
+
     private Dictionary<uint, Dictionary<AttachPointKind, WorldSpawnPosition>> _attachPoints = [];
 
     /// <summary>Attach point id → the '$' helper name that carries it in a mesh.</summary>
     private Dictionary<AttachPointKind, string> _helperNames = [];
+
+    /// <summary>
+    /// The model state a resolved attach point belongs to: the one the state table names 'normal'.
+    /// </summary>
+    /// <remarks>
+    /// Read from the shipped state table rather than assumed, so the value follows the data. Models that
+    /// do not define it fall back to their lowest state, which is why this is a preference rather than a
+    /// filter - selecting on it alone would resolve nothing for those models.
+    /// </remarks>
+    private uint _normalModelStateId = DefaultNormalModelStateId;
+
+    /// <summary>Used only when the state table is missing or does not name a normal state.</summary>
+    private const uint DefaultNormalModelStateId = 1;
+
+    private const string NormalModelStateName = "normal";
 
     /// <summary>Parsed prefab libraries, held only while the cache is being built.</summary>
     private readonly Dictionary<string, Dictionary<string, List<(string Mesh, Vector3 Offset)>>> _prefabMeshCache =
@@ -56,6 +83,7 @@ public class ModelAttachPointGameData : Singleton<ModelAttachPointGameData>, IGa
     public void Load(SqliteConnection connection)
     {
         _attachPoints = [];
+        _normalModelStateId = LoadNormalModelStateId(connection);
         _helperNames = LoadHelperNames(connection);
         if (_helperNames.Count == 0)
         {
@@ -63,7 +91,7 @@ public class ModelAttachPointGameData : Singleton<ModelAttachPointGameData>, IGa
             return;
         }
 
-        var stamp = BuildClientDataStamp();
+        var stamp = BuildCacheStamp();
         if (TryLoadCache(stamp, out var cached))
         {
             _attachPoints = cached;
@@ -87,15 +115,18 @@ public class ModelAttachPointGameData : Singleton<ModelAttachPointGameData>, IGa
                 continue;
             }
 
-            // A house prefab is dozens of brushes — the building shells plus scenery. The attach helpers sit
-            // in the building meshes and can be spread across several of them, so every brush is read and the
-            // results merged, each shifted by where the prefab places that brush.
-            var helpers = new Dictionary<string, Vector3>(StringComparer.OrdinalIgnoreCase);
+            // Attach helpers may be spread across any of a model's meshes, so all of them contribute, each
+            // shifted by where its brush is placed. Order is fixed upstream so the merge is repeatable.
+            var candidates = new List<(string Name, Vector3 Position)>();
             foreach (var (meshPath, brushOffset) in brushes)
             {
                 foreach (var (name, local) in ReadMeshHelpers(meshPath))
-                    helpers.TryAdd(name, local + brushOffset);
+                    candidates.Add((name, local + brushOffset));
             }
+
+            var helpers = MergeHelpers(candidates, out var conflicts);
+            foreach (var conflict in conflicts)
+                Logger.Warn($"Model {modelId} defines attach helper {conflict} at more than one position; using the first");
 
             if (helpers.Count == 0)
                 continue;
@@ -135,6 +166,65 @@ public class ModelAttachPointGameData : Singleton<ModelAttachPointGameData>, IGa
     {
         var set = _attachPoints.GetValueOrDefault(modelId);
         return set != null && set.TryGetValue(attachPoint, out var pos) ? pos : null;
+    }
+
+    /// <summary>
+    /// The id of the state named <see cref="NormalModelStateName"/>, or
+    /// <see cref="DefaultNormalModelStateId"/> when the table cannot supply one.
+    /// </summary>
+    private static uint LoadNormalModelStateId(SqliteConnection connection)
+    {
+        try
+        {
+            using var command = connection.CreateCommand();
+            command.CommandText = "SELECT id FROM enum_model_states WHERE name=@name";
+            command.Parameters.AddWithValue("@name", NormalModelStateName);
+            command.Prepare();
+            using var reader = new SQLiteWrapperReader(command.ExecuteReader());
+            if (reader.Read())
+                return reader.GetUInt32("id", DefaultNormalModelStateId);
+        }
+        catch (Exception exception)
+        {
+            Logger.Warn(exception, "Could not read the model state table; assuming {0} is the normal state",
+                DefaultNormalModelStateId);
+        }
+
+        return DefaultNormalModelStateId;
+    }
+
+    /// <summary>
+    /// Combines helper definitions from every mesh of a model into one set, reporting any name defined at
+    /// more than one position.
+    /// </summary>
+    /// <remarks>
+    /// The first definition of a name wins, so the caller must supply <paramref name="candidates"/> in a
+    /// deterministic order or the resolved position becomes a function of enumeration order. A name that
+    /// appears again at a different position is a genuine ambiguity in the data rather than something to
+    /// resolve silently, so it is reported through <paramref name="conflicts"/>.
+    /// </remarks>
+    internal static Dictionary<string, Vector3> MergeHelpers(
+        IReadOnlyList<(string Name, Vector3 Position)> candidates, out List<string> conflicts)
+    {
+        const float samePositionTolerance = 0.0001f;
+
+        var merged = new Dictionary<string, Vector3>(StringComparer.OrdinalIgnoreCase);
+        var reported = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        conflicts = [];
+
+        foreach (var (name, position) in candidates)
+        {
+            if (merged.TryGetValue(name, out var existing))
+            {
+                if (Vector3.Distance(existing, position) > samePositionTolerance && reported.Add(name))
+                    conflicts.Add(name);
+                continue;
+            }
+
+            merged[name] = position;
+        }
+
+        return merged;
     }
 
     private static Dictionary<AttachPointKind, string> LoadHelperNames(SqliteConnection connection)
@@ -204,27 +294,52 @@ public class ModelAttachPointGameData : Singleton<ModelAttachPointGameData>, IGa
         if (subId == 0 || string.IsNullOrEmpty(subType))
             return [];
 
-        var uri = subType switch
+        // Invariant: every element of the model's selected state takes part in resolution. A model is
+        // described by several elements at once, and an attach point may be defined by any of them, so
+        // reading a subset silently leaves points unresolved.
+        //
+        // The state is the one named 'normal' where the model defines it, falling back to the lowest state
+        // present for models that do not. Ordering is explicit so that a repeated helper resolves the same
+        // way on every run.
+        var uris = subType switch
         {
-            "PrefabModel" => QueryScalar(connection,
-                "SELECT file_path AS uri FROM prefab_elements WHERE prefab_model_id=@id ORDER BY (state_id<>1), state_id LIMIT 1", subId),
-            "ShipModel" => QueryScalar(connection, "SELECT normal AS uri FROM ship_models WHERE id=@id", subId),
-            "VehicleModel" => QueryScalar(connection, "SELECT normal AS uri FROM vehicle_models WHERE id=@id", subId),
+            "PrefabModel" => QueryList(connection,
+                """
+                SELECT file_path AS uri FROM prefab_elements
+                 WHERE prefab_model_id=@id
+                   AND state_id = (SELECT state_id FROM prefab_elements
+                                    WHERE prefab_model_id=@id
+                                    ORDER BY (state_id<>@normalState), state_id
+                                    LIMIT 1)
+                 ORDER BY id
+                """, subId, _normalModelStateId),
+            "ShipModel" => QueryList(connection, "SELECT normal AS uri FROM ship_models WHERE id=@id", subId),
+            "VehicleModel" => QueryList(connection, "SELECT normal AS uri FROM vehicle_models WHERE id=@id", subId),
             // ActorModel is a character rig; its attach points are bones in a .chr, not helpers in a .cgf.
-            _ => null
+            _ => []
         };
 
-        return string.IsNullOrEmpty(uri) ? [] : ResolvePrefabUri(uri);
+        return [.. uris.SelectMany(ResolvePrefabUri)];
     }
 
-    private static string QueryScalar(SqliteConnection connection, string sql, uint id)
+    private static List<string> QueryList(SqliteConnection connection, string sql, uint id,
+        uint? normalState = null)
     {
+        var res = new List<string>();
         using var command = connection.CreateCommand();
         command.CommandText = sql;
         command.Parameters.AddWithValue("@id", id);
+        if (normalState.HasValue)
+            command.Parameters.AddWithValue("@normalState", normalState.Value);
         command.Prepare();
         using var reader = new SQLiteWrapperReader(command.ExecuteReader());
-        return reader.Read() ? reader.GetString("uri", string.Empty) : null;
+        while (reader.Read())
+        {
+            var uri = reader.GetString("uri", string.Empty);
+            if (!string.IsNullOrEmpty(uri))
+                res.Add(uri);
+        }
+        return res;
     }
 
     /// <summary>
@@ -359,24 +474,47 @@ public class ModelAttachPointGameData : Singleton<ModelAttachPointGameData>, IGa
     private static string CachePath => Path.Combine(FileManager.AppPath, "Data", CacheFileName);
 
     /// <summary>Identity of the client data behind the cache, so a new pak rebuilds it.</summary>
-    private static string BuildClientDataStamp()
+    /// <summary>
+    /// Identity of the currently loadable cache: this resolver's format version together with a
+    /// descriptor for each configured static-data source.
+    /// </summary>
+    private static string BuildCacheStamp() =>
+        ComposeCacheStamp(CacheFormatVersion, ClientFileManager.Sources.Select(DescribeSource));
+
+    /// <summary>
+    /// Builds the cache identity from its two inputs.
+    /// </summary>
+    /// <remarks>
+    /// The format version participates so that changing what the resolver reads discards a cache whose
+    /// sources are otherwise unchanged. Without it such a cache still matches, and the resolver keeps
+    /// serving results produced by the previous rules.
+    /// </remarks>
+    internal static string ComposeCacheStamp(int formatVersion, IEnumerable<string> sourceDescriptors) =>
+        string.Join(";", new[] { $"v{formatVersion}" }.Concat(sourceDescriptors));
+
+    /// <summary>
+    /// Whether a cache carrying <paramref name="cachedStamp"/> may be used now. Any difference rebuilds:
+    /// the stamp is an identity, not a version to compare for order.
+    /// </summary>
+    internal static bool IsCacheCurrent(string cachedStamp, string currentStamp) =>
+        !string.IsNullOrEmpty(cachedStamp) && string.Equals(cachedStamp, currentStamp, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Describes one configured source well enough that replacing it changes the cache identity.
+    /// </summary>
+    private static string DescribeSource(ClientSource source)
     {
-        var parts = new List<string>();
-        foreach (var source in ClientFileManager.Sources)
+        try
         {
-            try
-            {
-                var info = new FileInfo(source.PathName);
-                parts.Add(info.Exists
-                    ? $"{source.PathName}|{info.Length}|{info.LastWriteTimeUtc:O}"
-                    : $"{source.PathName}|dir");
-            }
-            catch
-            {
-                parts.Add(source.PathName);
-            }
+            var info = new FileInfo(source.PathName);
+            return info.Exists
+                ? $"{source.PathName}|{info.Length}|{info.LastWriteTimeUtc:O}"
+                : $"{source.PathName}|dir";
         }
-        return string.Join(";", parts);
+        catch
+        {
+            return source.PathName;
+        }
     }
 
     private static bool TryLoadCache(string stamp, out Dictionary<uint, Dictionary<AttachPointKind, WorldSpawnPosition>> data)
@@ -390,9 +528,9 @@ public class ModelAttachPointGameData : Singleton<ModelAttachPointGameData>, IGa
             var cache = JsonConvert.DeserializeObject<CacheFile>(File.ReadAllText(CachePath));
             if (cache?.Models == null || cache.Models.Count == 0)
                 return false;
-            if (!string.Equals(cache.Stamp, stamp, StringComparison.Ordinal))
+            if (!IsCacheCurrent(cache.Stamp, stamp))
             {
-                Logger.Info("Client data changed since the attach point cache was written; rebuilding");
+                Logger.Info("Attach point cache no longer matches its inputs; rebuilding");
                 return false;
             }
 

--- a/AAEmu.Game/Models/Game/Housing/BoundDoodadAlignment.cs
+++ b/AAEmu.Game/Models/Game/Housing/BoundDoodadAlignment.cs
@@ -1,0 +1,56 @@
+using System.Numerics;
+
+using AAEmu.Game.Models.Game.World.Transform;
+using AAEmu.Game.Utils;
+
+namespace AAEmu.Game.Models.Game.Housing;
+
+/// <summary>
+/// Decides whether a bound doodad's saved local transform still matches the offset its house template
+/// gives it.
+/// </summary>
+/// <remarks>
+/// Kept free of world state so the rule can be exercised directly. Both position and orientation are
+/// compared, because the realignment applies both: comparing position alone leaves a doodad that drifted
+/// only in rotation sitting wrong forever, since the check that guards the write never fires.
+/// </remarks>
+public static class BoundDoodadAlignment
+{
+    /// <summary>Positional difference, in metres, below which a doodad counts as already aligned.</summary>
+    public const float PositionToleranceMetres = 0.01f;
+
+    /// <summary>Angular difference, in radians, below which an axis counts as already aligned.</summary>
+    public const float RotationToleranceRadians = 0.0017f; // ~0.1 degrees
+
+    /// <summary>
+    /// Whether <paramref name="currentPosition"/> and <paramref name="currentRotationRadians"/> differ
+    /// from <paramref name="target"/> by more than the tolerances above.
+    /// </summary>
+    /// <param name="currentRotationRadians">Local rotation as (roll, pitch, yaw) in radians.</param>
+    /// <param name="target">The template offset, whose angles are in degrees.</param>
+    public static bool NeedsRealignment(Vector3 currentPosition, Vector3 currentRotationRadians,
+        WorldSpawnPosition target)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+
+        if (Vector3.Distance(currentPosition, target.AsPositionVector()) >= PositionToleranceMetres)
+            return true;
+
+        return ExceedsAngleTolerance(currentRotationRadians.X, target.Roll.DegToRad())
+               || ExceedsAngleTolerance(currentRotationRadians.Y, target.Pitch.DegToRad())
+               || ExceedsAngleTolerance(currentRotationRadians.Z, target.Yaw.DegToRad());
+    }
+
+    /// <summary>
+    /// Shortest angular distance between two angles, so that values a whole turn apart - or either side
+    /// of the wrap point, such as +179 and -179 degrees - are recognised as the same orientation rather
+    /// than as the largest possible difference.
+    /// </summary>
+    private static bool ExceedsAngleTolerance(float currentRadians, float targetRadians)
+    {
+        const float fullTurn = 2f * MathF.PI;
+
+        var difference = MathF.IEEERemainder(currentRadians - targetRadians, fullTurn);
+        return MathF.Abs(difference) >= RotationToleranceRadians;
+    }
+}

--- a/AAEmu.Game/Models/Game/Housing/HousingBindingDoodad.cs
+++ b/AAEmu.Game/Models/Game/Housing/HousingBindingDoodad.cs
@@ -7,5 +7,20 @@ public class HousingBindingDoodad
 {
     public AttachPointKind AttachPointId { get; set; }
     public uint DoodadId { get; set; }
+
+    /// <summary>
+    /// Offset from the house, valid only when <see cref="HasResolvedPosition"/> is set.
+    /// </summary>
     public WorldSpawnPosition Position { get; set; }
+
+    /// <summary>
+    /// Whether <see cref="Position"/> came from a source that actually defines this attach point.
+    /// </summary>
+    /// <remarks>
+    /// The origin is a legitimate offset, so the coordinate cannot carry this meaning itself: a binding
+    /// that genuinely sits at the house origin and one whose attach point was never found would be
+    /// indistinguishable. An unresolved binding must not be spawned, saved or realigned, because doing so
+    /// writes a position that was never defined and then treats it as authoritative on the next pass.
+    /// </remarks>
+    public bool HasResolvedPosition { get; set; }
 }

--- a/AAEmu.UnitTests/Game/GameData/ModelAttachPointCacheStampTests.cs
+++ b/AAEmu.UnitTests/Game/GameData/ModelAttachPointCacheStampTests.cs
@@ -1,0 +1,97 @@
+using AAEmu.Game.GameData;
+
+namespace AAEmu.UnitTests.Game.GameData;
+
+/// <summary>
+/// The attach point cache is reused whenever its identity matches. The identity has to include the
+/// resolver's format version, or a cache produced under the previous resolution rules keeps being served
+/// even though nothing about its inputs has changed - which is exactly how a resolver fix can appear to
+/// do nothing at all.
+/// </summary>
+public class ModelAttachPointCacheStampTests
+{
+    private static readonly string[] Sources =
+    [
+        "C:/game/data/one|1024|2026-08-01T00:00:00.0000000Z",
+        "C:/game/data/two|dir"
+    ];
+
+    [Test]
+    public async Task FormatVersionChange_InvalidatesAnOtherwiseMatchingCache()
+    {
+        // Same sources, byte for byte. Only the resolver changed.
+        var written = ModelAttachPointGameData.ComposeCacheStamp(1, Sources);
+        var current = ModelAttachPointGameData.ComposeCacheStamp(2, Sources);
+
+        await Assert.That(written).IsNotEqualTo(current);
+        await Assert.That(ModelAttachPointGameData.IsCacheCurrent(written, current)).IsFalse();
+    }
+
+    [Test]
+    public async Task UnchangedInputs_KeepTheCache()
+    {
+        var written = ModelAttachPointGameData.ComposeCacheStamp(2, Sources);
+        var current = ModelAttachPointGameData.ComposeCacheStamp(2, Sources);
+
+        await Assert.That(ModelAttachPointGameData.IsCacheCurrent(written, current)).IsTrue();
+    }
+
+    [Test]
+    public async Task ChangedSource_InvalidatesTheCache()
+    {
+        var written = ModelAttachPointGameData.ComposeCacheStamp(2, Sources);
+        var current = ModelAttachPointGameData.ComposeCacheStamp(2,
+            ["C:/game/data/one|2048|2026-08-02T00:00:00.0000000Z", "C:/game/data/two|dir"]);
+
+        await Assert.That(ModelAttachPointGameData.IsCacheCurrent(written, current)).IsFalse();
+    }
+
+    [Test]
+    public async Task AddedOrRemovedSource_InvalidatesTheCache()
+    {
+        var current = ModelAttachPointGameData.ComposeCacheStamp(2, Sources);
+
+        var fewer = ModelAttachPointGameData.ComposeCacheStamp(2, [Sources[0]]);
+        var more = ModelAttachPointGameData.ComposeCacheStamp(2, [.. Sources, "C:/game/data/three|dir"]);
+
+        await Assert.That(ModelAttachPointGameData.IsCacheCurrent(fewer, current)).IsFalse();
+        await Assert.That(ModelAttachPointGameData.IsCacheCurrent(more, current)).IsFalse();
+    }
+
+    [Test]
+    public async Task SourceOrder_IsPartOfTheIdentity()
+    {
+        var forward = ModelAttachPointGameData.ComposeCacheStamp(2, Sources);
+        var reversed = ModelAttachPointGameData.ComposeCacheStamp(2, [Sources[1], Sources[0]]);
+
+        await Assert.That(ModelAttachPointGameData.IsCacheCurrent(reversed, forward)).IsFalse();
+    }
+
+    [Test]
+    public async Task StampCarriesTheFormatVersion()
+    {
+        var stamp = ModelAttachPointGameData.ComposeCacheStamp(7, Sources);
+
+        await Assert.That(stamp.StartsWith("v7", StringComparison.Ordinal)).IsTrue();
+    }
+
+    [Test]
+    public async Task MissingStamp_IsNeverCurrent()
+    {
+        // A cache written before the stamp existed, or one truncated on disk, must rebuild rather than
+        // be trusted.
+        var current = ModelAttachPointGameData.ComposeCacheStamp(2, Sources);
+
+        await Assert.That(ModelAttachPointGameData.IsCacheCurrent(null, current)).IsFalse();
+        await Assert.That(ModelAttachPointGameData.IsCacheCurrent(string.Empty, current)).IsFalse();
+    }
+
+    [Test]
+    public async Task NoSources_StillProducesAVersionedIdentity()
+    {
+        var v1 = ModelAttachPointGameData.ComposeCacheStamp(1, []);
+        var v2 = ModelAttachPointGameData.ComposeCacheStamp(2, []);
+
+        await Assert.That(ModelAttachPointGameData.IsCacheCurrent(v1, v2)).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/GameData/ModelAttachPointMergeTests.cs
+++ b/AAEmu.UnitTests/Game/GameData/ModelAttachPointMergeTests.cs
@@ -1,0 +1,110 @@
+using System.Numerics;
+
+using AAEmu.Game.GameData;
+
+namespace AAEmu.UnitTests.Game.GameData;
+
+/// <summary>
+/// A model's attach helpers are gathered from several meshes, so the merge decides which definition wins.
+/// It has to be a function of the input alone, not of the order rows happen to come back in.
+/// </summary>
+public class ModelAttachPointMergeTests
+{
+    [Test]
+    public async Task MergesHelpersFromEveryMesh()
+    {
+        // The bug this guards: reading one element of a model resolved only the helpers in that mesh and
+        // left the rest unresolved.
+        var merged = ModelAttachPointGameData.MergeHelpers(
+        [
+            ("$cannon1", new Vector3(1f, 0f, 0f)),
+            ("$cannon2", new Vector3(2f, 0f, 0f)),
+            ("$heal_point0", new Vector3(3f, 0f, 0f))
+        ], out var conflicts);
+
+        await Assert.That(merged.Count).IsEqualTo(3);
+        await Assert.That(merged["$cannon2"]).IsEqualTo(new Vector3(2f, 0f, 0f));
+        await Assert.That(conflicts).IsEmpty();
+    }
+
+    [Test]
+    public async Task HelperNamesAreCaseInsensitive()
+    {
+        var merged = ModelAttachPointGameData.MergeHelpers(
+        [
+            ("$Cannon1", new Vector3(1f, 0f, 0f)),
+            ("$cannon1", new Vector3(1f, 0f, 0f))
+        ], out var conflicts);
+
+        await Assert.That(merged.Count).IsEqualTo(1);
+        await Assert.That(conflicts).IsEmpty();
+    }
+
+    [Test]
+    public async Task RepeatedHelperAtTheSamePosition_IsNotAConflict()
+    {
+        // Scenery meshes repeat across prefabs, so the same helper legitimately arrives more than once.
+        var merged = ModelAttachPointGameData.MergeHelpers(
+        [
+            ("$cannon0", new Vector3(1f, 2f, 3f)),
+            ("$cannon0", new Vector3(1f, 2f, 3f))
+        ], out var conflicts);
+
+        await Assert.That(merged.Count).IsEqualTo(1);
+        await Assert.That(conflicts).IsEmpty();
+    }
+
+    [Test]
+    public async Task ConflictingDefinition_IsReportedAndFirstWins()
+    {
+        var merged = ModelAttachPointGameData.MergeHelpers(
+        [
+            ("$cannon0", new Vector3(1f, 0f, 0f)),
+            ("$cannon0", new Vector3(9f, 0f, 0f))
+        ], out var conflicts);
+
+        await Assert.That(merged["$cannon0"]).IsEqualTo(new Vector3(1f, 0f, 0f));
+        await Assert.That(conflicts).IsEquivalentTo(new[] { "$cannon0" });
+    }
+
+    [Test]
+    public async Task ConflictIsReportedOnce_HoweverManyTimesItRepeats()
+    {
+        var merged = ModelAttachPointGameData.MergeHelpers(
+        [
+            ("$cannon0", new Vector3(1f, 0f, 0f)),
+            ("$cannon0", new Vector3(9f, 0f, 0f)),
+            ("$cannon0", new Vector3(8f, 0f, 0f))
+        ], out var conflicts);
+
+        await Assert.That(merged.Count).IsEqualTo(1);
+        await Assert.That(conflicts.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task OrderDecidesTheWinner_WhichIsWhyTheQueryIsOrdered()
+    {
+        // Documents the coupling: first-wins is only deterministic because the caller supplies a fixed
+        // order. Reverse the input and the result changes, so the ORDER BY is load-bearing.
+        (string, Vector3)[] candidates =
+        [
+            ("$cannon0", new Vector3(1f, 0f, 0f)),
+            ("$cannon0", new Vector3(9f, 0f, 0f))
+        ];
+
+        var forward = ModelAttachPointGameData.MergeHelpers(candidates, out _);
+        var reversed = ModelAttachPointGameData.MergeHelpers([.. candidates.Reverse()], out _);
+
+        await Assert.That(forward["$cannon0"]).IsEqualTo(new Vector3(1f, 0f, 0f));
+        await Assert.That(reversed["$cannon0"]).IsEqualTo(new Vector3(9f, 0f, 0f));
+    }
+
+    [Test]
+    public async Task NoCandidates_ResolvesNothing()
+    {
+        var merged = ModelAttachPointGameData.MergeHelpers([], out var conflicts);
+
+        await Assert.That(merged).IsEmpty();
+        await Assert.That(conflicts).IsEmpty();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Housing/BoundDoodadAlignmentTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Housing/BoundDoodadAlignmentTests.cs
@@ -1,0 +1,107 @@
+using System.Numerics;
+
+using AAEmu.Game.Models.Game.Housing;
+using AAEmu.Game.Models.Game.World.Transform;
+using AAEmu.Game.Utils;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Housing;
+
+/// <summary>
+/// The realignment guard decides whether a persisted bound doodad still matches its template offset.
+/// Getting it wrong is silent in both directions: too strict and every reconciliation rewrites and
+/// re-saves every doodad, too loose and a drifted one is never corrected.
+/// </summary>
+public class BoundDoodadAlignmentTests
+{
+    private static WorldSpawnPosition Target(float x = 1f, float y = 2f, float z = 3f,
+        float rollDeg = 0f, float pitchDeg = 0f, float yawDeg = 0f) =>
+        new() { X = x, Y = y, Z = z, Roll = rollDeg, Pitch = pitchDeg, Yaw = yawDeg };
+
+    private static Vector3 Radians(float rollDeg, float pitchDeg, float yawDeg) =>
+        new(rollDeg.DegToRad(), pitchDeg.DegToRad(), yawDeg.DegToRad());
+
+    [Test]
+    public async Task Matching_TransformNeedsNoRealignment()
+    {
+        var target = Target(yawDeg: 90f);
+
+        var needs = BoundDoodadAlignment.NeedsRealignment(
+            new Vector3(1f, 2f, 3f), Radians(0f, 0f, 90f), target);
+
+        await Assert.That(needs).IsFalse();
+    }
+
+    [Test]
+    public async Task PositionDrift_NeedsRealignment()
+    {
+        var needs = BoundDoodadAlignment.NeedsRealignment(
+            new Vector3(1f, 2f, 3.5f), Vector3.Zero, Target());
+
+        await Assert.That(needs).IsTrue();
+    }
+
+    [Test]
+    public async Task RotationOnlyDrift_NeedsRealignment()
+    {
+        // The position matches exactly; only the orientation is stale. Comparing position alone would
+        // leave this doodad wrong permanently, because the guard would return before applying rotation.
+        var needs = BoundDoodadAlignment.NeedsRealignment(
+            new Vector3(1f, 2f, 3f), Radians(0f, 0f, 0f), Target(yawDeg: 90f));
+
+        await Assert.That(needs).IsTrue();
+    }
+
+    [Test]
+    public async Task AngularWraparound_IsTheSameOrientation()
+    {
+        // 350 and -10 degrees are the same heading; so are 179 and -181.
+        var wrapped = BoundDoodadAlignment.NeedsRealignment(
+            new Vector3(1f, 2f, 3f), Radians(0f, 0f, 350f), Target(yawDeg: -10f));
+        var acrossPi = BoundDoodadAlignment.NeedsRealignment(
+            new Vector3(1f, 2f, 3f), Radians(0f, 0f, 179f), Target(yawDeg: -181f));
+
+        await Assert.That(wrapped).IsFalse();
+        await Assert.That(acrossPi).IsFalse();
+    }
+
+    [Test]
+    public async Task FullTurn_IsTheSameOrientation()
+    {
+        var needs = BoundDoodadAlignment.NeedsRealignment(
+            new Vector3(1f, 2f, 3f), Radians(0f, 0f, 360f), Target(yawDeg: 0f));
+
+        await Assert.That(needs).IsFalse();
+    }
+
+    [Test]
+    public async Task DriftWithinTolerance_IsIgnored()
+    {
+        var needs = BoundDoodadAlignment.NeedsRealignment(
+            new Vector3(1.001f, 2f, 3f), Radians(0f, 0f, 0.01f), Target());
+
+        await Assert.That(needs).IsFalse();
+    }
+
+    [Test]
+    public async Task EachRotationAxis_IsCompared()
+    {
+        var roll = BoundDoodadAlignment.NeedsRealignment(new Vector3(1f, 2f, 3f), Radians(45f, 0f, 0f), Target());
+        var pitch = BoundDoodadAlignment.NeedsRealignment(new Vector3(1f, 2f, 3f), Radians(0f, 45f, 0f), Target());
+        var yaw = BoundDoodadAlignment.NeedsRealignment(new Vector3(1f, 2f, 3f), Radians(0f, 0f, 45f), Target());
+
+        await Assert.That(roll).IsTrue();
+        await Assert.That(pitch).IsTrue();
+        await Assert.That(yaw).IsTrue();
+    }
+
+    [Test]
+    public async Task OriginTarget_IsAValidOffset()
+    {
+        // The origin has to be treated as a real position; "unresolved" is tracked separately, on the
+        // binding. A doodad away from an origin target still needs realigning.
+        var needs = BoundDoodadAlignment.NeedsRealignment(
+            new Vector3(5f, 0f, 0f), Vector3.Zero, Target(0f, 0f, 0f));
+
+        await Assert.That(needs).IsTrue();
+    }
+}


### PR DESCRIPTION
Crafting stations inside player houses could not be used. The client drew them in place and offered a craft cursor, but no interaction: their doodads were sitting at the house origin instead of at their attach point. Here is a fix for it