### PR TITLE
docs(readme): fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ See [Contributing](CONTRIBUTING.md) for details. Thanks to all the people who al
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=AAEmu/AAEmu,NL0bP/AAEmu&type=Timeline)](https://star-history.com/#AAEmu/AAEmu&NL0bP/AAEmu&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=AAEmu/AAEmu,NL0bP/AAEmu&type=Timeline)](https://star-history.dera.page/#AAEmu/AAEmu&NL0bP/AAEmu&Timeline)
 
 ## Licensing information
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the repository stargazer API used by star-history.com has been restricted. Switch the chart to the dera.page mirror, which uses a data source that requires no API token and is already used by many popular repositories. This keeps the chart rendering for our contributors.